### PR TITLE
Fixes adding more than one local variable

### DIFF
--- a/core/eval.c
+++ b/core/eval.c
@@ -376,7 +376,7 @@ obj_p amend(obj_p sym, obj_p val)
     env = &__INTERPRETER->stack[bp + as_lambda(lambda)->args->len];
 
     if (*env != NULL_OBJ)
-        set_obj(&as_list(*env)[0], sym, clone_obj(val));
+        set_obj(env, sym, clone_obj(val));
     else
     {
         *env = dict(vector(TYPE_SYMBOL, 1), vn_list(1, clone_obj(val)));


### PR DESCRIPTION
This would not work without the change:
```
(set f (fn []
  (let x 1)
  (let y 2)
  y))
(f)
```