### PR TITLE
Adds handling of EINTR to epoll_wait()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ tests: $(TESTS_OBJECTS) lib
 %.o: %.c
 	$(CC) -include core/def.h -c $^ $(CFLAGS) -o $@
 
-lib: CFLAGS = $(RELEASE_CFLAGS)
+lib: CFLAGS = $(RELEASE_CFLAGS) -DSYS_MALLOC
 lib: $(CORE_OBJECTS)
 	$(AR) rc lib$(TARGET).a $(CORE_OBJECTS)
 

--- a/core/epoll.c
+++ b/core/epoll.c
@@ -458,6 +458,9 @@ i64_t poll_run(poll_p poll) {
 
     while (poll->code == NULL_I64) {
         nfds = epoll_wait(poll->poll_fd, events, MAX_EVENTS, timeout);
+        if (nfds == -1 && errno == EINTR)
+            continue;
+
         if (nfds == -1)
             return 1;
 


### PR DESCRIPTION
I added handling of EINTR quasi-error to the epoll_wait() call. This stopped me from running perf tests with Rayforce. Now it works.