### PR TITLE
Fixed missing null terminator on errors sent back to KDB

### DIFF
--- a/ext/raykx/serde.c
+++ b/ext/raykx/serde.c
@@ -97,9 +97,9 @@ i64_t raykx_size_obj(obj_p obj) {
         case TYPE_ERR:
             l = AS_ERROR(obj)->msg->len;
             //If there isn't a null terminator on the original message add an extra byte to add one
-            if (AS_C8(AS_ERROR(obj)->msg)[l - 1] != '\0')
+            if (l == 0 || AS_C8(AS_ERROR(obj)->msg)[l - 1] != '\0')
                 l++;
-            return ISIZEOF(i8_t) + l + 1;
+            return ISIZEOF(i8_t) + l;
         case TYPE_NULL:
             return ISIZEOF(i8_t) + 1 + sizeof(i32_t);
         // // case TYPE_LAMBDA:


### PR DESCRIPTION
Error messages in KX require a null terminator. The RayKx plugin seems to trim them off. So, when RayKx return an error to the KDB session you get something like this

(This assumes that Rayforce is running, with RayKx listening on port 5051)
```
q)h:hopen[":127.0.0.1:5051"]
q)h["bad"]
'badmsg
  [0]  h["bad"]
```

`badmsg means that KDB was unable to deserialize the message,

After this fix is applied, if a KDB session connects into Rayforce via RayKx, it will get and an error is returned, it will be shown correctly, like this

```
q)h:hopen[":127.0.0.1:5051"]
q)h["bad"]
'undefined symbol: 'bad
  [0]  h["bad"]
```