### PR TITLE
test+fix: coverage pass 2 — 6 tests, 7 source bugs surfaced + fixed

### DIFF
--- a/src/core/numparse.c
+++ b/src/core/numparse.c
@@ -23,6 +23,8 @@
 
 #include "core/numparse.h"
 
+#include <rayforce.h>
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -402,15 +404,25 @@ size_t ray_parse_f64(const char *src, size_t len, double *dst) {
     }
 
     if (need_strtod) {
-        char stackbuf[128];
-        char *buf = (i + 1 <= sizeof(stackbuf)) ? stackbuf : malloc(i + 1);
+        /* Project policy: no libc malloc/free.  Use a stack buffer for
+         * the common case; fall back to the internal allocator for
+         * anything larger. */
+        char   stackbuf[128];
+        char  *buf;
+        ray_t *buf_block = NULL;
+        if (i + 1 <= sizeof(stackbuf)) {
+            buf = stackbuf;
+        } else {
+            buf_block = ray_alloc(i + 1);
+            buf = buf_block ? (char*)ray_data(buf_block) : NULL;
+        }
         if (buf) {
             memcpy(buf, src, i);
             buf[i] = '\0';
             char *endp = NULL;
             double v = strtod(buf, &endp);
             bool ok = (endp == buf + i);
-            if (buf != stackbuf) free(buf);
+            if (buf_block) ray_free(buf_block);
             if (ok) {
                 /* strtod already applied the leading sign in buf, so
                  * don't apply `neg` again. */

--- a/src/lang/syscmd.c
+++ b/src/lang/syscmd.c
@@ -290,13 +290,25 @@ ray_t* ray_syscmd_dispatch(const char* str, size_t len,
             return ray_error("domain", "unknown command");
         /* Shell fallback — pass the entire original string verbatim
          * so quoting/redirection survives.  Match .sys.exec semantics:
-         * return the host shell's exit code. */
-        char* cmd = (char*)malloc(len + 1);
-        if (!cmd) return ray_error("oom", NULL);
+         * return the host shell's exit code.
+         *
+         * Project policy: no libc malloc/free.  Use a stack buffer for
+         * the common short-command case; fall back to the internal
+         * allocator for anything larger. */
+        char  stackbuf[1024];
+        char* cmd;
+        ray_t* cmd_block = NULL;
+        if (len + 1 <= sizeof(stackbuf)) {
+            cmd = stackbuf;
+        } else {
+            cmd_block = ray_alloc(len + 1);
+            if (!cmd_block) return ray_error("oom", NULL);
+            cmd = (char*)ray_data(cmd_block);
+        }
         memcpy(cmd, str, len);
         cmd[len] = '\0';
         int rc = system(cmd);
-        free(cmd);
+        if (cmd_block) ray_free(cmd_block);
         return ray_i64(rc);
     }
 

--- a/src/ops/exec.c
+++ b/src/ops/exec.c
@@ -533,6 +533,19 @@ ray_t* broadcast_scalar(ray_t* atom, int64_t nrows) {
         vec = ray_vec_append(vec, elem);
         if (RAY_IS_ERR(vec)) return vec;
     }
+    /* Propagate null state from the source atom.  A typed-null atom
+     * (e.g. 0Nf returned by VAR/STDDEV with cnt<=1) carries its null
+     * bit in atom->nullmap[0] & 1.  Without this propagation, the
+     * scalar-select pipeline
+     *   exec_reduction → ray_typed_null(-RAY_F64) → broadcast_scalar
+     * would silently surface a stray 0.0 at (at result 0) instead of
+     * the 0Nf the by-keyed path correctly reports.  Stamp every
+     * output row null so downstream collection_elem / null-aware ops
+     * preserve atom semantics. */
+    if (RAY_ATOM_IS_NULL(atom)) {
+        for (int64_t r = 0; r < nrows; r++)
+            ray_vec_set_null(vec, r, true);
+    }
     return vec;
 }
 

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -44,11 +44,15 @@ static void reduce_acc_init(reduce_acc_t* acc) {
     acc->cnt = 0; acc->null_count = 0; acc->has_first = false;
 }
 
-/* Integer reduction loop — reads native type T, accumulates as i64 */
-#define REDUCE_LOOP_I(T, base, start, end, acc, has_nulls, null_bm) \
+/* Integer reduction loop — reads native type T, accumulates as i64.
+ * `idx` is an optional int64 selection vector: when non-NULL, iterate
+ * idx[start..end) and read d[idx[i]]; when NULL, iterate d[start..end)
+ * directly.  The branch is loop-invariant so the compiler hoists it. */
+#define REDUCE_LOOP_I(T, base, start, end, acc, has_nulls, null_bm, idx) \
     do { \
         const T* d = (const T*)(base); \
-        for (int64_t row = start; row < end; row++) { \
+        for (int64_t i = start; i < end; i++) { \
+            int64_t row = (idx) ? (idx)[i] : i; \
             if (has_nulls && (null_bm[row/8] >> (row%8)) & 1) { (acc)->null_count++; continue; } \
             int64_t v = (int64_t)d[row]; \
             /* sum/sum_sq may overflow on signed arithmetic — use defined \
@@ -63,11 +67,12 @@ static void reduce_acc_init(reduce_acc_t* acc) {
         } \
     } while (0)
 
-/* Float reduction loop */
-#define REDUCE_LOOP_F(base, start, end, acc, has_nulls, null_bm) \
+/* Float reduction loop — see REDUCE_LOOP_I for `idx` semantics. */
+#define REDUCE_LOOP_F(base, start, end, acc, has_nulls, null_bm, idx) \
     do { \
         const double* d = (const double*)(base); \
-        for (int64_t row = start; row < end; row++) { \
+        for (int64_t i = start; i < end; i++) { \
+            int64_t row = (idx) ? (idx)[i] : i; \
             if (has_nulls && (null_bm[row/8] >> (row%8)) & 1) { (acc)->null_count++; continue; } \
             double v = d[row]; \
             (acc)->sum_f += v; (acc)->sum_sq_f += v * v; (acc)->prod_f *= v; \
@@ -80,22 +85,23 @@ static void reduce_acc_init(reduce_acc_t* acc) {
 
 static void reduce_range(ray_t* input, int64_t start, int64_t end,
                          reduce_acc_t* acc, bool has_nulls,
-                         const uint8_t* null_bm) {
+                         const uint8_t* null_bm, const int64_t* idx) {
     void* base = ray_data(input);
     switch (input->type) {
     case RAY_BOOL: case RAY_U8:
-        REDUCE_LOOP_I(uint8_t, base, start, end, acc, has_nulls, null_bm); break;
+        REDUCE_LOOP_I(uint8_t, base, start, end, acc, has_nulls, null_bm, idx); break;
     case RAY_I16:
-        REDUCE_LOOP_I(int16_t, base, start, end, acc, has_nulls, null_bm); break;
+        REDUCE_LOOP_I(int16_t, base, start, end, acc, has_nulls, null_bm, idx); break;
     case RAY_I32: case RAY_DATE: case RAY_TIME:
-        REDUCE_LOOP_I(int32_t, base, start, end, acc, has_nulls, null_bm); break;
+        REDUCE_LOOP_I(int32_t, base, start, end, acc, has_nulls, null_bm, idx); break;
     case RAY_I64: case RAY_TIMESTAMP:
-        REDUCE_LOOP_I(int64_t, base, start, end, acc, has_nulls, null_bm); break;
+        REDUCE_LOOP_I(int64_t, base, start, end, acc, has_nulls, null_bm, idx); break;
     case RAY_F64:
-        REDUCE_LOOP_F(base, start, end, acc, has_nulls, null_bm); break;
+        REDUCE_LOOP_F(base, start, end, acc, has_nulls, null_bm, idx); break;
     case RAY_SYM: {
         /* Adaptive-width SYM columns — use read_col_i64 */
-        for (int64_t row = start; row < end; row++) {
+        for (int64_t i = start; i < end; i++) {
+            int64_t row = idx ? idx[i] : i;
             if (has_nulls && (null_bm[row/8] >> (row%8)) & 1) { acc->null_count++; continue; }
             int64_t v = read_col_i64(base, row, input->type, input->attrs);
             acc->sum_i += v; acc->sum_sq_i += v * v;
@@ -117,12 +123,13 @@ typedef struct {
     reduce_acc_t*  accs;   /* one per worker */
     bool           has_nulls;
     const uint8_t* null_bm;
+    const int64_t* idx;    /* NULL = no selection; else int64[total_pass] */
 } par_reduce_ctx_t;
 
 static void par_reduce_fn(void* ctx, uint32_t worker_id, int64_t start, int64_t end) {
     par_reduce_ctx_t* c = (par_reduce_ctx_t*)ctx;
     reduce_range(c->input, start, end, &c->accs[worker_id],
-                 c->has_nulls, c->null_bm);
+                 c->has_nulls, c->null_bm, c->idx);
 }
 
 static void reduce_merge(reduce_acc_t* dst, const reduce_acc_t* src, int8_t in_type) {
@@ -224,7 +231,6 @@ ray_t* exec_count_distinct(ray_graph_t* g, ray_op_t* op, ray_t* input) {
 }
 
 ray_t* exec_reduction(ray_graph_t* g, ray_op_t* op, ray_t* input) {
-    (void)g;
     if (!input || RAY_IS_ERR(input)) return input;
 
     /* TABLE input: COUNT returns row count, others need a column */
@@ -243,6 +249,32 @@ ray_t* exec_reduction(ray_graph_t* g, ray_op_t* op, ray_t* input) {
     bool has_nulls = (input->attrs & RAY_ATTR_HAS_NULLS) != 0;
     const uint8_t* null_bm = ray_vec_nullmap_bytes(input, NULL, NULL);
 
+    /* Selection-aware reduction: when a lazy WHERE filter has installed
+     * g->selection on the graph and the column we're reducing matches
+     * the selection's source-row count, the reduction must walk only
+     * the selected rows.  Without this, scalar aggs like
+     *   (select {s: (sum v) from: T where: (>= v 500)})
+     * silently sum the unfiltered column.  exec_group's by-keyed path
+     * already pulls the selection through match_idx — this is the
+     * non-grouped twin for OP_SUM/MIN/MAX/AVG/etc. dispatched from
+     * exec.c via a vector input (OP_SELECT projection of a scalar agg).
+     *
+     * We borrow g->selection — the caller (the OP_SUM dispatcher in
+     * exec.c, ultimately ray_execute) is responsible for releasing it.
+     * Only the materialised index block is freed here. */
+    ray_t* sel_idx_block = NULL;
+    const int64_t* sel_idx = NULL;
+    int64_t scan_n = len;
+    if (g && g->selection) {
+        ray_rowsel_t* sm = ray_rowsel_meta(g->selection);
+        if (sm->nrows == len) {
+            sel_idx_block = ray_rowsel_to_indices(g->selection);
+            if (!sel_idx_block) return ray_error("oom", NULL);
+            sel_idx = (const int64_t*)ray_data(sel_idx_block);
+            scan_n = sm->total_pass;
+        }
+    }
+
     /* O(1) short-circuit: first/last on numeric columns don't need a
      * full reduction pass.  Non-numeric types (STR, GUID) fall through
      * to the serial reduction path below. */
@@ -251,14 +283,19 @@ ray_t* exec_reduction(ray_graph_t* g, ray_op_t* op, ray_t* input) {
          in_type == RAY_I16 || in_type == RAY_BOOL || in_type == RAY_U8 ||
          in_type == RAY_TIMESTAMP || in_type == RAY_DATE || in_type == RAY_TIME ||
          in_type == RAY_SYM)) {
-        int64_t row;
+        int64_t row = -1;
         if (op->opcode == OP_FIRST) {
-            for (row = 0; row < len; row++)
-                if (!has_nulls || !((null_bm[row/8] >> (row%8)) & 1)) break;
+            for (int64_t i = 0; i < scan_n; i++) {
+                int64_t r = sel_idx ? sel_idx[i] : i;
+                if (!has_nulls || !((null_bm[r/8] >> (r%8)) & 1)) { row = r; break; }
+            }
         } else {
-            for (row = len - 1; row >= 0; row--)
-                if (!has_nulls || !((null_bm[row/8] >> (row%8)) & 1)) break;
+            for (int64_t i = scan_n - 1; i >= 0; i--) {
+                int64_t r = sel_idx ? sel_idx[i] : i;
+                if (!has_nulls || !((null_bm[r/8] >> (r%8)) & 1)) { row = r; break; }
+            }
         }
+        if (sel_idx_block) ray_release(sel_idx_block);
         if (row < 0 || row >= len)
             return ray_typed_null(-in_type);
         void* base = ray_data(input);
@@ -267,16 +304,17 @@ ray_t* exec_reduction(ray_graph_t* g, ray_op_t* op, ray_t* input) {
     }
 
     ray_pool_t* pool = ray_pool_get();
-    if (pool && len >= RAY_PARALLEL_THRESHOLD) {
+    if (pool && scan_n >= RAY_PARALLEL_THRESHOLD) {
         uint32_t nw = ray_pool_total_workers(pool);
         ray_t* accs_hdr;
         reduce_acc_t* accs = (reduce_acc_t*)scratch_calloc(&accs_hdr, nw * sizeof(reduce_acc_t));
-        if (!accs) return ray_error("oom", NULL);
+        if (!accs) { if (sel_idx_block) ray_release(sel_idx_block); return ray_error("oom", NULL); }
         for (uint32_t i = 0; i < nw; i++) reduce_acc_init(&accs[i]);
 
         par_reduce_ctx_t ctx = { .input = input, .accs = accs,
-                                 .has_nulls = has_nulls, .null_bm = null_bm };
-        ray_pool_dispatch(pool, par_reduce_fn, &ctx, len);
+                                 .has_nulls = has_nulls, .null_bm = null_bm,
+                                 .idx = sel_idx };
+        ray_pool_dispatch(pool, par_reduce_fn, &ctx, scan_n);
 
         /* Merge: worker 0 is the base, merge the rest in order */
         reduce_acc_t merged;
@@ -331,12 +369,14 @@ ray_t* exec_reduction(ray_graph_t* g, ray_op_t* op, ray_t* input) {
             default:       result = ray_error("nyi", NULL); break;
         }
         scratch_free(accs_hdr);
+        if (sel_idx_block) ray_release(sel_idx_block);
         return result;
     }
 
     reduce_acc_t acc;
     reduce_acc_init(&acc);
-    reduce_range(input, 0, len, &acc, has_nulls, null_bm);
+    reduce_range(input, 0, scan_n, &acc, has_nulls, null_bm, sel_idx);
+    if (sel_idx_block) ray_release(sel_idx_block);
 
     switch (op->opcode) {
         case OP_SUM:   return in_type == RAY_F64 ? ray_f64(acc.sum_f) : ray_i64(acc.sum_i);
@@ -1215,12 +1255,16 @@ typedef struct {
     da_val_t* max_val;   /* MAX [n_slots * n_aggs] */
     double*   sumsq_f64; /* sum-of-squares for STDDEV/VAR */
     int64_t*  count;     /* group counts [n_slots] */
+    int64_t*  first_row; /* min row index seen per slot (FIRST) [n_slots] */
+    int64_t*  last_row;  /* max row index seen per slot (LAST)  [n_slots] */
     /* Arena headers */
     ray_t* _h_sum;
     ray_t* _h_min;
     ray_t* _h_max;
     ray_t* _h_sumsq;
     ray_t* _h_count;
+    ray_t* _h_first_row;
+    ray_t* _h_last_row;
 } da_accum_t;
 
 static inline void da_accum_free(da_accum_t* a) {
@@ -1229,6 +1273,8 @@ static inline void da_accum_free(da_accum_t* a) {
     scratch_free(a->_h_max);
     scratch_free(a->_h_sumsq);
     scratch_free(a->_h_count);
+    scratch_free(a->_h_first_row);
+    scratch_free(a->_h_last_row);
 }
 
 /* Unified agg result emitter — used by both DA and HT paths.
@@ -1651,6 +1697,14 @@ static inline void da_accum_row(da_ctx_t* c, da_accum_t* acc, int32_t gid, int64
         return;
     }
 
+    /* Track per-slot row-index bounds when FIRST/LAST is needed.  Pool
+     * dispatch is work-stealing: tasks may be claimed by a single worker
+     * out of index order, so rows do NOT arrive in monotonic order within
+     * a worker.  Use explicit min/max comparison against r and update the
+     * stored value only when the new row beats the current bound. */
+    bool fl_take_first = (acc->first_row && r < acc->first_row[gid]);
+    bool fl_take_last  = (acc->last_row  && r > acc->last_row[gid]);
+
     for (uint8_t a = 0; a < n_aggs; a++) {
         if (!c->agg_ptrs[a]) continue;
         size_t idx = base + a;
@@ -1662,13 +1716,15 @@ static inline void da_accum_row(da_ctx_t* c, da_accum_t* acc, int32_t gid, int64
             else acc->sum[idx].i = (int64_t)((uint64_t)acc->sum[idx].i + (uint64_t)iv);
             if (acc->sumsq_f64) acc->sumsq_f64[idx] += fv * fv;
         } else if (op == OP_FIRST) {
-            if (acc->count[gid] == 1) {
+            if (fl_take_first) {
                 if (c->agg_types[a] == RAY_F64) acc->sum[idx].f = fv;
                 else acc->sum[idx].i = iv;
             }
         } else if (op == OP_LAST) {
-            if (c->agg_types[a] == RAY_F64) acc->sum[idx].f = fv;
-            else acc->sum[idx].i = iv;
+            if (fl_take_last) {
+                if (c->agg_types[a] == RAY_F64) acc->sum[idx].f = fv;
+                else acc->sum[idx].i = iv;
+            }
         } else if (op == OP_MIN) {
             if (c->agg_types[a] == RAY_F64) {
                 if (fv < acc->min_val[idx].f) acc->min_val[idx].f = fv;
@@ -1683,6 +1739,10 @@ static inline void da_accum_row(da_ctx_t* c, da_accum_t* acc, int32_t gid, int64
             }
         }
     }
+
+    /* Commit row-index bounds after value writes. */
+    if (fl_take_first) acc->first_row[gid] = r;
+    if (fl_take_last)  acc->last_row[gid]  = r;
 }
 
 static void da_accum_fn(void* ctx, uint32_t worker_id, int64_t start, int64_t end) {
@@ -2711,6 +2771,7 @@ da_path:;
             /* Recompute need_flags (da_fits may have changed scope) */
             uint8_t need_flags = DA_NEED_COUNT;
             bool all_sum = true;
+            bool da_has_first_last = false;
             for (uint8_t a = 0; a < n_aggs; a++) {
                 uint16_t aop = ext->agg_ops[a];
                 if (aop == OP_SUM || aop == OP_AVG || aop == OP_FIRST || aop == OP_LAST) need_flags |= DA_NEED_SUM;
@@ -2720,6 +2781,7 @@ da_path:;
                 else if (aop == OP_MAX) need_flags |= DA_NEED_MAX;
                 if (aop != OP_SUM && aop != OP_AVG && aop != OP_COUNT)
                     all_sum = false;
+                if (aop == OP_FIRST || aop == OP_LAST) da_has_first_last = true;
             }
 
             /* Compute strides: stride[k] = product of ranges[k+1..n_keys-1]
@@ -2813,6 +2875,18 @@ da_path:;
                 accums[w].count = (int64_t*)scratch_calloc(&accums[w]._h_count,
                     n_slots * sizeof(int64_t));
                 if (!accums[w].count) { alloc_ok = false; break; }
+                if (da_has_first_last) {
+                    accums[w].first_row = (int64_t*)scratch_alloc(
+                        &accums[w]._h_first_row, n_slots * sizeof(int64_t));
+                    if (!accums[w].first_row) { alloc_ok = false; break; }
+                    for (uint32_t s = 0; s < n_slots; s++)
+                        accums[w].first_row[s] = INT64_MAX;
+                    accums[w].last_row = (int64_t*)scratch_alloc(
+                        &accums[w]._h_last_row, n_slots * sizeof(int64_t));
+                    if (!accums[w].last_row) { alloc_ok = false; break; }
+                    for (uint32_t s = 0; s < n_slots; s++)
+                        accums[w].last_row[s] = INT64_MIN;
+                }
             }
             if (!alloc_ok) {
                 for (uint32_t w = 0; w < da_n_workers; w++)
@@ -2864,9 +2938,10 @@ da_path:;
             }
 
             /* Merge per-worker accumulators into accums[0].
-             * FIRST/LAST require worker-order-dependent merge (sequential).
-             * All other ops are commutative — dispatch over disjoint slot
-             * ranges for parallel merge. */
+             * FIRST/LAST need row-index-aware merge: pool dispatch is
+             * work-stealing, so worker_id ordering does not reflect global
+             * row order.  Use per-slot first_row/last_row to pick the
+             * worker whose entry has the smallest/largest row index. */
             if (has_first_last) {
                 for (uint32_t w = 1; w < da_n_workers; w++) {
                     da_accum_t* wa = &accums[w];
@@ -2877,6 +2952,10 @@ da_path:;
                     if (need_flags & DA_NEED_SUM) {
                         for (uint32_t s = 0; s < n_slots; s++) {
                             size_t base = (size_t)s * n_aggs;
+                            bool take_first = wa->first_row && merged->first_row &&
+                                wa->first_row[s] < merged->first_row[s];
+                            bool take_last  = wa->last_row && merged->last_row &&
+                                wa->last_row[s]  > merged->last_row[s];
                             for (uint8_t a = 0; a < n_aggs; a++) {
                                 size_t idx = base + a;
                                 uint16_t aop = ext->agg_ops[a];
@@ -2884,13 +2963,13 @@ da_path:;
                                     if (agg_types[a] == RAY_F64) merged->sum[idx].f += wa->sum[idx].f;
                                     else merged->sum[idx].i += wa->sum[idx].i;
                                 } else if (aop == OP_FIRST) {
-                                    if (merged->count[s] == 0 && wa->count[s] > 0)
-                                        merged->sum[idx] = wa->sum[idx];
+                                    if (take_first) merged->sum[idx] = wa->sum[idx];
                                 } else if (aop == OP_LAST) {
-                                    if (wa->count[s] > 0)
-                                        merged->sum[idx] = wa->sum[idx];
+                                    if (take_last)  merged->sum[idx] = wa->sum[idx];
                                 }
                             }
+                            if (take_first) merged->first_row[s] = wa->first_row[s];
+                            if (take_last)  merged->last_row[s]  = wa->last_row[s];
                         }
                     }
                     if (need_flags & DA_NEED_MIN) {

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -466,7 +466,13 @@ ght_layout_t ght_compute_layout(uint8_t n_keys, uint8_t n_aggs,
      * row (bit k = key k is null). Folding this slot into hash/memcmp lets
      * null and 0 form distinct groups. */
     uint16_t key_region = (uint16_t)((uint16_t)n_keys * 8 + 8);
-    ly.entry_stride = (uint16_t)(8 + key_region + (uint16_t)nv * 8);
+    /* Entry layout: hash | keys | null_mask | agg_vals | [entry_row?]
+     * Tail entry_row slot is appended only when any agg is FIRST/LAST,
+     * carrying the source-row index needed to merge correctly under
+     * work-stealing dispatch (see radix_phase1_fn / accum_from_entry). */
+    bool has_first_last = (ly.agg_is_first | ly.agg_is_last) != 0;
+    uint16_t entry_tail = has_first_last ? (uint16_t)8 : (uint16_t)0;
+    ly.entry_stride = (uint16_t)(8 + key_region + (uint16_t)nv * 8 + entry_tail);
 
     uint16_t off = (uint16_t)(8 + key_region);
     uint16_t block = (uint16_t)nv * 8;
@@ -474,6 +480,12 @@ ght_layout_t ght_compute_layout(uint8_t n_keys, uint8_t n_aggs,
     if (need_flags & GHT_NEED_MIN)   { ly.off_min   = off; off += block; }
     if (need_flags & GHT_NEED_MAX)   { ly.off_max   = off; off += block; }
     if (need_flags & GHT_NEED_SUMSQ) { ly.off_sumsq = off; off += block; }
+    /* Per-slot row-index bounds for FIRST/LAST.  Two int64 blocks of
+     * n_agg_vals slots each, allocated only when needed. */
+    if (has_first_last) {
+        ly.off_first_row = off; off += block;
+        ly.off_last_row  = off; off += block;
+    }
     ly.row_stride = off;
     return ly;
 }
@@ -605,6 +617,11 @@ static inline void init_accum_from_entry(char* row, const char* entry,
     const char* agg_data = entry + 8 + ((size_t)ly->n_keys + 1) * 8;
     uint8_t na = ly->n_aggs;
     uint8_t nf = ly->need_flags;
+    bool has_fl = (ly->agg_is_first | ly->agg_is_last) != 0;
+    /* Entry tail slot carries the source-row index when has_fl. */
+    int64_t entry_row = 0;
+    if (has_fl)
+        memcpy(&entry_row, entry + ly->entry_stride - 8, 8);
 
     for (uint8_t a = 0; a < na; a++) {
         int8_t s = ly->agg_val_slot[a];
@@ -625,6 +642,14 @@ static inline void init_accum_from_entry(char* row, const char* entry,
                 memcpy(row + ly->off_sumsq + s * 8, &sq, 8);
             }
         }
+        /* Seed per-slot row-index bounds with the row that opened this
+         * group.  Only writes the populated slots; unpopulated slot
+         * bytes stay zero from the memset above (harmless — those slots
+         * never participate in accum_from_entry's compare/update). */
+        if (has_fl) {
+            memcpy(row + ly->off_first_row + s * 8, &entry_row, 8);
+            memcpy(row + ly->off_last_row  + s * 8, &entry_row, 8);
+        }
     }
 }
 
@@ -638,6 +663,15 @@ static inline void accum_from_entry(char* row, const char* entry,
     const char* agg_data = entry + 8 + ((size_t)ly->n_keys + 1) * 8;
     uint8_t na = ly->n_aggs;
     uint8_t nf = ly->need_flags;
+    /* Entry's source-row index — only present when any agg is FIRST/LAST.
+     * Pool dispatch is work-stealing (atomic_fetch_add), so phase1 may
+     * scatter entries into radix bufs out of source-row order; reading
+     * the row index from the entry restores the absolute ordering that
+     * "keep init / always overwrite" assumed. */
+    bool has_fl = (ly->agg_is_first | ly->agg_is_last) != 0;
+    int64_t entry_row = 0;
+    if (has_fl)
+        memcpy(&entry_row, entry + ly->entry_stride - 8, 8);
 
     for (uint8_t a = 0; a < na; a++) {
         int8_t s = ly->agg_val_slot[a];
@@ -645,12 +679,21 @@ static inline void accum_from_entry(char* row, const char* entry,
         const char* val = agg_data + s * 8;
 
         uint8_t amask = (1u << a);
+        bool take_first = false, take_last = false;
+        if (has_fl && (ly->agg_is_first & amask)) {
+            int64_t fr; memcpy(&fr, row + ly->off_first_row + s * 8, 8);
+            take_first = (entry_row < fr);
+        }
+        if (has_fl && (ly->agg_is_last & amask)) {
+            int64_t lr; memcpy(&lr, row + ly->off_last_row + s * 8, 8);
+            take_last = (entry_row > lr);
+        }
         if (ly->agg_is_f64 & amask) {
             double v;
             memcpy(&v, val, 8);
             if (nf & GHT_NEED_SUM) {
-                if (ly->agg_is_first & amask) { /* keep init value */ }
-                else if (ly->agg_is_last & amask) { memcpy(row + ly->off_sum + s * 8, val, 8); }
+                if (ly->agg_is_first & amask) { if (take_first) memcpy(row + ly->off_sum + s * 8, val, 8); }
+                else if (ly->agg_is_last & amask) { if (take_last) memcpy(row + ly->off_sum + s * 8, val, 8); }
                 else { ROW_WR_F64(row, ly->off_sum, s) += v; }
             }
             if (nf & GHT_NEED_MIN) { double* p = &ROW_WR_F64(row, ly->off_min, s); if (v < *p) *p = v; }
@@ -660,14 +703,18 @@ static inline void accum_from_entry(char* row, const char* entry,
             int64_t v;
             memcpy(&v, val, 8);
             if (nf & GHT_NEED_SUM) {
-                if (ly->agg_is_first & amask) { /* keep init value */ }
-                else if (ly->agg_is_last & amask) { memcpy(row + ly->off_sum + s * 8, val, 8); }
+                if (ly->agg_is_first & amask) { if (take_first) memcpy(row + ly->off_sum + s * 8, val, 8); }
+                else if (ly->agg_is_last & amask) { if (take_last) memcpy(row + ly->off_sum + s * 8, val, 8); }
                 else { ROW_WR_I64(row, ly->off_sum, s) += v; }
             }
             if (nf & GHT_NEED_MIN) { int64_t* p = &ROW_WR_I64(row, ly->off_min, s); if (v < *p) *p = v; }
             if (nf & GHT_NEED_MAX) { int64_t* p = &ROW_WR_I64(row, ly->off_max, s); if (v > *p) *p = v; }
             if (nf & GHT_NEED_SUMSQ) { ROW_WR_F64(row, ly->off_sumsq, s) += (double)v * (double)v; }
         }
+        /* Commit row-index bounds after value writes so a later entry in
+         * the same merge sees the updated bound. */
+        if (take_first) memcpy(row + ly->off_first_row + s * 8, &entry_row, 8);
+        if (take_last)  memcpy(row + ly->off_last_row  + s * 8, &entry_row, 8);
     }
 }
 
@@ -756,10 +803,12 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
     uint8_t nk = ly->n_keys;
     uint8_t na = ly->n_aggs;
     uint8_t wide = ly->wide_key_mask;
+    bool has_fl = (ly->agg_is_first | ly->agg_is_last) != 0;
     uint32_t mask = ht->ht_cap - 1;
-    /* Stack buffer for one entry: hash + (nk+1) key slots + nv agg_vals.
-     * Max size: 8 + 9*8 + 8*8 = 144 bytes. */
-    char ebuf[8 + 9 * 8 + 8 * 8];
+    /* Stack buffer for one entry: hash + (nk+1) key slots + nv agg_vals
+     * + optional 8-byte source-row tail (FIRST/LAST).
+     * Max size: 8 + 9*8 + 8*8 + 8 = 152 bytes. */
+    char ebuf[8 + 9 * 8 + 8 * 8 + 8];
 
     /* Check which key columns can produce nulls (parent vec's HAS_NULLS
      * attr for slices) — skips per-row null checks on the fast path. */
@@ -827,6 +876,11 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
                 ev[vi] = read_col_i64(ray_data(ac), row, ac->type, ac->attrs);
             vi++;
         }
+        /* Tail slot: source row index for FIRST/LAST tie-breaking.  Same
+         * layout as the radix path's entries so accum_from_entry can read
+         * it from the same offset. */
+        if (has_fl)
+            memcpy(ebuf + ly->entry_stride - 8, &row, 8);
 
         mask = group_probe_entry(ht, ebuf, key_types, mask);
     }
@@ -860,7 +914,8 @@ typedef struct {
 static inline void radix_buf_push(radix_buf_t* buf, uint16_t entry_stride,
                                    uint64_t hash, const int64_t* keys, uint8_t n_keys,
                                    int64_t null_mask,
-                                   const int64_t* agg_vals, uint8_t n_agg_vals) {
+                                   const int64_t* agg_vals, uint8_t n_agg_vals,
+                                   bool has_first_last, int64_t row) {
     if (__builtin_expect(buf->count >= buf->cap, 0)) {
         uint32_t old_cap = buf->cap;
         uint32_t new_cap = old_cap * 2;
@@ -878,6 +933,9 @@ static inline void radix_buf_push(radix_buf_t* buf, uint16_t entry_stride,
     memcpy(dst + 8 + (size_t)n_keys * 8, &null_mask, 8);
     if (n_agg_vals)
         memcpy(dst + 8 + ((size_t)n_keys + 1) * 8, agg_vals, (size_t)n_agg_vals * 8);
+    /* Tail slot: source row index for FIRST/LAST tie-breaking. */
+    if (has_first_last)
+        memcpy(dst + entry_stride - 8, &row, 8);
     buf->count++;
 }
 
@@ -905,6 +963,7 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
     uint8_t nv = ly->n_agg_vals;
     uint8_t wide = ly->wide_key_mask;
     uint16_t estride = ly->entry_stride;
+    bool has_fl = (ly->agg_is_first | ly->agg_is_last) != 0;
     const int64_t* match_idx = c->match_idx;
 
     int64_t keys[8];
@@ -959,7 +1018,8 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
         }
 
         uint32_t part = RADIX_PART(h);
-        radix_buf_push(&my_bufs[part], estride, h, keys, nk, null_mask, agg_vals, nv);
+        radix_buf_push(&my_bufs[part], estride, h, keys, nk, null_mask,
+                       agg_vals, nv, has_fl, row);
     }
 }
 

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -781,6 +781,16 @@ typedef struct {
     uint16_t off_min;
     uint16_t off_max;
     uint16_t off_sumsq;
+    /* Per-slot source-row bounds for FIRST/LAST under work-stealing
+     * dispatch (see ght_compute_layout).  Allocated only when any agg
+     * is OP_FIRST or OP_LAST; otherwise both stay 0.  Each block is
+     * n_agg_vals * 8 bytes of int64 (initialized in init_accum_from_entry
+     * to the source row index of the entry that opened the group, then
+     * monotonically updated by accum_from_entry).  The matching entry
+     * tail slot at offset (entry_stride - 8) carries the source-row
+     * index of the row the entry was built from. */
+    uint16_t off_first_row;
+    uint16_t off_last_row;
     /* Wide-key support: bit k set iff key k does not fit in 8 bytes
      * (e.g. RAY_GUID = 16 B).  For wide keys the 8-byte key slot
      * stores a source-row index and the actual key bytes live in the

--- a/src/ops/system.c
+++ b/src/ops/system.c
@@ -25,6 +25,7 @@
 #include "lang/env.h"
 #include "lang/parse.h"
 #include "mem/heap.h"
+#include "mem/sys.h"
 #include "store/serde.h"
 #include "store/splay.h"
 #include "store/part.h"
@@ -369,8 +370,10 @@ ray_t* ray_os_list_fn(ray_t* x) {
     DIR* d = opendir(path);
     if (!d) return ray_error("io", "%s: %s", path, strerror(errno));
 
-    /* Collect names into a heap-allocated string array; capacity grows
-     * geometrically so big directories don't quadratic-realloc. */
+    /* Collect names into a sys-allocator string array; capacity grows
+     * geometrically so big directories don't quadratic-realloc.  Uses
+     * ray_sys_alloc/realloc/strdup/free (NOT libc) per project policy —
+     * mirrors the collect_part_dirs idiom in src/store/part.c. */
     char** names = NULL;
     int64_t count = 0;
     int64_t cap = 0;
@@ -381,16 +384,24 @@ ray_t* ray_os_list_fn(ray_t* x) {
             continue;
         if (count >= cap) {
             int64_t new_cap = cap == 0 ? 16 : cap * 2;
-            char** tmp = (char**)realloc(names, (size_t)new_cap * sizeof(char*));
-            if (!tmp) { closedir(d); for (int64_t i = 0; i < count; i++) free(names[i]); free(names); return ray_error("oom", NULL); }
+            char** tmp = (char**)ray_sys_realloc(names, (size_t)new_cap * sizeof(char*));
+            if (!tmp) {
+                closedir(d);
+                for (int64_t i = 0; i < count; i++) ray_sys_free(names[i]);
+                ray_sys_free(names);
+                return ray_error("oom", NULL);
+            }
             names = tmp;
             cap = new_cap;
         }
-        size_t nlen = strlen(ent->d_name) + 1;
-        names[count] = (char*)malloc(nlen);
-        if (!names[count]) { closedir(d); for (int64_t i = 0; i < count; i++) free(names[i]); free(names); return ray_error("oom", NULL); }
-        memcpy(names[count], ent->d_name, nlen);
-        count++;
+        char* dup = ray_sys_strdup(ent->d_name);
+        if (!dup) {
+            closedir(d);
+            for (int64_t i = 0; i < count; i++) ray_sys_free(names[i]);
+            ray_sys_free(names);
+            return ray_error("oom", NULL);
+        }
+        names[count++] = dup;
     }
     closedir(d);
 
@@ -398,17 +409,17 @@ ray_t* ray_os_list_fn(ray_t* x) {
 
     ray_t* result = ray_vec_new(RAY_SYM, count);
     if (!result || RAY_IS_ERR(result)) {
-        for (int64_t i = 0; i < count; i++) free(names[i]);
-        free(names);
+        for (int64_t i = 0; i < count; i++) ray_sys_free(names[i]);
+        ray_sys_free(names);
         return result ? result : ray_error("oom", NULL);
     }
     result->len = count;
     int64_t* out = (int64_t*)ray_data(result);
     for (int64_t i = 0; i < count; i++) {
         out[i] = ray_sym_intern(names[i], strlen(names[i]));
-        free(names[i]);
+        ray_sys_free(names[i]);
     }
-    free(names);
+    ray_sys_free(names);
     return result;
 }
 

--- a/src/table/dict.c
+++ b/src/table/dict.c
@@ -486,6 +486,24 @@ ray_t* ray_dict_upsert(ray_t* d, ray_t* key_atom, ray_t* val) {
         vals = lst;
     }
 
+    /* Empty-target adoption: if the dict is empty its keys-vec type was
+     * defaulted at construction (e.g. RAY_I64 for `(dict [] [])` from an
+     * empty `[]` literal — parse.c:514) and may not match the incoming
+     * key atom's type.  Replace the placeholder keys vec with one of the
+     * correct type so the type-dispatch below succeeds.  Without this,
+     * `(concat (dict [] []) (dict [a b] [1 2]))` errors "type". */
+    if (keys->len == 0 && keys->type != -key_atom->type
+        && !(keys->type == RAY_SYM && key_atom->type == -RAY_SYM)) {
+        int8_t kt = (int8_t)-key_atom->type;
+        ray_t* nk = (kt == RAY_SYM)
+            ? ray_sym_vec_new(RAY_SYM_W64, 0)
+            : ray_vec_new(kt, 0);
+        if (!nk || RAY_IS_ERR(nk)) { ray_release(d); return nk ? nk : ray_error("oom", NULL); }
+        ray_release(keys);
+        slots[0] = nk;
+        keys = nk;
+    }
+
     /* Append key — helper consumes `keys`, returns owned (possibly new) ref. */
     ray_t* new_keys = NULL;
     if (keys->type == RAY_SYM) {
@@ -554,7 +572,9 @@ ray_t* ray_dict_remove(ray_t* d, ray_t* key_atom) {
     /* Drop key element by slicing (build a smaller vec without idx). */
     int64_t n = keys->len;
     ray_t* new_keys = NULL;
-    if (keys->type == RAY_SYM) {
+    if (keys->type == RAY_LIST) {
+        new_keys = ray_list_new(n - 1);
+    } else if (keys->type == RAY_SYM) {
         new_keys = ray_sym_vec_new(keys->attrs & RAY_SYM_W_MASK, n - 1);
     } else if (keys->type == RAY_STR) {
         new_keys = ray_vec_new(RAY_STR, n - 1);
@@ -564,7 +584,15 @@ ray_t* ray_dict_remove(ray_t* d, ray_t* key_atom) {
     if (!new_keys || RAY_IS_ERR(new_keys)) { ray_release(d); return new_keys ? new_keys : ray_error("oom", NULL); }
 
     /* Copy keys[0..idx-1] then keys[idx+1..n-1] into new_keys. */
-    if (keys->type == RAY_STR) {
+    if (keys->type == RAY_LIST) {
+        ray_t** ks = (ray_t**)ray_data(keys);
+        for (int64_t i = 0; i < n; i++) {
+            if (i == idx) continue;
+            ray_t* nk = ray_list_append(new_keys, ks[i]);
+            if (!nk || RAY_IS_ERR(nk)) { ray_release(new_keys); ray_release(d); return nk ? nk : ray_error("oom", NULL); }
+            new_keys = nk;
+        }
+    } else if (keys->type == RAY_STR) {
         for (int64_t i = 0; i < n; i++) {
             if (i == idx) continue;
             size_t slen = 0;

--- a/test/rfl/dict/dict_coverage.rfl
+++ b/test/rfl/dict/dict_coverage.rfl
@@ -1,0 +1,207 @@
+;; Coverage-targeted invariants for src/table/dict.c.
+;;
+;; Existing dict.rfl/key.rfl/value.rfl cover only sym-keyed happy paths,
+;; leaving most of ray_dict_find_idx (typed-key dispatch), ray_dict_remove
+;; (key-deletion paths), the empty-dict/missing-key edge cases, and
+;; non-sym key dispatch in ray_dict_get uncovered.  This file exercises
+;; those branches without modifying any source.  No /tmp I/O performed.
+
+;; ========== EMPTY DICT ==========
+;; npairs == 0 path in fmt_dict + n<=0 short-circuit in ray_dict_find_idx.
+(count (dict [] [])) -- 0
+(type (dict [] [])) -- 'DICT
+(key (dict [] [])) -- []
+;; value of empty-keyed dict is empty LIST () not empty vec [] —
+;; ray_dict_new wraps vals in a LIST regardless of input type.
+(value (dict [] [])) -- (list)
+;; Lookup on empty dict — find_idx returns -1 (n<=0 branch, line 166).
+(at (dict [] []) 'missing) -- 0Nl
+
+;; ========== ray_dict_fn ERROR PATHS ==========
+;; (dict K V) requires K to be a typed vector (line 1690 in builtins.c).
+;; A LIST as keys should error.
+(dict (list 1 2) [10 20]) !- type
+;; A scalar atom as keys should error.
+(dict 1 [10]) !- type
+
+;; ========== ray_dict_get / ray_dict_find_idx — TYPED KEYS ==========
+;; SYM keys (line 209-231 in dict.c).  Note: rfl-constructed SYM vecs
+;; default to W64 (vec.c:181), so the W8/W16/W32 inner branches in
+;; find_idx remain unreachable from rfl — only the W64 default tail.
+(set Ds (dict [a b c d] [10 20 30 40]))
+(at Ds 'a) -- 10
+(at Ds 'd) -- 40
+(at Ds 'missing) -- 0Nl
+;; Key-type mismatch (sym dict probed with int) -- find_idx returns -1
+;; via the `key_atom->type != -kt` guard (line 177).
+(at Ds 7) -- 0Nl
+
+;; I64 keys (line 232-237) — `group` of i64 vec produces a typed-int dict.
+(set Gi (group [10 20 10 30 20]))
+(count Gi) -- 3
+(at Gi 10) -- [0 2]
+(at Gi 20) -- [1 4]
+(at Gi 30) -- [3]
+;; Missing int key — find_idx negative, ray_at returns 0Nl.
+(at Gi 99) -- 0Nl
+
+;; LIST keys carrying str atoms — `(group (list ...))` keeps keys as
+;; RAY_LIST (builtins.c L1936-1951), so lookups go through the LIST
+;; branch (line 169-174) and atom_eq's STR-vs-STR path.  Distinct from
+;; the dict-literal STR-vec path covered by `Dstr` below.
+(set Gs (group (list "alpha" "beta" "alpha" "gamma")))
+(at Gs "alpha") -- [0 2]
+(at Gs "beta") -- [1]
+(at Gs "gamma") -- [3]
+;; Missing string key (no atom_eq match).
+(at Gs "delta") -- 0Nl
+;; Empty-string query — distinct length, no match.
+(at Gs "") -- 0Nl
+
+;; BOOL keys (line 250-255) — group of bool vec.
+(set Gb (group [true false true true false]))
+(at Gb true) -- [0 2 3]
+(at Gb false) -- [1 4]
+
+;; F64 keys (line 261-265).
+(set Gf (group [1.5 2.5 1.5 3.5]))
+(at Gf 1.5) -- [0 2]
+(at Gf 2.5) -- [1]
+(at Gf 99.0) -- 0Nl
+
+;; I16 keys (line 245-249) — SHORT literal `1h`.
+(set Gh (group [1h 2h 1h 3h]))
+(at Gh 1h) -- [0 2]
+(at Gh 3h) -- [3]
+
+;; I32 keys (line 238-244) — INT literal `1i`.
+(set Gii (group [1i 2i 1i 4i]))
+(at Gii 1i) -- [0 2]
+(at Gii 4i) -- [3]
+
+;; U8 keys (line 250-255) — BYTE literal `0x01`.
+(set Gu (group [0x01 0x02 0x01 0x03]))
+(at Gu 0x01) -- [0 2]
+(at Gu 0x03) -- [3]
+
+;; DATE keys (line 238-244).
+(set Gd (group [2025.01.01 2025.02.02 2025.01.01]))
+(at Gd 2025.01.01) -- [0 2]
+(at Gd 2025.02.02) -- [1]
+
+;; TIMESTAMP keys (line 232-237).
+(set Gt (group [2025.01.01D00:00:00.000000000 2025.01.02D00:00:00.000000000 2025.01.01D00:00:00.000000000]))
+(at Gt 2025.01.01D00:00:00.000000000) -- [0 2]
+(at Gt 2025.01.02D00:00:00.000000000) -- [1]
+
+;; ========== HETEROGENEOUS LIST-KEYED DICT ==========
+;; Dict-literal parser builds a LIST when keys mix sym+str (parse.c
+;; line 732).  This triggers the RAY_LIST branch in ray_dict_find_idx
+;; (line 169-174 — atom_eq probe).
+(set Dh {a: 1 "b": 2})
+(count Dh) -- 2
+(at Dh 'a) -- 1
+(at Dh "b") -- 2
+;; Missing key falls through atom_eq loop.
+(at Dh 'zzz) -- 0Nl
+
+;; ========== ray_dict_remove ==========
+;; remove on non-dict — type-error guard in ray_remove_fn (system.c L620).
+(remove [1 2 3] 'a) !- type
+(remove 5 'a) !- type
+
+;; SYM-key removal (dict.c line 576-585 — the SYM branch in remove).
+(set Ds2 (dict [a b c] [1 2 3]))
+(remove Ds2 'b) -- (dict [a c] [1 3])
+;; Removing a missing sym key — early return on idx<0 (line 536).
+(remove Ds2 'zzz) -- (dict [a b c] [1 2 3])
+;; Remove first key.
+(remove Ds2 'a) -- (dict [b c] [2 3])
+;; Remove last key.
+(remove Ds2 'c) -- (dict [a b] [1 2])
+
+;; STR-key removal (dict.c line 567-575 — the STR branch in remove).
+(set Dstr {"x": 10 "y": 20 "z": 30})
+(count (remove Dstr "y")) -- 2
+(at (remove Dstr "y") "x") -- 10
+(at (remove Dstr "y") "z") -- 30
+;; The removed key now misses.
+(at (remove Dstr "y") "y") -- 0Nl
+
+;; Non-existent STR key — find_idx returns -1, remove returns d unchanged.
+(count (remove Dstr "missing")) -- 3
+
+;; LIST-keyed remove (Dh = {a: 1 "b": 2}) — keys->type == RAY_LIST falls
+;; to the generic else-branch in ray_dict_remove (line 562) which calls
+;; ray_vec_new(RAY_LIST, …).  ray_vec_new rejects type <= 0 (vec.c L178)
+;; so the operation surfaces as a type error.  This is a latent gap
+;; (no LIST-keys path in remove) — flagged in the bug summary.  Lock
+;; the observed behaviour so a future fix can intentionally update it:
+(remove Dh 'a) !- type
+
+;; ========== ray_dict_get ON NON-DICT ==========
+;; `at` on a non-dict bypasses ray_dict_find_idx; the dict path is only
+;; entered when v->type == RAY_DICT (collection.c L1514).  No additional
+;; case to add here, but verify the count guard.
+(count (dict [a] [1])) -- 1
+
+;; ========== SINGLE-KEY DICT ==========
+(set D1 (dict [only] [42]))
+(at D1 'only) -- 42
+(count D1) -- 1
+(remove D1 'only) -- (dict [] [])
+(count (remove D1 'only)) -- 0
+
+;; ========== LARGER DICT (cross-element loop iteration) ==========
+;; A 50-key i64 dict — ensures the inner DICT_FIND_LOOP iterates
+;; meaningfully past the first few slots, and find_idx returns
+;; tail-of-vector indices correctly.
+(set BigK (group (concat (til 50) (til 50))))
+(count BigK) -- 50
+(at BigK 0) -- [0 50]
+(at BigK 49) -- [49 99]
+(at BigK 50) -- 0Nl
+
+;; ========== KEYS WITH NULLS (null-aware find_idx — line 185-193, 197-201) ==========
+;; A dict with a null in its keys vector triggers the null-aware probe.
+;; (dict [1 0Nl 3] [10 20 30]) builds an I64 keys vec with the null bitmap
+;; bit set on slot 1 — the keys_have_nulls branch in find_idx must skip
+;; null slots when looking up a non-null key, and only match null when
+;; the query atom is itself null.
+(set Dn (dict [1 0Nl 3] [10 20 30]))
+(at Dn 1) -- 10
+(at Dn 3) -- 30
+;; Null query against a keys-with-nulls vec — currently routes to the
+;; null-key branch (line 188-193): probes slot-by-slot.  Returns vals
+;; for the null slot.  This documents observed behaviour rather than
+;; an asserted spec; if the contract changes, the test will surface it.
+(at Dn 0Nl) -- 20
+;; Missing non-null key — keys_have_nulls path skips null slot (line 199),
+;; never matches, returns 0Nl.
+(at Dn 99) -- 0Nl
+
+;; ========== CONCAT ON DICTS (exercises ray_dict_upsert append + replace) ==========
+;; Existing-key replace path (line 461-477 of ray_dict_upsert): keys
+;; that overlap take the value from the right dict.
+(concat (dict [a b] [1 2]) (dict [b] [99])) -- (dict [a b] [1 99])
+;; Missing-key append (line 480-521).
+(concat (dict [a] [1]) (dict [b] [2])) -- (dict [a b] [1 2])
+;; Both empty.
+(concat (dict [] []) (dict [] [])) -- {}
+;; Right-empty: bn=0 loop short-circuits, retained left dict returned.
+(concat (dict [a] [1]) (dict [] [])) -- (dict [a] [1])
+;; Left-empty has I64 keys (parser default for `[]`), so concat-driven
+;; upsert hits the keys-type vs key-atom-type mismatch (line 509-512 in
+;; ray_dict_upsert) and returns a type error.  Verifies the negative
+;; branch.
+(concat (dict [] []) (dict [a b] [1 2])) !- type
+
+;; ========== DICT FROM TABLE-ROW (ray_dict_new via ray_at_fn) ==========
+;; Table row access materialises a SYM-keyed, LIST-valued dict.
+(at (table [a b c] (list [10] [20] [30])) 0) -- {a:10 b:20 c:30}
+(count (at (table [a b c] (list [10] [20] [30])) 0)) -- 3
+
+;; ========== DICT/TABLE CAST (ray_dict_new on cast path) ==========
+(type (as 'DICT (table [x y] (list [1] [2])))) -- 'DICT
+(count (as 'DICT (table [x y] (list [1] [2])))) -- 2
+(at (as 'DICT (table [x y] (list [1 2] [3 4]))) 'x) -- [1 2]

--- a/test/rfl/dict/dict_coverage.rfl
+++ b/test/rfl/dict/dict_coverage.rfl
@@ -131,13 +131,17 @@
 ;; Non-existent STR key — find_idx returns -1, remove returns d unchanged.
 (count (remove Dstr "missing")) -- 3
 
-;; LIST-keyed remove (Dh = {a: 1 "b": 2}) — keys->type == RAY_LIST falls
-;; to the generic else-branch in ray_dict_remove (line 562) which calls
-;; ray_vec_new(RAY_LIST, …).  ray_vec_new rejects type <= 0 (vec.c L178)
-;; so the operation surfaces as a type error.  This is a latent gap
-;; (no LIST-keys path in remove) — flagged in the bug summary.  Lock
-;; the observed behaviour so a future fix can intentionally update it:
-(remove Dh 'a) !- type
+;; LIST-keyed remove (Dh = {a: 1 "b": 2}) — keys->type == RAY_LIST routes
+;; through the dedicated LIST branch in ray_dict_remove which builds a new
+;; RAY_LIST without the matched index.  Removing 'a leaves just {"b": 2}.
+(count (remove Dh 'a)) -- 1
+(at (remove Dh 'a) "b") -- 2
+(at (remove Dh 'a) 'a) -- 0Nl
+;; Removing the str-keyed pair leaves just {a: 1}.
+(count (remove Dh "b")) -- 1
+(at (remove Dh "b") 'a) -- 1
+;; Removing a missing key leaves the dict unchanged.
+(count (remove Dh 'zzz)) -- 2
 
 ;; ========== ray_dict_get ON NON-DICT ==========
 ;; `at` on a non-dict bypasses ray_dict_find_idx; the dict path is only
@@ -190,11 +194,11 @@
 (concat (dict [] []) (dict [] [])) -- {}
 ;; Right-empty: bn=0 loop short-circuits, retained left dict returned.
 (concat (dict [a] [1]) (dict [] [])) -- (dict [a] [1])
-;; Left-empty has I64 keys (parser default for `[]`), so concat-driven
-;; upsert hits the keys-type vs key-atom-type mismatch (line 509-512 in
-;; ray_dict_upsert) and returns a type error.  Verifies the negative
-;; branch.
-(concat (dict [] []) (dict [a b] [1 2])) !- type
+;; Left-empty has I64 keys (parser default for `[]`), but the empty-target
+;; adoption branch in ray_dict_upsert replaces the placeholder keys vec
+;; with one matching the incoming key atoms' type, so the concat resolves
+;; to the right-hand dict's contents.
+(concat (dict [] []) (dict [a b] [1 2])) -- (dict [a b] [1 2])
 
 ;; ========== DICT FROM TABLE-ROW (ray_dict_new via ray_at_fn) ==========
 ;; Table row access materialises a SYM-keyed, LIST-valued dict.

--- a/test/rfl/embedding/embedding_coverage.rfl
+++ b/test/rfl/embedding/embedding_coverage.rfl
@@ -11,6 +11,9 @@
 ;;     metrics (existing test only exercises l2)
 ;;   - hnsw-save / hnsw-load round trip
 ;;   - hnsw-free idempotency (second call must error, not double-free)
+;;   - rayvec_at_f64 RAY_I32 / RAY_I64 branches (lines 357-358)
+;;   - atom_to_i64 -RAY_I32 / -RAY_I16 branches (lines 541-542)
+;;   - empty-list shortcut in ray_knn_fn (lines 574-581)
 
 ;; ────────────── pre-flight: scrub any leftover save dirs ──────────────
 (.sys.exec "rm -rf /tmp/rfl_embcov_idx /tmp/rfl_embcov_idx_*")
@@ -147,6 +150,95 @@
 (hnsw-free Loaded)
 (hnsw-free Loaded) !- type
 (hnsw-free 5)      !- type
+
+;; ────────────── rayvec_at_f64: RAY_I32 / RAY_I64 element branches ──────────────
+;; rayvec_at_f64 (lines 352-361) switches on element type.  Existing
+;; tests only ever pass F64 vectors, leaving the I32/I64 cases dark.
+;; Both query_to_doubles (line 438) and per-row row_score (lines 415,
+;; 421) dispatch through it, so passing an integer query into cos-dist
+;; / l2-dist / inner-prod hits both arms.
+
+;; Integer query vectors → query_to_doubles walks the I32/I64 cases.
+;; cos-dist of [1.0 0.0] with itself ≈ 0; the integer-query result
+;; should match within fp tolerance.
+(cos-dist [1.0 0.0] (as 'I64 [1 0]))   -- 0.0   ;; L358 RAY_I64
+(cos-dist [1.0 0.0] (as 'I32 [1 0]))   -- 0.0   ;; L357 RAY_I32
+
+;; l2-dist with integer query — sanity that the I32/I64 path produces
+;; the same numeric answer as the F64 form.
+(l2-dist [0.0 0.0] (as 'I32 [3 4]))    -- 5.0   ;; L357 RAY_I32
+(l2-dist [0.0 0.0] (as 'I64 [3 4]))    -- 5.0   ;; L358 RAY_I64
+
+;; inner-prod with integer query.
+(inner-prod [1.0 2.0 3.0] (as 'I32 [4 5 6])) -- 32.0   ;; L357
+(inner-prod [1.0 2.0 3.0] (as 'I64 [4 5 6])) -- 32.0   ;; L358
+
+;; LIST element with integer type — knn iterates rayvec_at_f64 over
+;; each list row, hitting the I32/I64 cases on row data as well.
+(set Vi32 (list (as 'I32 [1 0 0]) (as 'I32 [0 1 0]) (as 'I32 [0 0 1])))
+(first (at (knn Vi32 [1.0 0.0 0.0] 1 'l2) '_rowid)) -- 0   ;; L357 row branch
+(first (at (knn Vi32 [1.0 0.0 0.0] 1 'l2) '_dist))  -- 0.0
+
+(set Vi64 (list [1 0 0] [0 1 0] [0 0 1]))
+(first (at (knn Vi64 [1.0 0.0 0.0] 1 'l2) '_rowid)) -- 0   ;; L358 row branch
+(first (at (knn Vi64 [1.0 0.0 0.0] 1 'l2) '_dist))  -- 0.0
+
+;; norm over a LIST of integer vectors also exercises rayvec_at_f64's
+;; I32/I64 arms via the ray_norm_fn LIST loop (line 510).
+(at (norm (list (as 'I32 [3 4]))) 0)  -- 5.0   ;; L357
+(at (norm (list [3 4])) 0)            -- 5.0   ;; L358 ([3 4] is I64)
+
+;; ────────────── atom_to_i64: -RAY_I32 / -RAY_I16 atom branches ──────────────
+;; atom_to_i64 (lines 537-545) extracts an int atom into int64_t.
+;; The -RAY_I64 case is already exercised by every plain literal k.
+;; -RAY_I32 needs a 1i-style suffix; -RAY_I16 needs 1h-style.
+;; knn's k argument and hnsw-build's M / ef_c arguments all funnel
+;; through atom_to_i64.
+
+;; knn k as I32 atom (1i) → atom_to_i64 hits case -RAY_I32 (L541).
+(first (at (knn V [1.0 0.0 0.0] 1i 'l2) '_rowid)) -- 0
+(count (knn V [1.0 0.0 0.0] 3i)) -- 3
+
+;; knn k as I16 atom (1h) → atom_to_i64 hits case -RAY_I16 (L542).
+(first (at (knn V [1.0 0.0 0.0] 1h 'l2) '_rowid)) -- 0
+(count (knn V [1.0 0.0 0.0] 3h)) -- 3
+
+;; hnsw-build with M and ef_c as I16/I32 atoms also funnels through
+;; atom_to_i64, providing redundant coverage of the same branches.
+(set IdxI16 (hnsw-build V 'l2 8h 64h))   ;; M, ef_c both I16 → L542
+(at (hnsw-info IdxI16) 'M)   -- 8
+(at (hnsw-info IdxI16) 'efc) -- 64
+(hnsw-free IdxI16)
+
+(set IdxI32 (hnsw-build V 'l2 16i 128i)) ;; M, ef_c both I32 → L541
+(at (hnsw-info IdxI32) 'M)   -- 16
+(at (hnsw-info IdxI32) 'efc) -- 128
+
+;; ann ef_s as I32/I16 atom hits atom_to_i64 again.
+(count (ann IdxI32 [1.0 0.0 0.0] 2 50i)) -- 2   ;; ef_s I32 → L541
+(count (ann IdxI32 [1.0 0.0 0.0] 2 50h)) -- 2   ;; ef_s I16 → L542
+
+;; ann k as I32/I16 atom — same atom_to_i64 path.
+(count (ann IdxI32 [1.0 0.0 0.0] 2i)) -- 2
+(count (ann IdxI32 [1.0 0.0 0.0] 2h)) -- 2
+
+(hnsw-free IdxI32)
+
+;; ────────────── empty-list shortcut in ray_knn_fn ──────────────
+;; Lines 572-581: when the column is an empty list and the query is a
+;; zero-length numeric vector (so query->len == dim == 0), ray_knn_fn
+;; returns a 2-column table {_rowid: I64, _dist: F64} with both columns
+;; empty.  Reachable only via this combination.
+(count (knn (list) (as 'F64 []) 1))            -- 0
+(count (at (knn (list) (as 'F64 []) 1) '_rowid)) -- 0
+(count (at (knn (list) (as 'F64 []) 1) '_dist))  -- 0
+(type (at (knn (list) (as 'F64 []) 1) '_rowid)) -- 'I64
+(type (at (knn (list) (as 'F64 []) 1) '_dist))  -- 'F64
+
+;; Same shortcut still triggers when an explicit metric is passed.
+(count (knn (list) (as 'F64 []) 5 'l2))     -- 0
+(count (knn (list) (as 'F64 []) 5 'cosine)) -- 0
+(count (knn (list) (as 'F64 []) 5 'ip))     -- 0
 
 ;; ────────────── teardown ──────────────
 (.sys.exec "rm -rf /tmp/rfl_embcov_idx /tmp/rfl_embcov_idx_*")

--- a/test/rfl/embedding/embedding_coverage.rfl
+++ b/test/rfl/embedding/embedding_coverage.rfl
@@ -1,0 +1,152 @@
+;; Coverage probe for src/ops/embedding.c — drives branches that the
+;; per-builtin tests (cos_dist.rfl, l2_dist.rfl, inner_prod.rfl,
+;; norm.rfl, hnsw.rfl) leave untouched.
+;;
+;; Specifically:
+;;   - LIST x query branch of cos-dist / l2-dist / inner-prod (vec_binary_metric)
+;;   - LIST branch of norm
+;;   - the entire ray_knn_fn (cosine / l2 / ip metrics, error paths,
+;;     empty-column shortcut)
+;;   - hnsw-build / ann / hnsw-info / hnsw-free under cosine and ip
+;;     metrics (existing test only exercises l2)
+;;   - hnsw-save / hnsw-load round trip
+;;   - hnsw-free idempotency (second call must error, not double-free)
+
+;; ────────────── pre-flight: scrub any leftover save dirs ──────────────
+(.sys.exec "rm -rf /tmp/rfl_embcov_idx /tmp/rfl_embcov_idx_*")
+
+;; ────────────── LIST x query distance fan-out ──────────────
+;; vec_binary_metric: a is RAY_LIST, b is numeric vec → F64 vector,
+;; one score per row.  Smoke-tests the LIST validation, query_to_doubles,
+;; and per-row row_score dispatch for all three metric kinds.
+(set Col (list [1.0 0.0 0.0] [0.0 1.0 0.0] [-1.0 0.0 0.0]))
+
+;; cos-dist: identical → 0, orthogonal → 1, opposite → 2.
+(at (cos-dist Col [1.0 0.0 0.0]) 0)  -- 0.0
+(at (cos-dist Col [1.0 0.0 0.0]) 1)  -- 1.0
+(at (cos-dist Col [1.0 0.0 0.0]) 2)  -- 2.0
+(count (cos-dist Col [1.0 0.0 0.0])) -- 3
+
+;; query x LIST symmetry — exercises the (b is LIST) swap branch.
+(at (cos-dist [1.0 0.0 0.0] Col) 0)  -- 0.0
+(at (cos-dist [1.0 0.0 0.0] Col) 2)  -- 2.0
+
+;; l2-dist over LIST — distances 0, sqrt(2), 2.
+(at (l2-dist Col [1.0 0.0 0.0]) 0)   -- 0.0
+(at (l2-dist Col [1.0 0.0 0.0]) 2)   -- 2.0
+1 -- (as 'I64 (< (abs (- (at (l2-dist Col [1.0 0.0 0.0]) 1) 1.41421356)) 0.0001))
+
+;; inner-prod over LIST — 1, 0, -1.
+(at (inner-prod Col [1.0 0.0 0.0]) 0) -- 1.0
+(at (inner-prod Col [1.0 0.0 0.0]) 1) -- 0.0
+(at (inner-prod Col [1.0 0.0 0.0]) 2) -- -1.0
+
+;; LIST x query length mismatch flagged.
+(cos-dist Col [1.0 0.0]) !- length
+
+;; ────────────── norm over LIST ──────────────
+;; Drives the LIST branch of ray_norm_fn (lines ~498-516).
+(count (norm Col)) -- 3
+(at (norm Col) 0)  -- 1.0
+(at (norm Col) 1)  -- 1.0
+(at (norm Col) 2)  -- 1.0
+
+;; norm with non-numeric input → type error
+(norm 'foo) !- type
+
+;; ────────────── ray_knn_fn — exact KNN via brute force ──────────────
+;; Default metric is cosine.  Row 0 should win against [1.0 0.0 0.0].
+(set V (list [1.0 0.0 0.0] [0.9 0.1 0.0] [0.0 1.0 0.0] [0.0 0.0 1.0] [0.5 0.5 0.0]))
+(first (at (knn V [1.0 0.0 0.0] 1) '_rowid)) -- 0
+(first (at (knn V [1.0 0.0 0.0] 1) '_dist))  -- 0.0
+
+;; k > nrows is clamped, not an error.
+(count (knn V [1.0 0.0 0.0] 99)) -- 5
+
+;; Result is sorted ascending by distance.
+(<= (first (at (knn V [1.0 0.0 0.0] 3) '_dist)) (last (at (knn V [1.0 0.0 0.0] 3) '_dist))) -- true
+
+;; Explicit metric symbols hit each switch arm.
+(first (at (knn V [1.0 0.0 0.0] 1 'cosine) '_rowid)) -- 0
+(first (at (knn V [1.0 0.0 0.0] 1 'l2)     '_rowid)) -- 0
+(first (at (knn V [1.0 0.0 0.0] 1 'ip)     '_rowid)) -- 0
+
+;; L2: identical → distance 0.
+(first (at (knn V [1.0 0.0 0.0] 1 'l2) '_dist)) -- 0.0
+
+;; Error paths in ray_knn_fn.
+(knn V [1.0 0.0 0.0])                  !- rank
+(knn 5 [1.0 0.0 0.0] 1)                !- type
+(knn V 5 1)                            !- type
+(knn V [1.0 0.0 0.0] 1.0)              !- type
+(knn V [1.0 0.0 0.0] 1 'bogus)         !- domain
+(knn V [1.0 0.0] 1)                    !- length
+(knn V [1.0 0.0 0.0] 0)                !- domain
+(knn V [1.0 0.0 0.0] -3)               !- domain
+
+;; ────────────── hnsw-build under cosine and ip ──────────────
+;; Existing hnsw.rfl only exercises 'l2.  Cover the other two metric
+;; branches in parse_metric_sym + the cosine path in ray_hnsw_search.
+(set IdxCos (hnsw-build V 'cosine))
+(at (hnsw-info IdxCos) 'metric) -- 'cosine
+(at (hnsw-info IdxCos) 'nrows)  -- 5
+(at (hnsw-info IdxCos) 'dim)    -- 3
+(first (at (ann IdxCos [1.0 0.0 0.0] 1) '_rowid)) -- 0
+(hnsw-free IdxCos)
+
+(set IdxIp (hnsw-build V 'ip 16 64))
+(at (hnsw-info IdxIp) 'metric) -- 'ip
+(at (hnsw-info IdxIp) 'M)      -- 16
+(at (hnsw-info IdxIp) 'efc)    -- 64
+(count (ann IdxIp [1.0 0.0 0.0] 2)) -- 2
+
+;; ann with explicit ef_s argument exercises the n == 4 branch.
+(count (ann IdxIp [1.0 0.0 0.0] 2 100)) -- 2
+
+;; ann argument validation.
+(ann IdxIp [1.0 0.0 0.0])         !- rank
+(ann 5    [1.0 0.0 0.0] 1)        !- type
+(ann IdxIp 5            1)        !- type
+(ann IdxIp [1.0 0.0 0.0] 1.0)     !- type
+(ann IdxIp [1.0 0.0]    1)        !- length
+(ann IdxIp [1.0 0.0 0.0] 0)       !- domain
+
+;; hnsw-build error paths.
+(hnsw-build)                  !- rank
+(hnsw-build 5)                !- type
+(hnsw-build V 'bogus)         !- domain
+(hnsw-build V 'l2 1.0)        !- type
+(hnsw-build V 'l2 8 "no")     !- type
+
+;; ────────────── hnsw-save / hnsw-load round trip ──────────────
+;; Persists the IP-metric index, frees the in-memory copy, reloads,
+;; and confirms metadata + a query still resolve.  Drives ray_hnsw_save_fn
+;; (lines 806-819) and ray_hnsw_load_fn (lines 822-835).
+(.sys.exec "mkdir -p /tmp/rfl_embcov_idx")
+(hnsw-save IdxIp "/tmp/rfl_embcov_idx")
+(hnsw-free IdxIp)
+
+(set Loaded (hnsw-load "/tmp/rfl_embcov_idx"))
+(at (hnsw-info Loaded) 'metric) -- 'ip
+(at (hnsw-info Loaded) 'nrows)  -- 5
+(at (hnsw-info Loaded) 'dim)    -- 3
+(count (ann Loaded [1.0 0.0 0.0] 3)) -- 3
+
+;; hnsw-save / hnsw-load argument validation.
+(hnsw-save 5 "/tmp/rfl_embcov_idx") !- type
+(hnsw-save Loaded 5)                !- type
+(hnsw-save Loaded "")               !- domain
+(hnsw-load 5)                       !- type
+(hnsw-load "")                      !- domain
+(hnsw-load "/tmp/rfl_embcov_idx_does_not_exist") !- io
+
+;; ────────────── hnsw-free idempotency contract ──────────────
+;; First free clears RAY_ATTR_HNSW; the second call must see a plain
+;; I64, fail hnsw_unwrap, and surface a type error rather than
+;; double-freeing the underlying index.
+(hnsw-free Loaded)
+(hnsw-free Loaded) !- type
+(hnsw-free 5)      !- type
+
+;; ────────────── teardown ──────────────
+(.sys.exec "rm -rf /tmp/rfl_embcov_idx /tmp/rfl_embcov_idx_*")

--- a/test/rfl/ops/exec_coverage.rfl
+++ b/test/rfl/ops/exec_coverage.rfl
@@ -1,0 +1,240 @@
+;; Targeted coverage for src/ops/exec.c — exercises the OP_<x> dispatcher
+;; branches that the existing suites under test/rfl/{table,sort,agg,
+;; integration} don't reach: OP_TIL edges, OP_IN parallel-worker path,
+;; OP_HEAD with SORT/GROUP/FILTER fusion, OP_TAIL on tables, OP_PIVOT
+;; with selection compaction, chained OP_FILTER (rowsel refine),
+;; HAVING-fusion (FILTER over GROUP), broadcast_scalar via SELECT
+;; expression, ANTIJOIN selection compaction, OP_EXTRACT in projection,
+;; and several error / empty-input edges.
+;;
+;; Cleanup pre-empts any leftover state from a previous failed run —
+;; we don't actually touch /tmp here, but follow the convention.
+(.sys.exec "rm -rf /tmp/rfl_exec_coverage")
+
+;; ====================================================================
+;; OP_TIL — exec.c:920-931
+;; ====================================================================
+;; Positive arg path; dispatcher emits a fresh I64 vector.
+(count (til 100)) -- 100
+(first (til 100)) -- 0
+(last (til 100)) -- 99
+
+;; n<=0 short-circuit branch — returns empty I64 vec, never touches d[].
+(count (til 0)) -- 0
+;; til of negative is rejected upstream, exercise the error path:
+(til -7) !- domain
+
+;; ====================================================================
+;; OP_HEAD — exec.c:1247-1421
+;; ====================================================================
+;; Plain table HEAD (no SORT/GROUP/FILTER child) — flat-column copy
+;; branch + n>nrows clamp + n=0 edge.
+(set TT (table [a b] (list [1 2 3 4 5 6 7 8 9 10] [10 20 30 40 50 60 70 80 90 100])))
+(count (select {from: TT take: 3})) -- 3
+(sum (at (select {from: TT take: 3}) 'a)) -- 6
+(count (select {from: TT take: 0})) -- 0
+(count (select {from: TT take: 999})) -- 10
+
+;; HEAD(SORT) fusion — exec.c:1252-1269 picks the sort+limit fast path.
+;; ascending take 3 → first three sorted values of a.
+(sum (at (select {from: TT asc: a take: 3}) 'a)) -- 6
+(sum (at (select {from: TT desc: a take: 3}) 'a)) -- 27
+
+;; HEAD(GROUP) fusion — exec.c:1276-1300 passes the limit hint into
+;; exec_group; trim happens after.  Use a 6-key group, take 2 groups.
+(set TG (table [g v] (list ['a 'b 'c 'a 'b 'c 'a 'b 'c] [1 2 3 4 5 6 7 8 9])))
+(count (select {s: (sum v) from: TG by: g take: 2})) -- 2
+
+;; HEAD(FILTER) fusion — exec.c:1301-1336 short-circuits the filter
+;; once N matches are gathered.  18 rows pass the predicate; take 5.
+(set TF (table [x y] (list [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20] [10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160 170 180 190 200])))
+(count (select {from: TF where: (> x 2) take: 5})) -- 5
+(sum (at (select {from: TF where: (> x 2) take: 5}) 'x)) -- 25
+
+;; HEAD over vector (not a table) — bottom of OP_HEAD, exec.c:1410-1421.
+;; (first V) is unary on a vector; fold via select projection then index.
+(first (at (select {from: TT take: 1}) 'a)) -- 1
+
+;; ====================================================================
+;; OP_TAIL — exec.c:1423-1534
+;; ====================================================================
+;; select { take: -N } compiles to OP_TAIL via query.c:3219.
+(count (select {from: TT take: -3})) -- 3
+(sum (at (select {from: TT take: -3}) 'a)) -- 27
+(count (select {from: TT take: -999})) -- 10
+(first (at (select {from: TT take: -1}) 'a)) -- 10
+
+;; ====================================================================
+;; OP_FILTER — chained refine + HAVING fusion — exec.c:1014-1080
+;; ====================================================================
+;; Nested select forces a chained filter — the inner select installs
+;; g->selection, the outer adds another predicate which hits the
+;; "if (g->selection)" branch at exec.c:1060 and calls
+;; ray_rowsel_refine.  (Dict keys are unique per-call, so two
+;; where: in one dict literal is not the right shape.)
+(count (select {from: (select {from: TF where: (> x 5)}) where: (< x 15)})) -- 9
+(sum (at (select {from: (select {from: TF where: (> x 5)}) where: (< x 15)}) 'x)) -- 90
+
+;; HAVING-fusion: FILTER-over-GROUP via outer select.  Inner select
+;; produces an aggregated table; outer select filters by the agg
+;; column.  The optimizer can rearrange this into a single FILTER(GROUP)
+;; DAG that exec.c:1019-1043 specializes — predicate evaluated
+;; against the GROUP output table.
+(set TH (table [k v] (list ['a 'a 'a 'b 'b 'c 'c 'c 'c 'd] [1 2 3 4 5 6 7 8 9 10])))
+(count (select {from: (select {c: (count v) from: TH by: k}) where: (>= c 3)})) -- 2
+
+;; Empty-pass filter — non-zero rows in, zero out.
+(count (select {from: TF where: (> x 99999)})) -- 0
+
+;; Filter on a vector (not table) input forces the eager path —
+;; exec.c:1075-1079.  Use (filter ...) builtin if exposed; otherwise
+;; the same path is hit by an aggregator over a filtered scalar list.
+(sum (at (select {from: TF where: (> x 0)}) 'y)) -- 2100
+
+;; ====================================================================
+;; OP_PIVOT with selection compaction — exec.c:1158-1172
+;; ====================================================================
+;; Build a fixture and consume its result via a project that drives
+;; pivot dispatch through ray_execute.
+(set TP (table [r c v] (list ['A 'A 'B 'B 'A] ['x 'y 'x 'y 'y] [1 2 3 4 5])))
+(count (pivot TP 'r 'c 'v sum)) -- 2
+
+;; ====================================================================
+;; OP_GROUP — multi-key + multi-aggregator (exec.c:1100-1156)
+;; ====================================================================
+;; Single key hits sequential exec_group; ensures dispatcher path runs.
+(count (select {s: (sum v) m: (max v) n: (min v) c: (count v) from: TH by: k})) -- 4
+(sum (at (select {s: (sum v) from: TH by: k}) 's)) -- 55
+
+;; ====================================================================
+;; OP_JOIN, OP_ANTIJOIN — selection compaction branches
+;; (exec.c:1174-1209)
+;; ====================================================================
+;; Pre-filter the left table so g->selection is non-NULL when the
+;; join hands off to sel_compact.
+(set L (table [k v] (list [1 2 3 4 5 6] [10 20 30 40 50 60])))
+(set R (table [k w] (list [2 4 6 8] [200 400 600 800])))
+(count (inner-join [k] (select {from: L where: (> k 1)}) R)) -- 3
+(count (anti-join  [k] (select {from: L where: (> k 1)}) R)) -- 2
+
+;; ====================================================================
+;; OP_WINDOW_JOIN with selection-compacted left — exec.c:1211-1227
+;; ====================================================================
+(set tr (table [Sym Time Price] (list ['a 'a 'a 'b] [10:00:01.000 10:00:05.000 10:00:09.000 10:00:01.000] [100 200 300 400])))
+(set qu (table [Sym Time Bid] (list ['a 'a 'a 'b 'b] [10:00:00.000 10:00:02.000 10:00:04.000 10:00:00.000 10:00:02.000] [99 100 101 199 200])))
+(set iv (map-left + [-2000 2000] (at tr 'Time)))
+(count (at (window-join [Sym Time] iv tr qu {m: (min Bid)}) 'm)) -- 4
+
+;; ====================================================================
+;; OP_SORT with selection compaction — exec.c:1082-1098
+;; ====================================================================
+;; Filter then sort — sel_compact runs because g->selection is set.
+(first (at (select {from: TT where: (> a 4) asc: a}) 'a)) -- 5
+(first (at (select {from: TT where: (> a 4) desc: a}) 'a)) -- 10
+
+;; ====================================================================
+;; OP_SELECT projection with broadcast_scalar — exec.c:1620-1631
+;; ====================================================================
+;; A constant scalar in the projection dictionary lands as an atom
+;; (vec->type < 0); broadcast_scalar fans it out to N rows.
+(count (select {k: 42 from: TT})) -- 10
+(sum (at (select {k: 42 from: TT}) 'k)) -- 420
+
+;; Constant string in projection — exercises the -RAY_STR branch of
+;; broadcast_scalar (exec.c:507-517).
+(count (select {tag: "x" from: TT})) -- 10
+
+;; Constant float — exercises the F64 atom branch.
+(sum (at (select {f: 1.5 from: TT}) 'f)) -- 15.0
+
+;; Constant bool — exercises the BOOL atom branch.
+(sum (as 'I64 (at (select {b: true from: TT}) 'b))) -- 10
+
+;; Empty table broadcast — exec.c:492-503 returns a 0-length typed vec.
+(count (at (select {k: 7 from: TT where: (< a 0)}) 'k)) -- 0
+
+;; ====================================================================
+;; OP_EXTRACT — eager temporal extract inside aggregator (exec.c:1564
+;; only fires when the call is compiled into the DAG via the
+;; long-form name (year/month/...).  The short alias (yyyy x) is an
+;; eval-level builtin that calls ray_temporal_extract directly, so
+;; it bypasses exec.c.  Keep the eval-level form here as a smoke
+;; test of the surrounding sum/at machinery rather than of
+;; exec_extract proper.
+(set TD (table [d v] (list [2024.01.15 2024.06.30 2025.12.31] [10 20 30])))
+(sum (yyyy (at TD 'd))) -- 6073
+
+;; ====================================================================
+;; OP_IN — parallel worker path — exec.c:799-803
+;; ====================================================================
+;; Need col_len >= 65536 to enter the ray_pool_dispatch branch.  Build
+;; a 70k-row table and probe a small set; result row-count is the
+;; matching subset.  Computed: range 0..69999, set {1,2,3} → 3.
+(set N1 70000)
+(set TBig (table [v] (list (% (til N1) 100000))))
+(count (select {from: TBig where: (in v [1 2 3])})) -- 3
+(sum  (at (select {from: TBig where: (in v [1 2 3])}) 'v)) -- 6
+
+;; OP_NOT_IN: dispatcher reaches the same exec_in body but with
+;; negate=1 (exec.c:651).  At col_len=70000 this also exercises the
+;; parallel worker dispatch.  Use both forms for diversity.
+(count (select {from: TBig where: (not-in v [1 2 3])})) -- 69997
+(count (select {from: TBig where: (not (in v [1 2 3]))})) -- 69997
+
+;; OP_IN over float column hits use_double=1 path — exec.c:763-775.
+(set TBigF (table [f] (list (as 'F64 (% (til 70000) 1000)))))
+(count (select {from: TBigF where: (in f [1.0 2.0 3.0])})) -- 210
+
+;; ====================================================================
+;; OP_FIRST / OP_LAST / OP_AVG / OP_SUM with lazy filter — exec.c:984-1004
+;; ====================================================================
+;; sel_compact branch fires because filter→reduction sees a TABLE input
+;; and a live g->selection.  Not strictly required (reductions accept
+;; rowsel directly) but the dispatcher branch covers the swap anyway.
+(sum (at (select {from: TT where: (> a 3)}) 'a)) -- 49
+(first (at (select {from: TT where: (> a 7)}) 'a)) -- 8
+(last  (at (select {from: TT where: (> a 7)}) 'a)) -- 10
+
+;; ====================================================================
+;; OP_COUNT_DISTINCT — exec.c:1006-1012
+;; ====================================================================
+;; Hit via (distinct …) inside an aggregator-shaped expression.
+(count (distinct (at TG 'g))) -- 3
+(count (distinct [1 1 2 2 3 3 4 4 5])) -- 5
+
+;; ====================================================================
+;; OP_IF in projection — exec.c:1536-1538
+;; ====================================================================
+;; Conditional column derived from an existing column.
+(sum (at (select {z: (if (> a 5) 1 0) from: TT}) 'z)) -- 5
+
+;; ====================================================================
+;; OP_LIKE / OP_ILIKE — exec.c:1540-1546
+;; ====================================================================
+;; LIKE inside a where: clause; the predicate is a BOOL column
+;; produced by exec_like and consumed by the lazy-filter branch.
+(set TS (table [s v] (list ['Apple 'Banana 'Cherry 'Apricot 'Berry] [1 2 3 4 5])))
+(count (select {from: TS where: (like s "A*")})) -- 2
+(count (select {from: TS where: (ilike s "a*")})) -- 2
+
+;; ====================================================================
+;; OP_STRLEN / OP_UPPER / OP_LOWER / OP_SUBSTR — exec.c:1548-1559
+;; ====================================================================
+;; All four exercised inside a projection so they reach exec_string_*
+;; helpers via ray_execute → exec_node.
+(set TStr (table [s] (list ["alpha" "bravo" "charlie"])))
+(sum (at (select {n: (strlen s) from: TStr}) 'n)) -- 17
+(first (at (select {u: (upper s) from: TStr}) 'u)) -- "ALPHA"
+(set TUp (table [s] (list ["BETA" "GAMMA"])))
+(first (at (select {u: (lower s) from: TUp}) 'u)) -- "beta"
+
+;; ====================================================================
+;; ALIAS / MATERIALIZE — exec.c:1572-1578 are pass-through dispatchers
+;; ====================================================================
+;; A nested select forces materialize semantics through the executor.
+(count (select {from: (select {from: TT take: 5}) take: 3})) -- 3
+
+;; ====================================================================
+;; Cleanup
+;; ====================================================================
+(.sys.exec "rm -rf /tmp/rfl_exec_coverage")

--- a/test/rfl/ops/exec_coverage.rfl
+++ b/test/rfl/ops/exec_coverage.rfl
@@ -235,6 +235,242 @@
 (count (select {from: (select {from: TT take: 5}) take: 3})) -- 3
 
 ;; ====================================================================
+;; PASS 2 ADDITIONS — extending coverage of OP_IN dispatch branches,
+;; broadcast_scalar empty-output type cases, and small-typed-column
+;; scan paths in exec_in_worker.
+;; ====================================================================
+
+;; ====================================================================
+;; broadcast_scalar — empty output for each scalar atom type
+;; (exec.c:494-503).  We already cover -RAY_I64 via TT.where:(<a 0)
+;; above; here we hit -RAY_F64, -RAY_BOOL, -RAY_SYM, -RAY_STR.
+;; ====================================================================
+;; Empty F64 broadcast.
+(count (at (select {f: 1.5 from: TT where: (< a 0)}) 'f)) -- 0
+;; Empty BOOL broadcast.
+(count (at (select {b: true from: TT where: (< a 0)}) 'b)) -- 0
+;; Empty SYM broadcast — projecting a sym atom into 0 rows.
+(count (at (select {tag: 'AAPL from: TT where: (< a 0)}) 'tag)) -- 0
+;; Empty STR broadcast — already covered above for the non-empty case;
+;; here we exercise the L496 -RAY_STR empty branch.
+(count (at (select {tag: "x" from: TT where: (< a 0)}) 'tag)) -- 0
+
+;; ====================================================================
+;; OP_IN — small-table (col_len < threshold) sequential dispatch
+;; (exec.c:803).  Hit the typed-column read macros L569-590 / L717-742
+;; for each integer-family / float-family column type.
+;; ====================================================================
+
+;; Cross-type fixture: a tiny (50-row) table with one column per
+;; distinct width / signedness so OP_IN reads them through each
+;; switch arm.  Uses the same recipe as the integration suite's
+;; cross_type_workout.rfl but at small scale.
+(set N2 50)
+(set TX (table [i64c i32c i16c f64c boolc symc datec timec] (list (til N2) (as 'I32 (% (til N2) 100)) (as 'I16 (% (til N2) 50)) (as 'F64 (% (til N2) 10)) (take [true false] N2) (take ['AAPL 'GOOG 'MSFT 'TSLA] N2) (take [2024.01.01 2024.01.02 2024.01.03] N2) (take [09:30:00.000 10:00:00.000 11:30:00.000] N2))))
+
+;; I64 col, I64 set — sequential exec_in_worker via use_double=0.
+(count (select {from: TX where: (in i64c [1 2 3 4 5])})) -- 5
+;; I32 col, I64 set — RAY_I32 read in IN_READ_I64.
+(count (select {from: TX where: (in i32c [0 1 2])})) -- 3
+;; I16 col, I64 set — RAY_I16 read.  i16c = i64c%50 over rows 0..49,
+;; so i16c is 0..49 with each value appearing once.
+(count (select {from: TX where: (in i16c [0 1 2])})) -- 3
+;; F64 col, F64 set — use_double=1, RAY_F64 read in IN_READ_F64.
+(count (select {from: TX where: (in f64c [0.0 1.0 2.0])})) -- 15
+;; F32 col, F64 set — use_double=1, RAY_F32 read in IN_READ_F64.
+;; F64 col, I64 set — mixed: float promotion path with integer probe.
+(count (select {from: TX where: (in f64c [0 1 2])})) -- 15
+;; I32 col, F64 set — mixed: column read via IN_READ_F64 RAY_I32 arm.
+(count (select {from: TX where: (in i32c [0.0 1.0 2.0])})) -- 3
+;; BOOL col probe — IN_READ_I64 RAY_BOOL arm.
+(count (select {from: TX where: (in boolc [true])})) -- 25
+;; DATE col, I64 set — RAY_DATE arm shares the I32 path (epoch days).
+;; The set [0 1 2] would not match any actual date values; check that
+;; the column is exercised but produces 0.  Use the column directly:
+;; equality vs literal date is the dag-friendly form.
+(count (select {from: TX where: (in datec [2024.01.01 2024.01.02])})) -- 34
+;; TIME col, I64 set — RAY_TIME arm.
+(count (select {from: TX where: (in timec [09:30:00.000])})) -- 17
+;; SYM col, SYM set — IN_READ_I64 RAY_SYM arm via ray_read_sym.
+;; AAPL at indices 0,4,...,48 = 13 rows; GOOG at 1,5,...,49 = 13 rows.
+(count (select {from: TX where: (in symc ['AAPL 'GOOG])})) -- 26
+
+;; ====================================================================
+;; OP_IN — atom set (set is a scalar literal) — exec.c:763-779.
+;; ====================================================================
+;; Integer atom set, integer column — hits the !use_double / atom
+;; branch at L777-778.
+(count (select {from: TX where: (in i64c 7)})) -- 1
+(count (select {from: TX where: (in i32c 5)})) -- 1
+;; Float atom set, float column — hits the use_double / atom branch
+;; at L763-768.
+(count (select {from: TX where: (in f64c 3.0)})) -- 5
+;; Sym atom set, sym column — hits the !use_double / atom branch
+;; for sym (i64-mode comparison via interned ids).  TSLA at
+;; indices 3,7,...,47 = 12 rows.
+(count (select {from: TX where: (in symc 'TSLA)})) -- 12
+;; Bool atom — atom branch in i64 mode.
+(count (select {from: TX where: (in boolc true)})) -- 25
+
+;; ====================================================================
+;; OP_IN — heap-allocated probe buffer (set_len > 32) — exec.c:752-758.
+;; The stack-allocated probe arrays only fit 32 entries; longer sets
+;; force ray_alloc(bytes) and the conditional svf/svi pointer swap.
+;; ====================================================================
+;; 35-element integer set — exceeds the stack threshold of 32.
+(count (select {from: TX where: (in i64c [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34])})) -- 35
+;; Same for the float branch — heap path with use_double=1.
+(count (select {from: TX where: (in f64c [0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0 14.0 15.0 16.0 17.0 18.0 19.0 20.0 21.0 22.0 23.0 24.0 25.0 26.0 27.0 28.0 29.0 30.0 31.0 32.0 33.0 34.0])})) -- 50
+;; not-in with a >32-element set — same heap branch but with negate=1.
+(count (select {from: TX where: (not-in i64c [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34])})) -- 15
+
+;; ====================================================================
+;; OP_IN — empty column short-circuit — exec.c:658-663.
+;; col_len == 0 returns an empty BOOL vec.  Build an empty table by
+;; filtering an existing one with an impossible predicate, then re-
+;; query it.  The outer ray_execute compacts the inner result so the
+;; outer's g->table is genuinely 0 rows.
+;; ====================================================================
+(count (select {from: (select {from: TT where: (< a 0)}) where: (in a [1 2 3])})) -- 0
+(count (select {from: (select {from: TT where: (< a 0)}) where: (not-in a [1 2 3])})) -- 0
+
+;; ====================================================================
+;; OP_IN — RAY_STR error path — exec.c:675-676.
+;; Either side being RAY_STR returns ray_error("nyi").  We assert it
+;; produces an `nyi`-tagged error rather than running the kernel.
+;; ====================================================================
+(set TStrCol (table [s] (list ["alpha" "beta" "gamma"])))
+(select {from: TStrCol where: (in s ["alpha"])}) !- nyi
+
+;; ====================================================================
+;; OP_IN — sym-vs-non-sym type mismatch — exec.c:691-693 sets
+;; set_len=0, so no row matches; not-in returns all rows.
+;; ====================================================================
+;; SYM column probed against I64 set: classifier disagrees → empty
+;; probe → in=0 everywhere, not-in=N everywhere.
+(count (select {from: TX where: (in symc [1 2 3])})) -- 0
+(count (select {from: TX where: (not-in symc [1 2 3])})) -- 50
+;; I64 column probed against SYM set — symmetric mismatch.
+(count (select {from: TX where: (in i64c ['AAPL])})) -- 0
+(count (select {from: TX where: (not-in i64c ['AAPL])})) -- 50
+
+;; ====================================================================
+;; OP_IN — null-aware row handling.  exec_in_worker bails out per
+;; row (ob[i]=0) when the column has nulls and the row is null.
+;; This exercises the col_has_nulls && ray_vec_is_null branch in both
+;; the use_double and !use_double loops.
+;; ====================================================================
+(set TNul (table [v f] (list [1 0Nl 2 0Nl 3] [1.0 0Nf 2.0 0Nf 3.0])))
+;; Integer null branch — null rows never match, never count.
+(count (select {from: TNul where: (in v [1 2 3])})) -- 3
+(count (select {from: TNul where: (not-in v [1 2 3])})) -- 0
+;; Float null branch — same, via use_double=1.
+(count (select {from: TNul where: (in f [1.0 2.0 3.0])})) -- 3
+(count (select {from: TNul where: (not-in f [1.0 2.0 3.0])})) -- 0
+
+;; OP_IN — null elements in the SET — set_has_nulls branch at
+;; exec.c:771 (use_double) and L781 (!use_double).  The probe-buffer
+;; build skips nulls so a null col row can't accidentally match.
+(count (select {from: TNul where: (in v [1 0Nl 2 3])})) -- 3
+(count (select {from: TNul where: (in f [1.0 0Nf 2.0 3.0])})) -- 3
+
+;; ====================================================================
+;; HEAD on a flat (non-parted, non-mapcommon) column with various
+;; element sizes — exec.c:1393-1405 col_esz branches.  Reuse TX so
+;; the table HEAD path executes with multiple typed columns at once.
+;; ====================================================================
+(count (select {from: TX take: 5})) -- 5
+(sum  (at (select {from: TX take: 5}) 'i64c)) -- 10
+(sum  (at (select {from: TX take: 5}) 'i32c)) -- 10
+(sum  (at (select {from: TX take: 5}) 'i16c)) -- 10
+(sum  (at (select {from: TX take: 5}) 'f64c)) -- 10.0
+;; ASCII bool column should sum to 3 (true=1) over the first 5 rows
+;; of the alternating [true false] pattern.
+(sum  (as 'I64 (at (select {from: TX take: 5}) 'boolc))) -- 3
+
+;; ====================================================================
+;; TAIL — same range of element sizes via TX.
+;; ====================================================================
+(count (select {from: TX take: -5})) -- 5
+;; Last 5 rows of a 50-row alternating bool pattern: positions 45..49
+;; are [false true false true false] → sum=2.
+(sum (as 'I64 (at (select {from: TX take: -5}) 'boolc))) -- 2
+;; Last 5 i32c values: 45..49 → 45+46+47+48+49 = 235.
+(sum (at (select {from: TX take: -5}) 'i32c)) -- 235
+
+;; ====================================================================
+;; OP_LIKE / OP_ILIKE on STR (rather than SYM) columns — exec.c:1540-1546.
+;; ====================================================================
+;; Existing tests cover SYM; here we hit STR via the projection-driven
+;; predicate evaluator.
+(set TSt (table [s v] (list ["Apple" "Banana" "Cherry" "Apricot" "Berry"] [1 2 3 4 5])))
+(count (select {from: TSt where: (like s "A*")})) -- 2
+(count (select {from: TSt where: (ilike s "a*")})) -- 2
+;; "Cherry" and "Berry" both contain "err" → 2 matches.
+(count (select {from: TSt where: (like s "*err*")})) -- 2
+(count (select {from: TSt where: (ilike s "*err*")})) -- 2
+
+;; ====================================================================
+;; OP_STRLEN, OP_UPPER, OP_LOWER, OP_SUBSTR, OP_REPLACE, OP_TRIM, OP_CONCAT
+;; in select projections — exec.c:1548-1562.  We already cover STRLEN/
+;; UPPER/LOWER on STR columns; add SUBSTR/REPLACE/TRIM/CONCAT and
+;; the SYM-column variants of UPPER/LOWER (which dispatch through
+;; exec_string_unary's sym branch).
+;; ====================================================================
+;; SUBSTR projection: take chars 0..2 of each STR.
+(first (at (select {p: (substr s 0 3) from: TSt}) 'p)) -- "App"
+;; CONCAT projection.
+(first (at (select {p: (concat s "!") from: TSt}) 'p)) -- "Apple!"
+
+;; ====================================================================
+;; OP_IF — multiple input shapes for the ternary.  The current test
+;; covers only the I64-comparison-on-vector form; here we add a BOOL-
+;; column-direct predicate, a STR-output branch, and a F64-output
+;; branch — each takes a different fast path inside exec_if.
+;; ====================================================================
+;; BOOL column predicate (no comparison required).  Over rows 0..4
+;; boolc alternates [true false true false true] → if-result is
+;; [10 20 10 20 10] = 70.
+(sum (at (select {z: (if boolc 10 20) from: TX where: (< i64c 5)}) 'z)) -- 70
+;; F64 output branch.
+(sum (at (select {f: (if (> i32c 24) 1.0 0.0) from: TX}) 'f)) -- 25.0
+
+;; ====================================================================
+;; OP_FILTER — refine path with a chained selection over a typed
+;; column.  exec.c:1059-1072 (the lazy-rowsel branch with non-NULL
+;; g->selection).  Inner where: installs a selection; outer where: hits
+;; the refine path.  Already covered for I64; here we use SYM and F64
+;; column types for type-diversity inside ray_rowsel_refine.
+;; ====================================================================
+(count (select {from: (select {from: TX where: (== symc 'AAPL)}) where: (< i64c 20)})) -- 5
+(count (select {from: (select {from: TX where: (>= f64c 5.0)}) where: (< f64c 8.0)})) -- 15
+
+;; ====================================================================
+;; Empty-pass FILTER: predicate eliminates every row.  The
+;; ray_rowsel_from_pred branch returns NULL for "all-pass"; this
+;; assertion exercises the "all-fail" symmetric case.
+;; ====================================================================
+(count (select {from: TX where: (> i64c 999)})) -- 0
+(sum  (at (select {from: TX where: (> i64c 999)}) 'i64c)) -- 0
+
+;; ====================================================================
+;; OP_FIRST / OP_LAST under selection on STR / SYM columns — already
+;; covered for I64; type-diversity now hits the column-type branches
+;; in exec_reduction.
+;; ====================================================================
+;; First sym after filter (>= i64c 4): rows 4..49. symc at i=4 is
+;; (i%4)=0 → 'AAPL.
+(first (at (select {from: TX where: (>= i64c 4)}) 'symc)) -- 'AAPL
+;; Last sym for filter (< i64c 4): rows 0..3 → ['AAPL 'GOOG 'MSFT 'TSLA].
+(last  (at (select {from: TX where: (< i64c 4)}) 'symc))  -- 'TSLA
+
+;; ====================================================================
+;; OP_COUNT_DISTINCT on SYM column under filter.
+;; ====================================================================
+(count (distinct (at TX 'symc))) -- 4
+(count (distinct (at TX 'boolc))) -- 2
+
+;; ====================================================================
 ;; Cleanup
 ;; ====================================================================
 (.sys.exec "rm -rf /tmp/rfl_exec_coverage")

--- a/test/rfl/ops/group_coverage.rfl
+++ b/test/rfl/ops/group_coverage.rfl
@@ -1,0 +1,208 @@
+;; Coverage targets for src/ops/group.c — exercises code paths that
+;; existing test/rfl/agg/*.rfl, table/select.rfl, table/query.rfl, and
+;; integration/{radix_groupby,groupby_aggregators}.rfl miss:
+;;
+;;   * 7+ aggregators in one select (emit_agg_columns multi-pass, lines ~1245)
+;;   * Statistical aggs on degenerate groups: var/stddev with cnt<=1
+;;     hits the insuf=true → ray_vec_set_null branch (lines 1287, 3534)
+;;   * F64 group-by key (DA path rejects F64 — line 2621 — forces HT path)
+;;   * Multi-key F64+SYM, DATE+SYM combinations
+;;   * Empty result via where: false (n_scan==0 path)
+;;   * 100k-row inputs to drive parallel/radix dispatch
+;;   * Key arity 1, 2, 3, 4 (multi-key composite GID, lines ~1411-1434)
+;;   * Uniform single-group (every row same key)
+;;   * FIRST+LAST in DA path multi-worker merge (has_first_last, line 2870)
+;;   * SUM(scan +/- const) — try_affine_sumavg_input pathway
+;;
+;; No /tmp files used by this test (no external state).
+;; Cleanup: nothing to clean — all data is in-memory.
+
+;; ────────────── 1. Multi-aggregator: 8 aggs in one select ──────────────
+;; Maximum n_aggs <= 8 (group.c:2274 enforces this); pack to the limit
+;; to exercise the inner per-aggregator emit loop in emit_agg_columns
+;; (group.c:1264-1318) for every supported op.
+(set N 200)
+(set T (table [g v f] (list (% (til N) 4) (til N) (as 'F64 (* 0.25 (til N))))))
+(set M8 (select {c: (count v) s: (sum v) mn: (min v) mx: (max v) av: (avg v) fi: (first v) la: (last v) sd: (stddev v) from: T by: g}))
+(count M8) -- 4
+(sum (at M8 'c)) -- 200
+(sum (at M8 's)) -- 19900
+;; with 4 groups of 50, min sum = 0+4+8+...+196 = 4900, max sum = 3+7+...+199 = 5050
+(min (at M8 's)) -- 4900
+(max (at M8 's)) -- 5050
+
+;; ────────────── 2. Stat aggs on cnt==1 groups (degenerate) ──────────────
+;; Sample variance/stddev require cnt > 1 (group.c:1286/3534). With
+;; one row per group, the result column must carry nulls.
+;; var_pop / stddev_pop (population) only require cnt > 0 → defined.
+(set Tone (table [g v] (list [10 20 30 40] [1.0 2.0 3.0 4.0])))
+(count (select {v: (var v) from: Tone by: g})) -- 4
+(count (select {v: (var_pop v) from: Tone by: g})) -- 4
+(count (select {s: (stddev v) from: Tone by: g})) -- 4
+(count (select {s: (stddev_pop v) from: Tone by: g})) -- 4
+;; var_pop on a single value is 0; sum across 4 groups is 0
+(sum (at (select {v: (var_pop v) from: Tone by: g}) 'v)) -- 0.0
+
+;; ────────────── 3. F64 key — forces HT path (DA rejects F64) ──────────────
+;; group.c:2621 lists DA-eligible types; RAY_F64 is not in it, so float
+;; keys take the radix or sequential HT path through ght_compute_layout.
+(set Tf64 (table [k v] (list [1.5 2.5 1.5 2.5 3.5 1.5] [10 20 30 40 50 60])))
+(count (select {s: (sum v) from: Tf64 by: k})) -- 3
+(sum (at (select {s: (sum v) from: Tf64 by: k}) 's)) -- 210
+(max (at (select {s: (sum v) from: Tf64 by: k}) 's)) -- 100
+
+;; ────────────── 4. Empty result (where: false → n_scan==0) ──────────────
+;; The selection is non-NULL but total_pass == 0. Code at group.c:2287-2293
+;; sets match_idx with n_scan=0; later loops should produce an empty group
+;; set. Result is a 0-row table.
+(set Tw (table [g v] (list ['a 'b 'c 'a 'b 'c] [1 2 3 4 5 6])))
+(count (select {s: (sum v) from: Tw by: g where: (== g 'NONE)})) -- 0
+(count (select {c: (count v) from: Tw by: g where: (< v -100)})) -- 0
+;; multi-agg empty group also works (each emit just iterates 0 times)
+(count (select {s: (sum v) c: (count v) m: (max v) from: Tw by: g where: (== v 9999)})) -- 0
+
+;; ────────────── 5. 100k+ rows for radix path (RAY_PARALLEL_THRESHOLD=64K) ──────────────
+;; group.c:3135 dispatches the radix-partitioned parallel path when
+;; nrows >= RAY_PARALLEL_THRESHOLD AND n_total > 1.  100k rows guarantees
+;; we cross the threshold; mixed-cardinality keys force phase1+phase2+phase3.
+(set N100k 100000)
+(set Tbig (table [g v] (list (% (til N100k) 250) (til N100k))))
+(count (select {c: (count v) from: Tbig by: g})) -- 250
+;; total sum invariant
+(sum (at (select {s: (sum v) from: Tbig by: g}) 's)) -- 4999950000
+;; 6-agg call drives radix_phase3 emit-side per-agg writes
+(set Mbig (select {c: (count v) s: (sum v) mn: (min v) mx: (max v) av: (avg v) sd: (stddev v) from: Tbig by: g}))
+(count Mbig) -- 250
+(sum (at Mbig 'c)) -- 100000
+
+;; ────────────── 6. Multi-key arity 1 / 2 / 3 / 4 ──────────────
+;; Composite-GID indexers (group.c:1411-1434) and HT row-stride packing
+;; both scale with n_keys. Cover up to 4 keys to exercise the layout
+;; permutations (every key contributes one stride word).  Keys are
+;; computed via til/divmod so reachable composite tuples follow LCM:
+;;   by a       — 2 distinct  (i%2)
+;;   by [a b]   — 6 distinct  (LCM(2,3)=6)
+;;   by [a b c] — 12 distinct (LCM(2,3,4)=12)
+;;   by [a b c d] — 60 distinct (LCM(2,3,4,5)=60)
+(set Tk (table [a b c d v] (list (% (til 240) 2) (% (til 240) 3) (% (til 240) 4) (% (til 240) 5) (til 240))))
+(count (select {s: (sum v) from: Tk by: a})) -- 2
+(count (select {s: (sum v) from: Tk by: [a b]})) -- 6
+(count (select {s: (sum v) from: Tk by: [a b c]})) -- 12
+(count (select {s: (sum v) from: Tk by: [a b c d]})) -- 60
+;; total preserved across all groupings
+(sum (at (select {s: (sum v) from: Tk by: a}) 's)) -- 28680
+(sum (at (select {s: (sum v) from: Tk by: [a b c d]}) 's)) -- 28680
+
+;; ────────────── 7. Single-group (uniform keys) ──────────────
+;; All rows in one group: tests min/max edge where a single accumulator
+;; receives every row. emit_agg_columns walks 1 grp_count.
+(set Tuni (table [g v] (list (take 'X 100) (til 100))))
+(count (select {s: (sum v) c: (count v) from: Tuni by: g})) -- 1
+(first (at (select {s: (sum v) from: Tuni by: g}) 's)) -- 4950
+(first (at (select {c: (count v) from: Tuni by: g}) 'c)) -- 100
+
+;; ────────────── 8. FIRST/LAST with multi-worker merge (DA path) ──────────────
+;; group.c:2860-2922 has a special has_first_last branch that does
+;; a sequential, order-aware merge across workers. Need >RAY_PARALLEL_THRESHOLD
+;; rows AND a low-cardinality int key (DA-eligible) to land here.
+(set Nfl 80000)
+(set Tfl (table [g v] (list (% (til Nfl) 4) (til Nfl))))
+(count (select {fi: (first v) la: (last v) from: Tfl by: g})) -- 4
+;; SHOULD be: first(v)=g per group → sum 6;  last(v) per group →
+;; sum 319990 for Nfl=80000.  Both first() AND last() return truncated
+;; values in the parallel path (nrows >= 65536, has_first_last merge in
+;; group.c:2860-2922).  Probed on master 2026-04-30:
+;;   N=65000 first sum=6   last sum=259990   (sequential, OK)
+;;   N=65536 first sum≠6   last sum≠262134   (parallel kicks in, broken)
+;;   N=80000 first=262150  last=32758        expected 6, 319990
+;; Asserting just (count ...) so we exercise the parallel-merge branch
+;; without locking the wrong value.  Re-add value asserts once fixed.
+
+;; ────────────── 9. Affine SUM/AVG (sum (+ col const)) ──────────────
+;; group.c:2336-2340 detects SUM/AVG of (scan + const) and aggregates
+;; the base column with a remembered bias applied at emit time.
+(set Ta (table [g v] (list ['a 'b 'a 'b 'a 'b] [10 20 30 40 50 60])))
+(count (select {s: (sum (+ v 100)) from: Ta by: g})) -- 2
+;; group 'a: rows have v in {10, 30, 50}, +100 each → sum = 30+90+90 = 90+300 = 390
+;; sum of (v+100) = (10+30+50) + 3*100 = 90 + 300 = 390
+;; group 'b: (20+40+60) + 3*100 = 120 + 300 = 420
+;; total = 810
+(sum (at (select {s: (sum (+ v 100)) from: Ta by: g}) 's)) -- 810
+
+;; ────────────── 10. Scalar agg (n_keys==0) — no by clause ──────────────
+;; group.c:2421-2608 is the scalar fast-path with a flat reduction.
+;; Multi-agg + no group exercises emit_agg_columns with grp_count=1.
+(set Ts (table [v] (list (til 1000))))
+(set Sca (select {s: (sum v) c: (count v) av: (avg v) mn: (min v) mx: (max v) from: Ts}))
+(at (at Sca 's) 0) -- 499500
+(at (at Sca 'c) 0) -- 1000
+(at (at Sca 'mn) 0) -- 0
+(at (at Sca 'mx) 0) -- 999
+
+;; ────────────── 11. Scalar agg over filtered (selection on n_keys=0) ──────────────
+;; The scalar tight loop has a "specialized when no match_idx" branch
+;; (group.c:2513-2525); a where clause forces the generic path.
+;; KNOWN BUG (master 2026-04-30): scalar agg form `select {agg: ... from: T where: P}`
+;; ignores the where: clause — sum returns 499500 (full sum) not 374750 (v>=500 only).
+;; Two-step (select+sum) works correctly.  Probed:
+;;   (sum (at (select {from: T where: (>= v 500)}) 'v))                   -> 374750 (correct)
+;;   (at (at (select {s: (sum v) from: T where: (>= v 500)}) 's) 0)       -> 499500 (wrong)
+;; Asserting count(c) which IS computed correctly (whole-table count regardless
+;; of where:) — exercises the path without locking the buggy sum value.
+(set Sfilt (select {s: (sum v) c: (count v) from: Ts where: (>= v 500)}))
+(at (at Sfilt 'c) 0) -- 1000
+
+;; ────────────── 12. DATE key (DA-eligible, narrow range) ──────────────
+;; RAY_DATE is on the DA-eligible list (group.c:2622). With only 3
+;; distinct dates, we hit the dense-array fast path with composite
+;; reverse-decode at line 3027-3029.
+(set Td (table [d v] (list (take [2024.01.01 2024.01.02 2024.01.03] 300) (til 300))))
+(count (select {s: (sum v) from: Td by: d})) -- 3
+(sum (at (select {s: (sum v) from: Td by: d}) 's)) -- 44850
+
+;; ────────────── 13. BOOL key (DA-eligible, range==2) ──────────────
+;; Smallest possible DA composite — exercises the special-case
+;; n_slots=2 path and the boolean read of key column.
+(set Tb (table [b v] (list (take [true false] 600) (til 600))))
+(count (select {s: (sum v) c: (count v) mn: (min v) mx: (max v) from: Tb by: b})) -- 2
+(sum (at (select {s: (sum v) from: Tb by: b}) 's)) -- 179700
+
+;; ────────────── 14. Stat aggs in multi-agg group with mixed sufficient/insufficient ──────────────
+;; Some groups have >1 row (var well-defined), others have exactly 1
+;; (var → null).  The HT-path null-flag prep runs after the parallel
+;; phase3 (group.c:3328-3347) — fixup branch for VAR/STDDEV when nullmap
+;; prep failed.  Mixed cnt encourages the planner through this branch.
+(set Tmix (table [g v] (list ['a 'a 'a 'b 'c 'c 'd] [1.0 2.0 3.0 5.0 7.0 9.0 11.0])))
+(count (select {v: (var v) s: (stddev v) c: (count v) from: Tmix by: g})) -- 4
+
+;; ────────────── 15. SYM key, large cardinality (radix HT path) ──────────────
+;; SYM keys are ineligible for DA (group.c:2621), so the radix-partitioned
+;; HT path (group.c:3135-3417) handles them when nrows >= 64K (parallel).
+;; Multi-agg drives the per-aggregator finalize loop (line 3369).
+(set Nsym 70000)
+(set syms (take ['s0 's1 's2 's3 's4 's5 's6 's7 's8 's9] Nsym))
+(set Tsm (table [k v] (list syms (til Nsym))))
+(count (select {s: (sum v) c: (count v) av: (avg v) from: Tsm by: k})) -- 10
+(sum (at (select {s: (sum v) c: (count v) from: Tsm by: k}) 's)) -- 2449965000
+(sum (at (select {s: (sum v) c: (count v) from: Tsm by: k}) 'c)) -- 70000
+;; multi-agg with min/max/stddev exercises radix_phase3 nullmap fixup
+(count (select {mn: (min v) mx: (max v) sd: (stddev v) sp: (stddev_pop v) from: Tsm by: k})) -- 10
+
+;; ────────────── 16. Group-by then access expression (chained) ──────────────
+;; Tests the full select pipeline including projection/at after group.
+;; Filter to a single group makes positional access deterministic.
+(set Tch (table [g v] (list ['p 'q 'p 'q 'p 'q] [1 2 3 4 5 6])))
+(first (at (select {s: (sum v) from: Tch by: g where: (== g 'p)}) 's)) -- 9
+(first (at (select {c: (count v) from: Tch by: g where: (== g 'p)}) 'c)) -- 3
+(first (at (select {s: (sum v) from: Tch by: g where: (== g 'q)}) 's)) -- 12
+(sum (at (select {s: (sum v) c: (count v) from: Tch by: g}) 's)) -- 21
+(sum (at (select {s: (sum v) c: (count v) from: Tch by: g}) 'c)) -- 6
+
+;; ────────────── 17. var_pop with all-equal values → 0 ──────────────
+;; In a uniform group, sum² / n - mean² = 0 exactly (modulo FP).  The
+;; line `if (var_pop < 0) var_pop = 0;` (group.c:1292/3541) clamps any
+;; tiny negative residual.
+(set Teq (table [g v] (list (take 'g 100) (take 42 100))))
+(at (at (select {v: (var_pop v) from: Teq by: g}) 'v) 0) -- 0.0
+(at (at (select {v: (var v) from: Teq by: g}) 'v) 0) -- 0.0
+(at (at (select {s: (stddev_pop v) from: Teq by: g}) 's) 0) -- 0.0

--- a/test/rfl/ops/group_coverage.rfl
+++ b/test/rfl/ops/group_coverage.rfl
@@ -108,15 +108,14 @@
 (set Nfl 80000)
 (set Tfl (table [g v] (list (% (til Nfl) 4) (til Nfl))))
 (count (select {fi: (first v) la: (last v) from: Tfl by: g})) -- 4
-;; SHOULD be: first(v)=g per group → sum 6;  last(v) per group →
-;; sum 319990 for Nfl=80000.  Both first() AND last() return truncated
-;; values in the parallel path (nrows >= 65536, has_first_last merge in
-;; group.c:2860-2922).  Probed on master 2026-04-30:
-;;   N=65000 first sum=6   last sum=259990   (sequential, OK)
-;;   N=65536 first sum≠6   last sum≠262134   (parallel kicks in, broken)
-;;   N=80000 first=262150  last=32758        expected 6, 319990
-;; Asserting just (count ...) so we exercise the parallel-merge branch
-;; without locking the wrong value.  Re-add value asserts once fixed.
+;; first(v) per group is the v at the smallest rowid in that group:
+;; group g sees rowids {g, g+4, g+8, ...}; the smallest rowid is g
+;; itself, and v[g] = g.  Sum across groups = 0+1+2+3 = 6.
+(sum (at (select {fi: (first v) from: Tfl by: g}) 'fi)) -- 6
+;; last(v) per group is v at the largest rowid in that group:
+;; (Nfl-4)+g, (Nfl-3), (Nfl-2), (Nfl-1) = 79996,79997,79998,79999.
+;; Sum = 4*(Nfl-4) + (0+1+2+3) = 320000-16+6 = 319990.
+(sum (at (select {la: (last v) from: Tfl by: g}) 'la)) -- 319990
 
 ;; ────────────── 9. Affine SUM/AVG (sum (+ col const)) ──────────────
 ;; group.c:2336-2340 detects SUM/AVG of (scan + const) and aggregates
@@ -142,15 +141,11 @@
 ;; ────────────── 11. Scalar agg over filtered (selection on n_keys=0) ──────────────
 ;; The scalar tight loop has a "specialized when no match_idx" branch
 ;; (group.c:2513-2525); a where clause forces the generic path.
-;; KNOWN BUG (master 2026-04-30): scalar agg form `select {agg: ... from: T where: P}`
-;; ignores the where: clause — sum returns 499500 (full sum) not 374750 (v>=500 only).
-;; Two-step (select+sum) works correctly.  Probed:
-;;   (sum (at (select {from: T where: (>= v 500)}) 'v))                   -> 374750 (correct)
-;;   (at (at (select {s: (sum v) from: T where: (>= v 500)}) 's) 0)       -> 499500 (wrong)
-;; Asserting count(c) which IS computed correctly (whole-table count regardless
-;; of where:) — exercises the path without locking the buggy sum value.
+;; Scalar agg form `select {agg: ... from: T where: P}` honours where:
+;; via exec_reduction's selection-aware path (see fix in group.c).
 (set Sfilt (select {s: (sum v) c: (count v) from: Ts where: (>= v 500)}))
-(at (at Sfilt 'c) 0) -- 1000
+(at (at Sfilt 's) 0) -- 374750
+(at (at Sfilt 'c) 0) -- 500
 
 ;; ────────────── 12. DATE key (DA-eligible, narrow range) ──────────────
 ;; RAY_DATE is on the DA-eligible list (group.c:2622). With only 3

--- a/test/rfl/ops/group_coverage.rfl
+++ b/test/rfl/ops/group_coverage.rfl
@@ -217,22 +217,19 @@
 (>= (at (at (select {sd: (stddev f) from: TvF}) 'sd) 0) 28867.0) -- true
 
 ;; ────────────── 20. Scalar VAR/STDDEV with cnt<=1 via select (insufficient) ──────────────
-;; (select {v: (var v) ...}) routes through exec_reduction's OP_VAR branch
-;; (group.c:233).  KNOWN INCONSISTENCY (master 2026-05-01): scalar path
-;; returns 0.0 for cnt==1 while the by-keyed path correctly returns 0Nf.
-;; Probed:
-;;   (at (select {v: (var v) from: T1 by: g}) 'v)  → [0Nf]   (correct)
-;;   (at (select {v: (var v) from: T1}) 'v)        → 0.0     (wrong-ish)
-;; Sample variance of a single value is mathematically undefined
-;; (denominator n-1 = 0), so 0Nf is the right answer.  Lock in observed
-;; behaviour for now; flip to 0Nf once exec_reduction propagates insuf.
+;; Sample variance/stddev with n=1 are mathematically undefined
+;; (denominator n-1 = 0).  exec_reduction returns the typed-null atom
+;; (0Nf), and broadcast_scalar (exec.c) propagates the null bit into
+;; the 1-row result column so (at result 0) reports 0Nf.
+;; Population variants (var_pop / stddev_pop) divide by n and are
+;; well-defined for n=1, returning 0.0.
 (set Ttiny (table [v f] (list [42] (as 'F64 [3.14]))))
-(at (at (select {v: (var v) from: Ttiny}) 'v) 0) -- 0.0
-(at (at (select {sd: (stddev v) from: Ttiny}) 'sd) 0) -- 0.0
+(at (at (select {v: (var v) from: Ttiny}) 'v) 0) -- 0Nf
+(at (at (select {sd: (stddev v) from: Ttiny}) 'sd) 0) -- 0Nf
 (at (at (select {vp: (var_pop v) from: Ttiny}) 'vp) 0) -- 0.0
 (at (at (select {sp: (stddev_pop v) from: Ttiny}) 'sp) 0) -- 0.0
 ;; F64 cnt==1 case
-(at (at (select {v: (var f) from: Ttiny}) 'v) 0) -- 0.0
+(at (at (select {v: (var f) from: Ttiny}) 'v) 0) -- 0Nf
 (at (at (select {vp: (var_pop f) from: Ttiny}) 'vp) 0) -- 0.0
 
 ;; ────────────── 21. F64 group with stat aggs (HT path emit) ──────────────

--- a/test/rfl/ops/group_coverage.rfl
+++ b/test/rfl/ops/group_coverage.rfl
@@ -201,3 +201,296 @@
 (at (at (select {v: (var_pop v) from: Teq by: g}) 'v) 0) -- 0.0
 (at (at (select {v: (var v) from: Teq by: g}) 'v) 0) -- 0.0
 (at (at (select {s: (stddev_pop v) from: Teq by: g}) 's) 0) -- 0.0
+
+;; ────────────── 18. Scalar VAR/STDDEV via select (parallel, ≥64K rows) ──────────────
+;; (select {... from: T}) routes through exec_group's scalar fast path
+;; (group.c:2480-2668).  F64 100k rows triggers the parallel scalar
+;; sumsq merge branch (group.c:2613-2616) and the F64 var/stddev emit
+;; (group.c:1330-1343).  Validates the F64 sumsq + sum + count path.
+(set TvF (table [f] (list (as 'F64 (til 100000)))))
+(set vF1 (at (at (select {vp: (var_pop f) from: TvF}) 'vp) 0))
+;; var_pop of 0..N-1 = (N²-1)/12 = (100000²-1)/12 ≈ 833333333.25
+(>= vF1 833333000.0) -- true
+(<= vF1 833334000.0) -- true
+(>= (at (at (select {sp: (stddev_pop f) from: TvF}) 'sp) 0) 28867.0) -- true
+(>= (at (at (select {v: (var f) from: TvF}) 'v) 0) 833333000.0) -- true
+(>= (at (at (select {sd: (stddev f) from: TvF}) 'sd) 0) 28867.0) -- true
+
+;; ────────────── 20. Scalar VAR/STDDEV with cnt<=1 via select (insufficient) ──────────────
+;; (select {v: (var v) ...}) routes through exec_reduction's OP_VAR branch
+;; (group.c:233).  KNOWN INCONSISTENCY (master 2026-05-01): scalar path
+;; returns 0.0 for cnt==1 while the by-keyed path correctly returns 0Nf.
+;; Probed:
+;;   (at (select {v: (var v) from: T1 by: g}) 'v)  → [0Nf]   (correct)
+;;   (at (select {v: (var v) from: T1}) 'v)        → 0.0     (wrong-ish)
+;; Sample variance of a single value is mathematically undefined
+;; (denominator n-1 = 0), so 0Nf is the right answer.  Lock in observed
+;; behaviour for now; flip to 0Nf once exec_reduction propagates insuf.
+(set Ttiny (table [v f] (list [42] (as 'F64 [3.14]))))
+(at (at (select {v: (var v) from: Ttiny}) 'v) 0) -- 0.0
+(at (at (select {sd: (stddev v) from: Ttiny}) 'sd) 0) -- 0.0
+(at (at (select {vp: (var_pop v) from: Ttiny}) 'vp) 0) -- 0.0
+(at (at (select {sp: (stddev_pop v) from: Ttiny}) 'sp) 0) -- 0.0
+;; F64 cnt==1 case
+(at (at (select {v: (var f) from: Ttiny}) 'v) 0) -- 0.0
+(at (at (select {vp: (var_pop f) from: Ttiny}) 'vp) 0) -- 0.0
+
+;; ────────────── 21. F64 group with stat aggs (HT path emit) ──────────────
+;; F64 key forces HT path (line 2683); F64 value triggers F64 emit
+;; (group.c:3582-3625) for SUM, AVG, MIN, MAX, FIRST, LAST, VAR, STDDEV.
+(set Tfg (table [k f] (list [1.5 2.5 1.5 2.5 1.5 2.5] (as 'F64 [10.0 20.0 30.0 40.0 50.0 60.0]))))
+(count (select {s: (sum f) av: (avg f) mn: (min f) mx: (max f) fi: (first f) la: (last f) v: (var f) sd: (stddev f) from: Tfg by: k})) -- 2
+;; Sum across both groups = 10+20+30+40+50+60 = 210
+(sum (at (select {s: (sum f) from: Tfg by: k}) 's)) -- 210.0
+;; Min across groups: 10 + 20 = 30
+(sum (at (select {mn: (min f) from: Tfg by: k}) 'mn)) -- 30.0
+;; Max across groups: 50 + 60 = 110
+(sum (at (select {mx: (max f) from: Tfg by: k}) 'mx)) -- 110.0
+;; var_pop per group (1.5: 10,30,50; mean=30; var_pop=((20)²+0+(20)²)/3 = 800/3)
+;; var per group (2.5: 20,40,60; mean=40; var=400)
+(count (select {v: (var f) vp: (var_pop f) sd: (stddev f) sp: (stddev_pop f) from: Tfg by: k})) -- 2
+
+;; ────────────── 22. DA path with FIRST+LAST+stat (parallel, ≥64K rows) ──────────────
+;; Triggers has_first_last=true branch (group.c:2945-3001) with VAR/STDDEV
+;; needing both DA_NEED_SUM and DA_NEED_SUMSQ.  4 keys × 80K rows.
+(set Nfls 80000)
+(set Tfls (table [g v] (list (% (til Nfls) 4) (til Nfls))))
+(count (select {fi: (first v) la: (last v) v: (var v) sd: (stddev v) from: Tfls by: g})) -- 4
+;; First across groups: g sees rowids {g, g+4, g+8, ...}; first(v) = g; sum = 6
+(sum (at (select {fi: (first v) v: (var v) from: Tfls by: g}) 'fi)) -- 6
+;; Last across groups: rowids end at Nfls-4+g, ..., Nfls-1; sum = 4*(Nfls-4) + 6 = 319990
+(sum (at (select {la: (last v) sd: (stddev v) from: Tfls by: g}) 'la)) -- 319990
+
+;; ────────────── 23. DA path with FIRST+LAST+MIN+MAX+stat (parallel, ≥64K rows) ──────────────
+;; Adds MIN and MAX to has_first_last branch — exercises lines 2975-2997
+;; (min/max merge alongside FIRST/LAST/stat).
+(count (select {fi: (first v) la: (last v) mn: (min v) mx: (max v) sd: (stddev v) from: Tfls by: g})) -- 4
+;; min(v) per group g = g (smallest row id in group); sum = 0+1+2+3 = 6
+(sum (at (select {mn: (min v) la: (last v) from: Tfls by: g}) 'mn)) -- 6
+;; max(v) per group g = Nfls-4+g (largest row id); sum = 4*(Nfls-4) + 6 = 319990
+(sum (at (select {mx: (max v) fi: (first v) from: Tfls by: g}) 'mx)) -- 319990
+
+;; ────────────── 24. DA path low-cardinality F64 agg + FIRST/LAST/min/max ──────────────
+;; F64 agg input within DA path: triggers F64 branches in da_accum_row
+;; (group.c:1715, 1729, 1735) and emit_agg_columns F64 SUM/MIN/MAX/etc.
+(set NflF 80000)
+(set TflF (table [g f] (list (% (til NflF) 4) (as 'F64 (til NflF)))))
+(count (select {s: (sum f) mn: (min f) mx: (max f) fi: (first f) la: (last f) sd: (stddev f) from: TflF by: g})) -- 4
+
+;; ────────────── 25. Scalar agg parallel with MIN/MAX (≥64K rows) ──────────────
+;; Hits scalar_accum_fn DA_NEED_MIN/MAX init paths (group.c:2522-2538)
+;; and scalar parallel merge of min/max (lines 2617-2638).
+(set Tsm2 (table [v] (list (til 100000))))
+(at (at (select {mn: (min v) mx: (max v) c: (count v) from: Tsm2}) 'mn) 0) -- 0
+(at (at (select {mn: (min v) mx: (max v) c: (count v) from: Tsm2}) 'mx) 0) -- 99999
+;; F64 scalar parallel min/max
+(set TsmF (table [f] (list (as 'F64 (til 100000)))))
+(at (at (select {mn: (min f) mx: (max f) sd: (stddev f) from: TsmF}) 'mn) 0) -- 0.0
+(at (at (select {mn: (min f) mx: (max f) sd: (stddev f) from: TsmF}) 'mx) 0) -- 99999.0
+
+;; ────────────── 26. Scalar agg parallel with FIRST+LAST (≥64K rows) ──────────────
+;; Hits scalar parallel merge FIRST/LAST branches (2599-2604).
+(at (at (select {fi: (first v) la: (last v) from: Tsm2}) 'fi) 0) -- 0
+(at (at (select {fi: (first v) la: (last v) from: Tsm2}) 'la) 0) -- 99999
+(at (at (select {fi: (first f) la: (last f) from: TsmF}) 'fi) 0) -- 0.0
+(at (at (select {fi: (first f) la: (last f) from: TsmF}) 'la) 0) -- 99999.0
+
+;; ────────────── 27. Scalar agg parallel SUM_F64 specialized loop ──────────────
+;; n_aggs==1 + no match_idx + F64 type → scalar_sum_f64_fn (group.c:1588).
+(set Tsf64 (table [f] (list (as 'F64 (til 100000)))))
+(at (at (select {s: (sum f) from: Tsf64}) 's) 0) -- 4999950000.0
+(at (at (select {av: (avg f) from: Tsf64}) 'av) 0) -- 49999.5
+
+;; ────────────── 28. AVG with affine input (group.c:1322-1323) ──────────────
+;; (avg (+ v const)) detects affine, aggregates base, biases at emit.
+;; Per-group avg(v+100) = avg(v) + 100.
+(count (select {a: (avg (+ v 100)) from: Ta by: g})) -- 2
+;; Group 'a: v∈{10,30,50}, avg(v+100) = 30+100 = 130
+;; Group 'b: v∈{20,40,60}, avg(v+100) = 40+100 = 140
+(sum (at (select {a: (avg (+ v 100)) from: Ta by: g}) 'a)) -- 270.0
+
+;; ────────────── 29. AVG affine with F64 (group.c:1322-1323 F64 branch) ──────────────
+(set Taf (table [g f] (list ['a 'b 'a 'b] (as 'F64 [1.0 2.0 3.0 4.0]))))
+(count (select {a: (avg (+ f 10.0)) from: Taf by: g})) -- 2
+;; 'a: f∈{1,3}, avg(f+10) = 2+10 = 12
+;; 'b: f∈{2,4}, avg(f+10) = 3+10 = 13
+(sum (at (select {a: (avg (+ f 10.0)) from: Taf by: g}) 'a)) -- 25.0
+
+;; ────────────── 30. I16 narrow-int key (DA-eligible) ──────────────
+;; group.c:2683 lists RAY_I16; narrow-int key + I16 esz=2 hits DA case 2
+;; (group.c:1781 DA_SINGLE_KEY_LOOP with uint16_t).
+(set Ti16 (table [k v] (list (as 'I16 (% (til 200) 30)) (til 200))))
+(count (select {s: (sum v) c: (count v) from: Ti16 by: k})) -- 30
+(sum (at (select {s: (sum v) from: Ti16 by: k}) 's)) -- 19900
+
+;; ────────────── 31. I32 narrow-int key (DA-eligible, esz=4) ──────────────
+(set Ti32 (table [k v] (list (as 'I32 (% (til 240) 12)) (til 240))))
+(count (select {s: (sum v) c: (count v) from: Ti32 by: k})) -- 12
+(sum (at (select {s: (sum v) from: Ti32 by: k}) 's)) -- 28680
+
+;; ────────────── 32. U8 key (DA-eligible, esz=1) ──────────────
+(set Tu8 (table [k v] (list (as 'U8 (% (til 200) 17)) (til 200))))
+(count (select {s: (sum v) c: (count v) from: Tu8 by: k})) -- 17
+(sum (at (select {s: (sum v) from: Tu8 by: k}) 's)) -- 19900
+
+;; ────────────── 33. TIMESTAMP key (DA-eligible) ──────────────
+;; RAY_TIMESTAMP is on the DA list (group.c:2682).  3 distinct timestamps.
+(set Tts (table [t v] (list (take [2024.01.01D00:00:00.000000000 2024.01.01D00:00:01.000000000 2024.01.01D00:00:02.000000000] 300) (til 300))))
+(count (select {s: (sum v) from: Tts by: t})) -- 3
+(sum (at (select {s: (sum v) from: Tts by: t}) 's)) -- 44850
+
+;; ────────────── 34. TIME key (DA-eligible, esz=4) ──────────────
+(set Ttm (table [t v] (list (take [09:30:00.000 10:00:00.000 11:30:00.000] 300) (til 300))))
+(count (select {s: (sum v) from: Ttm by: t})) -- 3
+(sum (at (select {s: (sum v) from: Ttm by: t}) 's)) -- 44850
+
+;; ────────────── 35. Multi-key with mixed-width DA (uniform_esz=false) ──────────────
+;; group.c:1834-1838: when keys have different esz, uses generic
+;; da_composite_gid (no typed loop).  Mix BOOL (esz=1) + I32 (esz=4).
+(set Tmw (table [b i v] (list (take [true false true false] 240) (as 'I32 (% (til 240) 5)) (til 240))))
+(count (select {s: (sum v) from: Tmw by: [b i]})) -- 10
+(sum (at (select {s: (sum v) from: Tmw by: [b i]}) 's)) -- 28680
+
+;; ────────────── 36. HT path: large-cardinality DA-ineligible F64 key ──────────────
+;; F64 key with many distinct values forces sequential HT path
+;; (small data <64K) hits group.c:3501-3706 single_ht emit.
+(set Tfh (table [k v] (list [1.5 2.5 3.5 4.5 5.5 6.5 7.5 8.5 9.5 10.5 1.5 2.5] [1 2 3 4 5 6 7 8 9 10 11 12])))
+(count (select {s: (sum v) c: (count v) mn: (min v) mx: (max v) sd: (stddev v) from: Tfh by: k})) -- 10
+;; Sum: 1+2+...+12 = 78
+(sum (at (select {s: (sum v) from: Tfh by: k}) 's)) -- 78
+;; Group 1.5 (rows 0,10): sum=12; group 2.5 (rows 1,11): sum=14
+;; Other groups single-row → var/stddev null.
+
+;; ────────────── 37. HT path stddev/var nullmap fixup (radix phase 3, 100k SYM) ──────────────
+;; Already partially covered in section 15.  Add a case where some groups
+;; are singletons (var=null) to exercise the post-phase3 fixup loop
+;; (group.c:3409-3426): set the null bit on insufficient-cnt groups.
+(set Nh 70000)
+(set Tnh (table [k v] (list (% (til Nh) 65000) (til Nh))))
+(count (select {v: (var v) sd: (stddev v) c: (count v) from: Tnh by: k})) -- 65000
+
+;; ────────────── 38. Group with stat aggs on count==0 result (where:) ──────────────
+;; All filtered out → empty group set, no var fixup needed.
+(count (select {v: (var v) sd: (stddev v) from: Tw by: g where: (== g 'NONE)})) -- 0
+;; Filtered-out scalar agg: empty input → cnt==0 var/stddev returns null
+(at (at (select {v: (var v) from: Tw where: (== g 'NONE)}) 'v) 0) -- 0Nf
+(at (at (select {sd: (stddev v) from: Tw where: (== g 'NONE)}) 'sd) 0) -- 0Nf
+(at (at (select {vp: (var_pop v) from: Tw where: (== g 'NONE)}) 'vp) 0) -- 0Nf
+
+;; ────────────── 39. Single-row group: FIRST==LAST, var=null ──────────────
+;; Each row in its own group exercises the cnt==1 insufficient branch
+;; (group.c:1332-1333) for VAR/STDDEV, AVG=value itself.
+(set Tu (table [g v f] (list [10 20 30 40 50] [1 2 3 4 5] (as 'F64 [1.0 2.0 3.0 4.0 5.0]))))
+(count (select {v: (var v) sd: (stddev v) av: (avg v) from: Tu by: g})) -- 5
+;; AVG of single rows: 1+2+3+4+5 = 15.0
+(sum (at (select {av: (avg v) from: Tu by: g}) 'av)) -- 15.0
+
+;; ────────────── 40. Mixed F64 + I64 aggs in DA path ──────────────
+;; Triggers both is_f64=true and is_f64=false code paths in same emit.
+(set Tmf (table [g v f] (list (% (til 100) 5) (til 100) (as 'F64 (til 100)))))
+(count (select {s: (sum v) sf: (sum f) mn: (min v) mxf: (max f) from: Tmf by: g})) -- 5
+;; sum(v) per group = sum_{i=0,5,10,...,95} g+i  for each remainder
+;; Total over all groups = sum 0..99 = 4950
+(sum (at (select {s: (sum v) sf: (sum f) from: Tmf by: g}) 's)) -- 4950
+(sum (at (select {sf: (sum f) from: Tmf by: g}) 'sf)) -- 4950.0
+
+;; ────────────── 41. Group 'G' with where: → scalar selection-aware reduction ──────────────
+;; Already partially covered.  Add F64-typed reductions through the
+;; selection-aware path (exec_reduction's sel_idx branch, group.c:268-276).
+(at (at (select {av: (avg f) sd: (stddev f) from: Taf where: (>= f 2.0)}) 'av) 0) -- 3.0
+(at (at (select {mn: (min f) mx: (max f) from: Taf where: (>= f 2.0)}) 'mn) 0) -- 2.0
+
+;; ────────────── 43. Scalar agg with all-stat-aggs combination ──────────────
+;; Multi-agg pack of var, var_pop, stddev, stddev_pop, sum, count, avg
+;; in scalar mode (no by) — exercises full need_flags=SUM+SUMSQ+COUNT.
+(set Tall (table [v] (list (til 200))))
+(count (select {s: (sum v) c: (count v) av: (avg v) v: (var v) vp: (var_pop v) sd: (stddev v) sp: (stddev_pop v) from: Tall})) -- 200
+(at (at (select {s: (sum v) c: (count v) av: (avg v) v: (var v) vp: (var_pop v) sd: (stddev v) sp: (stddev_pop v) from: Tall}) 's) 0) -- 19900
+(at (at (select {c: (count v) v: (var v) sd: (stddev v) from: Tall}) 'c) 0) -- 200
+
+;; ────────────── 44. Group var/stddev with mixed enough/insufficient ──────────────
+;; HT path (radix or sequential) finalize loop over var/stddev (group.c:3409-3426)
+;; and emit_agg_columns insuf branch (1332-1333) — set null bit on cnt<=1.
+(set Tmv (table [g v] (list ['x 'y 'z 'x 'x 'y] [10 20 30 40 50 60])))
+(count (select {v: (var v) vp: (var_pop v) sd: (stddev v) sp: (stddev_pop v) from: Tmv by: g})) -- 3
+
+;; ────────────── 45. Group result chained: count of (group result) ──────────────
+;; Verify table operations after group still work (column access pattern).
+(count (at (select {s: (sum v) from: Ta by: g}) 's)) -- 2
+
+;; ────────────── 46. Stat aggs with 0-row input via where: ──────────────
+;; var/stddev with where: that filters to 0 rows in scalar mode → null.
+;; Exercises insufficient branch with cnt==0 on the parallel scalar path
+;; via the where:-driven selection (cnt becomes 0 after selection compaction).
+(at (at (select {v: (var v) from: Tall where: (< v 0)}) 'v) 0) -- 0Nf
+(at (at (select {sd: (stddev v) from: Tall where: (< v 0)}) 'sd) 0) -- 0Nf
+(at (at (select {vp: (var_pop v) from: Tall where: (< v 0)}) 'vp) 0) -- 0Nf
+
+;; ────────────── 48. Group with multiple key types & I16 mix ──────────────
+;; Composite GID across different element-size keys (uniform_esz=false).
+(set Tmix2 (table [a b v] (list (as 'I16 (% (til 60) 3)) (% (til 60) 4) (til 60))))
+(count (select {s: (sum v) from: Tmix2 by: [a b]})) -- 12
+(sum (at (select {s: (sum v) from: Tmix2 by: [a b]}) 's)) -- 1770
+
+;; ────────────── 49. Scalar agg on F64 with where: (selection-aware) ──────────────
+;; F64 reduction with selection — exercises sel_idx in REDUCE_LOOP_F.
+(set Tfsel (table [f] (list (as 'F64 [1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0]))))
+(at (at (select {s: (sum f) from: Tfsel where: (>= f 5.0)}) 's) 0) -- 45.0
+(at (at (select {av: (avg f) from: Tfsel where: (>= f 5.0)}) 'av) 0) -- 7.5
+(at (at (select {mn: (min f) from: Tfsel where: (>= f 5.0)}) 'mn) 0) -- 5.0
+(at (at (select {mx: (max f) from: Tfsel where: (>= f 5.0)}) 'mx) 0) -- 10.0
+
+;; ────────────── 50. Group on i64 key with stat aggs F64 (HT path emit F64) ──────────────
+;; Sequential HT emit branch for F64 var/stddev via group.c:3611-3624.
+;; F64 agg input + i64 key with cardinality > DA limit (e.g. dense range
+;; pushed past DA budget).  Use a key range that fits DA but with F64 agg.
+(set Tflarge (table [g f] (list (% (til 1200) 30) (as 'F64 (til 1200)))))
+(count (select {s: (sum f) v: (var f) sd: (stddev f) vp: (var_pop f) sp: (stddev_pop f) from: Tflarge by: g})) -- 30
+
+;; ────────────── 51. Group with sym key, count + stat (no DA — sym still DA-eligible if range fits) ──────────────
+;; SYM keys with low cardinality go through DA (group.c:2681 lists RAY_SYM).
+;; Tests DA-path SYM key reads via read_col_i64 with attrs (line 1488).
+(set Tsymk (table [k v] (list (take ['a 'b 'c 'd] 200) (til 200))))
+(count (select {s: (sum v) av: (avg v) v: (var v) sd: (stddev v) from: Tsymk by: k})) -- 4
+(sum (at (select {s: (sum v) from: Tsymk by: k}) 's)) -- 19900
+
+;; ────────────── 52. Radix HT path with FIRST/LAST + stddev (≥64K F64 key) ──────────────
+;; F64 key forces HT path; >=64K rows enables radix.  FIRST/LAST + var
+;; exercises radix_phase3 F64 OP_FIRST/OP_LAST emit (group.c:3101-3103)
+;; and radix_phase3 F64 OP_VAR/STDDEV emit (group.c:3105-3119).
+(set Nfh 70000)
+(set Tfhk (table [k v] (list (as 'F64 (% (til Nfh) 100)) (til Nfh))))
+(count (select {fi: (first v) la: (last v) sd: (stddev v) v: (var v) from: Tfhk by: k})) -- 100
+
+;; ────────────── 53. SYM key DA path with FIRST/LAST (≥64K rows, low card) ──────────────
+;; SYM key 5 cards + 70K rows + FIRST/LAST hits the DA path with
+;; SYM read_col_i64 (group.c:1488) and DA's has_first_last branch.
+(set Nslf 70000)
+(set Tslf (table [k v] (list (take ['s0 's1 's2 's3 's4] Nslf) (til Nslf))))
+(count (select {fi: (first v) la: (last v) c: (count v) from: Tslf by: k})) -- 5
+
+;; ────────────── 54. Multi-agg with COUNT only (no SUM/MIN/MAX needed) ──────────────
+;; Pure COUNT(*) — no need_flags (other than DA_NEED_COUNT).  Tests the
+;; all_sum=true fast path of da_accum_row (group.c:1683-1697).
+(set Tcnt (table [g v] (list (% (til 1000) 50) (til 1000))))
+(count (select {c: (count v) from: Tcnt by: g})) -- 50
+(sum (at (select {c: (count v) from: Tcnt by: g}) 'c)) -- 1000
+
+;; ────────────── 55. Multi-agg parallel scalar with mixed types ──────────────
+;; Parallel scalar agg path with all-stat-aggs and large F64 input —
+;; covers parallel scalar merge for DA_NEED_SUMSQ and DA_NEED_SUM.
+(set Tps (table [v f] (list (til 100000) (as 'F64 (til 100000)))))
+(at (at (select {sv: (sum v) sf: (sum f) from: Tps}) 'sv) 0) -- 4999950000
+(at (at (select {sv: (sum v) sf: (sum f) from: Tps}) 'sf) 0) -- 4999950000.0
+;; var/stddev on f, sum on v (multiple aggs over multiple types in scalar)
+(>= (at (at (select {vp: (var_pop f) sv: (sum v) from: Tps}) 'vp) 0) 833333000.0) -- true
+
+;; ────────────── 56. Sequential HT path: First/Last on F64 (group.c:3608) ──────────────
+;; Builds on section 21 (Tfg) — adds first/last sum-of-result checks
+;; that section 21 lacked, exercising the F64 OP_FIRST/OP_LAST emit
+;; (group.c:3608) in sequential HT path.
+;; First per group: 1.5→10.0, 2.5→20.0; sum = 30.0
+(sum (at (select {fi: (first f) from: Tfg by: k}) 'fi)) -- 30.0
+;; Last per group: 1.5→50.0, 2.5→60.0; sum = 110.0
+(sum (at (select {la: (last f) from: Tfg by: k}) 'la)) -- 110.0
+

--- a/test/rfl/ops/idxop_coverage.rfl
+++ b/test/rfl/ops/idxop_coverage.rfl
@@ -1,0 +1,311 @@
+;; Coverage workout for src/ops/idxop.c -- the per-vector accelerator
+;; index layer (zone / hash / sort / bloom).  Existing rfl coverage is
+;; limited to the zone+has?+drop path on i64 in test/rfl/table/link.rfl;
+;; this file walks every kind across every supported numeric type, the
+;; round-trip lifecycle (build / drop / rebuild / overwrite), the meta
+;; surface (.idx.info, .idx.has?), and the documented error paths from
+;; prepare_attach (non-vec, non-numeric, list).
+;;
+;; Public surface (registered in src/lang/eval.c:2381-2387):
+;;   .idx.zone v   -> v with zone   index attached
+;;   .idx.hash v   -> v with hash   index attached
+;;   .idx.sort v   -> v with sort   index attached
+;;   .idx.bloom v  -> v with bloom  index attached
+;;   .idx.drop v   -> v with index removed (no-op if none)
+;;   .idx.has? v   -> b8 (true iff HAS_INDEX is set and index != NULL)
+;;   .idx.info v   -> dict of kind/length/... or null when no index
+
+;; ────────────── cleanup (no on-disk state, but spec mandates) ──────────────
+(.sys.exec "rm -rf /tmp/rfl_idxop*")
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; ZONE -- min/max/n_nulls (zone_scan_int / zone_scan_float)
+;; ════════════════════════════════════════════════════════════════════════════
+
+;; ── i64 path: es=8 in zone_scan_int (idxop.c:240-266) ──
+(set vi64 [5 1 9 3 7])
+(set zi64 (.idx.zone vi64))
+(.idx.has? zi64) -- true
+(at (.idx.info zi64) 'kind) -- 'zone
+(at (.idx.info zi64) 'length) -- 5
+(at (.idx.info zi64) 'min) -- 1
+(at (.idx.info zi64) 'max) -- 9
+(at (.idx.info zi64) 'n_nulls) -- 0
+
+;; ── i64 with inline nulls: any_value=true, n_nulls counted ──
+(set vi64n [5 0Nl 9 0Nl 7])
+(set zi64n (.idx.zone vi64n))
+(at (.idx.info zi64n) 'min) -- 5
+(at (.idx.info zi64n) 'max) -- 9
+(at (.idx.info zi64n) 'n_nulls) -- 2
+
+;; ── i64 all-nulls: any_value=false branch (idxop.c:261) zeroes min/max ──
+(set vi64z [0Nl 0Nl 0Nl])
+(set zi64z (.idx.zone vi64z))
+(at (.idx.info zi64z) 'min) -- 0
+(at (.idx.info zi64z) 'max) -- 0
+(at (.idx.info zi64z) 'n_nulls) -- 3
+
+;; ── empty vector: n=0, any_value=false ──
+(set ve [])
+(set ze (.idx.zone ve))
+(at (.idx.info ze) 'length) -- 0
+(at (.idx.info ze) 'min) -- 0
+(at (.idx.info ze) 'max) -- 0
+(at (.idx.info ze) 'n_nulls) -- 0
+
+;; ── i32 path: es=4 in zone_scan_int (idxop.c:253) ──
+(set vi32 (as 'I32 [10 -3 50 0]))
+(set zi32 (.idx.zone vi32))
+(at (.idx.info zi32) 'min) -- -3
+(at (.idx.info zi32) 'max) -- 50
+
+;; ── i16 path: es=2 in zone_scan_int (idxop.c:252) ──
+(set vi16 (as 'I16 [100 -200 300 0]))
+(set zi16 (.idx.zone vi16))
+(at (.idx.info zi16) 'min) -- -200
+(at (.idx.info zi16) 'max) -- 300
+
+;; ── u8 path: es=1 in zone_scan_int (idxop.c:251) ──
+(set vu8 (as 'U8 [10 1 50 5]))
+(set zu8 (.idx.zone vu8))
+(at (.idx.info zu8) 'min) -- 1
+(at (.idx.info zu8) 'max) -- 50
+
+;; ── bool path: es=1 in zone_scan_int + RAY_BOOL switch arm ──
+(set vb [true false true true])
+(set zb (.idx.zone vb))
+(at (.idx.info zb) 'min) -- 0
+(at (.idx.info zb) 'max) -- 1
+
+;; ── f64 path: zone_scan_float es=8 (idxop.c:268-293) ──
+(set vf64 [1.5 -2.5 3.14 0.0])
+(set zf64 (.idx.zone vf64))
+(at (.idx.info zf64) 'min) -- -2.5
+(at (.idx.info zf64) 'max) -- 3.14
+
+;; F32 zone-scan branch (idxop.c:278) skipped — `(as 'F32 ...)` errors
+;; with "domain"; F32 isn't an exposed cast target.  Coverage via direct
+;; C call would be needed to hit the es=4 float path.
+
+;; ── date path: routes to zone_scan_int es=4 (idxop.c:300-301) ──
+(set vd [2024.01.15 2024.06.30 2024.02.29])
+(set zd (.idx.zone vd))
+(.idx.has? zd) -- true
+(at (.idx.info zd) 'kind) -- 'zone
+
+;; ── timestamp path: routes to zone_scan_int es=8 (idxop.c:302-304) ──
+(set vts (as 'TIMESTAMP [5 1 3 2 4]))
+(set zts (.idx.zone vts))
+(.idx.has? zts) -- true
+(at (.idx.info zts) 'min) -- 1
+(at (.idx.info zts) 'max) -- 5
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; HASH -- chained open-addressing build (idxop.c:403-453)
+;; ════════════════════════════════════════════════════════════════════════════
+
+;; ── small i64: capacity rounds to power-of-two >= max(8, 2n) ──
+(set hi64 (.idx.hash [10 20 30 40 50]))
+(.idx.has? hi64) -- true
+(at (.idx.info hi64) 'kind) -- 'hash
+(at (.idx.info hi64) 'n_keys) -- 5
+(at (.idx.info hi64) 'capacity) -- 16
+
+;; ── empty: capacity floors at 8, chain stays len=0 (idxop.c:417 special-case) ──
+(set hempty (.idx.hash []))
+(at (.idx.info hempty) 'kind) -- 'hash
+(at (.idx.info hempty) 'n_keys) -- 0
+(at (.idx.info hempty) 'capacity) -- 8
+
+;; ── n=2 (n < 4 branch): next_pow2(8) = 8 (idxop.c:409) ──
+(set h2 (.idx.hash [42 99]))
+(at (.idx.info h2) 'capacity) -- 8
+
+;; ── duplicates: every row enters the chain, n_keys counts non-null rows ──
+(set hdup (.idx.hash [7 7 7 7]))
+(at (.idx.info hdup) 'n_keys) -- 4
+
+;; ── nulls excluded from n_keys (idxop.c:432) ──
+(set hwithn (.idx.hash [1 0Nl 2 0Nl 3]))
+(at (.idx.info hwithn) 'n_keys) -- 3
+
+;; ── f64 hash: numeric_key_word float branch + canonicalisation ──
+(set hf (.idx.hash [1.5 2.5 3.5 1.5]))
+(at (.idx.info hf) 'n_keys) -- 4
+(at (.idx.info hf) 'kind) -- 'hash
+
+;; ── large vec, crosses default morsel boundary (>256 rows) ──
+;; til 300 -> i64 [0..299]; n=300, cap = next_pow2(600) = 1024
+(set hbig (.idx.hash (til 300)))
+(at (.idx.info hbig) 'n_keys) -- 300
+(at (.idx.info hbig) 'capacity) -- 1024
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; SORT -- ascending permutation (idxop.c:462-479)
+;; ════════════════════════════════════════════════════════════════════════════
+
+(set si (.idx.sort [50 10 30 20 40]))
+(.idx.has? si) -- true
+(at (.idx.info si) 'kind) -- 'sort
+(at (.idx.info si) 'perm_len) -- 5
+(at (.idx.info si) 'length) -- 5
+
+(set sf (.idx.sort [3.14 1.5 -2.5 0.0]))
+(at (.idx.info sf) 'kind) -- 'sort
+(at (.idx.info sf) 'perm_len) -- 4
+
+;; sort on empty -- ray_sort_indices with len=0 returns an empty I64
+(set sempty (.idx.sort []))
+(at (.idx.info sempty) 'perm_len) -- 0
+
+;; sort over morsel boundary
+(set sbig (.idx.sort (til 300)))
+(at (.idx.info sbig) 'perm_len) -- 300
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; BLOOM -- 3-hash filter, bits sized to next_pow2(8 * n_set) (idxop.c:489-537)
+;; ════════════════════════════════════════════════════════════════════════════
+
+;; n_set < 8 -> target_bits=64 floor (idxop.c:499-501)
+(set bs (.idx.bloom [1 2 3]))
+(.idx.has? bs) -- true
+(at (.idx.info bs) 'kind) -- 'bloom
+(at (.idx.info bs) 'n_keys) -- 3
+(at (.idx.info bs) 'k) -- 3
+(at (.idx.info bs) 'm_bits) -- 64
+
+;; n_set=10, 8*10=80, next_pow2(80)=128
+(set bm (.idx.bloom (til 10)))
+(at (.idx.info bm) 'n_keys) -- 10
+(at (.idx.info bm) 'm_bits) -- 128
+
+;; bloom over a float column -- exercises numeric_key_word float path
+(set bf (.idx.bloom [1.5 2.5 3.5 4.5 5.5 6.5 7.5 8.5 9.5 10.5]))
+(at (.idx.info bf) 'n_keys) -- 10
+(at (.idx.info bf) 'k) -- 3
+
+;; bloom with all-null vec: n_set=0 -> 64-bit floor, n_keys=0
+(set bz (.idx.bloom [0Nl 0Nl 0Nl]))
+(at (.idx.info bz) 'n_keys) -- 0
+(at (.idx.info bz) 'm_bits) -- 64
+
+;; bloom over morsel boundary
+(set bbig (.idx.bloom (til 300)))
+(at (.idx.info bbig) 'n_keys) -- 300
+;; 8*300=2400, next_pow2(2400)=4096
+(at (.idx.info bbig) 'm_bits) -- 4096
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; LIFECYCLE -- drop / rebuild / overwrite
+;; ════════════════════════════════════════════════════════════════════════════
+
+;; drop returns vector without HAS_INDEX (idxop.c:549-592)
+(set lv [1 2 3 4 5])
+(set lvi (.idx.zone lv))
+(.idx.has? lvi) -- true
+(set lvd (.idx.drop lvi))
+(.idx.has? lvd) -- false
+;; .idx.info on a vec without index returns null (idxop.c:630)
+(nil? (.idx.info lvd)) -- true
+
+;; drop on a vec that has no index is a no-op (idxop.c:552 early return)
+(set plain [1 2 3])
+(.idx.has? plain) -- false
+(set plain-d (.idx.drop plain))
+(.idx.has? plain-d) -- false
+
+;; double-drop is idempotent
+(set dd1 (.idx.drop (.idx.drop (.idx.zone [9 8 7]))))
+(.idx.has? dd1) -- false
+
+;; rebuild: zone -> drop -> hash -> drop -> sort -> drop -> bloom
+(set rv [11 22 33 44])
+(set rvz (.idx.zone rv))
+(at (.idx.info rvz) 'kind) -- 'zone
+(set rvz2 (.idx.drop rvz))
+(set rvh (.idx.hash rvz2))
+(at (.idx.info rvh) 'kind) -- 'hash
+(set rvh2 (.idx.drop rvh))
+(set rvs (.idx.sort rvh2))
+(at (.idx.info rvs) 'kind) -- 'sort
+(set rvs2 (.idx.drop rvs))
+(set rvb (.idx.bloom rvs2))
+(at (.idx.info rvb) 'kind) -- 'bloom
+
+;; build over an already-indexed vec drops + rebuilds (idxop.c:361-365)
+(set ov [3 1 4 1 5 9 2 6])
+(set ovz (.idx.zone ov))
+(at (.idx.info ovz) 'kind) -- 'zone
+;; second .idx.hash on the same vec rebuilds: zone first dropped then hash attached
+(set ovh (.idx.hash ovz))
+(at (.idx.info ovh) 'kind) -- 'hash
+(at (.idx.info ovh) 'n_keys) -- 8
+
+;; ── original binding semantics: .idx.* returns COW'd ref; old name unaffected
+;; vis a vis index attachment because the old binding holds the pre-COW pointer ──
+(set base [7 8 9])
+(.idx.has? base) -- false
+(set baseI (.idx.zone base))
+(.idx.has? baseI) -- true
+(.idx.has? base) -- false
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; ERROR PATHS (prepare_attach / drop_fn) -- idxop.c:353-374
+;; ════════════════════════════════════════════════════════════════════════════
+
+;; ── non-numeric vec: sym vector hits numeric_elem_size==0 -> "nyi" ──
+(.idx.zone ['AAPL 'GOOG 'MSFT]) !- nyi
+(.idx.hash ['a 'b 'c]) !- nyi
+(.idx.sort ['x 'y]) !- nyi
+(.idx.bloom ['p 'q]) !- nyi
+
+;; ── string vec also unsupported in v1 ──
+(.idx.zone ["alpha" "beta"]) !- nyi
+(.idx.hash ["a" "b"]) !- nyi
+
+;; ── non-vector input (atom): ray_is_vec -> false -> "type" error ──
+(.idx.zone 42) !- type
+(.idx.hash 3.14) !- type
+(.idx.sort 'sym) !- type
+(.idx.bloom "x") !- type
+
+;; ── heterogeneous list: not a typed vec -> type error ──
+(.idx.zone (list 1 'sym 1.5)) !- type
+(.idx.hash (list 1 "two")) !- type
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; INTROSPECTION shape -- ray_index_info dict surface (idxop.c:629-697)
+;; ════════════════════════════════════════════════════════════════════════════
+
+;; zone info exposes parent_type and saved_attrs (idxop.c:643-646)
+(set ii (.idx.info (.idx.zone [1 2 3])))
+(at ii 'kind) -- 'zone
+(at ii 'length) -- 3
+;; parent_type for RAY_I64 is its enum value; we don't pin the exact int,
+;; just that the field exists and is non-negative
+(>= (at ii 'parent_type) 0) -- true
+(>= (at ii 'saved_attrs) 0) -- true
+
+;; hash info exposes capacity & n_keys (idxop.c:668-672)
+(set hi (.idx.info (.idx.hash [1 2 3 4])))
+(at hi 'kind) -- 'hash
+(>= (at hi 'capacity) 8) -- true
+
+;; sort info has perm_len (idxop.c:674-677)
+(set sii (.idx.info (.idx.sort [3 1 2])))
+(at sii 'kind) -- 'sort
+(at sii 'perm_len) -- 3
+
+;; bloom info has m_bits / k / n_keys (idxop.c:679-685)
+(set bii (.idx.info (.idx.bloom [1 2 3])))
+(at bii 'kind) -- 'bloom
+(at bii 'k) -- 3
+(>= (at bii 'm_bits) 64) -- true
+
+;; .idx.has? on non-indexed atom returns false (no HAS_INDEX bit)
+(.idx.has? 42) -- false
+(.idx.has? "abc") -- false
+
+;; ────────────── cleanup ──────────────
+(.sys.exec "rm -rf /tmp/rfl_idxop*")

--- a/test/rfl/system/syscmd_coverage.rfl
+++ b/test/rfl/system/syscmd_coverage.rfl
@@ -65,6 +65,39 @@
 ;; returns what it has).  Reset state for any later toggle tests.
 (.sys.timeit 0)          -- 0
 
+;; ────────────── arg_as_i64: type-fallthrough (lines 85-86) ──────────────
+;; arg_as_i64 has an explicit early-return for every integer kind plus
+;; STR; any other typed arg falls past all branches into the final
+;; `*err = 1; return 0;` pair (lines 85-86).  Reaching it requires a
+;; non-null, non-int, non-bool, non-string atom routed past the
+;; string-dispatch guard — i.e. a direct `.sys.timeit` / `.sys.listen`
+;; call with a typed atom (float, sym, etc.).  The handler then sees
+;; err=1 and returns "type".  These probes are the only path from rfl
+;; that hit lines 85-86.
+(.sys.timeit 1.5)    !- type
+(.sys.timeit 3.14)   !- type
+(.sys.listen 1.5)    !- type
+(.sys.listen 3.14)   !- type
+;; State should be untouched by the failed timeit calls above (the
+;; type guard runs before the profiler flag is poked).  Confirm by
+;; toggling and reading back.
+(.sys.timeit 0)      -- 0
+(.sys.timeit 1)      -- 1
+(.sys.timeit 0)      -- 0
+
+;; ────────────── arg_as_i64: type-fallthrough (lines 85-86) ──────────
+;; Float atoms hit the final *err=1; return 0 branch — neither I64/I32/I16/U8/BOOL
+;; nor STR.  Only reachable via direct `.sys.timeit`/`.sys.listen` calls
+;; (the .sys.cmd dispatcher always wraps args as strings).
+(.sys.timeit 1.5)    !- type
+(.sys.timeit 3.14)   !- type
+(.sys.listen 1.5)    !- type
+(.sys.listen 3.14)   !- type
+;; Post-condition: state unchanged after type errors.
+(.sys.timeit 0)      -- 0
+(.sys.timeit 1)      -- 1
+(.sys.timeit 0)      -- 0
+
 ;; ────────────── h_timeit: no-arg toggle (arg_is_null branch, line 100) ──
 ;; Force off, then toggle: state flips on and back off.  Final value
 ;; is observable through the return code.

--- a/test/rfl/system/syscmd_coverage.rfl
+++ b/test/rfl/system/syscmd_coverage.rfl
@@ -1,0 +1,179 @@
+;; syscmd_coverage.rfl — extra coverage for src/lang/syscmd.c.
+;;
+;; Companion to syscmd.rfl.  That file pins down the happy paths;
+;; this one walks the error / coercion / dispatcher branches that
+;; coverage flagged as untouched.  Every assertion targets a
+;; specific branch in syscmd.c so the file doubles as a map from
+;; behaviour to source line.
+;;
+;; Each `.rfl` runs in a fresh runtime (test/main.c rfl_setup /
+;; rfl_teardown), so the profiler flag and env count seen here are
+;; the bare post-init values.  We exploit that for the toggle
+;; tests below.
+;;
+;; Exercises:
+;;   arg_as_i64        (lines 65-87)  — every typed branch
+;;   h_timeit          (line 98)      — null-arg toggle, type error
+;;   h_listen          (line 125)     — domain / type / nyi
+;;   h_env             (line 163)     — count > 0, with-arg variadic
+;;   ray_syscmd_lookup (line 240)     — alias path via "?" / "t"
+;;   ray_syscmd_dispatch (line 270)   — leading tab, shell fallback,
+;;                                       REPL-only rejection, empty
+;;   ray_syscmd_string_dispatch_fn (line 327) — non-string guard
+;;   invoke_by_name    (line 336)     — direct .sys.<name>
+;;   ray_sys_listen_fn (line 347)     — direct call
+;;   ray_sys_timeit_fn (line 353)     — variadic 0 args
+;;   ray_sys_env_fn    (line 356)     — variadic with arg
+
+;; ────────────── start: clean any stragglers from a prior run ──────────────
+(.sys.cmd "rm -f /tmp/rfl_syscmd_cov*") -- 0
+
+;; ────────────── arg_as_i64: typed-int branches via .sys.timeit ──────────────
+;; Each non-string integer kind takes a distinct early-return path in
+;; arg_as_i64 (lines 68-72).  Driving them through .sys.timeit is the
+;; cleanest way to round-trip the result back into Rayfall.
+(.sys.timeit 1)        -- 1
+(.sys.timeit 0)        -- 0
+(.sys.timeit 1i)       -- 1
+(.sys.timeit 0i)       -- 0
+(.sys.timeit 1h)       -- 1
+(.sys.timeit 0h)       -- 0
+(.sys.timeit 0x01)     -- 1
+(.sys.timeit 0x00)     -- 0
+(.sys.timeit true)     -- 1
+(.sys.timeit false)    -- 0
+
+;; ────────────── arg_as_i64: STR branches via .sys.cmd dispatch ──────────────
+;; The string parser handles leading whitespace, optional sign, then
+;; digits (lines 73-84).  Drive each sub-branch.
+(.sys.cmd "timeit 1")       -- 1
+(.sys.cmd "timeit 0")       -- 0
+(.sys.cmd "timeit +1")      -- 1
+(.sys.cmd "timeit -1")      -- 1
+(.sys.cmd "timeit 42")      -- 1
+;; Multi-digit + accumulator: 100 ≠ 0, so toggle goes ON.
+(.sys.cmd "timeit 100")     -- 1
+(.sys.cmd "timeit 0")       -- 0
+
+;; Empty-after-sign / non-digit start → type error (line 80).
+(.sys.cmd "timeit +")    !- type
+(.sys.cmd "timeit -")    !- type
+(.sys.cmd "timeit abc")  !- type
+(.sys.cmd "timeit 1.5")  -- 1
+;; ^ "1.5" parses up to the dot → 1, profile turns on; the trailing
+;; ".5" is not an error (the parser stops at first non-digit and
+;; returns what it has).  Reset state for any later toggle tests.
+(.sys.timeit 0)          -- 0
+
+;; ────────────── h_timeit: no-arg toggle (arg_is_null branch, line 100) ──
+;; Force off, then toggle: state flips on and back off.  Final value
+;; is observable through the return code.
+(.sys.timeit 0)   -- 0
+(.sys.timeit)     -- 1
+(.sys.timeit)     -- 0
+
+;; ────────────── ray_sys_timeit_fn: variadic with extra args ignored ──────
+;; The variadic adapter (line 353) only forwards the first arg.
+(.sys.timeit 1) -- 1
+(.sys.timeit 0) -- 0
+
+;; ────────────── h_env: count > 0 + variadic with arg branch ──────────────
+;; ray_sys_env_fn takes optional arg via variadic adapter (line 356);
+;; arg is ignored by h_env (line 164).  Both call shapes work.
+(> (.sys.env) 0)    -- true
+(> (.sys.env 1) 0)  -- true
+(> (.sys.env "x") 0) -- true
+
+;; ────────────── h_listen: domain / type / nyi branches ──────────────
+;; The test runtime (test/main.c) does not register a poll instance,
+;; so any port that passes the range check hits the "nyi: no main
+;; event loop attached" branch (line 133).  Out-of-range ports fail
+;; earlier with `domain` (line 130); non-numeric arg fails earliest
+;; with `type` (line 129).
+(.sys.listen 0)       !- domain
+(.sys.listen -1)      !- domain
+(.sys.listen 65536)   !- domain
+(.sys.listen 99999)   !- domain
+(.sys.listen 8080)    !- nyi
+(.sys.listen 1)       !- nyi
+(.sys.listen 65535)   !- nyi
+;; String coerces through arg_as_i64; numeric string → nyi, junk → type.
+(.sys.listen "8080")  !- nyi
+(.sys.listen "abc")   !- type
+
+;; Same surface via .sys.cmd string dispatch — exercises the dispatcher
+;; path through to h_listen, which is a separate code path from the
+;; direct ray_sys_listen_fn entry above.
+(.sys.cmd "listen 8080")  !- nyi
+(.sys.cmd "listen -1")    !- domain
+(.sys.cmd "listen 65536") !- domain
+
+;; ────────────── ray_syscmd_lookup: alias path ──────────────
+;; Lookup walks both `name` and `alias` slots (lines 244-247).
+;; `?` is the alias for help; `t` for timeit.  REPL-only verbs
+;; should still 404 with the domain message, proving the alias
+;; matched and the REPL-only flag was honoured.
+(.sys.cmd "?")     !- domain
+(.sys.cmd "t 1")   -- 1
+(.sys.cmd "t 0")   -- 0
+;; Unknown alias / typo'd name falls through to the shell fallback.
+;; The shell will not have an "xyznosuchcmd" binary, so the host
+;; shell prints to stderr and returns a nonzero exit code.  We
+;; assert only that it's not 0.
+(== 0 (.sys.cmd "xyznosuchcmd_rfl_cov 2>/dev/null")) -- false
+
+;; ────────────── ray_syscmd_dispatch: leading-whitespace / tab trim ──────
+;; The leading-whitespace skip (line 274) accepts tabs as well as
+;; spaces.  Embedded literal tab via concat — the runtime sees the
+;; tab byte and skips it before tokenising.
+(.sys.cmd " timeit 1") -- 1
+(.sys.cmd " timeit 0") -- 0
+
+;; Whitespace-only / empty → "empty command" (line 275).  Tab-only
+;; covers the second whitespace char.
+(.sys.cmd "")     !- domain
+(.sys.cmd " ")    !- domain
+(.sys.cmd "  ")   !- domain
+
+;; ────────────── ray_syscmd_dispatch: shell fallback ──────────────
+;; Unknown command + allow_shell=true (the .sys.cmd path) routes to
+;; system(2) (lines 291-301).  Exit code is the shell's WEXITSTATUS-
+;; encoded value; pin only the success / failure split, not exact
+;; numbers (those depend on libc and shell).
+(.sys.cmd "true")  -- 0
+(== 0 (.sys.cmd "false")) -- false
+;; Multi-token shell command verbatim through to system(): proves the
+;; full original buffer (not just the head word) reached system().
+(.sys.cmd "test 1 -eq 1") -- 0
+(== 0 (.sys.cmd "test 1 -eq 2")) -- false
+
+;; ────────────── REPL-only verbs rejected from non-REPL ──────────────
+;; clear/help/q/quit carry RAY_SYSCMD_REPL_ONLY.  Through .sys.cmd we
+;; get an explicit `domain` (line 309-310) instead of a silent no-op.
+(.sys.cmd "clear") !- domain
+(.sys.cmd "help")  !- domain
+(.sys.cmd "?")     !- domain
+(.sys.cmd "quit")  !- domain
+;; Note: bare `q` is an alias of `quit` — also REPL-only.  We do NOT
+;; assert (.sys.cmd "q") here because if the dispatcher were ever
+;; broken to bypass the REPL guard, it would call exit(0) and silently
+;; pass the test.  Better to leave that probe to the C-side tests.
+
+;; ────────────── ray_syscmd_string_dispatch_fn: non-string guard ──────────
+;; The Rayfall surface check (line 328) rejects non-string args
+;; cleanly before the dispatcher ever sees them.
+(.sys.cmd 42)     !- type
+(.sys.cmd 1.5)    !- type
+(.sys.cmd 'foo)   !- type
+(.sys.cmd [1 2])  !- type
+
+;; ────────────── invoke_by_name: REPL-only rejection on direct call ──────
+;; Direct .sys.<name> for any REPL-only verb would also error
+;; (line 339-340), but the only REPL-only verbs in the table are
+;; help/clear/q/quit and none of them are bound flat under .sys.<name>.
+;; Best-effort: confirm the registered .sys.* surface excludes them.
+;; (We leave this as documentation — the registry in eval.c registers
+;; only timeit/listen/env/cmd; clear/help/q have no .sys.* binding.)
+
+;; ────────────── end: cleanup ──────────────
+(.sys.cmd "rm -f /tmp/rfl_syscmd_cov*") -- 0

--- a/test/rfl/table/select.rfl
+++ b/test/rfl/table/select.rfl
@@ -28,6 +28,21 @@
 (sum (at (select {s: (sum size) from: trades by: sym}) 's)) -- 1240
 (sum (at (select {s: (sum size) from: trades by: sym where: (== sym 'AAPL)}) 's)) -- 460
 
+;; ── scalar aggregation (no `by:`) must honour `where:` — the lazy WHERE
+;; rowsel is consumed by exec_reduction over the column vector.  Two-step
+;; (filter then sum) and single-step (sum inside select) must agree.
+(at (at (select {s: (sum size) from: trades where: (== sym 'AAPL)}) 's) 0) -- 460
+(at (at (select {s: (sum size) from: trades where: (> price 200)}) 's) 0) -- 780
+(at (at (select {c: (count size) from: trades where: (== sym 'AAPL)}) 'c) 0) -- 4
+(at (at (select {m: (max price) from: trades where: (== sym 'GOOG)}) 'm) 0) -- 2810.0
+(at (at (select {m: (min size) from: trades where: (> price 200.0)}) 'm) 0) -- 40
+(at (at (select {a: (avg size) from: trades where: (== sym 'AAPL)}) 'a) 0) -- 115.0
+
+;; Larger fixture (>= RAY_PARALLEL_THRESHOLD) to exercise the parallel
+;; reduction worker path of exec_reduction.
+(set big-T (table [v] (list (til 100000))))
+(at (at (select {s: (sum v) from: big-T where: (>= v 50000)}) 's) 0) -- 3749975000
+
 ;; ────────────── 15-row fixture (sym, price, size, tms, d) ──────────────
 (set trades-15 (table [sym price size tms d] (list ['AAPL 'GOOG 'MSFT 'AAPL 'GOOG 'MSFT 'AAPL 'GOOG 'MSFT 'AMZN 'TSLA 'AAPL 'GOOG 'MSFT 'TSLA] [150.0 2800.0 310.0 151.5 2795.0 309.0 152.0 2810.0 311.0 3300.0 700.0 150.5 2805.0 312.0 702.5] [100 50 200 150 40 250 120 60 180 75 90 110 55 190 95] [09:30:15.000 09:30:15.100 09:30:15.200 09:30:15.300 09:30:15.400 09:30:15.500 09:30:15.600 09:30:15.700 09:30:15.800 09:30:15.900 09:30:16.000 09:30:16.100 09:30:16.200 09:30:16.300 09:30:16.400] [2024.01.15 2024.01.15 2024.01.15 2024.01.15 2024.01.15 2024.01.16 2024.01.16 2024.01.16 2024.01.16 2024.01.16 2024.01.17 2024.01.17 2024.01.17 2024.01.17 2024.01.17])))
 


### PR DESCRIPTION
## Summary

Second batch of the coverage push. **Two halves:**

1. **6 new test files** (~1500 lines) extending coverage on red-zone files identified after pass-1 landed.
2. **7 source bug fixes** surfaced *by* the new tests — first/last parallel-merge work-stealing, scalar agg ignoring \`where:\`, dict LIST-keys remove, dict empty-concat, broadcast_scalar null propagation, plus libc-malloc policy violations in syscmd/numparse/system.

## Coverage delta

| File | Before | After |
|------|--------|-------|
| \`src/ops/group.c\` | 54% | **70%** |
| \`src/ops/idxop.c\` | 63% | **85%** |
| \`src/table/dict.c\` | 44% | **61%** |
| \`src/lang/syscmd.c\` | 57% | 60% |
| \`src/ops/embedding.c\` | 60% | 63% |
| \`src/ops/exec.c\` | 54% | 56% |
| \`src/core/numparse.c\` | — | **88%** (touched by malloc fix) |
| \`src/ops/system.c\` | — | **84%** (touched by malloc fix) |
| **TOTAL line coverage** | ~64.5% | **68.84%** |

\`exec.c\`/\`filter.c\`/\`dump.c\`/\`embedding.c\` have a structural ceiling — large portions are orphan/unreachable from rfl. Documented offline in \`dead_code_report.md\` (not committed; for design discussion).

## Source bugs fixed

### Heap-corruption / correctness

1. **first()/last() in \`select {... by:}\` returned wrong values for nrows ≥ 65536** (commits \`ce9be101\` DA path, \`4b3f7190\` HT/radix path). \`ray_pool_dispatch\` is work-stealing; per-worker accumulators / radix entries had no row-index tracking, so the merge picked by worker_id rather than source row. Fix: per-slot \`first_row[]\`/\`last_row[]\` + row-index-aware merge.

2. **Scalar agg ignored \`where:\`** (\`ce9be101\`). \`select {s: (sum v) from: T where: P}\` returned full-table sum instead of filtered. Fix: thread an optional \`idx\` param through \`reduce_range\`/\`REDUCE_LOOP_*\`/\`par_reduce_fn\` and materialise \`g->selection\` via \`ray_rowsel_to_indices\`.

3. **\`broadcast_scalar\` discarded null bit** (\`c1b089ad\`). Scalar VAR/STDDEV with cnt=1 returned \`0.0\` instead of \`0Nf\`; \`exec_reduction\` correctly produced the typed-null atom but \`broadcast_scalar\` only memcpy'd the value, never the nullmap. Fix: stamp every output row null when source atom is null.

4. **\`ray_dict_remove\` failed on LIST-keyed dicts** (\`810a9cfb\`). Heterogeneous \`{a: 1 \"b\": 2}\` has \`keys->type == RAY_LIST\`; the else-arm called \`ray_vec_new(0, ...)\` which rejects type≤0. Fix: add LIST-keys branch.

5. **Empty-dict concat type-mismatch** (\`810a9cfb\`). \`(concat (dict [] []) (dict [a b] [1 2]))\` errored \"type\" because empty \`(dict [] [])\` defaults keys to RAY_I64. Fix: in \`ray_dict_upsert\`, adopt the incoming key type when target is empty.

### Project-policy violations (libc malloc/free)

6. **\`ray_syscmd_dispatch\` shell fallback** (\`af13c995\`) — \`malloc(len+1)\` for cmd copy → stack buffer + \`ray_alloc\` fallback.
7. **\`ray_parse_f64\` strtod overflow** (\`198671b4\`) — same pattern, same fix.
8. **\`ray_os_list_fn\`** (\`59195ac1\`) — \`realloc\`/\`malloc\`/\`free\` × 8 for names array → \`ray_sys_realloc\`/\`ray_sys_strdup\`/\`ray_sys_free\` (mirrors \`collect_part_dirs\` idiom in \`store/part.c\`).

## Test plan

- [x] \`make test\` — 991/992 pass (1 skipped, 0 failed)
- [x] All 7 fix-commits include reduced repros that turn green after the fix
- [x] Pre-fix bug repros documented in commit messages
- [x] No regression in existing tests (rebased on master \`e422086b\`)

## Out of scope

Two source observations still open (parked, will revisit):
- DA scalar (n_keys==0) parallel path has the same first/last work-stealing pattern, currently dead code.
- HT path STR-key rejection (\`group.c:3186\`) may be partially shadowed by an eval-level fallback — need to confirm whether STR by: works through a different route or actually hits the nyi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)