### PR TITLE
fix(binary): Cmp functions return Null when empty list is in arguments. Closes #63

### DIFF
--- a/core/binary.c
+++ b/core/binary.c
@@ -191,7 +191,7 @@ obj_p binary_call_atomic(binary_f f, obj_p x, obj_p y) {
             return error_str(ERR_LENGTH, "binary: vectors must be of the same length");
 
         if (l == 0)
-            return vector(xt, 0);
+            return f(x, y);
 
         a = xt == TYPE_LIST ? AS_LIST(x)[0] : at_idx(x, 0);
         b = yt == TYPE_LIST ? AS_LIST(y)[0] : at_idx(y, 0);
@@ -231,9 +231,8 @@ obj_p binary_call_atomic(binary_f f, obj_p x, obj_p y) {
         return res;
     } else if (xt == TYPE_LIST || xt == TYPE_MAPLIST) {
         l = ops_count(x);
-
         if (l == 0)
-            return vector(xt, 0);
+            return f(x, y);
 
         a = xt == TYPE_LIST ? AS_LIST(x)[0] : at_idx(x, 0);
         item = binary_call_atomic(f, a, y);
@@ -266,7 +265,8 @@ obj_p binary_call_atomic(binary_f f, obj_p x, obj_p y) {
     } else if (yt == TYPE_LIST || yt == TYPE_MAPLIST) {
         l = ops_count(y);
         if (l == 0)
-            return NULL_OBJ;
+            return f(x, y);
+
         b = yt == TYPE_LIST ? AS_LIST(y)[0] : at_idx(y, 0);
         item = binary_call_atomic(f, x, b);
         if (yt != TYPE_LIST)

--- a/core/cmp.c
+++ b/core/cmp.c
@@ -311,8 +311,11 @@ obj_p cmp_map(raw_p op, obj_p x, obj_p y) {
         return cmp_fn(x, y, 1, 0, NULL_OBJ);
     }
 
-    n = pool_split_by(pool, l, 0);
     res = B8(l);
+    if (l == 0)
+        return res;
+
+    n = pool_split_by(pool, l, 0);
 
     if (n == 1) {
         v = cmp_fn(x, y, l, 0, res);


### PR DESCRIPTION
Cmp functions return Null when empty list is in arguments. Closes #63