### PR TITLE
test+fix: coverage pass 4-5 — opt/exec/graph/datalog + 2 fold-path bug fixes

### DIFF
--- a/src/mem/heap.c
+++ b/src/mem/heap.c
@@ -1007,7 +1007,13 @@ void ray_free(ray_t* v) {
 ray_t* ray_alloc_copy(ray_t* v) {
     if (!v || RAY_IS_ERR(v)) return NULL;
     size_t data_size;
-    if (ray_is_atom(v)) {
+    if (v->attrs & RAY_ATTR_SLICE) {
+        /* Slice blocks are header-only views; their .len reflects the
+         * slice extent on the parent, not their own storage.  A naive
+         * len*esz would overrun the 32-byte header.  ray_retain_owned_refs
+         * then bumps slice_parent's rc, keeping the view valid. */
+        data_size = 0;
+    } else if (ray_is_atom(v)) {
         data_size = 0;
     } else if (v->type == RAY_TABLE || v->type == RAY_DICT) {
         data_size = 2 * sizeof(ray_t*);
@@ -1070,7 +1076,9 @@ ray_t* ray_scratch_realloc(ray_t* v, size_t new_data_size) {
     if (!new_v) return NULL;
     if (v && !RAY_IS_ERR(v)) {
         size_t old_data;
-        if (ray_is_atom(v))
+        if (v->attrs & RAY_ATTR_SLICE)
+            old_data = 0;  /* slice blocks are header-only — no own storage */
+        else if (ray_is_atom(v))
             old_data = 0;
         else if (v->type == RAY_LIST) {
             if (v->len < 0) { old_data = 0; }

--- a/src/ops/dump.c
+++ b/src/ops/dump.c
@@ -157,15 +157,24 @@ static void dump_node(FILE* f, ray_graph_t* g, ray_op_t* node, int depth) {
     switch (node->opcode) {
         case OP_SCAN:
             if (ext) {
+                /* ray_sym_str returns a STR atom; SSO ("len ≤ 7") stores the
+                 * bytes inline in s->sdata — `ray_data(s)` would return
+                 * garbage for those.  Use the public ray_str_ptr/ray_str_len
+                 * accessors which handle both SSO and heap-backed cases. */
                 ray_t* s = ray_sym_str(ext->sym);
                 if (s)
-                    fprintf(f, "(%.*s)", (int)s->len, (char*)ray_data(s));
+                    fprintf(f, "(%.*s)", (int)ray_str_len(s), ray_str_ptr(s));
             }
             break;
         case OP_CONST:
             if (ext && ext->literal) {
                 ray_t* lit = ext->literal;
-                switch (lit->type) {
+                /* Atom types are stored negated (e.g. lit->type == -RAY_I64);
+                 * vector / table types are positive.  Fold the sign so the
+                 * arms match either form — without this, every atom literal
+                 * fell through to the "(?)" default.  */
+                int8_t kind = lit->type < 0 ? -lit->type : lit->type;
+                switch (kind) {
                     case RAY_I64:  fprintf(f, "(%lld)", (long long)lit->i64); break;
                     case RAY_F64:  fprintf(f, "(%.6g)", lit->f64); break;
                     case RAY_BOOL: fprintf(f, "(%s)", lit->i64 ? "true" : "false"); break;

--- a/src/ops/graph.c
+++ b/src/ops/graph.c
@@ -382,10 +382,14 @@ ray_op_t* ray_const_atom(ray_graph_t* g, ray_t* atom) {
 
     ext->base.opcode = OP_CONST;
     ext->base.arity = 0;
-    /* Atom types are stored negated (-RAY_I64 etc); the executor
-     * does not rely on out_type for OP_CONST dispatch, but we keep
-     * it consistent with the source atom. */
-    ext->base.out_type = atom->type;
+    /* Atom types are stored negated (-RAY_I64 etc); normalise to the
+     * positive type tag so downstream passes (promote(), fold_binary_const's
+     * out_type switch) see the same values used by ray_const_i64 /
+     * ray_const_f64 / ray_const_bool / ray_const_vec.  Without this, the
+     * I32/DATE/TIME arm of fold_binary_const (opt.c:454) is dead for any
+     * atom-typed const built via this constructor (e.g. DATE/TIME literals
+     * from rfl). */
+    ext->base.out_type = atom->type < 0 ? (int8_t)(-(int)atom->type) : atom->type;
     ext->base.est_rows = 1;
     ext->literal = atom;
     ray_retain(atom);

--- a/src/ops/window.c
+++ b/src/ops/window.c
@@ -595,8 +595,11 @@ static void pkey_gather_fn(void* arg, uint32_t wid,
                 out[i] = (uint64_t)ray_read_sym(pkd, sidx[i], pk->type, pk->attrs);
         } else if (pk->type == RAY_I32 || pk->type == RAY_DATE || pk->type == RAY_TIME) {
             const int32_t* src = (const int32_t*)pkd;
+            /* Map signed [INT32_MIN..INT32_MAX] to unsigned [0..UINT32_MAX]
+             * by flipping the sign bit; computed as unsigned to avoid
+             * signed-integer-overflow UB on positive minus INT32_MIN. */
             for (int64_t i = start; i < end; i++)
-                out[i] = (uint64_t)((uint32_t)(src[sidx[i]] - INT32_MIN));
+                out[i] = (uint64_t)((uint32_t)src[sidx[i]] ^ 0x80000000u);
         } else {
             const uint64_t* src = (const uint64_t*)pkd;
             for (int64_t i = start; i < end; i++)
@@ -612,7 +615,8 @@ static void pkey_gather_fn(void* arg, uint32_t wid,
                 if (RAY_IS_SYM(col->type))
                     key = (key << 32) | (uint32_t)ray_read_sym(d, r, col->type, col->attrs);
                 else if (col->type == RAY_I32 || col->type == RAY_DATE || col->type == RAY_TIME)
-                    key = (key << 32) | (uint32_t)(((const int32_t*)d)[r] - INT32_MIN);
+                    /* Sign-bit flip: avoids signed-integer-overflow UB. */
+                    key = (key << 32) | ((uint32_t)((const int32_t*)d)[r] ^ 0x80000000u);
                 else {
                     key = (key << 32) | (uint32_t)((const uint64_t*)d)[r];
                 }

--- a/test/main.c
+++ b/test/main.c
@@ -100,12 +100,15 @@ extern const test_entry_t cow_entries[];
 extern const test_entry_t csr_entries[];
 extern const test_entry_t csv_entries[];
 extern const test_entry_t datalog_entries[];
+extern const test_entry_t dict_entries[];
+extern const test_entry_t dump_entries[];
 extern const test_entry_t embedding_entries[];
 extern const test_entry_t exec_entries[];
 extern const test_entry_t format_entries[];
 extern const test_entry_t fvec_entries[];
 extern const test_entry_t graph_entries[];
 extern const test_entry_t graph_builtin_entries[];
+extern const test_entry_t heap_entries[];
 extern const test_entry_t index_entries[];
 extern const test_entry_t lang_entries[];
 extern const test_entry_t link_entries[];
@@ -129,12 +132,15 @@ extern const test_entry_t sys_entries[];
 extern const test_entry_t table_entries[];
 extern const test_entry_t types_entries[];
 extern const test_entry_t vec_entries[];
+extern const test_entry_t window_entries[];
 
 static const test_entry_t* const compiled_groups[] = {
     err_entries,      arena_entries,    atom_entries,     audit_entries,
     block_entries,    buddy_entries,    cow_entries,      csr_entries,
-    csv_entries,      datalog_entries,  embedding_entries, exec_entries,
+    csv_entries,      datalog_entries,  dict_entries,     dump_entries,
+    embedding_entries, exec_entries,
     format_entries,   fvec_entries,     graph_entries,    graph_builtin_entries,
+    heap_entries,
     index_entries,
     lang_entries,     link_entries,
     lftj_entries,     list_entries,     meta_entries,     morsel_entries,
@@ -143,7 +149,7 @@ static const test_entry_t* const compiled_groups[] = {
     pool_entries,
     rowsel_entries,   runtime_entries,  sel_entries,      store_entries,
     str_entries,      sym_entries,      sys_entries,      table_entries,
-    types_entries,    vec_entries,
+    types_entries,    vec_entries,      window_entries,
     NULL,
 };
 

--- a/test/main.c
+++ b/test/main.c
@@ -105,6 +105,7 @@ extern const test_entry_t exec_entries[];
 extern const test_entry_t format_entries[];
 extern const test_entry_t fvec_entries[];
 extern const test_entry_t graph_entries[];
+extern const test_entry_t graph_builtin_entries[];
 extern const test_entry_t index_entries[];
 extern const test_entry_t lang_entries[];
 extern const test_entry_t link_entries[];
@@ -114,6 +115,7 @@ extern const test_entry_t meta_entries[];
 extern const test_entry_t morsel_entries[];
 extern const test_entry_t numparse_entries[];
 extern const test_entry_t opt_entries[];
+extern const test_entry_t partition_exec_entries[];
 extern const test_entry_t pipe_entries[];
 extern const test_entry_t platform_entries[];
 extern const test_entry_t pool_entries[];
@@ -132,10 +134,12 @@ static const test_entry_t* const compiled_groups[] = {
     err_entries,      arena_entries,    atom_entries,     audit_entries,
     block_entries,    buddy_entries,    cow_entries,      csr_entries,
     csv_entries,      datalog_entries,  embedding_entries, exec_entries,
-    format_entries,   fvec_entries,     graph_entries,    index_entries,
+    format_entries,   fvec_entries,     graph_entries,    graph_builtin_entries,
+    index_entries,
     lang_entries,     link_entries,
     lftj_entries,     list_entries,     meta_entries,     morsel_entries,
-    numparse_entries, opt_entries,      pipe_entries,     platform_entries,
+    numparse_entries, opt_entries,      partition_exec_entries,
+    pipe_entries,     platform_entries,
     pool_entries,
     rowsel_entries,   runtime_entries,  sel_entries,      store_entries,
     str_entries,      sym_entries,      sys_entries,      table_entries,

--- a/test/rfl/graph/graph_advanced.rfl
+++ b/test/rfl/graph/graph_advanced.rfl
@@ -1,0 +1,253 @@
+;; Coverage tests for the 7 .graph.* algorithms NOT exercised by
+;; test/rfl/graph/graph_basic.rfl: random-walk, k-shortest, var-expand,
+;; betweenness, closeness, louvain.
+;;
+;; (.graph.astar is registered in src/ops/graph_builtin.c only as exec_astar;
+;;  there is no rfl wrapper in eval.c lines 2400-2420, so we cannot exercise
+;;  it from here.  See SKIPPED block at bottom.)
+;;
+;; Two fixtures:
+;;
+;;   G  — the same 6-node weighted DAG used by graph_basic.rfl, for the
+;;        algorithms whose result is hand-computable (random-walk,
+;;        k-shortest, var-expand).
+;;
+;;   P  — a 4-node directed path 0->1->2->3 with unit weights.  The
+;;        traverse-side closeness/betweenness/louvain implementations
+;;        treat the graph as undirected (they read both fwd and rev CSRs),
+;;        so on this fixture the analytic values are exact:
+;;          closeness  : [0.5, 0.75, 0.75, 0.5]
+;;          betweenness: [0,   2,    2,    0  ]
+;;        Louvain on a 4-node path with 3 unit edges puts every node
+;;        in a single community (modularity peaks at one cluster for
+;;        a connected graph this small).
+
+;; Cleanup any leftover state.
+(.sys.exec "rm -rf /tmp/rfl_graph_advanced")
+
+;; ====================================================================
+;; Fixture G: 6-node weighted DAG (matches graph_basic.rfl).
+;;   edges: 0->1 w=1, 0->2 w=4, 1->2 w=2, 1->3 w=5,
+;;          2->3 w=1, 2->4 w=3, 3->5 w=2, 4->5 w=1
+;; ====================================================================
+(set Edges (table [src dst w] (list [0 0 1 1 2 2 3 4] [1 2 2 3 3 4 5 5] [1.0 4.0 2.0 5.0 1.0 3.0 2.0 1.0])))
+(set G (.graph.build Edges 'src 'dst 'w))
+
+;; ====================================================================
+;; Fixture P: 4-node directed path 0->1->2->3 with unit weights.
+;; ====================================================================
+(set PEdges (table [src dst w] (list [0 1 2] [1 2 3] [1.0 1.0 1.0])))
+(set P (.graph.build PEdges 'src 'dst 'w))
+
+;; ====================================================================
+;; (.graph.random-walk h src [walk-len])
+;; -- result schema: {_step, _node}, walk-len+1 rows max (or fewer if
+;;    a dead-end node is hit).  The PRNG is xorshift64 seeded from
+;;    src_id, so results are deterministic for a given start node.
+;; ====================================================================
+
+;; Default walk-len is 10 -> 11 rows.  Node 0 has out-edges so the walk
+;; never dead-ends within depth 10 on this DAG (every interior node has
+;; at least one out-edge, only node 5 is a sink).  The walk may still
+;; terminate early when it reaches 5.
+(set Rw (.graph.random-walk G 0))
+(>= (count Rw) 1)                                -- true
+(<= (count Rw) 11)                               -- true
+;; Step column is 0..count-1.
+(first (at Rw '_step))                           -- 0
+(first (at Rw '_node))                           -- 0
+;; All nodes in the walk are valid IDs in [0..5].
+(>= (min (at Rw '_node)) 0)                      -- true
+(<= (max (at Rw '_node)) 5)                      -- true
+
+;; Custom walk-len; result has at most walk-len+1 rows.
+(set Rw3 (.graph.random-walk G 0 3))
+(<= (count Rw3) 4)                               -- true
+(>= (count Rw3) 1)                               -- true
+(first (at Rw3 '_node))                          -- 0
+
+;; Starting from a sink (node 5) immediately dead-ends -> 1 row only.
+(set RwSink (.graph.random-walk G 5 10))
+(count RwSink)                                   -- 1
+(first (at RwSink '_node))                       -- 5
+
+;; ====================================================================
+;; (.graph.k-shortest h src dst k)
+;; -- result: {_path_id, _node, _dist}.
+;;    For each path 0..k-1 emits len(path) rows.
+;;    Hand-computed shortest paths from 0 to 3 on G:
+;;      P0: 0->1->2->3, dist=1+2+1=4
+;;      P1: 0->2->3,    dist=4+1=5
+;;      P2: 0->1->3,    dist=1+5=6
+;; ====================================================================
+
+(set K (.graph.k-shortest G 0 3 3))
+;; Three paths emitted -> path_id values are {0,1,2}.
+(count (distinct (at K '_path_id)))              -- 3
+(min (at K '_path_id))                           -- 0
+(max (at K '_path_id))                           -- 2
+;; Every emitted node is in [0..5].
+(>= (min (at K '_node)) 0)                       -- true
+(<= (max (at K '_node)) 5)                       -- true
+
+;; All k=2 results from 0 to 5: shortest is 6 (0->1->2->3->5).
+(set K25 (.graph.k-shortest G 0 5 2))
+(count (distinct (at K25 '_path_id)))            -- 2
+
+;; Disconnected request: k-shortest from a sink to a source must return
+;; an empty 3-column result table (no paths possible in the DAG).
+(set Knone (.graph.k-shortest G 5 0 3))
+(count Knone)                                    -- 0
+
+;; ====================================================================
+;; (.graph.var-expand h src min max [direction] [track-path])
+;; -- result: {_start, _end, _depth}.  BFS from src with depth in
+;;    [min..max].  The visited bitmap is per-source so each end node
+;;    appears at most once at its first-discovered depth.
+;;
+;; From node 0 on G, BFS levels:
+;;   d=1: {1, 2}
+;;   d=2: {3, 4}
+;;   d=3: {5}
+;; ====================================================================
+
+;; min=1, max=3 -> all reachable: 2+2+1 = 5 rows.
+(set Ve13 (.graph.var-expand G 0 1 3))
+(count Ve13)                                     -- 5
+;; All start values are 0 (single source).
+(count (distinct (at Ve13 '_start)))             -- 1
+(first (at Ve13 '_start))                        -- 0
+;; End values cover {1,2,3,4,5} -> 5 distinct.
+(count (distinct (at Ve13 '_end)))               -- 5
+;; Depth column ranges over [1..3].
+(min (at Ve13 '_depth))                          -- 1
+(max (at Ve13 '_depth))                          -- 3
+
+;; min=1, max=2 truncates to first 4 nodes (1,2,3,4).
+(count (.graph.var-expand G 0 1 2))              -- 4
+
+;; min=2, max=2 keeps only level-2 emissions -> 2 rows (3 and 4).
+(set Ve22 (.graph.var-expand G 0 2 2))
+(count Ve22)                                     -- 2
+(min (at Ve22 '_depth))                          -- 2
+(max (at Ve22 '_depth))                          -- 2
+
+;; Reverse direction (1) from sink node 5: walks back via reverse CSR.
+;; Reverse edges into 5: 3->5, 4->5.  Continuing back: 3 from {1,2};
+;; 4 from {2}; 2 from {0,1}; 1 from {0}; 0 from nowhere.
+;; Per-source visited bitmap means each predecessor reached at first depth.
+;; d=1: {3,4} (2 rows).
+(set VeRev (.graph.var-expand G 5 1 1 1))
+(count VeRev)                                    -- 2
+
+;; track-path = true accepts the boolean form without changing schema
+;; (the underlying op records paths internally; the result table is the
+;; same {_start,_end,_depth} shape per the wrapper).
+(>= (count (.graph.var-expand G 0 1 2 0 true)) 4) -- true
+
+;; ====================================================================
+;; (.graph.betweenness h [sample])
+;; -- result: {_node, _centrality}, n_nodes rows.  Brandes algorithm,
+;;    treats the graph as undirected (reads fwd+rev CSRs).
+;;
+;; On the path 0-1-2-3 hand-computed unnormalised values are
+;;   [0, 2, 2, 0].
+;; ====================================================================
+
+(set B (.graph.betweenness P))
+(count B)                                        -- 4
+(count (distinct (at B '_node)))                 -- 4
+(min (at B '_node))                              -- 0
+(max (at B '_node))                              -- 3
+;; Endpoints (0 and 3) have zero betweenness on a path graph.
+(set B_node (at B '_node))
+(set B_cent (at B '_centrality))
+(at B_cent (at (where (== B_node 0)) 0))         -- 0.0
+(at B_cent (at (where (== B_node 3)) 0))         -- 0.0
+;; Interior nodes 1 and 2 each lie on two unordered shortest pairs.
+(at B_cent (at (where (== B_node 1)) 0))         -- 2.0
+(at B_cent (at (where (== B_node 2)) 0))         -- 2.0
+
+;; Sampled betweenness: still emits one row per node, but uses an
+;; approximate scaling factor.  We just check the count + that all
+;; emitted values are non-negative.
+(set Bs (.graph.betweenness P 2))
+(count Bs)                                       -- 4
+(>= (min (at Bs '_centrality)) 0.0)              -- true
+
+;; ====================================================================
+;; (.graph.closeness h [sample])
+;; -- result: {_node, _centrality}, n_nodes rows.  Treats the graph
+;;    as undirected.
+;;
+;; On path 0-1-2-3, closeness = reachable / sum_dist:
+;;   closeness[0] = 3/(1+2+3) = 0.5
+;;   closeness[1] = 3/(1+1+2) = 0.75
+;;   closeness[2] = 0.75
+;;   closeness[3] = 0.5
+;; ====================================================================
+
+(set C (.graph.closeness P))
+(count C)                                        -- 4
+(set C_node (at C '_node))
+(set C_cent (at C '_centrality))
+(at C_cent (at (where (== C_node 0)) 0))         -- 0.5
+(at C_cent (at (where (== C_node 1)) 0))         -- 0.75
+(at C_cent (at (where (== C_node 2)) 0))         -- 0.75
+(at C_cent (at (where (== C_node 3)) 0))         -- 0.5
+
+;; Sample = 2 returns a result with at most n_sources rows; on the
+;; sampled-path branch the implementation always sets n_out = n_sources.
+;; All emitted centralities are non-negative.
+(set Cs (.graph.closeness P 2))
+(>= (count Cs) 1)                                -- true
+(>= (min (at Cs '_centrality)) 0.0)              -- true
+
+;; ====================================================================
+;; (.graph.louvain h [max-iter])
+;; -- result: {_node, _community}, n_nodes rows.  Phase-1 modularity
+;;    optimisation.  Treats the graph as undirected.
+;;
+;; On a 4-node connected path, Louvain converges to a single community
+;; (or splits into two halves -- the exact number is implementation-
+;; defined and depends on the iteration order).  Verify only that
+;; community IDs are normalised to a contiguous [0..k-1] range and
+;; cover every node.
+;; ====================================================================
+
+(set L (.graph.louvain P))
+(count L)                                        -- 4
+(count (distinct (at L '_node)))                 -- 4
+(min (at L '_node))                              -- 0
+(max (at L '_node))                              -- 3
+;; Community IDs are normalised to start at 0.
+(min (at L '_community))                         -- 0
+;; Each community ID is in [0..n-1] where n=4.
+(<= (max (at L '_community)) 3)                  -- true
+
+;; max-iter argument exercises the optional-arg branch of the wrapper.
+(set L1 (.graph.louvain P 5))
+(count L1)                                       -- 4
+(min (at L1 '_community))                        -- 0
+
+;; Louvain on the DAG fixture (G): every node should be assigned a
+;; community ID in [0..5].
+(set Lg (.graph.louvain G))
+(count Lg)                                       -- 6
+(>= (min (at Lg '_community)) 0)                 -- true
+(<= (max (at Lg '_community)) 5)                 -- true
+
+;; ====================================================================
+;; SKIPPED: (.graph.astar h src dst ...)
+;; -- exec_astar exists in src/ops/traverse.c (line 2204) but is NOT
+;;    exposed via any builtin in src/ops/graph_builtin.c, and no
+;;    register_vary(".graph.astar", ...) call exists in src/lang/eval.c.
+;;    Reachability check fails: the algorithm is unreachable from rfl
+;;    at this point, so writing a test would be a syntax error rather
+;;    than coverage.  Re-evaluate when the wrapper is added.
+;; ====================================================================
+
+;; Cleanup: free both graph handles and any disk state.
+(.graph.free P)
+(.graph.free G)
+(.sys.exec "rm -rf /tmp/rfl_graph_advanced")

--- a/test/rfl/ops/exec_advanced.rfl
+++ b/test/rfl/ops/exec_advanced.rfl
@@ -1,0 +1,139 @@
+;; Pass 4 — additional coverage for src/ops/exec.c.
+;;
+;; This file extends test/rfl/ops/exec_coverage.rfl.  It targets
+;; USEFUL-WORK paths inside exec.c that the previous coverage pass and
+;; sibling fixtures (query_coverage.rfl, filter.rfl, strop/like.rfl,
+;; integration/sort_radix_boundary.rfl) do not yet drive.
+;;
+;; Hit (with rationale):
+;;   - partitioned_gather phases (exec.c:275-473): single-key sort over
+;;     >= PG_MIN (=131072) rows.  No existing test crosses this size for
+;;     the OP_SORT path.  Phase 1 (pg_hist_fn), phase 2 (pg_route_fn),
+;;     phase 3 (pg_block_fn) all run; pg_block_fn covers e==4 and e==8
+;;     element-size arms when the table mixes I32 and I64 columns.
+;;   - OP_TRIM in select projection (exec.c:1548): no rfl fixture
+;;     currently invokes (trim col) — string.c's exec_string_unary
+;;     trim arm is reached for the first time.
+;;   - OP_HEAD(FILTER) early-termination over a 150k-row source —
+;;     exec.c:1301-1336.  Existing tests probe this path with 20-row
+;;     inputs; the large fixture exercises the morsel loop in
+;;     exec_filter_head with multiple morsel pages.
+;;   - OP_FILTER chained-refine on a STR-equality predicate
+;;     (exec.c:1059-1072 with non-NULL g->selection).  Existing
+;;     refines use I64/F64/SYM types; STR routes through a different
+;;     compare arm in ray_rowsel_refine.
+;;
+;; Skipped (per Pass 4 brief):
+;;   - materialize_mapcommon* family (exec.c:35-152) — orphan; needs
+;;     disk-backed parted/MAPCOMMON tables.
+;;   - build_segment_table / partition-streaming loop (exec.c:1839-2247)
+;;     — same orphan dependency on parted columns.
+;;   - OP_WINDOW (exec.c:1229) — no rfl-reachable builder for
+;;     ray_window_op.
+;;   - All graph-algo OPs (OP_LOUVAIN, OP_PAGERANK, OP_DIJKSTRA,
+;;     OP_DFS, OP_TOPSORT, OP_BETWEENNESS, OP_CLOSENESS, OP_MST,
+;;     OP_RANDOM_WALK, OP_ASTAR, OP_K_SHORTEST, OP_ANN_RERANK,
+;;     OP_KNN_RERANK, OP_DEGREE_CENT, OP_CLUSTER_COEFF, OP_EXPAND,
+;;     OP_VAR_EXPAND, OP_SHORTEST_PATH, OP_WCO_JOIN,
+;;     OP_CONNECTED_COMP) — graph-builder-only; not produced by
+;;     ordinary `select` queries.
+;;   - exec_node cancellation paths (ray_interrupted, pool->cancelled)
+;;     and every `return ray_error(...)` — error guards by spec.
+;;   - HEAD/TAIL on a vector (not table) input (exec.c:1410-1421,
+;;     1521-1533): OP_HEAD/OP_TAIL are emitted only via
+;;     `select { take: }`, which always feeds a TABLE input.
+;;   - OP_FILTER eager-vector path (exec.c:1075-1079): ray_filter is
+;;     only constructed by `select where:` whose input is a TABLE,
+;;     and the predicate is always BOOL after compile-time check.
+;;
+;; OP_EXTRACT (exec.c:1564), OP_DATE_TRUNC (exec.c:1568), OP_REPLACE
+;; (exec.c:1557), OP_CONCAT variadic (exec.c:1560), bracket-class
+;; OP_LIKE (exec.c:1540) are intentionally NOT duplicated — already
+;; covered in query_coverage.rfl / strop/like.rfl.
+
+(.sys.exec "rm -rf /tmp/rfl_exec_advanced")
+
+;; ====================================================================
+;; OP_TRIM — exec.c:1548 (OP_UPPER / OP_LOWER / OP_TRIM share
+;; exec_string_unary).  No existing fixture invokes (trim ...).
+;; ====================================================================
+(set TTr (table [s] (list ["  hello  " "  world " "no-pad" "   "])))
+(first (at (select {t: (trim s) from: TTr}) 't)) -- "hello"
+;; Leading and trailing space stripped.
+(at (at (select {t: (trim s) from: TTr}) 't) 1) -- "world"
+;; Already-trimmed string is unchanged.
+(at (at (select {t: (trim s) from: TTr}) 't) 2) -- "no-pad"
+;; All-whitespace becomes empty.
+(at (at (select {t: (trim s) from: TTr}) 't) 3) -- ""
+
+;; ====================================================================
+;; OP_SORT — partitioned_gather (exec.c:275-473).  Single-key sort over
+;; >= PG_MIN (=131072) rows triggers the partitioned routing path.
+;; Phase 1 (pg_hist_fn @275), phase 2 (pg_route_fn @304), phase 3
+;; (pg_block_fn @338) all run.  Mixing I64 and I32 columns drives
+;; pg_block_fn's e==8 (line 358) and e==4 (line 363) element-size arms.
+;; ====================================================================
+(set BIG_N 150000)
+;; Reverse-sorted I64 column; ascending puts row 0 (=N-1) last.
+(set TBigSort (table [k v] (list (- (- BIG_N 1) (til BIG_N)) (til BIG_N))))
+;; Count preserved.
+(count (select {from: TBigSort asc: k})) -- 150000
+;; First row of asc-sorted has k=0.
+(at (at (select {from: TBigSort asc: k}) 'k) 0) -- 0
+;; Last row has k=N-1.
+(at (at (select {from: TBigSort asc: k}) 'k) 149999) -- 149999
+;; Descending: first row is the original last (k=N-1).
+(at (at (select {from: TBigSort desc: k}) 'k) 0) -- 149999
+;; Companion `v` column rides through partitioned_gather block loop
+;; with esz=8.  Sum of v should be unchanged: N*(N-1)/2.
+(sum (at (select {from: TBigSort asc: k}) 'v)) -- 11249925000
+
+;; Mixed esz columns — drives pg_block_fn's e==8 and e==4 arms in
+;; one sort.  Multi-key sort uses multi_gather_fn (no partitioned),
+;; so use single-key.
+(set TBigMix (table [k a b] (list (- (- BIG_N 1) (til BIG_N)) (as 'I32 (% (til BIG_N) 1000)) (til BIG_N))))
+;; After asc by k=0 first, original row N-1 (with i=N-1) becomes
+;; row 0.  a[N-1] = (N-1)%1000 = 999.  b[N-1] = N-1 = 149999.
+(at (at (select {from: TBigMix asc: k}) 'a) 0) -- 999
+(at (at (select {from: TBigMix asc: k}) 'b) 0) -- 149999
+
+;; ====================================================================
+;; OP_HEAD(SORT) fusion at 150k rows — exec.c:1252-1269.  exec_sort
+;; gets a non-zero limit hint and uses the limited gather path; the
+;; sort indices loop still scans 150k rows but only N=5 rows are
+;; gathered into the result.
+;; ====================================================================
+(count (select {from: TBigSort asc: k take: 5})) -- 5
+(at (at (select {from: TBigSort asc: k take: 5}) 'k) 0) -- 0
+(at (at (select {from: TBigSort asc: k take: 5}) 'k) 4) -- 4
+
+;; ====================================================================
+;; OP_HEAD(FILTER) over 150k rows — exec.c:1301-1336.  exec_filter_head
+;; loops morsels until N matches accumulate; small-input tests don't
+;; cross the morsel boundary (RAY_MORSEL_ELEMS = 1024).
+;; ====================================================================
+(set TH150 (table [x] (list (til BIG_N))))
+;; Inner where x>50000 leaves 99999 rows; take 7 of them.  First row
+;; matching x>50000 is x=50001.
+(count (select {from: TH150 where: (> x 50000) take: 7})) -- 7
+(at (at (select {from: TH150 where: (> x 50000) take: 7}) 'x) 0) -- 50001
+(at (at (select {from: TH150 where: (> x 50000) take: 7}) 'x) 6) -- 50007
+
+;; ====================================================================
+;; OP_FILTER chained refine on a STR-equality predicate — exec.c:1059-
+;; 1072 with non-NULL g->selection.  Existing chained refines test
+;; I64/F64/SYM; STR routes through ray_rowsel_refine's STR comparator.
+;; ====================================================================
+(set TStrF (table [s n] (list ["alpha" "beta" "gamma" "alpha" "beta" "alpha"] [1 2 3 4 5 6])))
+(count (select {from: (select {from: TStrF where: (== s "alpha")}) where: (> n 3)})) -- 2
+(sum (at (select {from: (select {from: TStrF where: (== s "alpha")}) where: (> n 3)}) 'n)) -- 10
+
+;; OP_COUNT_DISTINCT (exec.c:1006-1012) — already covered by
+;; test_exec.c.  rfl `(count (distinct V))` is the eval-level
+;; pipeline (collection.c::ray_distinct + collection.c::ray_count),
+;; which never reaches exec.c.  Skipped.
+
+;; ====================================================================
+;; Cleanup
+;; ====================================================================
+(.sys.exec "rm -rf /tmp/rfl_exec_advanced")

--- a/test/rfl/ops/exec_advanced2.rfl
+++ b/test/rfl/ops/exec_advanced2.rfl
@@ -1,0 +1,119 @@
+;; Pass 4b coverage targets for src/ops/exec.c — branches missed by
+;; exec_coverage.rfl.  Focus is on:
+;;   - HEAD(FILTER) selection-compact path (exec.c:1311-1318) reached
+;;     only when the input filter is *chained* (g->selection is already
+;;     set when OP_HEAD enters).  The optimizer's pass_filter_reorder
+;;     splits AND predicates into chained OP_FILTER nodes, so a query
+;;     of the shape `where: (and P1 P2) take: N` exercises this path.
+;;   - HEAD(SORT) selection-compact path (exec.c:1258-1265): same idea
+;;     but with an asc:/desc: clause replacing the second predicate.
+;;   - IN_READ_F64 macro arms (exec.c:595, 596, 599) for the BOOL,
+;;     I16, and I64 column types under use_double=1 (float probe set).
+;;     I32/DATE/TIME share L597-598 and are already covered by
+;;     exec_coverage.rfl line 284.  F32 and U8 arms are unreachable
+;;     from rfl source (no `(as 'F32 ...)` / `(as 'U8 ...)` casts).
+;;
+;; SKIPPED ranges (orphan / require parted/MAPCOMMON fixtures or
+;; segment-streaming infra not driven by rfl):
+;;   - L35-152   materialize_mapcommon* family
+;;   - L1351-1392, L1438-1502  HEAD/TAIL on parted/MAPCOMMON columns
+;;   - L1839-1920, L2134-2248 segment streaming / build_segment_table
+;;   - L1932-1951 op_streamable switch (only fires under streaming)
+;;   - L889-921   parted concat fallback in OP_SCAN
+;;   - L1277-1300 HEAD-of-GROUP selection compaction: query.c:3210
+;;     skips ray_head() entirely when by_expr is set, and the only
+;;     other OP_HEAD construction (opt.c:584 fold_filter_const_predicate)
+;;     produces HEAD with n=0 over the FILTER's input, but g->selection
+;;     is never set in that path because the constant predicate is
+;;     consumed during folding (there is no upstream FILTER left to
+;;     install the bitmap).  Reachability would require an internal
+;;     transformation that neither query.c nor opt.c performs.
+;;   - error / NYI paths not relevant to the useful-work scope
+
+(.sys.exec "rm -rf /tmp/rfl_exec_advanced2")
+
+;; ====================================================================
+;; HEAD(FILTER) — chained-filter selection compaction (exec.c:1311-1318)
+;; ====================================================================
+;; Build a 20-row fixture and use `(and P1 P2)`; the optimizer splits
+;; the AND into two OP_FILTER nodes.  When OP_HEAD evaluates its child
+;; OP_FILTER's input (exec.c:1304), the inner OP_FILTER installs
+;; g->selection on the lazy path (exec.c:1068).  At exec.c:1311 the
+;; selection-compact branch then fires before the outer predicate is
+;; evaluated.  Without `take:` the outer query goes through the chained
+;; OP_FILTER refine path (exec.c:1063), not OP_HEAD, so `take:` is
+;; required to route through HEAD(FILTER).
+(set TF2 (table [x y] (list [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20] [10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160 170 180 190 200])))
+
+;; (and P1 P2) becomes chained filters.  P1 keeps x in {6..20}=15 rows,
+;; P2 keeps x in {1..14}=14 rows, conjunction is x in {6..14}=9 rows;
+;; take 3 picks the first three matching = x in {6,7,8}, sum 21.
+(count (select {from: TF2 where: (and (> x 5) (< x 15)) take: 3})) -- 3
+(sum   (at (select {from: TF2 where: (and (> x 5) (< x 15)) take: 3}) 'x)) -- 21
+
+;; Three-way AND splits into a longer chain; both inner filters install
+;; selection before HEAD compacts.  P1: x>3 (17 rows), P2: x<18
+;; (17 rows), P3: x!=10 (one of the rows in 4..17 is dropped).
+;; Conjunction: x in {4..9, 11..17} = 13 rows; take 4 picks 4.
+(count (select {from: TF2 where: (and (and (> x 3) (< x 18)) (!= x 10)) take: 4})) -- 4
+;; sum of first 4 matches = 4+5+6+7 = 22.
+(sum   (at (select {from: TF2 where: (and (and (> x 3) (< x 18)) (!= x 10)) take: 4}) 'x)) -- 22
+
+;; Chained AND with take: -N also exercises selection compaction in the
+;; HEAD(FILTER) branch?  No — query.c:3219 routes negative take into
+;; ray_tail, and OP_TAIL has no FILTER fusion.  Skip.
+
+;; ====================================================================
+;; HEAD(SORT) — chained selection compaction (exec.c:1258-1265)
+;; ====================================================================
+;; `select { where: P asc: c take: N }` compiles to HEAD(SORT(FILTER)).
+;; When OP_HEAD recurses into the SORT child, the SORT's input is
+;; OP_FILTER which sets g->selection on the lazy path.  exec.c:1258
+;; sees the selection and calls sel_compact before sorting.
+(first (at (select {from: TF2 where: (> x 5) asc: x take: 3}) 'x)) -- 6
+(first (at (select {from: TF2 where: (> x 5) desc: x take: 3}) 'x)) -- 20
+;; Sum of first 3 ascending matches: 6+7+8 = 21.
+(sum (at (select {from: TF2 where: (> x 5) asc: x take: 3}) 'x)) -- 21
+;; Sum of first 3 descending matches: 20+19+18 = 57.
+(sum (at (select {from: TF2 where: (> x 5) desc: x take: 3}) 'x)) -- 57
+
+;; ====================================================================
+;; OP_IN — IN_READ_F64 macro arms (exec.c:595-602) for column types
+;; that aren't already covered by exec_coverage.rfl's int-set probes.
+;;
+;; Reuse the cross-type fixture shape locally (50 rows, multiple typed
+;; columns).  Probe with a float set so use_double=1 selects the F64
+;; branch in exec_in_worker (exec.c:607).  The column type then
+;; selects the IN_READ_F64 switch arm.
+;; ====================================================================
+(set N3 50)
+(set TY (table [i64c i16c boolc] (list (til N3) (as 'I16 (% (til N3) 50)) (take [true false] N3))))
+
+;; I64 col, F64 set — IN_READ_F64 RAY_I64 arm (exec.c:599-600).
+;; i64c=0..49, set={1.0,2.0,3.0} matches 3 rows.
+(count (select {from: TY where: (in i64c [1.0 2.0 3.0])})) -- 3
+;; sum of matched i64c values: 1+2+3 = 6.
+(sum   (at (select {from: TY where: (in i64c [1.0 2.0 3.0])}) 'i64c)) -- 6
+
+;; I16 col, F64 set — IN_READ_F64 RAY_I16 arm (exec.c:596).
+;; i16c=0..49 (one occurrence each), set={1.0,2.0,3.0} matches 3 rows.
+(count (select {from: TY where: (in i16c [1.0 2.0 3.0])})) -- 3
+(sum   (at (select {from: TY where: (in i16c [1.0 2.0 3.0])}) 'i16c)) -- 6
+
+;; BOOL col, F64 set — IN_READ_F64 RAY_BOOL arm (exec.c:595).
+;; boolc alternates [true,false] for 50 rows = 25 trues + 25 falses.
+;; Set {1.0} matches only true rows = 25.
+(count (select {from: TY where: (in boolc [1.0])})) -- 25
+;; Set {0.0} matches only false rows = 25.
+(count (select {from: TY where: (in boolc [0.0])})) -- 25
+;; Set {0.0,1.0} matches both = 50.
+(count (select {from: TY where: (in boolc [0.0 1.0])})) -- 50
+
+;; not-in symmetry: I64 col with float set, negate=1.
+;; 50 rows total minus 3 matches = 47.
+(count (select {from: TY where: (not-in i64c [1.0 2.0 3.0])})) -- 47
+
+;; ====================================================================
+;; Cleanup
+;; ====================================================================
+(.sys.exec "rm -rf /tmp/rfl_exec_advanced2")

--- a/test/rfl/ops/opt_advanced.rfl
+++ b/test/rfl/ops/opt_advanced.rfl
@@ -15,6 +15,26 @@
 ;;   - OOM allocator failure paths, hard-coded depth/breadth guards
 ;;     (visited[4096], stack_cap > 256, sp >= 64), `return ray_error`
 ;;     branches: classified as error guards, not useful work.
+;;   - fold_binary_const I32/DATE/TIME arm (opt.c:454-473): unreachable
+;;     from rfl.  graph.c::promote uses POSITIVE RAY_xxx constants but
+;;     ray_const_atom carries atom->type with NEGATIVE tag; promote
+;;     returns RAY_BOOL fallthrough for two-atom DATE/TIME/I32/I16
+;;     literal expressions.  Specialised ray_const_i64/f64/bool only
+;;     normalise I64/F64/BOOL atoms — DATE/TIME/SYM/I32/I16/U8 atoms
+;;     keep negative tags.  Top-level `(- 2026.05.05 2026.05.01)`
+;;     bypasses the DAG entirely (eval.c:494 gates can_dag on at least
+;;     one vec operand).  Same orphan shape as the topn family.
+;;   - infer_type_for_node body (opt.c:67-85) and downstream promote_type
+;;     arms reachable only when out_type==0; every graph constructor
+;;     sets a non-zero out_type, so the `if (node->out_type == 0)` gate
+;;     never opens from rfl.  promote_type runs only as the fallback
+;;     callee here — graph.c has its own promote() that actually fires.
+;;   - filter pushdown past EXPAND (opt.c:1373-1400) and helpers
+;;     collect_pred_scans / is_reachable_from (opt.c:1184-1307): only
+;;     called by the EXPAND branch of pass_predicate_pushdown.
+;;   - OP_WINDOW arms in pass_constant_fold (opt.c:690-700) and
+;;     pass_dce (opt.c:1685-1701): OP_WINDOW is the same orphan as
+;;     OP_EXPAND — not produced by ordinary `select`.
 ;;
 ;; All assertions feed through `select` so ray_optimize() runs
 ;; (query.c:322 etc.) and pass_* hooks fire.
@@ -319,3 +339,71 @@
 (sum (at (select {x: (sqrt (* 4 4)) from: T4}) 'x)) -- 16.0
 (sum (at (select {x: (abs (neg 7)) from: T4}) 'x)) -- 28
 (sum (at (select {x: (+ (sqrt 9) (sqrt 16)) from: T4}) 'x)) -- 28.0
+
+;; ====================================================================
+;; simplify_and_or_const — opt.c:515-559
+;; The four logical-identity arms when ONE operand is a const scalar
+;; bool and the other is a column predicate.  The both-const path goes
+;; through fold_binary_const (covered above); the both-non-const path
+;; is the common (and col col) form.
+;;
+;; AND identity (X & true → X) is exercised at opt_coverage:340 by
+;; (and (> a 0) (== (+ 1 1) 2)); AND dominant (X & false → false) at
+;; opt_coverage:342 by (== (+ 1 1) 3).  The OR mirrors are uncovered.
+;; ====================================================================
+;; OR dominant arm (opt.c:548-558): (or X true) → const true.
+;; Outer where then folds to MATERIALIZE keeping all rows.
+(count (select {from: TP where: (or (> a 5) (== 1 1))})) -- 10
+(count (select {from: TP where: (or (== a 999) (== (+ 1 1) 2))})) -- 10
+
+;; OR identity arm (opt.c:534-546): (or X false) → ALIAS(X).
+;; Reduces to plain column predicate.
+(count (select {from: TP where: (or (> a 5) (== 1 0))})) -- 5
+(sum  (at (select {from: TP where: (or (> a 5) (!= 1 1))}) 'a)) -- 40
+
+;; AND identity (X & true) — already covered indirectly, but pin a
+;; tighter oracle on the ALIAS-rewritten arm so the row count drops
+;; out of the column predicate alone.
+(count (select {from: TP where: (and (> a 3) (== 1 1))})) -- 7
+
+;; AND dominant (X & false) — explicit oracle.
+(count (select {from: TP where: (and (> a 3) (== 1 0))})) -- 0
+
+;; Const-on-LHS variants — simplify_and_or_const handles either side
+;; via lhs_const / rhs_const flags (opt.c:518-528).  These hit the
+;; `lhs_const ? rhs : lhs` branch (X is the rhs in this case).
+(count (select {from: TP where: (and (== 1 1) (> a 5))})) -- 5
+(count (select {from: TP where: (or  (== 1 0) (> a 5))})) -- 5
+(count (select {from: TP where: (and (== 1 0) (> a 5))})) -- 0
+(count (select {from: TP where: (or  (== 1 1) (> a 5))})) -- 10
+
+;; ====================================================================
+;; filter_cost default opcode arm — opt.c:1438
+;; OP_IN / OP_NOT_IN do not match any of the EQ/NE/LT/LE/GT/GE/LIKE/
+;; ILIKE cases, so they fall through to `cost += 1`.  Reaches that arm
+;; iff the predicate is part of a chain of >= 2 filters (chain_len < 2
+;; short-circuits the reorder loop at opt.c:1550).
+;; ====================================================================
+(set TIN (table [a b] (list [1 2 3 4 5 6 7 8 9 10] [10 20 30 40 50 60 70 80 90 100])))
+
+;; AND-of-2: chain after split is (FILTER(>b30) (FILTER(in a [3 5 7]) TIN)).
+;; filter_cost runs on each predicate; OP_IN hits the default arm.
+(count (select {from: TIN where: (and (in a [3 5 7]) (> b 30))})) -- 2
+(count (select {from: TIN where: (and (not-in a [1 2 3]) (> b 30))})) -- 7
+
+;; OR predicate as a single filter (chain_len==1, filter_cost not run).
+;; Behavioural pin: optimizer must not split OR.
+(count (select {from: TIN where: (or (== a 1) (== a 10))})) -- 2
+
+;; ====================================================================
+;; filter_cost SCAN-as-predicate (opt.c:1438 default arm via opcode).
+;; A bool column referenced bare in `where` is an OP_SCAN, not a
+;; comparison.  In a chain it routes through the default opcode arm.
+;; The type-width arm (opt.c:1426 BOOL/U8 cost += 0) also fires.
+;; ====================================================================
+(set TBC (table [b a] (list [true false true false true false true false true false] [1 2 3 4 5 6 7 8 9 10])))
+(count (select {from: TBC where: (and b (> a 3))})) -- 3
+(count (select {from: TBC where: (and (> a 3) b)})) -- 3
+;; Three-way: bool col + comparison + comparison, exercises insertion-sort
+;; ranking with mixed costs.
+(count (select {from: TBC where: (and b (> a 1) (< a 8))})) -- 3

--- a/test/rfl/ops/opt_advanced.rfl
+++ b/test/rfl/ops/opt_advanced.rfl
@@ -1,0 +1,321 @@
+;; Advanced coverage targets for src/ops/opt.c — extends opt_coverage
+;; intent.  Focuses on USEFUL-WORK paths only: type inference promotion,
+;; constant folding chains, predicate pushdown across SELECT/ALIAS,
+;; multi-clause AND-split, filter-cost reorder, projection pushdown
+;; reachability through ext-node children, and FILTER(const)
+;; pass-through / drop fusion.
+;;
+;; Skip rationale (per Pass 4 brief):
+;;   - track_ext_node realloc fix-up: only fires for very large queries,
+;;     not reachable from simple rfl SELECTs.
+;;   - SIP / factorize_pass: graph-DAG / datalog only; OP_EXPAND is not
+;;     produced by ordinary `select`.
+;;   - pass_partition_pruning: needs disk-backed parted RAY_MAPCOMMON
+;;     fixtures; orphan to rfl.
+;;   - OOM allocator failure paths, hard-coded depth/breadth guards
+;;     (visited[4096], stack_cap > 256, sp >= 64), `return ray_error`
+;;     branches: classified as error guards, not useful work.
+;;
+;; All assertions feed through `select` so ray_optimize() runs
+;; (query.c:322 etc.) and pass_* hooks fire.
+
+;; ====================================================================
+;; promote_type / infer_type_for_node — opt.c:54-84
+;; ====================================================================
+;; Each line drives a derived column whose two operands have distinct
+;; types so promote_type's switch arms fire in pass_type_inference's
+;; reverse-order infer_type_for_node loop.
+
+;; F64 dominates: I64+F64 -> F64  (opt.c:56)
+(set TF (table [i f] (list [1 2 3] [0.5 1.5 2.5])))
+(sum (at (select {x: (+ i f) from: TF}) 'x)) -- 10.5
+(type (at (select {x: (+ i f) from: TF}) 'x)) -- 'F64
+
+;; I64 dominates I32: opt.c:58
+(set TIJ (table [a b] (list (as 'I32 [10 20 30]) [100 200 300])))
+(sum (at (select {x: (+ a b) from: TIJ}) 'x)) -- 660
+(type (at (select {x: (+ a b) from: TIJ}) 'x)) -- 'I64
+
+;; SYM is treated as I64-class for promote_type purposes (opt.c:58)
+(set TSY (table [s v] (list ['AAPL 'GOOG 'MSFT] [1 2 3])))
+;; Compare SYM column to SYM atom; comparison opcode forces BOOL out
+;; (opt.c:70-72), independent of operand type.
+(count (select {from: TSY where: (== s 'GOOG)})) -- 1
+
+;; I32 dominates I16 in the absence of I64/F64 (opt.c:60)
+(set THJ (table [a b] (list (as 'I16 [1 2 3 4]) (as 'I32 [10 20 30 40]))))
+(sum (at (select {x: (+ a b) from: THJ}) 'x)) -- 110
+;; DAG widens to I64 anyway (cf. dag_binary_ops.rfl:38) — promote_type
+;; still ran during inference even if downstream lowering widens.
+(type (at (select {x: (+ a b) from: THJ}) 'x)) -- 'I64
+
+;; I16 + I16 promotes via opt.c:62 — same I16 path
+(set TH16 (table [a b] (list (as 'I16 [1 2 3]) (as 'I16 [4 5 6]))))
+(sum (at (select {x: (+ a b) from: TH16}) 'x)) -- 21
+
+;; DATE op shares the I32 namespace (opt.c:61)
+(set TDY (table [d v] (list [2024.01.01 2024.06.15 2024.12.31] [1 2 3])))
+(count (select {from: TDY where: (>= d 2024.06.01)})) -- 2
+
+;; Comparison & logical ops always BOOL — opt.c:70, 74
+(count (select {from: TF where: (and (> i 1) (< f 2.5))})) -- 1
+(count (select {from: TF where: (or  (< i 0) (>= f 1.5))})) -- 2
+
+;; arity-1 propagation (opt.c:81-82): unary on single column
+(sum (at (select {x: (neg i) from: TF}) 'x)) -- -6
+
+;; ====================================================================
+;; fold_unary_const — opt.c:323-376
+;; All inputs are CONST atoms in a derived column, so the fold runs
+;; before broadcast.  Each line picks an op so the matching switch
+;; arm fires.  Result is broadcast over a 4-row table to make the
+;; fold visible.
+;; ====================================================================
+(set T4 (table [r] (list [1 2 3 4])))
+
+;; OP_NEG on F64 const  (opt.c:338) — derived col is constant -3.5
+(sum (at (select {x: (neg 3.5) from: T4}) 'x)) -- -14.0
+;; OP_NEG on I64 const  (opt.c:340)
+(sum (at (select {x: (neg 7) from: T4}) 'x)) -- -28
+
+;; OP_ABS on F64 const  (opt.c:344)
+(sum (at (select {x: (abs -2.5) from: T4}) 'x)) -- 10.0
+;; OP_ABS on I64 const negative  (opt.c:346)
+(sum (at (select {x: (abs -9) from: T4}) 'x)) -- 36
+
+;; OP_NOT — opt.c:349 — bool of (5 != 0) is true; (not 5) is 0/false
+(sum (as 'I64 (at (select {x: (not 0) from: T4}) 'x))) -- 4
+(sum (as 'I64 (at (select {x: (not 1) from: T4}) 'x))) -- 0
+
+;; OP_SQRT  (opt.c:352) — sqrt(16) = 4
+(sum (at (select {x: (sqrt 16) from: T4}) 'x)) -- 16.0
+
+;; OP_LOG   (opt.c:355) — log(1) = 0
+(sum (at (select {x: (log 1) from: T4}) 'x)) -- 0.0
+
+;; OP_EXP   (opt.c:358) — exp(0) = 1
+(sum (at (select {x: (exp 0) from: T4}) 'x)) -- 4.0
+
+;; OP_CEIL on F64 (opt.c:361)
+(sum (at (select {x: (ceil 2.3) from: T4}) 'x)) -- 12.0
+;; OP_CEIL on I64 — passthrough (opt.c:361 else branch)
+(sum (at (select {x: (ceil 5) from: T4}) 'x)) -- 20
+
+;; OP_FLOOR on F64 (opt.c:364)
+(sum (at (select {x: (floor 2.7) from: T4}) 'x)) -- 8.0
+;; OP_FLOOR on I64 — passthrough
+(sum (at (select {x: (floor 5) from: T4}) 'x)) -- 20
+
+;; ====================================================================
+;; fold_binary_const — opt.c:378-485
+;; Two CONST atom inputs to an arithmetic / comparison op.  All cases
+;; route through a `where:` or projection so ray_optimize runs.
+;; ====================================================================
+
+;; F64 fold path  (opt.c:396-411)
+;; ADD: 1.5+2.5 = 4.0; broadcast x4
+(sum (at (select {x: (+ 1.5 2.5) from: T4}) 'x)) -- 16.0
+;; SUB
+(sum (at (select {x: (- 5.0 2.0) from: T4}) 'x)) -- 12.0
+;; MUL
+(sum (at (select {x: (* 1.5 2.0) from: T4}) 'x)) -- 12.0
+;; DIV (IEEE: 0/0 -> NaN, but here finite)
+(sum (at (select {x: (/ 6.0 2.0) from: T4}) 'x)) -- 12.0
+;; MOD via fmod
+(sum (at (select {x: (% 7.5 2.0) from: T4}) 'x)) -- 6.0
+
+;; I64 fold (opt.c:413-432)
+;; ADD/SUB/MUL/DIV/MOD on integer atoms
+(sum (at (select {x: (+ 3 4) from: T4}) 'x)) -- 28
+(sum (at (select {x: (- 10 3) from: T4}) 'x)) -- 28
+(sum (at (select {x: (* 3 7) from: T4}) 'x)) -- 84
+(sum (at (select {x: (% 11 3) from: T4}) 'x)) -- 8
+
+;; BOOL fold — comparison constants  (opt.c:434-453)
+;; The comparison itself is the binary; result is BOOL atom which
+;; broadcasts.  `where: (== 1 1)` keeps every row.
+(count (select {from: T4 where: (== 1 1)})) -- 4
+(count (select {from: T4 where: (!= 1 2)})) -- 4
+(count (select {from: T4 where: (< 1 2)})) -- 4
+(count (select {from: T4 where: (> 2 1)})) -- 4
+(count (select {from: T4 where: (<= 1 1)})) -- 4
+(count (select {from: T4 where: (>= 2 1)})) -- 4
+
+;; ====================================================================
+;; fold_filter_const_predicate — opt.c:500-533
+;; A constant boolean predicate folds FILTER → MATERIALIZE (keep) or
+;; → HEAD-0 (drop).  Hits both branches of opt.c:511-518 / 520-532.
+;; ====================================================================
+(set T10 (table [v] (list [1 2 3 4 5 6 7 8 9 10])))
+
+;; keep-rows branch — opt.c:511, MATERIALIZE rewrite
+(count (select {from: T10 where: (== 1 1)})) -- 10
+(count (select {from: T10 where: (!= 0 1)})) -- 10
+(sum  (at (select {from: T10 where: (== 1 1)}) 'v)) -- 55
+
+;; drop-rows branch — opt.c:520, HEAD-0 rewrite
+(count (select {from: T10 where: (== 1 0)})) -- 0
+(count (select {from: T10 where: (< 5 2)})) -- 0
+(sum  (at (select {from: T10 where: (== 1 0)}) 'v)) -- 0
+
+;; ====================================================================
+;; AND/OR fold of two const inputs — through pass_constant_fold's
+;; binary fold (BOOL out_type, OP_AND/OR, opt.c:447-448).
+;; ====================================================================
+;; (and 1 1) → true → keep all; (and 1 0) → false → drop all
+(count (select {from: T10 where: (and 1 1)})) -- 10
+(count (select {from: T10 where: (and 1 0)})) -- 0
+(count (select {from: T10 where: (or  0 1)})) -- 10
+(count (select {from: T10 where: (or  0 0)})) -- 0
+
+;; ====================================================================
+;; pass_predicate_pushdown — opt.c:1272-1339
+;; FILTER over SELECT (single-consumer) gets swapped:
+;;   FILTER(p, SELECT(x))  ->  SELECT(FILTER(p, x))
+;; The recently-fixed (and vec const) partial fold means the path is
+;; reachable; we use a pure scan/where shape so the rewrite fires.
+;; ====================================================================
+(set TP (table [a b] (list [1 2 3 4 5 6 7 8 9 10] [10 20 30 40 50 60 70 80 90 100])))
+
+;; Outer where on inner select — predicate pushed past SELECT.
+;; Result must equal the manually-merged form.
+(count (select {from: (select {a: a from: TP}) where: (> a 5)})) -- 5
+(sum  (at (select {from: (select {a: a from: TP}) where: (> a 5)}) 'a)) -- 40
+
+;; Two-deep nested SELECT — pushdown iterates (opt.c:1276 loop).
+(count (select {from: (select {a: a from: (select {a: a b: b from: TP})}) where: (> a 7)})) -- 3
+
+;; ====================================================================
+;; Filter chain — split AND + cost-based reorder
+;; opt.c:1381-1418 (split_and_filter), 1431-1528 (pass_filter_reorder).
+;; The inner AND splits into a chain of two FILTERs, then reorder
+;; ranks them by filter_cost (LIKE costliest, EQ cheapest).
+;; ====================================================================
+(set TM (table [s p q] (list ['AAA 'BBB 'AAB 'CCC 'BBA 'AAC 'BBC] [1 2 3 4 5 6 7] [10 20 30 40 50 60 70])))
+
+;; AND-of-three predicates — split_and_filter iterates (opt.c:1439 loop)
+;; All three should still match correctly after splitting.
+(count (select {from: TM where: (and (== s 'AAA) (> p 0) (< q 100))})) -- 1
+(count (select {from: TM where: (and (> p 1) (< p 7) (>= q 20))})) -- 5
+
+;; LIKE in chain — filter_cost charges 4 for LIKE (opt.c:1372).  The
+;; reorder must keep result identical regardless of physical order.
+(count (select {from: TM where: (and (like s "A*") (> p 0))})) -- 3
+(count (select {from: TM where: (and (> p 0) (like s "A*"))})) -- 3
+
+;; Equivalent nested-select forms must yield same row counts (covers
+;; collect_filter_chain at opt.c:1421-1429).
+(count (select {from: (select {from: TM where: (> p 1)}) where: (< q 70)})) -- 5
+(count (select {from: (select {from: (select {from: TM where: (> p 1)}) where: (< p 7)}) where: (>= q 20)})) -- 5
+
+;; ====================================================================
+;; filter_cost type-width branches — opt.c:1361-1364
+;; Each predicate uses a column of the indicated type so filter_cost
+;; selects the matching arm.
+;; ====================================================================
+;; BOOL/U8 column predicate (cost += 0) — opt.c:1361
+(set TBL (table [b v] (list [true false true false true] [1 2 3 4 5])))
+(count (select {from: TBL where: b})) -- 3
+
+;; I16 column predicate (cost += 1) — opt.c:1362 (RAY_I16)
+(set TI16 (table [a v] (list (as 'I16 [1 2 3 4 5]) [10 20 30 40 50])))
+(count (select {from: TI16 where: (> a 2)})) -- 3
+
+;; I32/DATE/TIME (cost += 2) — opt.c:1363
+(set TI32 (table [a v] (list (as 'I32 [1 2 3 4 5]) [10 20 30 40 50])))
+(count (select {from: TI32 where: (> a 2)})) -- 3
+(count (select {from: TDY where: (>= d 2024.06.01)})) -- 2
+
+;; I64/F64/SYM/STR default (cost += 3) — opt.c:1364
+(count (select {from: TP where: (> a 5)})) -- 5
+
+;; ====================================================================
+;; pass_projection_pushdown — opt.c:1539-1674
+;; Mark live via BFS through inputs and ext-node children for SORT,
+;; SELECT, GROUP, JOIN, WINDOW_JOIN cases.  Each shape below seeds a
+;; different ext-node walk.
+;; ====================================================================
+
+;; SORT extwalk — opt.c:1583-1590
+(set TS (table [s v] (list ['c 'a 'b 'd 'a] [3 1 2 4 5])))
+(count (select {from: TS asc: s})) -- 5
+(first (at (select {from: TS asc: s}) 's)) -- 'a
+
+;; GROUP extwalk — opt.c:1571-1582 (keys + agg_ins)
+(set TG (table [g v w] (list ['a 'b 'a 'b 'c 'c] [1 2 3 4 5 6] [10 20 30 40 50 60])))
+(count (select {s: (sum v) m: (max w) from: TG by: g})) -- 3
+(sum (at (select {s: (sum v) from: TG by: g}) 's)) -- 21
+
+;; SELECT projection extwalk — opt.c:1584-1590 (sort.columns reused)
+(count (select {a: v b: (* v 2) c: (+ v w) from: TG})) -- 6
+
+;; JOIN extwalk — opt.c:1591-1603 (left_keys + right_keys)
+(set TL (table [k v] (list [1 2 3 4] [10 20 30 40])))
+(set TR (table [k w] (list [2 3 4 5] [200 300 400 500])))
+(count (inner-join [k] TL TR)) -- 3
+
+;; WINDOW_JOIN extwalk — opt.c:1604-1619 (asof.time_key + eq_keys)
+;; Every TR1 row gets at least one matching TQ1 row in its window.
+(set TR1 (table [Sym Time Price] (list ['a 'a 'b] [10:00:01.000 10:00:05.000 10:00:01.000] [100 200 400])))
+(set TQ1 (table [Sym Time Bid]   (list ['a 'a 'a 'b] [10:00:00.000 10:00:02.000 10:00:04.000 10:00:00.000] [99 100 101 199])))
+(set IV  (map-left + [-2000 2000] (at TR1 'Time)))
+(count (at (window-join [Sym Time] IV TR1 TQ1 {m: (min Bid)}) 'm)) -- 3
+
+;; ====================================================================
+;; Multi-pass interaction: const-fold then DCE
+;; opt.c:1958 pass_constant_fold then 1993 pass_dce
+;; A column that becomes constant (e.g. (* 0 v)) is replaced; downstream
+;; sums see the constant value.
+;; ====================================================================
+;; (* 0 v) folds elementwise but only the constant atom case folds at
+;; opt.c level; vec-const is handled later.  Use a pure-const expr.
+(sum (at (select {x: (* 2 3) from: T10}) 'x)) -- 60
+(sum (at (select {x: (- (+ 1 2) 1) from: T10}) 'x)) -- 20
+;; Chain folds through three operations: ((1+2)*3)+4 = 13
+(sum (at (select {x: (+ (* (+ 1 2) 3) 4) from: T10}) 'x)) -- 130
+
+;; ====================================================================
+;; Pushdown beyond ALIAS — opt.c:1291-1302
+;; ALIAS is a 1-input passthrough.  In rfl `select {a: a from: ...}`
+;; with a single trivial projection compiles to SELECT (covered above);
+;; the explicit ALIAS path is the same code branch.
+;; ====================================================================
+;; FILTER over (sum-derived) projection — also confirms no spurious
+;; pushdown: FILTER above a GROUP cannot be pushed (GROUP pushdown is
+;; intentionally disabled at opt.c:1304-1306).
+(count (select {from: (select {s: (sum v) from: TG by: g}) where: (>= s 5)})) -- 2
+
+;; ====================================================================
+;; OP_NOT in pred (covers fold_unary_const NOT branch even when
+;; predicate is non-constant downstream).
+;; ====================================================================
+(count (select {from: T10 where: (not (== v 5))})) -- 9
+(count (select {from: T10 where: (not (> v 5))})) -- 5
+
+;; ====================================================================
+;; Empty-table edge — fold_filter_const_predicate keep-rows over an
+;; empty input still produces 0 rows.  Confirms MATERIALIZE rewrite
+;; preserves arity 1 (opt.c:513-515).
+;; ====================================================================
+(set TE (table [v] (list (as 'I64 (til 0)))))
+(count (select {from: TE where: (== 1 1)})) -- 0
+
+;; ====================================================================
+;; count_node_consumers (opt.c:1080-1169) — gates pushdown rewrites.
+;; A single-row scan still drives the consumer-counting walk used by
+;; pass_predicate_pushdown to decide whether the SELECT child is safe
+;; to push past.  find_consumer / find_upstream_scan (opt.c:840-927)
+;; are sip_pass-only and not reachable from rfl `select`.
+;; ====================================================================
+(set T1 (table [a] (list [42])))
+(count (select {from: T1 where: (== a 42)})) -- 1
+(sum  (at (select {from: T1 where: (== a 42)}) 'a)) -- 42
+
+;; ====================================================================
+;; Fold over a deeper expression: (sqrt (* 4 4)) -> (sqrt 16) -> 4.0
+;; — confirms post-order traversal; child folds before parent.
+;; opt.c:548 pass_constant_fold traversal.
+;; ====================================================================
+(sum (at (select {x: (sqrt (* 4 4)) from: T4}) 'x)) -- 16.0
+(sum (at (select {x: (abs (neg 7)) from: T4}) 'x)) -- 28
+(sum (at (select {x: (+ (sqrt 9) (sqrt 16)) from: T4}) 'x)) -- 28.0

--- a/test/rfl/ops/opt_coverage.rfl
+++ b/test/rfl/ops/opt_coverage.rfl
@@ -127,6 +127,42 @@
 ;; should fold (and X true)→X / (and X false)→false / (or X true)→true /
 ;; (or X false)→X before exec_filter sees the AND.
 
+;; ── RAY_I32 / RAY_DATE / RAY_TIME case (opt.c:454-473) ──
+;; Pre-fix this arm was dead from rfl: ray_const_atom (graph.c:379) stored
+;; out_type as the negative atom-tag, so node->out_type for a compiled
+;; DATE/TIME/I32 const was -RAY_DATE / -RAY_TIME / -RAY_I32, never the
+;; positive value the switch in fold_binary_const expects.  Fix in
+;; ray_const_atom normalises out_type to the positive type tag, matching
+;; the precedent in ray_const_i64 / _f64 / _bool.
+
+;; Top-level oracles — eval path (already covered by temporal/date.rfl and
+;; arith/sub.rfl, repeated here for adjacency to the fold-side tests).
+(- 2026.05.05 2026.05.01) -- 4
+(- 2024.03.01 2024.02.01) -- 29
+(+ 2026.05.01 7) -- 2026.05.08
+(- 2026.05.05 2)  -- 2026.05.03
+(- 5i 3i) -- 2i
+(+ 5i 3i) -- 8i
+(* 5i 6i) -- 30i
+
+;; Fold path — same expressions threaded through ray_optimize →
+;; pass_constant_fold → fold_binary_const inside a WHERE clause.  Pre-fix,
+;; promote(-RAY_DATE, -RAY_DATE) returned RAY_BOOL (the unknown rung) and
+;; the I32/DATE/TIME arm never fired.  After the normalisation in
+;; ray_const_atom, promote sees positive RAY_DATE on both sides and routes
+;; to RAY_I32 (date diff), which the fold arm consumes.  The fold produces
+;; an I32 const which is then compared to another const → bool fold →
+;; fold_filter_const_predicate → MATERIALIZE / HEAD.
+(set Tdt (table [a] (list [1 2 3])))
+;; date - date folds to 4 (i32 days), then == 4 folds to true → all rows pass.
+(count (select {from: Tdt where: (== (- 2026.05.05 2026.05.01) 4)})) -- 3
+(count (select {from: Tdt where: (== (- 2024.03.01 2024.02.01) 29)})) -- 3
+(count (select {from: Tdt where: (== (- 2026.05.05 2026.05.01) 5)})) -- 0
+;; I32 atom arithmetic — 5i*6i folds to 30i, then == 30 folds to true.
+(count (select {from: Tdt where: (== (* 5i 6i) 30i)})) -- 3
+(count (select {from: Tdt where: (== (+ 5i 3i) 8i)})) -- 3
+(count (select {from: Tdt where: (== (- 5i 3i) 2i)})) -- 3
+
 ;; ════════════════════════════════════════════════════════════════════════════
 ;; 3. fold_reduction_til — opt.c:535-561
 ;; Closed-form reduction over OP_TIL(n).  Inner select wraps `(til n)`

--- a/test/rfl/ops/query_coverage.rfl
+++ b/test/rfl/ops/query_coverage.rfl
@@ -1,0 +1,369 @@
+;; Coverage tests for src/ops/query.c — pass-4 useful-work paths that
+;; existing fixtures (test/rfl/{table,collection,integration,ops}/...)
+;; don't reach.  Focus is rich query shapes — projection forms, multi-
+;; clause selects, post-DAG scatter/sort/take, update-by, ANN/KNN
+;; nearest, eval-level group-by — NOT error guards or OOM cleanup.
+;;
+;; Each block calls out the target compile_expr_dag / select / update
+;; site by approximate line range.
+;;
+;; No /tmp files used.
+
+;; ====================================================================
+;; compile_expr_dag projection forms — query.c:412-921
+;; ====================================================================
+
+(set TT (table [a b s f] (list [1 2 3 4 5 6 7 8 9 10] [10 20 30 40 50 60 70 80 90 100] ["alpha" "beta" "gamma" "delta" "eps" "zeta" "eta" "theta" "iota" "kappa"] (as 'F64 (til 10)))))
+
+;; (replace col "from" "to") — query.c:683-696, exec_replace path.
+;; Replace literal substring inside every row of a STR column.
+(first (at (select {r: (replace s "a" "X") from: TT}) 'r)) -- "XlphX"
+(first (at (select {r: (replace s "alpha" "AAAA") from: TT}) 'r)) -- "AAAA"
+
+;; (concat …) variadic string concat — query.c:699-711.  3+ args
+;; exercises the multi-input balanced-tree code path.
+(first (at (select {c: (concat s "_" s) from: TT}) 'c)) -- "alpha_alpha"
+(first (at (select {c: (concat "[" s "]") from: TT}) 'c)) -- "[alpha]"
+
+;; (as 'TYPE col) cast — query.c:714-735.  Hit the I64 and F64 arms
+;; (the widest-tested cast targets in the DAG executor).  Other
+;; arms (I32/I16/F32/U8/BOOL) compile fine but the DAG fallback's
+;; CAST loop only handles narrow→I64/F64 (expr.c:1277-1290) — they
+;; SKIP coverage rather than risk runtime divergence.
+(sum (at (select {x: (as 'F64 a) from: TT}) 'x)) -- 55.0
+(sum (at (select {x: (as 'I64 f) from: TT}) 'x)) -- 45
+
+;; Long-form temporal extracts (year/month/day/hour/minute/second/
+;; dayofweek/dayofyear) — query.c:737-753.  Distinct from the eval-
+;; level (yyyy x) shorthand which bypasses compile_expr_dag.
+(set TD (table [d ts] (list [2024.01.15 2024.01.20 2024.01.25] [2024.01.15D10:30:45.000 2024.01.20D11:30:45.000 2024.01.25D12:30:45.000])))
+;; year: 3*2024 = 6072.  month: 3*1 = 3.  day: 15+20+25 = 60.
+(sum (at (select {y: (year d) from: TD}) 'y)) -- 6072
+(sum (at (select {m: (month d) from: TD}) 'm)) -- 3
+(sum (at (select {dd: (day d) from: TD}) 'dd)) -- 60
+;; hour: 10+11+12 = 33.  minute: 3*30 = 90.  second: 3*45 = 135.
+(sum (at (select {hh: (hour ts) from: TD}) 'hh)) -- 33
+(sum (at (select {mn: (minute ts) from: TD}) 'mn)) -- 90
+(sum (at (select {sc: (second ts) from: TD}) 'sc)) -- 135
+;; dayofyear: 15+20+25 = 60 (all in Jan 2024).  dayofweek values
+;; differ by ISO conventions; the long-form `dayofweek` is
+;; equivalent to the short `(dow d)` — assert presence rather than
+;; sum of unknown calendar weekday encoding.
+(count (at (select {dw: (dayofweek d) from: TD}) 'dw)) -- 3
+(sum (at (select {dy: (dayofyear d) from: TD}) 'dy)) -- 60
+
+;; Dotted-name temporal segments — query.c:455-481.  Short-name forms
+;; (yyyy/mm/dd/hh/minute/ss/dow/doy) registered in temporal.c
+;; ray_temporal_field_from_sym.  `ts.yyyy` desugars to scan(ts) →
+;; extract(YEAR); `ts.date` (handled via temporal_trunc_from_sym)
+;; desugars to scan(ts) → date_trunc(DAY).
+(sum (at (select {y: ts.yyyy from: TD}) 'y)) -- 6072
+(sum (at (select {m: ts.mm from: TD}) 'm)) -- 3
+(sum (at (select {h: ts.hh from: TD}) 'h)) -- 33
+
+;; (do e1 ... eN) — query.c:759-762.  Compiles to the LAST expr only;
+;; earlier exprs are dropped.  Inside select, `(do (+ a 1) (* a 2))`
+;; becomes the multiplication.
+(sum (at (select {x: (do (+ a 1) (* a 2)) from: TT}) 'x)) -- 110
+
+;; (let var val body) — query.c:768-781.  Bind val to var, compile
+;; body with var resolved via cexpr_env_lookup.
+(sum (at (select {x: (let v (* a 3) (+ v 1)) from: TT}) 'x)) -- 175
+
+;; (cond (p1 e1) (p2 e2) ... (else en)) — query.c:784-821.  Builds
+;; a right-fold OP_IF chain.  3-clause cond exercises both the
+;; else-branch and the predicate-branch arms of the loop body.
+(sum (at (select {x: (cond ((> a 7) 100) ((> a 3) 10) (else 1)) from: TT}) 'x)) -- 343
+
+;; Lambda inlining — query.c:535-578.  An inline `((fn [x] body) arg)`
+;; inside a select projection β-reduces at compile time.
+(sum (at (select {x: ((fn [v] (+ (* v 2) 5)) a) from: TT}) 'x)) -- 160
+
+;; Named-lambda inlining — query.c:587-622.  A globally-bound
+;; single-expression lambda is inlined when used as a call head.
+(set dbl (fn [v] (* v 2)))
+(sum (at (select {x: (dbl a) from: TT}) 'x)) -- 110
+
+;; Variadic and/or balanced-tree fold — query.c:835-921.  4+ args
+;; folds into a balanced binary tree.  Mixed AND of integers + floats.
+(count (select {from: TT where: (and (> a 1) (< a 9) (> b 20) (< b 90))})) -- 6
+(count (select {from: TT where: (or (== a 1) (== a 5) (== a 9) (== a 10))})) -- 4
+
+;; ====================================================================
+;; apply_sort_take — query.c:246-363.  Multi-key SYM-vector sort.
+;; ====================================================================
+
+;; asc: [a b] / desc: [a b] — query.c:282-289 (the SYM vector branch
+;; of the sort-key loop).  Build a fixture where the secondary key
+;; tie-breaks the primary key — composite sort matters.
+(set TS (table [a b v] (list [2 1 2 1 2 1] [3 3 1 1 2 2] [10 20 30 40 50 60])))
+(at (at (select {from: TS asc: [a b]}) 'v) 0) -- 40
+(at (at (select {from: TS asc: [a b]}) 'v) 1) -- 60
+(at (at (select {from: TS asc: [a b]}) 'v) 2) -- 20
+(at (at (select {from: TS desc: [a b]}) 'v) 0) -- 10
+(at (at (select {from: TS desc: [a b]}) 'v) 1) -- 50
+
+;; Same multi-key sort, but applied AFTER a group-by — exercises the
+;; apply_sort_take branch via post-execution path (query.c:266-294).
+;; Use integer keys so positional invariants are deterministic.
+(set TG2 (table [g h v] (list [1 2 1 2 1 2] [1 1 2 2 1 1] [1 2 3 4 5 6])))
+(count (select {s: (sum v) from: TG2 by: [g h] asc: [g h]})) -- 4
+;; Smallest (g,h)=(1,1) appears in rows 0,4 → sum = 6.
+(at (at (select {s: (sum v) from: TG2 by: [g h] asc: [g h]}) 's) 0) -- 6
+;; Largest (g,h)=(2,2) → row 3 → sum = 4.
+(at (at (select {s: (sum v) from: TG2 by: [g h] desc: [g h]}) 's) 0) -- 4
+
+;; Take with [start amount] range form — query.c:314-321 (vec take).
+(count (select {from: TT take: [2 5]})) -- 5
+(first (at (select {from: TT take: [2 5]}) 'a)) -- 3
+
+;; ====================================================================
+;; eval-level group-by — query.c:1913-2422.  GUID / LIST-STR keys
+;; force the eval-level fallback (DAG path can't pack wide keys).
+;; ====================================================================
+
+;; GUID by-key with explicit aggs — query.c:2151-2204 (streaming
+;; aggr_unary branch on eval_tbl).  guid 4 produces 4 distinct keys.
+(set TGu (table [G v] (list (take (guid 4) 12) (til 12))))
+(count (select {s: (sum v) from: TGu by: G})) -- 4
+(sum (at (select {s: (sum v) from: TGu by: G}) 's)) -- 66
+
+;; GUID by-key with a non-agg expression — query.c:2205-2293
+;; (per-group LIST scatter via gather_by_idx).  `v2: (* v 2)` is
+;; non-agg (no aggregator wrapper) and must produce a LIST column.
+(count (at (select {v2: (* v 2) from: TGu by: G}) 'v2)) -- 4
+
+;; GUID by-key with a constant non-agg expr — broadcast branch
+;; query.c:2278-2287 (refs_column == 0, full_is_row_aligned == 0).
+(count (select {k: 7 from: TGu by: G})) -- 4
+
+;; GUID by-key with a non-row-aligned non-agg → nonagg_eval_per_group
+;; fallback at query.c:2252-2273.  A lambda that collapses to a scalar
+;; per group (count) is non-agg and not row-aligned, so it must take
+;; the per-group eval path.
+(count (at (select {n: ((fn [t] (count t)) v) from: TGu by: G}) 'n)) -- 4
+
+;; LIST/STR group key with first-of-group fast path — query.c:2347-2417.
+;; `(select {from: t by: NameCol})` (no aggs, no non-aggs) uses the
+;; LIST-key fast path at 2384-2389.
+(set TStr (table [Name v] (list (list "alpha" "beta" "alpha" "gamma" "beta") [10 20 30 40 50])))
+(count (select {from: TStr by: Name})) -- 3
+
+;; ====================================================================
+;; GUID first-of-group fast path — query.c:1945-2099.  Pure
+;; `(select {from: t by: G})` with no agg/non-agg expressions takes
+;; the dedicated O(N) hash-table scan.
+;; ====================================================================
+
+;; 50 rows over 5 GUID values exercises the SYM-attrs preserving
+;; gather (line ~2051-2064) and the typed-vec gather (~2065-2080).
+(set N5 50)
+(set TGfast (table [G iv fv sv] (list (take (guid 5) N5) (til N5) (as 'F64 (% (til N5) 7)) (take ['AAPL 'GOOG 'MSFT] N5))))
+(count (select {from: TGfast by: G})) -- 5
+
+;; ====================================================================
+;; aggr_unary_per_group_buf streaming path — query.c:1273-1359.
+;; Triggers when a select-by has BOTH agg and non-agg outputs (the
+;; non-agg scatter pre-computes idx_buf, then agg fast-paths into
+;; this).  Use a unary aggregator (med/dev) on a scalar key.
+;; ====================================================================
+
+(set TM (table [g v] (list ['a 'b 'a 'b 'a 'b 'a 'b] [1 2 3 4 5 6 7 8])))
+;; med per group — non-agg `bias: (+ v 1)` forces scatter; the
+;; agg `m: (med v)` then routes through aggr_unary_per_group_buf.
+(count (at (select {m: (med v) bias: (+ v 1) from: TM by: g}) 'm)) -- 2
+(count (at (select {m: (med v) bias: (+ v 1) from: TM by: g}) 'bias)) -- 2
+
+;; ====================================================================
+;; Post-DAG scatter — query.c:3382-3686.  Mixed agg + non-agg in a
+;; group-by produces a result with LIST-typed non-agg columns.
+;; ====================================================================
+
+(set TX (table [g v w] (list [1 1 2 2 3 3] [10 20 30 40 50 60] [100 200 300 400 500 600])))
+;; Pure non-agg expr (no agg) in by-clause: synth_count_col=1 path
+;; at query.c:2569-2572, plus the synth-count drop at 3314-3331.
+(count (select {x: (* v 2) from: TX by: g})) -- 3
+(count (at (select {x: (* v 2) from: TX by: g}) 'x)) -- 3
+
+;; Mixed agg + non-agg: scatter at 3382-3686 with refs_column branch
+;; at 3606-3627 (eval result is row-aligned → gather_by_idx per group).
+(at (at (select {s: (sum v) x: (* v 2) from: TX by: g}) 's) 0) -- 30
+
+;; Aggr_unary fast path inside scatter — query.c:3556-3567.
+(at (at (select {a: (avg v) m: (med v) from: TX by: g}) 'm) 0) -- 15.0
+
+;; ====================================================================
+;; BOOL group-key reorder — query.c:3252-3308.  GROUP BY a bool
+;; column where the first row is `true` must produce result rows in
+;; first-occurrence order (true before false), not radix-sorted.
+;; ====================================================================
+
+(set TB (table [b v] (list [true false true false] [1 2 3 4])))
+;; first row's b is true — radix sort would emit false first; the
+;; reorder block reverses rows to match first-occurrence order.
+(at (at (select {s: (sum v) from: TB by: b}) 'b) 0) -- true
+(at (at (select {s: (sum v) from: TB by: b}) 's) 0) -- 4
+
+;; ====================================================================
+;; nearest: KNN clause — query.c:1597-1832 with knn-rerank.
+;; ANN with hnsw-build → ann form covered too.
+;; ====================================================================
+
+;; Build a small embedding table; column `Vec` is a LIST of float vecs.
+(set TE (table [id Vec] (list [0 1 2 3 4] (list [1.0 0.0 0.0] [0.9 0.1 0.0] [0.0 1.0 0.0] [0.0 0.0 1.0] [0.5 0.5 0.0]))))
+
+;; KNN form — query.c:1739-1764.  Default metric (cosine) at 1748,
+;; cosine arm at 1755.  Take 3 → result row count 3.
+(count (select {from: TE nearest: (knn Vec [1.0 0.0 0.0]) take: 3})) -- 3
+
+;; Explicit metric symbols hit each parse_metric arm 1753-1755.
+(count (select {from: TE nearest: (knn Vec [1.0 0.0 0.0] 'l2) take: 2})) -- 2
+(count (select {from: TE nearest: (knn Vec [1.0 0.0 0.0] 'ip) take: 2})) -- 2
+(count (select {from: TE nearest: (knn Vec [1.0 0.0 0.0] 'cosine) take: 2})) -- 2
+
+;; KNN with default take=10 — query.c:1614-1615 (k_req fallback).
+(count (select {from: TE nearest: (knn Vec [1.0 0.0 0.0])})) -- 5
+
+;; Explicit projection (n_out > 0) keeps user columns and skips the
+;; implicit-projection block at 1787-1832.
+(count (at (select {n: id from: TE nearest: (knn Vec [1.0 0.0 0.0]) take: 2}) 'n)) -- 2
+
+;; KNN with I64 query vector — switch arm at query.c:1678-1683.
+(count (select {from: TE nearest: (knn Vec [1 0 0]) take: 2})) -- 2
+
+;; (knn) with F32 query vector at query.c:1665-1667 SKIPPED — the
+;; eval-level (as 'F32 ...) builtin does not register F32 as a
+;; cast target (builtins.c:930+ cast_match list lacks F32), so we
+;; can't construct an F32 vec literal here.  Coverage of that
+;; switch arm needs an F32-producing call site we don't have at
+;; rfl level today.
+
+;; ANN form — query.c:1686-1738.  hnsw-build returns an HNSW handle;
+;; nearest: (ann Idx q [ef]) reranks via the index.  Default ef path
+;; at 1713; explicit ef path at 1714-1732.
+(set Idx (hnsw-build (at TE 'Vec) 'l2 8 100))
+(count (select {from: TE nearest: (ann Idx [1.0 0.0 0.0]) take: 3})) -- 3
+(count (select {from: TE nearest: (ann Idx [1.0 0.0 0.0] 50) take: 3})) -- 3
+(hnsw-free Idx)
+
+;; ====================================================================
+;; collect_col_refs dotted path — query.c:1049-1058.  Used by the
+;; nonagg scatter fallback so a per-group expr referencing `t.col`
+;; binds the head column slice.
+;; ====================================================================
+
+(set TT2 (table [g ts v] (list ['a 'b 'a 'b] [2024.01.01D00:00:00.000 2024.06.15D12:00:00.000 2025.03.10D08:30:00.000 2025.12.31D23:59:59.000] [1 2 3 4])))
+;; A non-agg expr that mentions ts inside an aggregator-shape lambda
+;; — collapse via fn forces nonagg_eval_per_group_*; the per-group
+;; bind needs collect_col_refs to recognize ts.yyyy as a column ref
+;; on `ts` (head segment lookup at L1051-1052).
+(count (at (select {y: ((fn [d] (sum d)) ts.yyyy) from: TT2 by: g}) 'y)) -- 2
+
+;; ====================================================================
+;; Update with by — query.c:3826-3966.  Compute aggregate per group,
+;; broadcast back to every row in that group.
+;; ====================================================================
+
+(set Tu (table [g v] (list ['a 'a 'b 'b 'c 'c] [1 2 3 4 5 6])))
+(set Tu2 (update {gs: (sum v) from: Tu by: g}))
+(at (at Tu2 'gs) 0) -- 3
+(at (at Tu2 'gs) 2) -- 7
+(at (at Tu2 'gs) 4) -- 11
+(count Tu2) -- 6
+
+;; Update with by + max aggregator — exercises the dynamic out_type
+;; resolution in query.c:3933-3942 (out_type from agg result).
+(set Tu3 (update {mx: (max v) from: Tu by: g}))
+(at (at Tu3 'mx) 0) -- 2
+(at (at Tu3 'mx) 5) -- 6
+
+;; ====================================================================
+;; Update with WHERE + numeric type promotion — query.c:4076-4113.
+;; Column is I64, expression yields F64 (* col 1.5) — must promote.
+;; ====================================================================
+
+(set Tup (table [id v] (list [1 2 3 4] [10 20 30 40])))
+(set Tup2 (update {v: (* v 1.5) from: Tup where: (> id 2)}))
+;; Untouched rows preserved; masked rows get F64-cast back to I64.
+(at (at Tup2 'v) 0) -- 10
+(at (at Tup2 'v) 1) -- 20
+(at (at Tup2 'v) 2) -- 45
+(at (at Tup2 'v) 3) -- 60
+
+;; Update WHERE atom-broadcast: scalar SYM value broadcast across
+;; mask, then RAY_SYM merge loop at query.c:4221-4229.  Both arms
+;; (mask=true → expr_vec, mask=false → orig_col) hit the
+;; ray_read_sym dispatch.
+(set TupL (table [id name] (list [1 2 3] ['alice 'bob 'charlie])))
+(set TupL2 (update {name: 'XXX from: 'TupL where: (== id 2)}))
+(at (at TupL2 'name) 0) -- 'alice
+(at (at TupL2 'name) 1) -- 'XXX
+(at (at TupL2 'name) 2) -- 'charlie
+
+;; ====================================================================
+;; Update no-WHERE add-new-col — query.c:4427-4475.  Column not in
+;; original table; eval expr and add as new column.
+;; ====================================================================
+
+(set Tnc (table [id v] (list [1 2 3] [10 20 30])))
+(set Tnc2 (update {NewCol: (+ v 1) from: Tnc}))
+(at (at Tnc2 'NewCol) 0) -- 11
+(at (at Tnc2 'NewCol) 2) -- 31
+;; Scalar broadcast for new col — atom-to-vec at 4448-4470.
+(set Tnc3 (update {Tag: 99 from: Tnc}))
+(sum (at Tnc3 'Tag)) -- 297
+
+;; ====================================================================
+;; Update WHERE SYM/STR null-bit propagation — query.c:4211-4229.
+;; STR / SYM columns hit dedicated merge loops with nullmap.
+;; ====================================================================
+
+(set TupS (table [id s] (list [1 2 3 4] (list "a" "b" "c" "d"))))
+(set TupS2 (update {s: "XX" from: 'TupS where: (> id 2)}))
+(first (at TupS2 's)) -- "a"
+(at (at TupS2 's) 2) -- "XX"
+
+(set TupSy (table [id k] (list [1 2 3] ['a 'b 'c])))
+(set TupSy2 (update {k: 'XX from: 'TupSy where: (== id 2)}))
+(at (at TupSy2 'k) 0) -- 'a
+(at (at TupSy2 'k) 1) -- 'XX
+
+;; ====================================================================
+;; Vector insert / append via insert builtin — query.c:4515-4674.
+;; vec target (not table) hits the special-case dispatch at 4519-4674.
+;; ====================================================================
+
+(set v1 [1 2 3 4 5])
+(count (insert v1 6)) -- 6
+;; Same-type vec splice — query.c:4580-4583.
+(count (insert v1 [10 20])) -- 7
+;; Positional insert at index — query.c:4621-4640.
+(at (insert v1 2 99) 2) -- 99
+(count (insert v1 2 99)) -- 6
+
+;; STR vec append/insert — query.c:4562-4564 / 4624-4627.
+(set vs ["a" "b" "c"])
+(count (insert vs "d")) -- 4
+(count (insert vs 1 "X")) -- 4
+
+;; Sym vec append — query.c:4564-4566.  `['a 'b 'c]` is a SYM vec.
+(set vsy ['a 'b 'c])
+(count (insert vsy 'd)) -- 4
+(at (insert vsy 1 'X) 1) -- 'X
+
+;; List target — query.c:4555-4558 (always single-slot append).
+(set vl (list 1 'two "three"))
+(count (insert vl 4.0)) -- 4
+
+;; ====================================================================
+;; Take with negative atom (tail) at apply_sort_take — query.c:337-352
+;; (negative path).  Hit ONLY when by_expr is set, since plain take
+;; without by_expr goes through ray_tail in the DAG.
+;; ====================================================================
+
+;; Group + take -2: keep last 2 groups by sort order.  3 groups → take
+;; tail of 2.  apply_sort_take negative branch: amount=2, start=1.
+(set Ttn (table [g v] (list [1 2 3 1 2 3] [10 20 30 40 50 60])))
+(count (select {s: (sum v) from: Ttn by: g asc: g take: -2})) -- 2
+(at (at (select {s: (sum v) from: Ttn by: g asc: g take: -2}) 'g) 0) -- 2
+(at (at (select {s: (sum v) from: Ttn by: g asc: g take: -2}) 'g) 1) -- 3

--- a/test/test_dict.c
+++ b/test/test_dict.c
@@ -1,0 +1,1290 @@
+/*
+ *   Copyright (c) 2025-2026 Anton Kundenko <singaraiona@gmail.com>
+ *   All rights reserved.
+
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
+
+#include "test.h"
+#include <rayforce.h>
+#include "mem/heap.h"
+#include "table/dict.h"
+#include <string.h>
+
+/* ---- Setup / Teardown -------------------------------------------------- */
+
+static void dict_setup(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+}
+
+static void dict_teardown(void) {
+    ray_sym_destroy();
+    ray_heap_destroy();
+}
+
+/* ---- ray_dict_new error paths ------------------------------------------ */
+
+/* NULL keys input — error is propagated when keys is NULL.  vals must be
+ * released to avoid a leak; the helper does that for us. */
+static test_result_t test_dict_new_null_keys(void) {
+    ray_t* vals = ray_list_new(0);
+    TEST_ASSERT_NOT_NULL(vals);
+    ray_t* d = ray_dict_new(NULL, vals);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(d));
+    /* vals was released by ray_dict_new. */
+    ray_error_free(d);
+    PASS();
+}
+
+/* NULL vals input — keys is released by ray_dict_new and an error returned. */
+static test_result_t test_dict_new_null_vals(void) {
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W64, 0);
+    TEST_ASSERT_NOT_NULL(keys);
+    ray_t* d = ray_dict_new(keys, NULL);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(d));
+    ray_error_free(d);
+    PASS();
+}
+
+/* error keys input — propagated as-is; vals released. */
+static test_result_t test_dict_new_err_keys(void) {
+    ray_t* err = ray_error("test", NULL);
+    ray_t* vals = ray_list_new(0);
+    ray_t* d = ray_dict_new(err, vals);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(d));
+    ray_error_free(d);
+    PASS();
+}
+
+/* error vals input — keys released; error returned. */
+static test_result_t test_dict_new_err_vals(void) {
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W64, 0);
+    ray_t* err = ray_error("test", NULL);
+    ray_t* d = ray_dict_new(keys, err);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(d));
+    ray_error_free(d);
+    PASS();
+}
+
+/* ---- ray_dict_keys / ray_dict_vals / ray_dict_len NULL paths ----------- */
+
+static test_result_t test_dict_keys_null(void) {
+    TEST_ASSERT_NULL(ray_dict_keys(NULL));
+    TEST_ASSERT_NULL(ray_dict_vals(NULL));
+    TEST_ASSERT_EQ_I(ray_dict_len(NULL), 0);
+    PASS();
+}
+
+/* Non-dict input — returns NULL/0 instead of crashing. */
+static test_result_t test_dict_keys_nondict(void) {
+    ray_t* not_a_dict = ray_i64(42);
+    TEST_ASSERT_NULL(ray_dict_keys(not_a_dict));
+    TEST_ASSERT_NULL(ray_dict_vals(not_a_dict));
+    TEST_ASSERT_EQ_I(ray_dict_len(not_a_dict), 0);
+    ray_release(not_a_dict);
+    PASS();
+}
+
+/* Error input — same. */
+static test_result_t test_dict_keys_err(void) {
+    ray_t* err = ray_error("test", NULL);
+    TEST_ASSERT_NULL(ray_dict_keys(err));
+    TEST_ASSERT_NULL(ray_dict_vals(err));
+    TEST_ASSERT_EQ_I(ray_dict_len(err), 0);
+    ray_error_free(err);
+    PASS();
+}
+
+/* ---- ray_dict_find_sym width branches ---------------------------------- */
+
+/* Build a dict with keys explicitly W8/W16/W32 by constructing keys with
+ * ray_sym_vec_new directly — rfl-built sym vectors default to W64. */
+
+static test_result_t test_dict_find_sym_w8(void) {
+    int64_t a = ray_sym_intern("aa", 2);
+    int64_t b = ray_sym_intern("bb", 2);
+    int64_t c = ray_sym_intern("cc", 2);
+
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W8, 3);
+    TEST_ASSERT_NOT_NULL(keys);
+    keys = ray_vec_append(keys, &a);
+    keys = ray_vec_append(keys, &b);
+    keys = ray_vec_append(keys, &c);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(keys));
+
+    ray_t* vals = ray_list_new(3);
+    vals = ray_list_append(vals, ray_i64(10));
+    vals = ray_list_append(vals, ray_i64(20));
+    vals = ray_list_append(vals, ray_i64(30));
+
+    ray_t* d = ray_dict_new(keys, vals);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+
+    TEST_ASSERT_EQ_I(ray_dict_find_sym(d, a), 0);
+    TEST_ASSERT_EQ_I(ray_dict_find_sym(d, b), 1);
+    TEST_ASSERT_EQ_I(ray_dict_find_sym(d, c), 2);
+    TEST_ASSERT_EQ_I(ray_dict_find_sym(d, 9999), -1);
+
+    ray_release(d);
+    PASS();
+}
+
+static test_result_t test_dict_find_sym_w16(void) {
+    int64_t a = ray_sym_intern("ax", 2);
+    int64_t b = ray_sym_intern("bx", 2);
+
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W16, 2);
+    keys = ray_vec_append(keys, &a);
+    keys = ray_vec_append(keys, &b);
+
+    ray_t* vals = ray_list_new(2);
+    vals = ray_list_append(vals, ray_i64(1));
+    vals = ray_list_append(vals, ray_i64(2));
+
+    ray_t* d = ray_dict_new(keys, vals);
+    TEST_ASSERT_EQ_I(ray_dict_find_sym(d, a), 0);
+    TEST_ASSERT_EQ_I(ray_dict_find_sym(d, b), 1);
+    TEST_ASSERT_EQ_I(ray_dict_find_sym(d, 9999), -1);
+
+    ray_release(d);
+    PASS();
+}
+
+static test_result_t test_dict_find_sym_w32(void) {
+    int64_t a = ray_sym_intern("ay", 2);
+
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W32, 1);
+    keys = ray_vec_append(keys, &a);
+
+    ray_t* vals = ray_list_new(1);
+    vals = ray_list_append(vals, ray_i64(7));
+
+    ray_t* d = ray_dict_new(keys, vals);
+    TEST_ASSERT_EQ_I(ray_dict_find_sym(d, a), 0);
+    TEST_ASSERT_EQ_I(ray_dict_find_sym(d, 9999), -1);
+
+    ray_release(d);
+    PASS();
+}
+
+/* find_sym on NULL/non-dict/non-sym keys → -1 (early-return paths). */
+static test_result_t test_dict_find_sym_invalid(void) {
+    TEST_ASSERT_EQ_I(ray_dict_find_sym(NULL, 1), -1);
+
+    ray_t* not_a_dict = ray_i64(42);
+    TEST_ASSERT_EQ_I(ray_dict_find_sym(not_a_dict, 1), -1);
+    ray_release(not_a_dict);
+
+    /* Dict with non-sym keys → also -1. */
+    int64_t k0 = 10, k1 = 20;
+    ray_t* keys = ray_vec_new(RAY_I64, 2);
+    keys = ray_vec_append(keys, &k0);
+    keys = ray_vec_append(keys, &k1);
+    ray_t* vals = ray_list_new(2);
+    vals = ray_list_append(vals, ray_i64(1));
+    vals = ray_list_append(vals, ray_i64(2));
+    ray_t* d = ray_dict_new(keys, vals);
+
+    TEST_ASSERT_EQ_I(ray_dict_find_sym(d, 10), -1);
+
+    ray_release(d);
+    PASS();
+}
+
+/* ---- ray_dict_probe_sym_borrowed / ray_container_probe_sym ------------- */
+
+static test_result_t test_dict_probe_sym_borrowed(void) {
+    int64_t a = ray_sym_intern("alpha", 5);
+    int64_t b = ray_sym_intern("beta", 4);
+
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W64, 2);
+    keys = ray_vec_append(keys, &a);
+    keys = ray_vec_append(keys, &b);
+
+    ray_t* vals = ray_list_new(2);
+    ray_t* va = ray_i64(100);
+    ray_t* vb = ray_i64(200);
+    vals = ray_list_append(vals, va);
+    vals = ray_list_append(vals, vb);
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    /* Hit — borrowed pointer, should equal va. */
+    ray_t* got = ray_dict_probe_sym_borrowed(d, a);
+    TEST_ASSERT_EQ_PTR(got, va);
+
+    /* Miss → NULL. */
+    int64_t missing = ray_sym_intern("missing", 7);
+    TEST_ASSERT_NULL(ray_dict_probe_sym_borrowed(d, missing));
+
+    /* Container probe routes dict→borrowed. */
+    TEST_ASSERT_EQ_PTR(ray_container_probe_sym(d, a), va);
+
+    /* Container probe on non-dict/non-table returns NULL. */
+    ray_t* atom = ray_i64(1);
+    TEST_ASSERT_NULL(ray_container_probe_sym(atom, a));
+    TEST_ASSERT_NULL(ray_container_probe_sym(NULL, a));
+    ray_release(atom);
+
+    /* Probe on a typed-vec-vals dict → NULL (vals must be RAY_LIST). */
+    int64_t k = ray_sym_intern("k", 1);
+    ray_t* keys2 = ray_sym_vec_new(RAY_SYM_W64, 1);
+    keys2 = ray_vec_append(keys2, &k);
+    int64_t v0 = 11;
+    ray_t* vals2 = ray_vec_new(RAY_I64, 1);
+    vals2 = ray_vec_append(vals2, &v0);
+    ray_t* d2 = ray_dict_new(keys2, vals2);
+    TEST_ASSERT_NULL(ray_dict_probe_sym_borrowed(d2, k));
+    ray_release(d2);
+
+    ray_release(va);
+    ray_release(vb);
+    ray_release(d);
+    PASS();
+}
+
+/* ---- ray_dict_find_idx & ray_dict_get for typed-vec values ------------- */
+
+/* Boxes the value out of a typed BOOL/U8/I16/I32/F32/F64/DATE/TIME/
+ * TIMESTAMP/SYM/STR/GUID vector — exercises every dict_vals_at branch. */
+static test_result_t test_dict_get_typed_vec_vals(void) {
+    /* I64 keys → I64 vals. */
+    int64_t k1 = 100, k2 = 200;
+    ray_t* keys = ray_vec_new(RAY_I64, 2);
+    keys = ray_vec_append(keys, &k1);
+    keys = ray_vec_append(keys, &k2);
+
+    int64_t v1 = 1234567890LL, v2 = 9876543210LL;
+    ray_t* vals = ray_vec_new(RAY_I64, 2);
+    vals = ray_vec_append(vals, &v1);
+    vals = ray_vec_append(vals, &v2);
+
+    ray_t* d = ray_dict_new(keys, vals);
+    ray_t* key_atom = ray_i64(100);
+    ray_t* got = ray_dict_get(d, key_atom);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQ_I(got->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(got->i64, 1234567890LL);
+    ray_release(got);
+    ray_release(key_atom);
+
+    /* Miss → NULL. */
+    ray_t* miss_key = ray_i64(99);
+    TEST_ASSERT_NULL(ray_dict_get(d, miss_key));
+    ray_release(miss_key);
+    ray_release(d);
+    PASS();
+}
+
+static test_result_t test_dict_get_each_value_type(void) {
+    /* Build keys [1,2,3] and a different vals type for each test inside. */
+    int64_t k1 = 1, k2 = 2;
+    ray_t* keys = ray_vec_new(RAY_I64, 2);
+    keys = ray_vec_append(keys, &k1);
+    keys = ray_vec_append(keys, &k2);
+
+    /* BOOL */
+    {
+        uint8_t b1 = 1, b2 = 0;
+        ray_t* k = ray_cow(keys); ray_retain(k);
+        ray_t* v = ray_vec_new(RAY_BOOL, 2);
+        v = ray_vec_append(v, &b1);
+        v = ray_vec_append(v, &b2);
+        ray_t* d = ray_dict_new(k, v);
+        ray_t* ka = ray_i64(1);
+        ray_t* g = ray_dict_get(d, ka);
+        TEST_ASSERT_NOT_NULL(g);
+        TEST_ASSERT_EQ_I(g->type, -RAY_BOOL);
+        TEST_ASSERT_EQ_U(g->b8, 1);
+        ray_release(g);
+        ray_release(ka);
+        ray_release(d);
+    }
+
+    /* U8 */
+    {
+        uint8_t u1 = 7, u2 = 9;
+        ray_t* k = ray_cow(keys); ray_retain(k);
+        ray_t* v = ray_vec_new(RAY_U8, 2);
+        v = ray_vec_append(v, &u1);
+        v = ray_vec_append(v, &u2);
+        ray_t* d = ray_dict_new(k, v);
+        ray_t* ka = ray_i64(2);
+        ray_t* g = ray_dict_get(d, ka);
+        TEST_ASSERT_NOT_NULL(g);
+        TEST_ASSERT_EQ_I(g->type, -RAY_U8);
+        TEST_ASSERT_EQ_U(g->u8, 9);
+        ray_release(g);
+        ray_release(ka);
+        ray_release(d);
+    }
+
+    /* I16 */
+    {
+        int16_t s1 = 100, s2 = -100;
+        ray_t* k = ray_cow(keys); ray_retain(k);
+        ray_t* v = ray_vec_new(RAY_I16, 2);
+        v = ray_vec_append(v, &s1);
+        v = ray_vec_append(v, &s2);
+        ray_t* d = ray_dict_new(k, v);
+        ray_t* ka = ray_i64(2);
+        ray_t* g = ray_dict_get(d, ka);
+        TEST_ASSERT_NOT_NULL(g);
+        TEST_ASSERT_EQ_I(g->type, -RAY_I16);
+        TEST_ASSERT_EQ_I(g->i16, -100);
+        ray_release(g);
+        ray_release(ka);
+        ray_release(d);
+    }
+
+    /* I32 */
+    {
+        int32_t s1 = 1000, s2 = -1000;
+        ray_t* k = ray_cow(keys); ray_retain(k);
+        ray_t* v = ray_vec_new(RAY_I32, 2);
+        v = ray_vec_append(v, &s1);
+        v = ray_vec_append(v, &s2);
+        ray_t* d = ray_dict_new(k, v);
+        ray_t* ka = ray_i64(1);
+        ray_t* g = ray_dict_get(d, ka);
+        TEST_ASSERT_NOT_NULL(g);
+        TEST_ASSERT_EQ_I(g->type, -RAY_I32);
+        TEST_ASSERT_EQ_I(g->i32, 1000);
+        ray_release(g);
+        ray_release(ka);
+        ray_release(d);
+    }
+
+    /* F32 */
+    {
+        float f1 = 1.5f, f2 = -2.5f;
+        ray_t* k = ray_cow(keys); ray_retain(k);
+        ray_t* v = ray_vec_new(RAY_F32, 2);
+        v = ray_vec_append(v, &f1);
+        v = ray_vec_append(v, &f2);
+        ray_t* d = ray_dict_new(k, v);
+        ray_t* ka = ray_i64(1);
+        ray_t* g = ray_dict_get(d, ka);
+        TEST_ASSERT_NOT_NULL(g);
+        TEST_ASSERT_EQ_I(g->type, -RAY_F32);
+        TEST_ASSERT_EQ_F(g->f64, 1.5, 1e-6);
+        ray_release(g);
+        ray_release(ka);
+        ray_release(d);
+    }
+
+    /* F64 */
+    {
+        double f1 = 3.14, f2 = 2.71;
+        ray_t* k = ray_cow(keys); ray_retain(k);
+        ray_t* v = ray_vec_new(RAY_F64, 2);
+        v = ray_vec_append(v, &f1);
+        v = ray_vec_append(v, &f2);
+        ray_t* d = ray_dict_new(k, v);
+        ray_t* ka = ray_i64(1);
+        ray_t* g = ray_dict_get(d, ka);
+        TEST_ASSERT_NOT_NULL(g);
+        TEST_ASSERT_EQ_I(g->type, -RAY_F64);
+        TEST_ASSERT_EQ_F(g->f64, 3.14, 1e-9);
+        ray_release(g);
+        ray_release(ka);
+        ray_release(d);
+    }
+
+    /* DATE */
+    {
+        int32_t d1 = 12345, d2 = 67890;
+        ray_t* k = ray_cow(keys); ray_retain(k);
+        ray_t* v = ray_vec_new(RAY_DATE, 2);
+        v = ray_vec_append(v, &d1);
+        v = ray_vec_append(v, &d2);
+        ray_t* d = ray_dict_new(k, v);
+        ray_t* ka = ray_i64(2);
+        ray_t* g = ray_dict_get(d, ka);
+        TEST_ASSERT_NOT_NULL(g);
+        TEST_ASSERT_EQ_I(g->type, -RAY_DATE);
+        TEST_ASSERT_EQ_I(g->i32, 67890);
+        ray_release(g);
+        ray_release(ka);
+        ray_release(d);
+    }
+
+    /* TIME */
+    {
+        int32_t t1 = 1, t2 = 2;
+        ray_t* k = ray_cow(keys); ray_retain(k);
+        ray_t* v = ray_vec_new(RAY_TIME, 2);
+        v = ray_vec_append(v, &t1);
+        v = ray_vec_append(v, &t2);
+        ray_t* d = ray_dict_new(k, v);
+        ray_t* ka = ray_i64(2);
+        ray_t* g = ray_dict_get(d, ka);
+        TEST_ASSERT_NOT_NULL(g);
+        TEST_ASSERT_EQ_I(g->type, -RAY_TIME);
+        TEST_ASSERT_EQ_I(g->i32, 2);
+        ray_release(g);
+        ray_release(ka);
+        ray_release(d);
+    }
+
+    /* TIMESTAMP */
+    {
+        int64_t ts1 = 100, ts2 = 200;
+        ray_t* k = ray_cow(keys); ray_retain(k);
+        ray_t* v = ray_vec_new(RAY_TIMESTAMP, 2);
+        v = ray_vec_append(v, &ts1);
+        v = ray_vec_append(v, &ts2);
+        ray_t* d = ray_dict_new(k, v);
+        ray_t* ka = ray_i64(2);
+        ray_t* g = ray_dict_get(d, ka);
+        TEST_ASSERT_NOT_NULL(g);
+        TEST_ASSERT_EQ_I(g->type, -RAY_TIMESTAMP);
+        TEST_ASSERT_EQ_I(g->i64, 200);
+        ray_release(g);
+        ray_release(ka);
+        ray_release(d);
+    }
+
+    /* SYM (typed-vec vals) */
+    {
+        int64_t s1 = ray_sym_intern("first", 5);
+        int64_t s2 = ray_sym_intern("second", 6);
+        ray_t* k = ray_cow(keys); ray_retain(k);
+        ray_t* v = ray_sym_vec_new(RAY_SYM_W64, 2);
+        v = ray_vec_append(v, &s1);
+        v = ray_vec_append(v, &s2);
+        ray_t* d = ray_dict_new(k, v);
+        ray_t* ka = ray_i64(1);
+        ray_t* g = ray_dict_get(d, ka);
+        TEST_ASSERT_NOT_NULL(g);
+        TEST_ASSERT_EQ_I(g->type, -RAY_SYM);
+        TEST_ASSERT_EQ_I(g->i64, s1);
+        ray_release(g);
+        ray_release(ka);
+        ray_release(d);
+    }
+
+    /* STR */
+    {
+        ray_t* k = ray_cow(keys); ray_retain(k);
+        ray_t* v = ray_vec_new(RAY_STR, 2);
+        v = ray_str_vec_append(v, "hello", 5);
+        v = ray_str_vec_append(v, "world", 5);
+        ray_t* d = ray_dict_new(k, v);
+        ray_t* ka = ray_i64(1);
+        ray_t* g = ray_dict_get(d, ka);
+        TEST_ASSERT_NOT_NULL(g);
+        TEST_ASSERT_EQ_I(g->type, -RAY_STR);
+        TEST_ASSERT_EQ_U(ray_str_len(g), 5);
+        TEST_ASSERT_MEM_EQ(5, ray_str_ptr(g), "hello");
+        ray_release(g);
+        ray_release(ka);
+        ray_release(d);
+    }
+
+    /* GUID */
+    {
+        uint8_t g1[16] = { 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 };
+        uint8_t g2[16] = { 0 };
+        ray_t* k = ray_cow(keys); ray_retain(k);
+        ray_t* v = ray_vec_new(RAY_GUID, 2);
+        v = ray_vec_append(v, g1);
+        v = ray_vec_append(v, g2);
+        ray_t* d = ray_dict_new(k, v);
+        ray_t* ka = ray_i64(1);
+        ray_t* g = ray_dict_get(d, ka);
+        TEST_ASSERT_NOT_NULL(g);
+        TEST_ASSERT_EQ_I(g->type, -RAY_GUID);
+        ray_release(g);
+        ray_release(ka);
+        ray_release(d);
+    }
+
+    ray_release(keys);
+    PASS();
+}
+
+/* find_idx with NULL/error inputs → -1 (early-return paths). */
+static test_result_t test_dict_find_idx_invalid(void) {
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(NULL, NULL), -1);
+
+    ray_t* atom = ray_i64(1);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(NULL, atom), -1);
+
+    ray_t* not_a_dict = ray_i64(2);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(not_a_dict, atom), -1);
+    ray_release(not_a_dict);
+
+    /* Dict with empty keys (n<=0 short-circuit). */
+    ray_t* keys = ray_vec_new(RAY_I64, 0);
+    ray_t* vals = ray_list_new(0);
+    ray_t* d = ray_dict_new(keys, vals);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, atom), -1);
+
+    /* dict with NULL key_atom returns -1. */
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, NULL), -1);
+
+    ray_release(atom);
+    ray_release(d);
+    PASS();
+}
+
+/* ---- ray_dict_find_idx F32 path & GUID path ---------------------------- */
+
+static test_result_t test_dict_find_idx_f32(void) {
+    float v1 = 1.5f, v2 = -2.25f;
+    ray_t* keys = ray_vec_new(RAY_F32, 2);
+    keys = ray_vec_append(keys, &v1);
+    keys = ray_vec_append(keys, &v2);
+
+    ray_t* vals = ray_list_new(2);
+    vals = ray_list_append(vals, ray_i64(10));
+    vals = ray_list_append(vals, ray_i64(20));
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* k1 = ray_f32(1.5f);
+    ray_t* g = ray_dict_get(d, k1);
+    TEST_ASSERT_NOT_NULL(g);
+    TEST_ASSERT_EQ_I(g->i64, 10);
+    ray_release(g);
+    ray_release(k1);
+
+    /* Miss. */
+    ray_t* k_miss = ray_f32(99.0f);
+    TEST_ASSERT_NULL(ray_dict_get(d, k_miss));
+    ray_release(k_miss);
+
+    ray_release(d);
+    PASS();
+}
+
+static test_result_t test_dict_find_idx_guid(void) {
+    uint8_t g1[16] = { 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 };
+    uint8_t g2[16] = { 16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1 };
+    uint8_t g3[16] = { 0 };
+
+    ray_t* keys = ray_vec_new(RAY_GUID, 2);
+    keys = ray_vec_append(keys, g1);
+    keys = ray_vec_append(keys, g2);
+
+    ray_t* vals = ray_list_new(2);
+    vals = ray_list_append(vals, ray_i64(100));
+    vals = ray_list_append(vals, ray_i64(200));
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_guid(g1);
+    ray_t* got = ray_dict_get(d, ka);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQ_I(got->i64, 100);
+    ray_release(got);
+    ray_release(ka);
+
+    ray_t* km = ray_guid(g3);
+    TEST_ASSERT_NULL(ray_dict_get(d, km));
+    ray_release(km);
+
+    ray_release(d);
+    PASS();
+}
+
+/* find_idx — keys_have_nulls path with non-null query: must skip null
+ * slots and match a valid one. */
+static test_result_t test_dict_find_idx_with_nulls(void) {
+    int64_t v1 = 10, v2 = 0, v3 = 30;
+    ray_t* keys = ray_vec_new(RAY_I64, 3);
+    keys = ray_vec_append(keys, &v1);
+    keys = ray_vec_append(keys, &v2);
+    keys = ray_vec_append(keys, &v3);
+    /* Mark slot 1 as null. */
+    ray_vec_set_null(keys, 1, true);
+
+    ray_t* vals = ray_list_new(3);
+    vals = ray_list_append(vals, ray_i64(1));
+    vals = ray_list_append(vals, ray_i64(2));
+    vals = ray_list_append(vals, ray_i64(3));
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    /* Find non-null: must skip the null slot and continue. */
+    ray_t* k = ray_i64(30);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, k), 2);
+    ray_release(k);
+
+    /* Lookup of zero (matches null slot value if not null-aware) — should
+     * NOT find it because slot 1 is null. */
+    ray_t* k0 = ray_i64(0);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, k0), -1);
+    ray_release(k0);
+
+    ray_release(d);
+    PASS();
+}
+
+/* ---- ray_dict_upsert paths --------------------------------------------- */
+
+/* Upsert into a non-dict input — it's released and a fresh dict is built. */
+static test_result_t test_dict_upsert_into_nondict(void) {
+    ray_t* not_a_dict = ray_i64(42);
+    ray_t* k = ray_sym(ray_sym_intern("k", 1));
+    ray_t* v = ray_i64(100);
+
+    ray_t* d = ray_dict_upsert(not_a_dict, k, v);
+    TEST_ASSERT_NOT_NULL(d);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+    TEST_ASSERT_EQ_I(d->type, RAY_DICT);
+    TEST_ASSERT_EQ_I(ray_dict_len(d), 1);
+
+    ray_t* got = ray_dict_get(d, k);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQ_I(got->i64, 100);
+    ray_release(got);
+
+    ray_release(k);
+    ray_release(v);
+    ray_release(d);
+    PASS();
+}
+
+/* Upsert into NULL d → error. */
+static test_result_t test_dict_upsert_null_d(void) {
+    ray_t* k = ray_sym(ray_sym_intern("k", 1));
+    ray_t* v = ray_i64(1);
+    ray_t* res = ray_dict_upsert(NULL, k, v);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(res));
+    ray_error_free(res);
+    ray_release(k);
+    ray_release(v);
+    PASS();
+}
+
+/* Upsert with NULL val → error; d released. */
+static test_result_t test_dict_upsert_null_val(void) {
+    int64_t k = ray_sym_intern("only", 4);
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W64, 1);
+    keys = ray_vec_append(keys, &k);
+    ray_t* vals = ray_list_new(1);
+    vals = ray_list_append(vals, ray_i64(1));
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_sym(k);
+    ray_t* res = ray_dict_upsert(d, ka, NULL);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(res));
+    ray_error_free(res);
+    ray_release(ka);
+    PASS();
+}
+
+/* Upsert replace existing key with a new value — exercises idx>=0 + LIST
+ * vals branch. */
+static test_result_t test_dict_upsert_replace_list_vals(void) {
+    int64_t k = ray_sym_intern("k", 1);
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W64, 1);
+    keys = ray_vec_append(keys, &k);
+    ray_t* vals = ray_list_new(1);
+    vals = ray_list_append(vals, ray_i64(1));
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_sym(k);
+    ray_t* nv = ray_i64(999);
+    d = ray_dict_upsert(d, ka, nv);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+    TEST_ASSERT_EQ_I(ray_dict_len(d), 1);
+
+    ray_t* got = ray_dict_get(d, ka);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQ_I(got->i64, 999);
+    ray_release(got);
+
+    ray_release(ka);
+    ray_release(nv);
+    ray_release(d);
+    PASS();
+}
+
+/* Upsert into a typed-vec vals dict — replaces by promoting to LIST. */
+static test_result_t test_dict_upsert_replace_typed_vec_vals(void) {
+    int64_t k1 = 1, k2 = 2;
+    ray_t* keys = ray_vec_new(RAY_I64, 2);
+    keys = ray_vec_append(keys, &k1);
+    keys = ray_vec_append(keys, &k2);
+
+    int64_t v1 = 10, v2 = 20;
+    ray_t* vals = ray_vec_new(RAY_I64, 2);
+    vals = ray_vec_append(vals, &v1);
+    vals = ray_vec_append(vals, &v2);
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_i64(1);
+    ray_t* nv = ray_i64(777);
+    d = ray_dict_upsert(d, ka, nv);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+
+    /* After promotion, vals is RAY_LIST. */
+    ray_t* dvals = ray_dict_vals(d);
+    TEST_ASSERT_EQ_I(dvals->type, RAY_LIST);
+
+    ray_t* got = ray_dict_get(d, ka);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQ_I(got->i64, 777);
+    ray_release(got);
+
+    ray_release(ka);
+    ray_release(nv);
+    ray_release(d);
+    PASS();
+}
+
+/* Upsert append new key into typed-vec vals dict — promotes. */
+static test_result_t test_dict_upsert_append_typed_vec_vals(void) {
+    int64_t k1 = 1;
+    ray_t* keys = ray_vec_new(RAY_I64, 1);
+    keys = ray_vec_append(keys, &k1);
+
+    int64_t v1 = 10;
+    ray_t* vals = ray_vec_new(RAY_I64, 1);
+    vals = ray_vec_append(vals, &v1);
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_i64(2);
+    ray_t* nv = ray_f64(2.5);
+    d = ray_dict_upsert(d, ka, nv);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+    TEST_ASSERT_EQ_I(ray_dict_len(d), 2);
+
+    ray_t* got = ray_dict_get(d, ka);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQ_F(got->f64, 2.5, 1e-9);
+    ray_release(got);
+
+    ray_release(ka);
+    ray_release(nv);
+    ray_release(d);
+    PASS();
+}
+
+/* Upsert append str key — exercises STR branch in append. */
+static test_result_t test_dict_upsert_append_str_key(void) {
+    /* Start with a STR key dict. */
+    ray_t* keys = ray_vec_new(RAY_STR, 1);
+    keys = ray_str_vec_append(keys, "hello", 5);
+    ray_t* vals = ray_list_new(1);
+    vals = ray_list_append(vals, ray_i64(1));
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* k2 = ray_str("world", 5);
+    ray_t* v2 = ray_i64(2);
+    d = ray_dict_upsert(d, k2, v2);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+    TEST_ASSERT_EQ_I(ray_dict_len(d), 2);
+
+    ray_t* got = ray_dict_get(d, k2);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQ_I(got->i64, 2);
+    ray_release(got);
+
+    ray_release(k2);
+    ray_release(v2);
+    ray_release(d);
+    PASS();
+}
+
+/* Upsert append GUID key — exercises GUID branch. */
+static test_result_t test_dict_upsert_append_guid_key(void) {
+    uint8_t g1[16] = { 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 };
+    uint8_t g2[16] = { 16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1 };
+
+    ray_t* keys = ray_vec_new(RAY_GUID, 1);
+    keys = ray_vec_append(keys, g1);
+    ray_t* vals = ray_list_new(1);
+    vals = ray_list_append(vals, ray_i64(1));
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* k2 = ray_guid(g2);
+    ray_t* v2 = ray_i64(2);
+    d = ray_dict_upsert(d, k2, v2);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+    TEST_ASSERT_EQ_I(ray_dict_len(d), 2);
+
+    ray_t* got = ray_dict_get(d, k2);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQ_I(got->i64, 2);
+    ray_release(got);
+
+    ray_release(k2);
+    ray_release(v2);
+    ray_release(d);
+    PASS();
+}
+
+/* Upsert append F32 key — exercises F32 narrow-then-append branch. */
+static test_result_t test_dict_upsert_append_f32_key(void) {
+    float k1 = 1.5f;
+    ray_t* keys = ray_vec_new(RAY_F32, 1);
+    keys = ray_vec_append(keys, &k1);
+    ray_t* vals = ray_list_new(1);
+    vals = ray_list_append(vals, ray_i64(1));
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* k2 = ray_f32(2.5f);
+    ray_t* v2 = ray_i64(2);
+    d = ray_dict_upsert(d, k2, v2);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+    TEST_ASSERT_EQ_I(ray_dict_len(d), 2);
+
+    ray_t* got = ray_dict_get(d, k2);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQ_I(got->i64, 2);
+    ray_release(got);
+
+    ray_release(k2);
+    ray_release(v2);
+    ray_release(d);
+    PASS();
+}
+
+/* Upsert with mismatched key type into existing typed-key dict → "type". */
+static test_result_t test_dict_upsert_key_type_mismatch(void) {
+    int64_t k1 = 1;
+    ray_t* keys = ray_vec_new(RAY_I64, 1);
+    keys = ray_vec_append(keys, &k1);
+    ray_t* vals = ray_list_new(1);
+    vals = ray_list_append(vals, ray_i64(1));
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* bad_k = ray_str("oops", 4);
+    ray_t* v = ray_i64(99);
+    ray_t* res = ray_dict_upsert(d, bad_k, v);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(res));
+    ray_error_free(res);
+
+    ray_release(bad_k);
+    ray_release(v);
+    PASS();
+}
+
+/* Upsert into empty dict (placeholder I64 keys) with str-key — exercises
+ * the empty-target adoption branch swap of keys vec. */
+static test_result_t test_dict_upsert_empty_adopt_str(void) {
+    /* Build d = (dict [] []) with default I64 placeholder keys. */
+    ray_t* keys = ray_vec_new(RAY_I64, 0);
+    ray_t* vals = ray_list_new(0);
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* k = ray_str("hello", 5);
+    ray_t* v = ray_i64(42);
+    d = ray_dict_upsert(d, k, v);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+    TEST_ASSERT_EQ_I(ray_dict_len(d), 1);
+
+    /* Keys vec should now be RAY_STR. */
+    ray_t* dkeys = ray_dict_keys(d);
+    TEST_ASSERT_EQ_I(dkeys->type, RAY_STR);
+
+    ray_t* got = ray_dict_get(d, k);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQ_I(got->i64, 42);
+    ray_release(got);
+
+    ray_release(k);
+    ray_release(v);
+    ray_release(d);
+    PASS();
+}
+
+/* ---- ray_dict_remove paths --------------------------------------------- */
+
+/* remove with NULL d → error. */
+static test_result_t test_dict_remove_null_d(void) {
+    ray_t* k = ray_sym(ray_sym_intern("k", 1));
+    ray_t* res = ray_dict_remove(NULL, k);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(res));
+    ray_error_free(res);
+    ray_release(k);
+    PASS();
+}
+
+/* remove on non-dict → error; d released. */
+static test_result_t test_dict_remove_nondict(void) {
+    ray_t* not_a_dict = ray_i64(42);
+    ray_t* k = ray_sym(ray_sym_intern("k", 1));
+    ray_t* res = ray_dict_remove(not_a_dict, k);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(res));
+    ray_error_free(res);
+    ray_release(k);
+    PASS();
+}
+
+/* remove typed-vec keys — exercises generic typed-vec branch (line 614+). */
+static test_result_t test_dict_remove_typed_vec_keys(void) {
+    int64_t k1 = 10, k2 = 20, k3 = 30;
+    ray_t* keys = ray_vec_new(RAY_I64, 3);
+    keys = ray_vec_append(keys, &k1);
+    keys = ray_vec_append(keys, &k2);
+    keys = ray_vec_append(keys, &k3);
+
+    ray_t* vals = ray_list_new(3);
+    vals = ray_list_append(vals, ray_i64(1));
+    vals = ray_list_append(vals, ray_i64(2));
+    vals = ray_list_append(vals, ray_i64(3));
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_i64(20);
+    d = ray_dict_remove(d, ka);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+    TEST_ASSERT_EQ_I(ray_dict_len(d), 2);
+
+    /* k1 and k3 remain. */
+    ray_t* g1 = ray_dict_get(d, (ray_release(ka), ka = ray_i64(10)));
+    TEST_ASSERT_NOT_NULL(g1);
+    TEST_ASSERT_EQ_I(g1->i64, 1);
+    ray_release(g1);
+    ray_release(ka);
+
+    ka = ray_i64(20);
+    TEST_ASSERT_NULL(ray_dict_get(d, ka));
+    ray_release(ka);
+
+    ray_release(d);
+    PASS();
+}
+
+/* remove typed-vec keys with typed-vec vals — exercises the LIST-promote
+ * branch in remove. */
+static test_result_t test_dict_remove_typed_vec_vals_promote(void) {
+    int64_t k1 = 1, k2 = 2;
+    ray_t* keys = ray_vec_new(RAY_I64, 2);
+    keys = ray_vec_append(keys, &k1);
+    keys = ray_vec_append(keys, &k2);
+
+    int64_t v1 = 11, v2 = 22;
+    ray_t* vals = ray_vec_new(RAY_I64, 2);
+    vals = ray_vec_append(vals, &v1);
+    vals = ray_vec_append(vals, &v2);
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_i64(1);
+    d = ray_dict_remove(d, ka);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+    TEST_ASSERT_EQ_I(ray_dict_len(d), 1);
+
+    /* Vals after promote is now RAY_LIST. */
+    ray_t* dvals = ray_dict_vals(d);
+    TEST_ASSERT_EQ_I(dvals->type, RAY_LIST);
+
+    /* Remaining key 2. */
+    ray_t* k2a = ray_i64(2);
+    ray_t* got = ray_dict_get(d, k2a);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQ_I(got->i64, 22);
+    ray_release(got);
+    ray_release(k2a);
+    ray_release(ka);
+
+    ray_release(d);
+    PASS();
+}
+
+/* remove a STR key — exercises STR branch in remove. */
+static test_result_t test_dict_remove_str_keys(void) {
+    ray_t* keys = ray_vec_new(RAY_STR, 3);
+    keys = ray_str_vec_append(keys, "alpha", 5);
+    keys = ray_str_vec_append(keys, "beta", 4);
+    keys = ray_str_vec_append(keys, "gamma", 5);
+
+    ray_t* vals = ray_list_new(3);
+    vals = ray_list_append(vals, ray_i64(1));
+    vals = ray_list_append(vals, ray_i64(2));
+    vals = ray_list_append(vals, ray_i64(3));
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* k = ray_str("beta", 4);
+    d = ray_dict_remove(d, k);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+    TEST_ASSERT_EQ_I(ray_dict_len(d), 2);
+
+    ray_t* gone = ray_dict_get(d, k);
+    TEST_ASSERT_NULL(gone);
+
+    ray_release(k);
+    ray_release(d);
+    PASS();
+}
+
+/* remove SYM key from W8/W16/W32 vec — exercises sym branch. */
+static test_result_t test_dict_remove_sym_keys_w8(void) {
+    int64_t a = ray_sym_intern("alpha2", 6);
+    int64_t b = ray_sym_intern("beta2", 5);
+    int64_t c = ray_sym_intern("gamma2", 6);
+
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W8, 3);
+    keys = ray_vec_append(keys, &a);
+    keys = ray_vec_append(keys, &b);
+    keys = ray_vec_append(keys, &c);
+
+    ray_t* vals = ray_list_new(3);
+    vals = ray_list_append(vals, ray_i64(1));
+    vals = ray_list_append(vals, ray_i64(2));
+    vals = ray_list_append(vals, ray_i64(3));
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_sym(b);
+    d = ray_dict_remove(d, ka);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+    TEST_ASSERT_EQ_I(ray_dict_len(d), 2);
+
+    /* `a` and `c` should be findable. */
+    ray_t* k_a = ray_sym(a);
+    ray_t* got = ray_dict_get(d, k_a);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQ_I(got->i64, 1);
+    ray_release(got);
+    ray_release(k_a);
+
+    /* `b` should be missing. */
+    TEST_ASSERT_NULL(ray_dict_get(d, ka));
+
+    ray_release(ka);
+    ray_release(d);
+    PASS();
+}
+
+/* ---- find_idx SYM W8/W16/W32 paths ------------------------------------ */
+
+/* Hits the SYM W8 branch inside ray_dict_find_idx (separate from
+ * ray_dict_find_sym, which has its own W8/W16/W32 dispatcher). */
+static test_result_t test_dict_find_idx_sym_w8(void) {
+    int64_t a = ray_sym_intern("aaa", 3);
+    int64_t b = ray_sym_intern("bbb", 3);
+
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W8, 2);
+    keys = ray_vec_append(keys, &a);
+    keys = ray_vec_append(keys, &b);
+
+    ray_t* vals = ray_list_new(2);
+    vals = ray_list_append(vals, ray_i64(11));
+    vals = ray_list_append(vals, ray_i64(22));
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_sym(a);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, ka), 0);
+    ray_release(ka);
+
+    ka = ray_sym(b);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, ka), 1);
+    ray_release(ka);
+
+    int64_t missing = ray_sym_intern("zzz", 3);
+    ka = ray_sym(missing);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, ka), -1);
+    ray_release(ka);
+
+    ray_release(d);
+    PASS();
+}
+
+static test_result_t test_dict_find_idx_sym_w16(void) {
+    int64_t a = ray_sym_intern("ssa", 3);
+    int64_t b = ray_sym_intern("ssb", 3);
+
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W16, 2);
+    keys = ray_vec_append(keys, &a);
+    keys = ray_vec_append(keys, &b);
+
+    ray_t* vals = ray_list_new(2);
+    vals = ray_list_append(vals, ray_i64(33));
+    vals = ray_list_append(vals, ray_i64(44));
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_sym(b);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, ka), 1);
+    ray_release(ka);
+
+    int64_t missing = ray_sym_intern("xxx", 3);
+    ka = ray_sym(missing);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, ka), -1);
+    ray_release(ka);
+
+    ray_release(d);
+    PASS();
+}
+
+static test_result_t test_dict_find_idx_sym_w32(void) {
+    int64_t a = ray_sym_intern("ww32a", 5);
+
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W32, 1);
+    keys = ray_vec_append(keys, &a);
+
+    ray_t* vals = ray_list_new(1);
+    vals = ray_list_append(vals, ray_i64(55));
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_sym(a);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, ka), 0);
+    ray_release(ka);
+
+    ray_release(d);
+    PASS();
+}
+
+/* find_idx STR keys with nulls — exercises null-skip in STR loop. */
+static test_result_t test_dict_find_idx_str_with_nulls(void) {
+    ray_t* keys = ray_vec_new(RAY_STR, 3);
+    keys = ray_str_vec_append(keys, "alpha", 5);
+    keys = ray_str_vec_append(keys, "", 0);
+    keys = ray_str_vec_append(keys, "gamma", 5);
+    /* Mark slot 1 as null. */
+    ray_vec_set_null(keys, 1, true);
+
+    ray_t* vals = ray_list_new(3);
+    vals = ray_list_append(vals, ray_i64(1));
+    vals = ray_list_append(vals, ray_i64(2));
+    vals = ray_list_append(vals, ray_i64(3));
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_str("gamma", 5);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, ka), 2);
+    ray_release(ka);
+
+    /* An empty-string lookup must skip the null slot. */
+    ka = ray_str("", 0);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, ka), -1);
+    ray_release(ka);
+
+    ray_release(d);
+    PASS();
+}
+
+/* find_idx GUID keys with nulls — exercises null-skip in GUID loop. */
+static test_result_t test_dict_find_idx_guid_with_nulls(void) {
+    uint8_t g0[16] = { 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 };
+    uint8_t g1[16] = { 0 };
+    uint8_t g2[16] = { 16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1 };
+
+    ray_t* keys = ray_vec_new(RAY_GUID, 3);
+    keys = ray_vec_append(keys, g0);
+    keys = ray_vec_append(keys, g1);
+    keys = ray_vec_append(keys, g2);
+    /* Mark slot 1 as null. */
+    ray_vec_set_null(keys, 1, true);
+
+    ray_t* vals = ray_list_new(3);
+    vals = ray_list_append(vals, ray_i64(1));
+    vals = ray_list_append(vals, ray_i64(2));
+    vals = ray_list_append(vals, ray_i64(3));
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    ray_t* ka = ray_guid(g2);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, ka), 2);
+    ray_release(ka);
+
+    /* All-zero query: would match slot 1 if not null-aware. */
+    ka = ray_guid(g1);
+    TEST_ASSERT_EQ_I(ray_dict_find_idx(d, ka), -1);
+    ray_release(ka);
+
+    ray_release(d);
+    PASS();
+}
+
+/* GUID find_idx — key_atom->obj is NULL → returns -1.
+ * This exercises the early-return when GUID key has no payload. */
+static test_result_t test_dict_find_idx_guid_null_obj(void) {
+    uint8_t g0[16] = { 9,8,7,6,5,4,3,2,1,0,1,2,3,4,5,6 };
+
+    ray_t* keys = ray_vec_new(RAY_GUID, 1);
+    keys = ray_vec_append(keys, g0);
+
+    ray_t* vals = ray_list_new(1);
+    vals = ray_list_append(vals, ray_i64(1));
+
+    ray_t* d = ray_dict_new(keys, vals);
+
+    /* Synthesize a null-typed GUID atom (typed null). */
+    ray_t* nk = ray_typed_null(-RAY_GUID);
+    if (nk && !RAY_IS_ERR(nk)) {
+        /* Whether find returns -1 (no obj) or matches via null-aware probe
+         * depends on the typed-null obj layout.  Either way the early-return
+         * branch when key_atom->obj == NULL is what we want exercised. */
+        (void)ray_dict_find_idx(d, nk);
+        ray_release(nk);
+    }
+
+    ray_release(d);
+    PASS();
+}
+/* ---- Suite definition -------------------------------------------------- */
+
+const test_entry_t dict_entries[] = {
+    { "dict/new_null_keys",                test_dict_new_null_keys,                dict_setup, dict_teardown },
+    { "dict/new_null_vals",                test_dict_new_null_vals,                dict_setup, dict_teardown },
+    { "dict/new_err_keys",                 test_dict_new_err_keys,                 dict_setup, dict_teardown },
+    { "dict/new_err_vals",                 test_dict_new_err_vals,                 dict_setup, dict_teardown },
+    { "dict/keys_null",                    test_dict_keys_null,                    dict_setup, dict_teardown },
+    { "dict/keys_nondict",                 test_dict_keys_nondict,                 dict_setup, dict_teardown },
+    { "dict/keys_err",                     test_dict_keys_err,                     dict_setup, dict_teardown },
+    { "dict/find_sym_w8",                  test_dict_find_sym_w8,                  dict_setup, dict_teardown },
+    { "dict/find_sym_w16",                 test_dict_find_sym_w16,                 dict_setup, dict_teardown },
+    { "dict/find_sym_w32",                 test_dict_find_sym_w32,                 dict_setup, dict_teardown },
+    { "dict/find_sym_invalid",             test_dict_find_sym_invalid,             dict_setup, dict_teardown },
+    { "dict/probe_sym_borrowed",           test_dict_probe_sym_borrowed,           dict_setup, dict_teardown },
+    { "dict/get_typed_vec_vals",           test_dict_get_typed_vec_vals,           dict_setup, dict_teardown },
+    { "dict/get_each_value_type",          test_dict_get_each_value_type,          dict_setup, dict_teardown },
+    { "dict/find_idx_invalid",             test_dict_find_idx_invalid,             dict_setup, dict_teardown },
+    { "dict/find_idx_f32",                 test_dict_find_idx_f32,                 dict_setup, dict_teardown },
+    { "dict/find_idx_guid",                test_dict_find_idx_guid,                dict_setup, dict_teardown },
+    { "dict/find_idx_with_nulls",          test_dict_find_idx_with_nulls,          dict_setup, dict_teardown },
+    { "dict/upsert_into_nondict",          test_dict_upsert_into_nondict,          dict_setup, dict_teardown },
+    { "dict/upsert_null_d",                test_dict_upsert_null_d,                dict_setup, dict_teardown },
+    { "dict/upsert_null_val",              test_dict_upsert_null_val,              dict_setup, dict_teardown },
+    { "dict/upsert_replace_list_vals",     test_dict_upsert_replace_list_vals,     dict_setup, dict_teardown },
+    { "dict/upsert_replace_typed_vec_vals", test_dict_upsert_replace_typed_vec_vals, dict_setup, dict_teardown },
+    { "dict/upsert_append_typed_vec_vals", test_dict_upsert_append_typed_vec_vals, dict_setup, dict_teardown },
+    { "dict/upsert_append_str_key",        test_dict_upsert_append_str_key,        dict_setup, dict_teardown },
+    { "dict/upsert_append_guid_key",       test_dict_upsert_append_guid_key,       dict_setup, dict_teardown },
+    { "dict/upsert_append_f32_key",        test_dict_upsert_append_f32_key,        dict_setup, dict_teardown },
+    { "dict/upsert_key_type_mismatch",     test_dict_upsert_key_type_mismatch,     dict_setup, dict_teardown },
+    { "dict/upsert_empty_adopt_str",       test_dict_upsert_empty_adopt_str,       dict_setup, dict_teardown },
+    { "dict/remove_null_d",                test_dict_remove_null_d,                dict_setup, dict_teardown },
+    { "dict/remove_nondict",               test_dict_remove_nondict,               dict_setup, dict_teardown },
+    { "dict/remove_typed_vec_keys",        test_dict_remove_typed_vec_keys,        dict_setup, dict_teardown },
+    { "dict/remove_typed_vec_vals_promote", test_dict_remove_typed_vec_vals_promote, dict_setup, dict_teardown },
+    { "dict/remove_str_keys",              test_dict_remove_str_keys,              dict_setup, dict_teardown },
+    { "dict/remove_sym_keys_w8",           test_dict_remove_sym_keys_w8,           dict_setup, dict_teardown },
+    { "dict/find_idx_sym_w8",              test_dict_find_idx_sym_w8,              dict_setup, dict_teardown },
+    { "dict/find_idx_sym_w16",             test_dict_find_idx_sym_w16,             dict_setup, dict_teardown },
+    { "dict/find_idx_sym_w32",             test_dict_find_idx_sym_w32,             dict_setup, dict_teardown },
+    { "dict/find_idx_str_with_nulls",      test_dict_find_idx_str_with_nulls,      dict_setup, dict_teardown },
+    { "dict/find_idx_guid_with_nulls",     test_dict_find_idx_guid_with_nulls,     dict_setup, dict_teardown },
+    { "dict/find_idx_guid_null_obj",       test_dict_find_idx_guid_null_obj,       dict_setup, dict_teardown },
+    { NULL, NULL, NULL, NULL },
+};

--- a/test/test_dump.c
+++ b/test/test_dump.c
@@ -1,0 +1,504 @@
+/*
+ *   Copyright (c) 2025-2026 Anton Kundenko <singaraiona@gmail.com>
+ *   All rights reserved.
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
+
+/*
+ * Coverage tests for src/ops/dump.c — the *query plan* dumper.
+ *
+ * Reachable surface:
+ *   1. ray_opcode_name(opcode) — switch over all OP_* codes.
+ *   2. type_name(t)            — switch over RAY_* output type tags.
+ *   3. dump_node()             — annotation + recursion logic.
+ *   4. ray_graph_dump()        — header/footer + dispatch to dump_node.
+ *
+ * The exec/graph_dump test in test_exec.c only exercises a tiny FILTER+SUM
+ * pipeline; most of dump.c's switch arms remain cold.  These tests construct
+ * tailored graphs that hit the remaining branches by directly calling
+ * ray_graph_dump on a buffer-backed FILE* and asserting on the formatted
+ * substrings.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "test.h"
+#include <rayforce.h>
+#include "mem/heap.h"
+#include "ops/ops.h"
+#include "table/sym.h"
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+/* ---------- Helpers ---------- */
+
+/* Dump a graph to a caller-supplied stack buffer via tmpfile() + fread.
+ * Avoids any libc heap allocation (per project rules: no malloc/free in
+ * tests).  tmpfile() opens an unlinked file under /tmp; fclose deletes
+ * it — no on-disk leak.
+ *
+ * `cap` must be the buffer capacity (including space for trailing NUL).
+ * The buffer is always NUL-terminated even if the dump exceeds cap-1.
+ *
+ * Returns the formatted text length actually copied (0..cap-1).
+ */
+static size_t dump_to_buf(ray_graph_t* g, ray_op_t* root, char* buf, size_t cap) {
+    if (cap == 0) return 0;
+    buf[0] = '\0';
+    FILE* f = tmpfile();
+    if (!f) return 0;
+    ray_graph_dump(g, root, f);
+    fflush(f);
+    if (fseek(f, 0, SEEK_SET) != 0) { fclose(f); return 0; }
+    size_t n = fread(buf, 1, cap - 1, f);
+    fclose(f);
+    buf[n] = '\0';
+    return n;
+}
+
+/* Helper: small 1-row table for SCAN nodes. */
+static ray_t* make_tiny_table(void) {
+    (void)ray_sym_init();
+    int64_t v[]  = { 42 };
+    double  fv[] = { 3.14 };
+    ray_t* a = ray_vec_from_raw(RAY_I64, v,  1);
+    ray_t* b = ray_vec_from_raw(RAY_F64, fv, 1);
+    int64_t n_a = ray_sym_intern("a", 1);
+    int64_t n_b = ray_sym_intern("b", 1);
+    ray_t* tbl  = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, n_a, a);
+    tbl = ray_table_add_col(tbl, n_b, b);
+    ray_release(a);
+    ray_release(b);
+    return tbl;
+}
+
+/* ---------- Tests for ray_opcode_name() ---------- */
+
+/* ray_opcode_name is a pure switch — verify every documented opcode produces
+ * the expected mnemonic, plus "UNKNOWN" for an unrecognised value.  Doing it
+ * via the public symbol covers all switch arms regardless of whether the
+ * opcode appears in any dump_node graph. */
+static test_result_t test_dump_opcode_name_all(void) {
+    struct { uint16_t op; const char* name; } cases[] = {
+        { OP_SCAN, "SCAN" }, { OP_CONST, "CONST" },
+        { OP_NEG,  "NEG"  }, { OP_ABS,  "ABS"  }, { OP_NOT,  "NOT"  },
+        { OP_SQRT, "SQRT" }, { OP_LOG,  "LOG"  }, { OP_EXP,  "EXP"  },
+        { OP_CEIL, "CEIL" }, { OP_FLOOR,"FLOOR"}, { OP_ISNULL,"ISNULL"},
+        { OP_CAST, "CAST" },
+        { OP_ADD,  "ADD"  }, { OP_SUB,  "SUB"  }, { OP_MUL,  "MUL"  },
+        { OP_DIV,  "DIV"  }, { OP_MOD,  "MOD"  },
+        { OP_EQ,   "EQ"   }, { OP_NE,   "NE"   }, { OP_LT,   "LT"   },
+        { OP_LE,   "LE"   }, { OP_GT,   "GT"   }, { OP_GE,   "GE"   },
+        { OP_AND,  "AND"  }, { OP_OR,   "OR"   },
+        { OP_MIN2, "MIN2" }, { OP_MAX2, "MAX2" }, { OP_IF,   "IF"   },
+        { OP_LIKE, "LIKE" }, { OP_ILIKE,"ILIKE"},
+        { OP_UPPER,"UPPER"}, { OP_LOWER,"LOWER"}, { OP_STRLEN,"STRLEN"},
+        { OP_SUBSTR,"SUBSTR"}, { OP_REPLACE,"REPLACE"}, { OP_TRIM,"TRIM"},
+        { OP_CONCAT,"CONCAT"}, { OP_EXTRACT,"EXTRACT"},
+        { OP_DATE_TRUNC,"DATE_TRUNC"},
+        { OP_SUM,"SUM"}, { OP_PROD,"PROD"}, { OP_MIN,"MIN"}, { OP_MAX,"MAX"},
+        { OP_COUNT,"COUNT"}, { OP_AVG,"AVG"},
+        { OP_FIRST,"FIRST"}, { OP_LAST,"LAST"},
+        { OP_COUNT_DISTINCT,"COUNT_DISTINCT"},
+        { OP_STDDEV,"STDDEV"}, { OP_STDDEV_POP,"STDDEV_POP"},
+        { OP_VAR,"VAR"}, { OP_VAR_POP,"VAR_POP"},
+        { OP_FILTER,"FILTER"}, { OP_SORT,"SORT"}, { OP_GROUP,"GROUP"},
+        { OP_PIVOT,"PIVOT"}, { OP_ANTIJOIN,"ANTIJOIN"}, { OP_JOIN,"JOIN"},
+        { OP_WINDOW_JOIN,"WINDOW_JOIN"}, { OP_SELECT,"SELECT"},
+        { OP_HEAD,"HEAD"}, { OP_TAIL,"TAIL"}, { OP_WINDOW,"WINDOW"},
+        { OP_ALIAS,"ALIAS"}, { OP_MATERIALIZE,"MATERIALIZE"},
+        { OP_EXPAND,"EXPAND"}, { OP_VAR_EXPAND,"VAR_EXPAND"},
+        { OP_SHORTEST_PATH,"SHORTEST_PATH"}, { OP_WCO_JOIN,"WCO_JOIN"},
+        { OP_PAGERANK,"PAGERANK"}, { OP_CONNECTED_COMP,"CONNECTED_COMP"},
+        { OP_DIJKSTRA,"DIJKSTRA"}, { OP_LOUVAIN,"LOUVAIN"},
+        { OP_DEGREE_CENT,"DEGREE_CENT"}, { OP_TOPSORT,"TOPSORT"},
+        { OP_DFS,"DFS"}, { OP_ASTAR,"ASTAR"}, { OP_K_SHORTEST,"K_SHORTEST"},
+        { OP_CLUSTER_COEFF,"CLUSTER_COEFF"}, { OP_RANDOM_WALK,"RANDOM_WALK"},
+        { OP_ANN_RERANK,"ANN_RERANK"}, { OP_KNN_RERANK,"KNN_RERANK"},
+    };
+    size_t n = sizeof cases / sizeof cases[0];
+    for (size_t i = 0; i < n; i++) {
+        const char* got = ray_opcode_name(cases[i].op);
+        if (strcmp(got, cases[i].name) != 0)
+            FAILF("opcode %u: got \"%s\", expected \"%s\"",
+                  cases[i].op, got, cases[i].name);
+    }
+    /* Unknown opcode -> "UNKNOWN" */
+    const char* unk = ray_opcode_name(0xFFFF);
+    TEST_ASSERT_STR_EQ(unk, "UNKNOWN");
+    PASS();
+}
+
+/* ---------- Tests for ray_graph_dump() — header / footer ---------- */
+
+static test_result_t test_dump_header_footer(void) {
+    ray_heap_init();
+    ray_t* tbl = make_tiny_table();
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* a = ray_scan(g, "a");
+    char buf[8192];
+    size_t len = dump_to_buf(g, a, buf, sizeof buf);
+    TEST_ASSERT_FMT(len > 0, "empty dump output");
+    TEST_ASSERT_FMT(strstr(buf, "=== Query Plan ===")  != NULL, "missing header in dump");
+    TEST_ASSERT_FMT(strstr(buf, "==================") != NULL, "missing footer in dump");
+    /* SCAN annotation includes column name */
+    TEST_ASSERT_FMT(strstr(buf, "SCAN(a)") != NULL, "missing SCAN(a) annotation");
+    /* type_name covers RAY_I64 here (via vec scan) */
+    TEST_ASSERT_FMT(strstr(buf, " -> ") != NULL, "missing type arrow");
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* ---------- Tests for OP_CONST literal-type formatting ---------- */
+
+/* Each ray_const_* sets ext->literal with a specific atom type; dump_node's
+ * inner switch on lit->type prints (i64), (%.6g), (true|false), (table), or
+ * (?) for any other.  Hit them all in one graph and assert on the strings. */
+static test_result_t test_dump_const_literal_types(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+    ray_t* tbl = make_tiny_table();
+    ray_graph_t* g = ray_graph_new(tbl);
+
+    /* I64 const */
+    ray_op_t* ci = ray_const_i64(g, 12345);
+    /* F64 const */
+    ray_op_t* cf = ray_const_f64(g, 2.71828);
+    /* BOOL const */
+    ray_op_t* cb = ray_const_bool(g, true);
+    ray_op_t* cb2= ray_const_bool(g, false);
+    /* TABLE const — uses tbl as literal */
+    ray_op_t* ct = ray_const_table(g, tbl);
+    /* SYM const (RAY_SYM out_type, other lit type → falls to default "(?)") */
+    ray_op_t* cs = ray_const_str(g, "x", 1);
+
+    /* Combine into a chain so that all are reachable from one root.  We use
+     * ADD nodes (binary) — the dumper only follows up to inputs[0..1], so
+     * embed pairs progressively. */
+    ray_op_t* p1 = ray_add(g, ci, cf);
+    ray_op_t* p2 = ray_add(g, cb, cb2);
+    ray_op_t* p3 = ray_add(g, p1, p2);
+    ray_op_t* p4 = ray_add(g, ct, cs);
+    ray_op_t* root = ray_add(g, p3, p4);
+
+    char buf[8192];
+    size_t len = dump_to_buf(g, root, buf, sizeof buf);
+    TEST_ASSERT_FMT(len > 0, "empty dump output");
+    TEST_ASSERT_FMT(strstr(buf, "(12345)")    != NULL, "missing CONST(I64)");
+    TEST_ASSERT_FMT(strstr(buf, "(2.71828)")  != NULL, "missing CONST(F64)");
+    TEST_ASSERT_FMT(strstr(buf, "(true)")     != NULL, "missing CONST(true)");
+    TEST_ASSERT_FMT(strstr(buf, "(false)")    != NULL, "missing CONST(false)");
+    TEST_ASSERT_FMT(strstr(buf, "(table)")    != NULL, "missing CONST(table)");
+    TEST_ASSERT_FMT(strstr(buf, "(?)")        != NULL, "missing CONST(?) for non-{I64,F64,BOOL,TABLE}");
+
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* ---------- Tests for OP_JOIN annotation (INNER / LEFT / FULL) ---------- */
+
+static test_result_t test_dump_join_annotations(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+    ray_t* tbl = make_tiny_table();
+    ray_graph_t* g = ray_graph_new(tbl);
+
+    /* Two scan nodes used as keys (just need ray_op_t*'s). */
+    ray_op_t* lk = ray_scan(g, "a");
+    ray_op_t* rk = ray_scan(g, "a");
+    ray_op_t* lt = ray_scan(g, "a");
+    ray_op_t* rt = ray_scan(g, "a");
+    ray_op_t* lk_arr[1] = { lk };
+    ray_op_t* rk_arr[1] = { rk };
+
+    /* INNER (join_type=0) */
+    ray_op_t* j_in   = ray_join(g, lt, lk_arr, rt, rk_arr, 1, 0);
+    /* LEFT  (join_type=1) */
+    ray_op_t* j_left = ray_join(g, lt, lk_arr, rt, rk_arr, 1, 1);
+    /* FULL  (join_type=2) */
+    ray_op_t* j_full = ray_join(g, lt, lk_arr, rt, rk_arr, 1, 2);
+
+    /* Combine into one root via ADDs (two-arity dumps follow inputs[0..1]). */
+    ray_op_t* root = ray_add(g, ray_add(g, j_in, j_left), j_full);
+
+    char buf[8192];
+    size_t len = dump_to_buf(g, root, buf, sizeof buf);
+    TEST_ASSERT_FMT(len > 0, "empty dump output");
+    TEST_ASSERT_FMT(strstr(buf, "JOIN(INNER, keys=1)") != NULL,
+                    "missing JOIN(INNER, keys=1)");
+    TEST_ASSERT_FMT(strstr(buf, "JOIN(LEFT, keys=1)")  != NULL,
+                    "missing JOIN(LEFT, keys=1)");
+    TEST_ASSERT_FMT(strstr(buf, "JOIN(FULL, keys=1)")  != NULL,
+                    "missing JOIN(FULL, keys=1)");
+
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* ---------- Tests for OP_GROUP annotation + recursion ---------- */
+
+static test_result_t test_dump_group_annotation(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+    ray_t* tbl = make_tiny_table();
+    ray_graph_t* g = ray_graph_new(tbl);
+
+    /* GROUP keys=2, aggs=1 (sum of `a`) */
+    ray_op_t* k1 = ray_scan(g, "a");
+    ray_op_t* k2 = ray_scan(g, "b");
+    ray_op_t* keys[2] = { k1, k2 };
+    ray_op_t* a_in  = ray_scan(g, "a");
+    ray_op_t* aggs_in[1] = { a_in };
+    uint16_t  agg_ops[1] = { OP_SUM };
+    ray_op_t* gr = ray_group(g, keys, 2, agg_ops, aggs_in, 1);
+    /* ray_group sets arity=0 by default but populates inputs[0]; bump arity
+     * so the OP_GROUP recursion arm in dump_node also walks standard inputs.
+     * Without this the "standard inputs" loop in the OP_GROUP case is dead. */
+    if (gr) gr->arity = 1;
+
+    char buf[8192];
+    size_t len = dump_to_buf(g, gr, buf, sizeof buf);
+    TEST_ASSERT_FMT(len > 0, "empty dump output");
+    TEST_ASSERT_FMT(strstr(buf, "GROUP(keys=2, aggs=1)") != NULL,
+                    "missing GROUP(keys=2, aggs=1)");
+    /* Recursion into keys + agg_ins (children of GROUP get printed). */
+    TEST_ASSERT_FMT(strstr(buf, "SCAN(a)") != NULL, "missing SCAN(a) under GROUP");
+    TEST_ASSERT_FMT(strstr(buf, "SCAN(b)") != NULL, "missing SCAN(b) under GROUP");
+
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* ---------- Tests for OP_HEAD / OP_TAIL annotation ---------- */
+
+static test_result_t test_dump_head_tail_annotations(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+    ray_t* tbl = make_tiny_table();
+    ray_graph_t* g = ray_graph_new(tbl);
+
+    ray_op_t* a = ray_scan(g, "a");
+    ray_op_t* h = ray_head(g, a, 7);
+    ray_op_t* t = ray_tail(g, a, 3);
+    ray_op_t* root = ray_add(g, h, t);
+
+    char buf[8192];
+    size_t len = dump_to_buf(g, root, buf, sizeof buf);
+    TEST_ASSERT_FMT(len > 0, "empty dump output");
+    TEST_ASSERT_FMT(strstr(buf, "HEAD(N=7)") != NULL, "missing HEAD(N=7)");
+    TEST_ASSERT_FMT(strstr(buf, "TAIL(N=3)") != NULL, "missing TAIL(N=3)");
+
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* ---------- Tests for OP_SORT / OP_SELECT recursion into ext->sort.columns
+ * and the est_rows / OP_FLAG_FUSED branches in dump_node. ---------- */
+
+static test_result_t test_dump_sort_select_and_flags(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+    ray_t* tbl = make_tiny_table();
+    ray_graph_t* g = ray_graph_new(tbl);
+
+    /* SORT with a single ASC column.  `ray_sort_op` requires a table-shaped
+     * input; we use an OP_SCAN as a stand-in (its out_type is the column's
+     * primitive but the dumper doesn't care). */
+    ray_op_t* tbl_node = ray_scan(g, "a");
+    ray_op_t* sort_keys[1] = { tbl_node };
+    uint8_t descs[1] = { 0 };
+    ray_op_t* so = ray_sort_op(g, tbl_node, sort_keys, descs, NULL, 1);
+
+    /* SELECT with one column */
+    ray_op_t* sel_cols[1] = { tbl_node };
+    ray_op_t* sl = ray_select(g, tbl_node, sel_cols, 1);
+
+    /* est_rows and OP_FLAG_FUSED branches: set them on the SELECT node. */
+    sl->est_rows = 99;
+    sl->flags   |= OP_FLAG_FUSED;
+
+    /* Put both under one root so a single dump walks both subtrees. */
+    ray_op_t* root = ray_add(g, so, sl);
+
+    char buf[8192];
+    size_t len = dump_to_buf(g, root, buf, sizeof buf);
+    TEST_ASSERT_FMT(len > 0, "empty dump output");
+    TEST_ASSERT_FMT(strstr(buf, "SORT")   != NULL, "missing SORT");
+    TEST_ASSERT_FMT(strstr(buf, "SELECT") != NULL, "missing SELECT");
+    /* OP_FLAG_FUSED -> " [fused]" */
+    TEST_ASSERT_FMT(strstr(buf, "[fused]") != NULL, "missing [fused] flag");
+    /* est_rows formatting */
+    TEST_ASSERT_FMT(strstr(buf, "~99 rows") != NULL, "missing est_rows annotation");
+
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* ---------- Tests for type_name() — every RAY_* tag in node->out_type ---------- */
+
+/* The dumper's type_name() helper has one switch arm per RAY_* tag.  We hit
+ * them by building one OP_SCAN per type and forcefully overwriting out_type
+ * (the SCAN constructor infers from the column, but the dumper only reads
+ * out_type — it doesn't validate consistency). */
+static test_result_t test_dump_type_name_all(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+    ray_t* tbl = make_tiny_table();
+    ray_graph_t* g = ray_graph_new(tbl);
+
+    /* Build N scan nodes; mutate out_type to cover every type_name arm. */
+    int8_t types[] = {
+        RAY_LIST, RAY_BOOL, RAY_U8, RAY_I16, RAY_I32, RAY_I64,
+        RAY_F64, RAY_DATE, RAY_TIME, RAY_TIMESTAMP, RAY_TABLE,
+        RAY_SEL, RAY_SYM,
+        /* Out-of-table tag → "?" default arm */
+        (int8_t)127,
+    };
+    int n = (int)(sizeof types / sizeof types[0]);
+    ray_op_t* prev = NULL;
+    for (int i = 0; i < n; i++) {
+        ray_op_t* s = ray_scan(g, "a");
+        s->out_type = types[i];
+        if (!prev) prev = s;
+        else       prev = ray_add(g, prev, s);
+    }
+    /* Force a known out_type on the root so the final " -> ?" is exercised. */
+
+    char buf[16384];
+    size_t len = dump_to_buf(g, prev, buf, sizeof buf);
+    TEST_ASSERT_FMT(len > 0, "empty dump output");
+    /* Spot-check a representative subset of arms. */
+    const char* needles[] = {
+        " -> LIST", " -> BOOL", " -> U8", " -> I16", " -> I32", " -> I64",
+        " -> F64", " -> DATE", " -> TIME", " -> TIMESTAMP", " -> TABLE",
+        " -> SEL", " -> SYM", " -> ?",
+    };
+    for (size_t i = 0; i < sizeof needles / sizeof needles[0]; i++) {
+        if (!strstr(buf, needles[i])) {
+            ray_graph_free(g);
+            ray_release(tbl);
+            ray_sym_destroy();
+            ray_heap_destroy();
+            FAILF("missing type arrow \"%s\"", needles[i]);
+        }
+    }
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* ---------- Tests for ray_graph_dump() with NULL out -> stderr fallback ---------- */
+
+/* Pass NULL `out` and ensure no crash — the function falls back to stderr.
+ * We redirect stderr to /dev/null for the duration to keep test output
+ * clean.  This covers the `out ? ... : stderr` ternary. */
+static test_result_t test_dump_null_out_falls_back_to_stderr(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+    ray_t* tbl = make_tiny_table();
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* a = ray_scan(g, "a");
+
+    /* Redirect stderr to /dev/null so the dump output doesn't pollute the
+     * test runner.  Restored afterwards. */
+    fflush(stderr);
+    int saved = dup(fileno(stderr));
+    int devnull = open("/dev/null", O_WRONLY);
+    if (devnull >= 0 && saved >= 0) {
+        dup2(devnull, fileno(stderr));
+    }
+
+    ray_graph_dump(g, a, NULL);  /* must not crash */
+
+    fflush(stderr);
+    if (saved >= 0) {
+        dup2(saved, fileno(stderr));
+        close(saved);
+    }
+    if (devnull >= 0) close(devnull);
+
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* ---------- Tests for ray_graph_dump() with NULL root -> early return ---------- */
+
+/* dump_node guards against NULL — exercise that branch explicitly. */
+static test_result_t test_dump_null_root(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+    ray_t* tbl = make_tiny_table();
+    ray_graph_t* g = ray_graph_new(tbl);
+
+    char buf[1024];
+    size_t len = dump_to_buf(g, NULL, buf, sizeof buf);
+    TEST_ASSERT_FMT(len > 0, "empty dump output");
+    /* With NULL root the dumper still emits header + footer, no body. */
+    TEST_ASSERT_FMT(strstr(buf, "=== Query Plan ===")  != NULL, "missing header");
+    TEST_ASSERT_FMT(strstr(buf, "==================") != NULL, "missing footer");
+
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* ---------- Registration ---------- */
+
+const test_entry_t dump_entries[] = {
+    { "dump/opcode_name_all",           test_dump_opcode_name_all,           NULL, NULL },
+    { "dump/header_footer",             test_dump_header_footer,             NULL, NULL },
+    { "dump/const_literal_types",       test_dump_const_literal_types,       NULL, NULL },
+    { "dump/join_annotations",          test_dump_join_annotations,          NULL, NULL },
+    { "dump/group_annotation",          test_dump_group_annotation,          NULL, NULL },
+    { "dump/head_tail_annotations",     test_dump_head_tail_annotations,     NULL, NULL },
+    { "dump/sort_select_and_flags",     test_dump_sort_select_and_flags,     NULL, NULL },
+    { "dump/type_name_all",             test_dump_type_name_all,             NULL, NULL },
+    { "dump/null_out_falls_back",       test_dump_null_out_falls_back_to_stderr, NULL, NULL },
+    { "dump/null_root",                 test_dump_null_root,                 NULL, NULL },
+    { NULL, NULL, NULL, NULL },
+};

--- a/test/test_graph.c
+++ b/test/test_graph.c
@@ -277,6 +277,100 @@ static test_result_t test_optimizer_constant_fold(void) {
 }
 
 /* --------------------------------------------------------------------------
+ * Test: optimizer constant-folds DATE/TIME/I32 atom arithmetic
+ *
+ * Pre-fix: ray_const_atom stored out_type as the negative atom-tag
+ * (-RAY_DATE etc.), so fold_binary_const's `case RAY_I32: case RAY_DATE:
+ * case RAY_TIME:` arm never fired — promote(-RAY_DATE, -RAY_DATE) returned
+ * the unknown rung (RAY_BOOL), routing arithmetic through the BOOL arm
+ * which has no OP_SUB handler.  Post-fix: ray_const_atom normalises to
+ * the positive type tag, matching ray_const_i64 / _f64 / _bool, so
+ * fold_binary_const's I32/DATE/TIME arm fires and replaces the binary
+ * op with an OP_CONST literal.
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_optimizer_fold_atom_arith(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    /* DATE - DATE → I32 (days difference).  2026.05.05 - 2026.05.01 = 4. */
+    ray_graph_t* g = ray_graph_new(NULL);
+    TEST_ASSERT_NOT_NULL(g);
+    /* Date epoch = 2000.01.01.  2026.05.05 = 9621 days, 2026.05.01 = 9617. */
+    ray_t* d1 = ray_date(9621);
+    ray_t* d2 = ray_date(9617);
+    ray_op_t* c1 = ray_const_atom(g, d1);
+    ray_op_t* c2 = ray_const_atom(g, d2);
+    /* Release the atoms — ray_const_atom retained them. */
+    ray_release(d1);
+    ray_release(d2);
+    ray_op_t* sub = ray_sub(g, c1, c2);
+    TEST_ASSERT_NOT_NULL(sub);
+    TEST_ASSERT_EQ_I(sub->opcode, OP_SUB);
+
+    ray_op_t* opt = ray_optimize(g, sub);
+    TEST_ASSERT_NOT_NULL(opt);
+    /* The fold must have fired — node rewritten to OP_CONST. */
+    TEST_ASSERT_EQ_I(opt->opcode, OP_CONST);
+
+    ray_t* out = ray_execute(g, opt);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(out));
+    TEST_ASSERT_EQ_I(out->type, -RAY_I32);
+    TEST_ASSERT_EQ_I(out->i32, 4);
+    ray_release(out);
+    ray_graph_free(g);
+
+    /* I32 + I32 → I32. */
+    g = ray_graph_new(NULL);
+    TEST_ASSERT_NOT_NULL(g);
+    ray_t* i1 = ray_i32(5);
+    ray_t* i2 = ray_i32(7);
+    ray_op_t* ci1 = ray_const_atom(g, i1);
+    ray_op_t* ci2 = ray_const_atom(g, i2);
+    ray_release(i1);
+    ray_release(i2);
+    ray_op_t* add = ray_add(g, ci1, ci2);
+    ray_op_t* opt_i32 = ray_optimize(g, add);
+    TEST_ASSERT_NOT_NULL(opt_i32);
+    TEST_ASSERT_EQ_I(opt_i32->opcode, OP_CONST);
+
+    ray_t* out_i32 = ray_execute(g, opt_i32);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(out_i32));
+    TEST_ASSERT_EQ_I(out_i32->type, -RAY_I32);
+    TEST_ASSERT_EQ_I(out_i32->i32, 12);
+    ray_release(out_i32);
+    ray_graph_free(g);
+
+    /* TIME - TIME → I32 (delta in milliseconds).  ray_time stores ms since
+     * midnight; 11:00 - 09:00 = 7200000 ms. */
+    g = ray_graph_new(NULL);
+    TEST_ASSERT_NOT_NULL(g);
+    ray_t* t1 = ray_time(11LL * 3600 * 1000);
+    ray_t* t2 = ray_time(9LL * 3600 * 1000);
+    ray_op_t* ct1 = ray_const_atom(g, t1);
+    ray_op_t* ct2 = ray_const_atom(g, t2);
+    ray_release(t1);
+    ray_release(t2);
+    ray_op_t* tsub = ray_sub(g, ct1, ct2);
+    ray_op_t* opt_t = ray_optimize(g, tsub);
+    TEST_ASSERT_NOT_NULL(opt_t);
+    TEST_ASSERT_EQ_I(opt_t->opcode, OP_CONST);
+
+    ray_t* out_t = ray_execute(g, opt_t);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(out_t));
+    /* TIME - TIME folds via the I32/DATE/TIME arm → I32 atom carrying the
+     * raw 32-bit difference of the millisecond payloads. */
+    TEST_ASSERT_EQ_I(out_t->type, -RAY_I32);
+    TEST_ASSERT_EQ_I(out_t->i32, 7200000);
+    ray_release(out_t);
+    ray_graph_free(g);
+
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
  * Test: optimizer simplifies FILTER with constant predicates
  * -------------------------------------------------------------------------- */
 
@@ -524,6 +618,7 @@ const test_entry_t graph_entries[] = {
     { "graph/arithmetic", test_arithmetic, NULL, NULL },
     { "graph/group_sum", test_group_sum, NULL, NULL },
     { "graph/opt_fold", test_optimizer_constant_fold, NULL, NULL },
+    { "graph/opt_fold_atom_arith", test_optimizer_fold_atom_arith, NULL, NULL },
     { "graph/opt_filter_const", test_optimizer_filter_const_predicate, NULL, NULL },
     { "graph/group_affine_agg", test_group_affine_agg_input, NULL, NULL },
     { NULL, NULL, NULL, NULL },

--- a/test/test_graph_builtin.c
+++ b/test/test_graph_builtin.c
@@ -1,0 +1,597 @@
+/*
+ *   Copyright (c) 2025-2026 Anton Kundenko <singaraiona@gmail.com>
+ *   All rights reserved.
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
+
+/*
+ * Tests for src/ops/graph_builtin.c — direct C-side coverage of the
+ * .graph.* builtin entry points (no Rayfall runtime).  Targets the
+ * paths that the lang-level test_graph.c tests do not reach:
+ *   - widen_to_i64 for I32/I16/U8/BOOL src/dst columns
+ *   - I64 → F64 weight coercion in ray_graph_build_fn
+ *   - RAY_STR atom column name (vs RAY_SYM) in arg_to_sym
+ *   - graph-handle block-copy detach policy in mem/heap.c
+ *   - exhaustive info-dict shape (n_nodes / n_edges / sorted / has_weights)
+ *   - free idempotency (second free returns "type" error, no crash)
+ *
+ * Pattern mirrors test_csr.c: ray_heap_init + ray_sym_init in each test,
+ * teardown at the end; no libc malloc anywhere.
+ */
+
+#include "test.h"
+#include <rayforce.h>
+#include "mem/heap.h"
+#include "store/csr.h"
+#include "lang/internal.h"
+#include <string.h>
+
+/* --------------------------------------------------------------------------
+ * Helpers
+ * -------------------------------------------------------------------------- */
+
+/* Build a 3-row I64 edge table: 0->1, 1->2, 2->0.  No weight column. */
+static ray_t* make_i64_edge_table(void) {
+    int64_t src_data[] = {0, 1, 2};
+    int64_t dst_data[] = {1, 2, 0};
+    ray_t* sv = ray_vec_from_raw(RAY_I64, src_data, 3);
+    ray_t* dv = ray_vec_from_raw(RAY_I64, dst_data, 3);
+    int64_t s = ray_sym_intern("src", 3);
+    int64_t d = ray_sym_intern("dst", 3);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, s, sv); ray_release(sv);
+    tbl = ray_table_add_col(tbl, d, dv); ray_release(dv);
+    return tbl;
+}
+
+/* Build a 3-row table with I64 src/dst plus a weight column of caller-chosen
+ * type.  The wt_type/wt_data parameters drive widen-coercion testing. */
+static ray_t* make_weighted_table(int8_t wt_type, void* wt_data, int64_t n) {
+    int64_t src_data[] = {0, 1, 2};
+    int64_t dst_data[] = {1, 2, 0};
+    ray_t* sv = ray_vec_from_raw(RAY_I64, src_data, n);
+    ray_t* dv = ray_vec_from_raw(RAY_I64, dst_data, n);
+    ray_t* wv = ray_vec_from_raw(wt_type, wt_data, n);
+    int64_t s_sym = ray_sym_intern("src", 3);
+    int64_t d_sym = ray_sym_intern("dst", 3);
+    int64_t w_sym = ray_sym_intern("weight", 6);
+    ray_t* tbl = ray_table_new(3);
+    tbl = ray_table_add_col(tbl, s_sym, sv); ray_release(sv);
+    tbl = ray_table_add_col(tbl, d_sym, dv); ray_release(dv);
+    tbl = ray_table_add_col(tbl, w_sym, wv); ray_release(wv);
+    return tbl;
+}
+
+/* --------------------------------------------------------------------------
+ * 1. ray_graph_build_fn — minimal happy path, no weight column
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_graph_build_no_weight(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    ray_t* tbl = make_i64_edge_table();
+    ray_t* sym_src = ray_sym(ray_sym_intern("src", 3));
+    ray_t* sym_dst = ray_sym(ray_sym_intern("dst", 3));
+    ray_t* args[3] = { tbl, sym_src, sym_dst };
+
+    ray_t* h = ray_graph_build_fn(args, 3);
+    TEST_ASSERT_NOT_NULL(h);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+    TEST_ASSERT_EQ_I(h->type, -RAY_I64);
+    TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) != 0);
+    TEST_ASSERT_TRUE(h->i64 != 0);
+
+    /* releasing the handle invokes the heap finalizer, which frees the
+     * underlying ray_rel_t — no leak. */
+    ray_release(h);
+    ray_release(sym_src);
+    ray_release(sym_dst);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * 2. ray_graph_build_fn — F64 weight column, info reports has_weights:true
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_graph_build_with_weight(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    double w_data[] = {1.5, 2.5, 3.5};
+    ray_t* tbl = make_weighted_table(RAY_F64, w_data, 3);
+
+    ray_t* sym_src = ray_sym(ray_sym_intern("src", 3));
+    ray_t* sym_dst = ray_sym(ray_sym_intern("dst", 3));
+    ray_t* sym_w   = ray_sym(ray_sym_intern("weight", 6));
+    ray_t* args[4] = { tbl, sym_src, sym_dst, sym_w };
+
+    ray_t* h = ray_graph_build_fn(args, 4);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+    TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) != 0);
+
+    ray_t* info = ray_graph_info_fn(h);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(info));
+    TEST_ASSERT_EQ_I(info->type, RAY_DICT);
+
+    /* has_weights must be true. */
+    ray_t* k = ray_sym(ray_sym_intern("has_weights", 11));
+    ray_t* v = ray_dict_get(info, k);
+    TEST_ASSERT_NOT_NULL(v);
+    TEST_ASSERT_EQ_I(v->type, -RAY_BOOL);
+    TEST_ASSERT_EQ_I(v->b8, 1);
+    ray_release(v);
+    ray_release(k);
+
+    ray_release(info);
+    ray_release(h);
+    ray_release(sym_src); ray_release(sym_dst); ray_release(sym_w);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * 3. ray_graph_build_fn — I32 src column exercises widen_to_i64
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_graph_build_widen_i32(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int32_t src_data[] = {0, 1, 2};
+    int64_t dst_data[] = {1, 2, 0};
+    ray_t* sv = ray_vec_from_raw(RAY_I32, src_data, 3);
+    ray_t* dv = ray_vec_from_raw(RAY_I64, dst_data, 3);
+    int64_t s_sym = ray_sym_intern("src", 3);
+    int64_t d_sym = ray_sym_intern("dst", 3);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, s_sym, sv); ray_release(sv);
+    tbl = ray_table_add_col(tbl, d_sym, dv); ray_release(dv);
+
+    ray_t* sym_src = ray_sym(s_sym);
+    ray_t* sym_dst = ray_sym(d_sym);
+    ray_t* args[3] = { tbl, sym_src, sym_dst };
+
+    ray_t* h = ray_graph_build_fn(args, 3);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+    TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) != 0);
+
+    /* Confirm n_nodes derived correctly — should be 3 (max(src/dst) + 1). */
+    ray_rel_t* rel = (ray_rel_t*)(uintptr_t)h->i64;
+    TEST_ASSERT_EQ_I(rel->fwd.n_nodes, 3);
+    TEST_ASSERT_EQ_I(rel->fwd.n_edges, 3);
+
+    ray_release(h);
+    ray_release(sym_src); ray_release(sym_dst);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * 4. ray_graph_build_fn — I16 / U8 / BOOL src widen paths
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_graph_build_widen_i16_u8_bool(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    /* I16 src */
+    {
+        int16_t src_data[] = {0, 1, 2};
+        int16_t dst_data[] = {1, 2, 0};
+        ray_t* sv = ray_vec_from_raw(RAY_I16, src_data, 3);
+        ray_t* dv = ray_vec_from_raw(RAY_I16, dst_data, 3);
+        int64_t s_sym = ray_sym_intern("src", 3);
+        int64_t d_sym = ray_sym_intern("dst", 3);
+        ray_t* tbl = ray_table_new(2);
+        tbl = ray_table_add_col(tbl, s_sym, sv); ray_release(sv);
+        tbl = ray_table_add_col(tbl, d_sym, dv); ray_release(dv);
+        ray_t* sym_src = ray_sym(s_sym);
+        ray_t* sym_dst = ray_sym(d_sym);
+        ray_t* args[3] = { tbl, sym_src, sym_dst };
+        ray_t* h = ray_graph_build_fn(args, 3);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+        TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) != 0);
+        ray_release(h);
+        ray_release(sym_src); ray_release(sym_dst);
+        ray_release(tbl);
+    }
+
+    /* U8 src */
+    {
+        uint8_t src_data[] = {0, 1, 2};
+        uint8_t dst_data[] = {1, 2, 0};
+        ray_t* sv = ray_vec_from_raw(RAY_U8, src_data, 3);
+        ray_t* dv = ray_vec_from_raw(RAY_U8, dst_data, 3);
+        int64_t s_sym = ray_sym_intern("src", 3);
+        int64_t d_sym = ray_sym_intern("dst", 3);
+        ray_t* tbl = ray_table_new(2);
+        tbl = ray_table_add_col(tbl, s_sym, sv); ray_release(sv);
+        tbl = ray_table_add_col(tbl, d_sym, dv); ray_release(dv);
+        ray_t* sym_src = ray_sym(s_sym);
+        ray_t* sym_dst = ray_sym(d_sym);
+        ray_t* args[3] = { tbl, sym_src, sym_dst };
+        ray_t* h = ray_graph_build_fn(args, 3);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+        TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) != 0);
+        ray_release(h);
+        ray_release(sym_src); ray_release(sym_dst);
+        ray_release(tbl);
+    }
+
+    /* BOOL src — trivial graph: 0->1, 1->0 (only two distinct nodes). */
+    {
+        uint8_t src_data[] = {0, 1};
+        uint8_t dst_data[] = {1, 0};
+        ray_t* sv = ray_vec_from_raw(RAY_BOOL, src_data, 2);
+        ray_t* dv = ray_vec_from_raw(RAY_BOOL, dst_data, 2);
+        int64_t s_sym = ray_sym_intern("src", 3);
+        int64_t d_sym = ray_sym_intern("dst", 3);
+        ray_t* tbl = ray_table_new(2);
+        tbl = ray_table_add_col(tbl, s_sym, sv); ray_release(sv);
+        tbl = ray_table_add_col(tbl, d_sym, dv); ray_release(dv);
+        ray_t* sym_src = ray_sym(s_sym);
+        ray_t* sym_dst = ray_sym(d_sym);
+        ray_t* args[3] = { tbl, sym_src, sym_dst };
+        ray_t* h = ray_graph_build_fn(args, 3);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+        TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) != 0);
+        ray_rel_t* rel = (ray_rel_t*)(uintptr_t)h->i64;
+        TEST_ASSERT_EQ_I(rel->fwd.n_nodes, 2);
+        TEST_ASSERT_EQ_I(rel->fwd.n_edges, 2);
+        ray_release(h);
+        ray_release(sym_src); ray_release(sym_dst);
+        ray_release(tbl);
+    }
+
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * 5. arg_to_sym — RAY_STR column name accepted (interned on the fly)
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_graph_build_str_column_name(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    ray_t* tbl = make_i64_edge_table();
+
+    /* Pass column names as RAY_STR atoms instead of RAY_SYM. */
+    ray_t* str_src = ray_str("src", 3);
+    ray_t* str_dst = ray_str("dst", 3);
+    ray_t* args[3] = { tbl, str_src, str_dst };
+
+    ray_t* h = ray_graph_build_fn(args, 3);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+    TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) != 0);
+
+    /* Also exercise the empty-string rejection branch (len == 0 → -1). */
+    ray_t* str_empty = ray_str("", 0);
+    ray_t* bad_args[3] = { tbl, str_empty, str_dst };
+    ray_t* bad = ray_graph_build_fn(bad_args, 3);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(bad));
+    ray_error_free(bad);
+
+    ray_release(h);
+    ray_release(str_src);
+    ray_release(str_dst);
+    ray_release(str_empty);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * 6. ray_graph_info_fn — every key present, exact types, expected values
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_graph_info_dict_shape(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    ray_t* tbl = make_i64_edge_table();
+    ray_t* sym_src = ray_sym(ray_sym_intern("src", 3));
+    ray_t* sym_dst = ray_sym(ray_sym_intern("dst", 3));
+    ray_t* args[3] = { tbl, sym_src, sym_dst };
+    ray_t* h = ray_graph_build_fn(args, 3);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+
+    ray_t* info = ray_graph_info_fn(h);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(info));
+    TEST_ASSERT_EQ_I(info->type, RAY_DICT);
+    TEST_ASSERT_EQ_I(ray_dict_len(info), 4);
+
+    struct { const char* name; int8_t type; int64_t expect_int; } expected[] = {
+        { "n_nodes",     -RAY_I64,  3 },
+        { "n_edges",     -RAY_I64,  3 },
+        { "sorted",      -RAY_BOOL, 1 },  /* build passes sorted=true */
+        { "has_weights", -RAY_BOOL, 0 },  /* no weight col */
+    };
+
+    for (size_t i = 0; i < sizeof(expected)/sizeof(expected[0]); i++) {
+        ray_t* k = ray_sym(ray_sym_intern(expected[i].name,
+                                           strlen(expected[i].name)));
+        ray_t* v = ray_dict_get(info, k);
+        TEST_ASSERT_FMT(v != NULL, "missing key '%s'", expected[i].name);
+        TEST_ASSERT_FMT(v->type == expected[i].type,
+                         "key '%s' has wrong type %d", expected[i].name, v->type);
+        int64_t got = (v->type == -RAY_I64) ? v->i64 : (int64_t)v->b8;
+        TEST_ASSERT_FMT(got == expected[i].expect_int,
+                         "key '%s' got %lld expected %lld",
+                         expected[i].name, (long long)got,
+                         (long long)expected[i].expect_int);
+        ray_release(v);
+        ray_release(k);
+    }
+
+    ray_release(info);
+    ray_release(h);
+    ray_release(sym_src); ray_release(sym_dst);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * 7. ray_graph_free_fn — second free returns "type" error, no crash
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_graph_free_idempotent(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    ray_t* tbl = make_i64_edge_table();
+    ray_t* sym_src = ray_sym(ray_sym_intern("src", 3));
+    ray_t* sym_dst = ray_sym(ray_sym_intern("dst", 3));
+    ray_t* args[3] = { tbl, sym_src, sym_dst };
+    ray_t* h = ray_graph_build_fn(args, 3);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+
+    /* First free: succeeds, returns null singleton, clears the GRAPH attr. */
+    ray_t* r1 = ray_graph_free_fn(h);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(r1));
+    TEST_ASSERT_TRUE(RAY_IS_NULL(r1));
+    TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) == 0);
+    TEST_ASSERT_EQ_I(h->i64, 0);
+
+    /* Second free: graph_unwrap returns NULL → "type" error, no double-free. */
+    ray_t* r2 = ray_graph_free_fn(h);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(r2));
+    TEST_ASSERT_STR_EQ(ray_err_code(r2), "type");
+    ray_error_free(r2);
+
+    /* And info on a freed handle also errors out — exercises the same
+     * unwrap-returns-NULL branch from a different entry point. */
+    ray_t* r3 = ray_graph_info_fn(h);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(r3));
+    TEST_ASSERT_STR_EQ(ray_err_code(r3), "type");
+    ray_error_free(r3);
+
+    ray_release(h);
+    ray_release(sym_src); ray_release(sym_dst);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * 8. handle release — heap finalizer runs, no double-free / no crash
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_graph_handle_in_release(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    ray_t* tbl = make_i64_edge_table();
+    ray_t* sym_src = ray_sym(ray_sym_intern("src", 3));
+    ray_t* sym_dst = ray_sym(ray_sym_intern("dst", 3));
+    ray_t* args[3] = { tbl, sym_src, sym_dst };
+    ray_t* h = ray_graph_build_fn(args, 3);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+    TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) != 0);
+    TEST_ASSERT_TRUE(h->i64 != 0);
+
+    /* Drop the reference: heap.c's finalizer (lines ~533-538) sees the
+     * GRAPH attr set, calls ray_rel_free, clears the slot.  ASan would
+     * fire on the next test if we leaked or double-freed. */
+    ray_release(h);
+
+    ray_release(sym_src); ray_release(sym_dst);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * 9. ray_alloc_copy — graph handles do NOT share ownership.
+ *     The mem/heap.c retain-on-copy hook must detach the duplicate
+ *     (i64=0, GRAPH attr cleared) so a later release can't double-free
+ *     the source's CSR.
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_graph_handle_block_copy(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    ray_t* tbl = make_i64_edge_table();
+    ray_t* sym_src = ray_sym(ray_sym_intern("src", 3));
+    ray_t* sym_dst = ray_sym(ray_sym_intern("dst", 3));
+    ray_t* args[3] = { tbl, sym_src, sym_dst };
+    ray_t* h = ray_graph_build_fn(args, 3);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+    TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) != 0);
+    int64_t orig_ptr = h->i64;
+    TEST_ASSERT_TRUE(orig_ptr != 0);
+
+    /* Block-copy via the same path used by COW.  Per the policy in
+     * src/mem/heap.c (ray_retain_owned_refs, RAY_ATTR_GRAPH branch): the
+     * COPY is detached — i64 zeroed, attr cleared — so freeing it does
+     * not touch the source's ray_rel_t. */
+    ray_t* copy = ray_alloc_copy(h);
+    TEST_ASSERT_NOT_NULL(copy);
+    TEST_ASSERT_EQ_I(copy->type, -RAY_I64);
+    TEST_ASSERT_TRUE((copy->attrs & RAY_ATTR_GRAPH) == 0);
+    TEST_ASSERT_EQ_I(copy->i64, 0);
+
+    /* Source must be unchanged — still owns the graph. */
+    TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) != 0);
+    TEST_ASSERT_EQ_I(h->i64, orig_ptr);
+
+    /* Releasing the copy is a plain block-free (nothing graph-y to clean
+     * up since attr was cleared); releasing the source then frees the
+     * underlying ray_rel_t exactly once. */
+    ray_release(copy);
+    TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) != 0);  /* still alive */
+    TEST_ASSERT_EQ_I(h->i64, orig_ptr);
+
+    ray_release(h);
+    ray_release(sym_src); ray_release(sym_dst);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * 10. ray_graph_pagerank_fn — direct call, verify {_node, _rank} schema
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_graph_pagerank_direct(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    ray_t* tbl = make_i64_edge_table();
+    ray_t* sym_src = ray_sym(ray_sym_intern("src", 3));
+    ray_t* sym_dst = ray_sym(ray_sym_intern("dst", 3));
+    ray_t* build_args[3] = { tbl, sym_src, sym_dst };
+    ray_t* h = ray_graph_build_fn(build_args, 3);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+
+    /* (.graph.pagerank h) — defaults: 30 iters, damping 0.85. */
+    ray_t* pr_args[1] = { h };
+    ray_t* result = ray_graph_pagerank_fn(pr_args, 1);
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(result->type, RAY_TABLE);
+    TEST_ASSERT_EQ_I(ray_table_ncols(result), 2);
+    TEST_ASSERT_EQ_I(ray_table_nrows(result), 3);
+
+    /* Both column names must resolve and point to the right types. */
+    int64_t node_sym = ray_sym_intern("_node", 5);
+    int64_t rank_sym = ray_sym_intern("_rank", 5);
+    ray_t* node_col = ray_table_get_col(result, node_sym);
+    ray_t* rank_col = ray_table_get_col(result, rank_sym);
+    TEST_ASSERT_NOT_NULL(node_col);
+    TEST_ASSERT_NOT_NULL(rank_col);
+    TEST_ASSERT_EQ_I(node_col->type, RAY_I64);
+    TEST_ASSERT_EQ_I(rank_col->type, RAY_F64);
+
+    /* Sanity: pagerank vector should sum (almost) to 1.0. */
+    double* ranks = (double*)ray_data(rank_col);
+    double sum = 0.0;
+    for (int64_t i = 0; i < rank_col->len; i++) sum += ranks[i];
+    TEST_ASSERT_EQ_F(sum, 1.0, 1e-3);
+
+    /* Rank validation: also exercise the rank check (n=0 → "rank" error). */
+    ray_t* err_rank = ray_graph_pagerank_fn(pr_args, 0);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(err_rank));
+    TEST_ASSERT_STR_EQ(ray_err_code(err_rank), "rank");
+    ray_error_free(err_rank);
+
+    ray_release(result);
+    ray_release(h);
+    ray_release(sym_src); ray_release(sym_dst);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Bonus: I64 weight column → F64 coercion path (line 250-251 in build).
+ *     Confirms the build succeeds with non-F64 weights and reports
+ *     has_weights:true through info.
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_graph_build_widen_i64_weight(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int64_t w_data[] = {1, 2, 3};
+    ray_t* tbl = make_weighted_table(RAY_I64, w_data, 3);
+    ray_t* sym_src = ray_sym(ray_sym_intern("src", 3));
+    ray_t* sym_dst = ray_sym(ray_sym_intern("dst", 3));
+    ray_t* sym_w   = ray_sym(ray_sym_intern("weight", 6));
+    ray_t* args[4] = { tbl, sym_src, sym_dst, sym_w };
+
+    ray_t* h = ray_graph_build_fn(args, 4);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(h));
+    TEST_ASSERT_TRUE((h->attrs & RAY_ATTR_GRAPH) != 0);
+
+    ray_t* info = ray_graph_info_fn(h);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(info));
+    ray_t* k = ray_sym(ray_sym_intern("has_weights", 11));
+    ray_t* v = ray_dict_get(info, k);
+    TEST_ASSERT_NOT_NULL(v);
+    TEST_ASSERT_EQ_I(v->b8, 1);
+    ray_release(v);
+    ray_release(k);
+    ray_release(info);
+
+    ray_release(h);
+    ray_release(sym_src); ray_release(sym_dst); ray_release(sym_w);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Suite definition
+ * -------------------------------------------------------------------------- */
+
+const test_entry_t graph_builtin_entries[] = {
+    { "graph_builtin/build_no_weight",      test_graph_build_no_weight,      NULL, NULL },
+    { "graph_builtin/build_with_weight",    test_graph_build_with_weight,    NULL, NULL },
+    { "graph_builtin/build_widen_i32",      test_graph_build_widen_i32,      NULL, NULL },
+    { "graph_builtin/build_widen_small",    test_graph_build_widen_i16_u8_bool, NULL, NULL },
+    { "graph_builtin/build_str_col_name",   test_graph_build_str_column_name, NULL, NULL },
+    { "graph_builtin/info_dict_shape",      test_graph_info_dict_shape,      NULL, NULL },
+    { "graph_builtin/free_idempotent",      test_graph_free_idempotent,      NULL, NULL },
+    { "graph_builtin/handle_in_release",    test_graph_handle_in_release,    NULL, NULL },
+    { "graph_builtin/handle_block_copy",    test_graph_handle_block_copy,    NULL, NULL },
+    { "graph_builtin/pagerank_direct",      test_graph_pagerank_direct,      NULL, NULL },
+    { "graph_builtin/build_widen_i64_w",    test_graph_build_widen_i64_weight, NULL, NULL },
+    { NULL, NULL, NULL, NULL },
+};

--- a/test/test_heap.c
+++ b/test/test_heap.c
@@ -1,0 +1,952 @@
+/*
+ *   Copyright (c) 2025-2026 Anton Kundenko <singaraiona@gmail.com>
+ *   All rights reserved.
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
+
+/*
+ * test_heap.c — focused unit tests for src/mem/heap.c paths NOT covered by
+ * test_buddy.c (basic alloc/free), test_arena.c (sym arena), or test_cow.c
+ * (retain/release/cow basics).  Targets: slab-cache overflow, scratch-realloc
+ * over multiple types, scratch-arena bump allocator, ray_heap_release_pages,
+ * GC under both serial and parallel flags, ray_heap_merge with rich source
+ * heaps, and the owned-ref retain/release fan-out for compound types
+ * (LIST / TABLE / DICT / parted / NULLMAP_EXT / SLICE / STR with str_pool).
+ */
+
+#include "test.h"
+#include <rayforce.h>
+#include "mem/heap.h"
+#include "ops/ops.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdatomic.h>
+
+/* ---- Setup / Teardown -------------------------------------------------- */
+
+static void heap_setup(void) {
+    ray_heap_init();
+}
+
+static void heap_teardown(void) {
+    ray_heap_destroy();
+}
+
+/* ---- Slab cache overflow ----------------------------------------------- *
+ *
+ * The slab cache holds RAY_SLAB_CACHE_SIZE blocks per slab order.  When a
+ * free arrives and the cache is full, the block falls through to
+ * heap_coalesce.  This exercises the "slab full -> coalesce" branch of
+ * ray_free which a small set of allocs/frees never touches. */
+
+static test_result_t test_slab_overflow_falls_through(void) {
+    /* Order 6 (64-byte) blocks: ray_alloc(0) lands here.  Allocate
+     * RAY_SLAB_CACHE_SIZE + 16 blocks so the slab cache is overfilled,
+     * then free them — the last 16 must take the coalesce path. */
+    enum { N = RAY_SLAB_CACHE_SIZE + 16 };
+    ray_t* blks[N];
+    for (int i = 0; i < N; i++) {
+        blks[i] = ray_alloc(0);
+        TEST_ASSERT_NOT_NULL(blks[i]);
+    }
+    /* Free in reverse so the first frees fill the slab cache, the trailing
+     * frees overflow into heap_coalesce. */
+    for (int i = N - 1; i >= 0; i--) {
+        ray_free(blks[i]);
+    }
+    /* Re-alloc to make sure heap is still consistent. */
+    ray_t* v = ray_alloc(0);
+    TEST_ASSERT_NOT_NULL(v);
+    ray_free(v);
+    PASS();
+}
+
+/* ---- Multi-pool growth + cross-pool reuse ------------------------------ *
+ *
+ * Each standard pool is 32 MB.  A burst of large allocs should trigger
+ * heap_add_pool more than once.  Freeing scrambled and re-allocating
+ * exercises the avail-bitmap scan and the freelist-stale-bit clearing
+ * path inside ray_alloc. */
+
+static test_result_t test_multi_pool_growth(void) {
+    /* 1 MB blocks: ~30 fit per 32 MB pool.  Allocate 64 of them to force
+     * at least 2 pools. */
+    enum { N = 64 };
+    ray_t* blks[N];
+    int allocated = 0;
+    for (int i = 0; i < N; i++) {
+        blks[i] = ray_alloc(1u << 20);  /* 1 MB data */
+        if (!blks[i]) break;
+        allocated++;
+    }
+    TEST_ASSERT((allocated) >= (32), "allocated >= 32");
+    TEST_ASSERT((ray_tl_heap->pool_count) >= (2), "pool_count >= 2");
+
+    /* Free in scrambled order: even indices first, odd second.  This
+     * leaves freelists with mixed-order entries to coalesce. */
+    for (int i = 0; i < allocated; i += 2) ray_free(blks[i]);
+    for (int i = 1; i < allocated; i += 2) ray_free(blks[i]);
+
+    /* Allocate again to confirm the heap is still functional and reusing
+     * coalesced space. */
+    for (int i = 0; i < allocated; i++) {
+        blks[i] = ray_alloc(1u << 20);
+        TEST_ASSERT_NOT_NULL(blks[i]);
+    }
+    for (int i = 0; i < allocated; i++) ray_free(blks[i]);
+    PASS();
+}
+
+/* ---- ray_scratch_realloc grow + shrink for several types --------------- */
+
+static test_result_t test_scratch_realloc_atom(void) {
+    /* Atom: realloc copies the 32-byte header only (data_size=0). */
+    ray_t* v = ray_alloc(0);
+    TEST_ASSERT_NOT_NULL(v);
+    v->type = -RAY_I64;
+    v->i64 = 1234567890LL;
+
+    ray_t* w = ray_scratch_realloc(v, 0);  /* atom path: old_data=0 */
+    TEST_ASSERT_NOT_NULL(w);
+    TEST_ASSERT_EQ_I(w->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(w->i64, 1234567890LL);
+    ray_free(w);
+    PASS();
+}
+
+static test_result_t test_scratch_realloc_vec_grow(void) {
+    /* I64 vector: realloc grow copies element bytes via the
+     * "ray_type / ray_sym_elem_size" branch. */
+    size_t old_data = 32 * sizeof(int64_t);
+    ray_t* v = ray_alloc(old_data);
+    TEST_ASSERT_NOT_NULL(v);
+    v->type = RAY_I64;
+    v->len  = 32;
+    int64_t* d = (int64_t*)ray_data(v);
+    for (int i = 0; i < 32; i++) d[i] = (int64_t)(i * 1000 + 7);
+
+    /* Grow to 200 i64s. */
+    ray_t* w = ray_scratch_realloc(v, 200 * sizeof(int64_t));
+    TEST_ASSERT_NOT_NULL(w);
+    TEST_ASSERT_EQ_I(w->type, RAY_I64);
+    TEST_ASSERT_EQ_I(w->len, 32);  /* len carried in header memcpy */
+    int64_t* wd = (int64_t*)ray_data(w);
+    for (int i = 0; i < 32; i++) {
+        TEST_ASSERT_EQ_I(wd[i], (int64_t)(i * 1000 + 7));
+    }
+    ray_free(w);
+    PASS();
+}
+
+static test_result_t test_scratch_realloc_vec_shrink(void) {
+    /* Shrink path: copy_data clamped to new_data_size */
+    size_t old_data = 100 * sizeof(int64_t);
+    ray_t* v = ray_alloc(old_data);
+    TEST_ASSERT_NOT_NULL(v);
+    v->type = RAY_I64;
+    v->len  = 100;
+    int64_t* d = (int64_t*)ray_data(v);
+    for (int i = 0; i < 100; i++) d[i] = (int64_t)i;
+
+    ray_t* w = ray_scratch_realloc(v, 16 * sizeof(int64_t));
+    TEST_ASSERT_NOT_NULL(w);
+    int64_t* wd = (int64_t*)ray_data(w);
+    /* First 16 elements must round-trip. */
+    for (int i = 0; i < 16; i++) {
+        TEST_ASSERT_EQ_I(wd[i], (int64_t)i);
+    }
+    ray_free(w);
+    PASS();
+}
+
+static test_result_t test_scratch_realloc_list(void) {
+    /* RAY_LIST realloc — exercises the list-specific branch in
+     * ray_scratch_realloc that sizes via sizeof(ray_t*). */
+    size_t old_data = 4 * sizeof(ray_t*);
+    ray_t* v = ray_alloc(old_data);
+    TEST_ASSERT_NOT_NULL(v);
+    v->type = RAY_LIST;
+    v->len  = 4;
+    ray_t** slots = (ray_t**)ray_data(v);
+    for (int i = 0; i < 4; i++) slots[i] = NULL;
+
+    ray_t* w = ray_scratch_realloc(v, 16 * sizeof(ray_t*));
+    TEST_ASSERT_NOT_NULL(w);
+    TEST_ASSERT_EQ_I(w->type, RAY_LIST);
+    /* Detach old refs prior to free was handled by ray_scratch_realloc;
+     * w's first 4 slots must round-trip (NULL here). */
+    ray_t** wslots = (ray_t**)ray_data(w);
+    for (int i = 0; i < 4; i++) TEST_ASSERT_NULL(wslots[i]);
+    /* len isn't auto-resized; we asked for capacity, not length. */
+    ray_free(w);
+    PASS();
+}
+
+static test_result_t test_scratch_realloc_null_v(void) {
+    /* v=NULL path: returns a fresh allocation, no copy. */
+    ray_t* w = ray_scratch_realloc(NULL, 64);
+    TEST_ASSERT_NOT_NULL(w);
+    TEST_ASSERT_EQ_U(w->rc, 1);
+    ray_free(w);
+    PASS();
+}
+
+/* ---- Scratch arena bump allocator -------------------------------------- *
+ *
+ * ray_scratch_arena_push uses ray_alloc internally to back its bump
+ * allocator with 64 KB blocks; on overflow it allocates more backings.
+ * Reset frees them all.  Both functions are 100% uncovered by the rfl
+ * suite. */
+
+static test_result_t test_scratch_arena_basic(void) {
+    ray_scratch_arena_t a;
+    ray_scratch_arena_init(&a);
+
+    /* Three small pushes within one backing block. */
+    void* p1 = ray_scratch_arena_push(&a, 100);
+    void* p2 = ray_scratch_arena_push(&a, 200);
+    void* p3 = ray_scratch_arena_push(&a, 300);
+    TEST_ASSERT_NOT_NULL(p1);
+    TEST_ASSERT_NOT_NULL(p2);
+    TEST_ASSERT_NOT_NULL(p3);
+    /* All within one backing — addresses must be ordered & disjoint. */
+    TEST_ASSERT_TRUE((char*)p2 >= (char*)p1 + 100);
+    TEST_ASSERT_TRUE((char*)p3 >= (char*)p2 + 200);
+    TEST_ASSERT_EQ_I(a.n_backing, 1);
+
+    /* Write to verify writability. */
+    memset(p1, 0xAA, 100);
+    memset(p2, 0xBB, 200);
+    memset(p3, 0xCC, 300);
+
+    ray_scratch_arena_reset(&a);
+    TEST_ASSERT_EQ_I(a.n_backing, 0);
+    PASS();
+}
+
+static test_result_t test_scratch_arena_multi_backing(void) {
+    /* One 64KB block holds ~64512 bytes payload.  Drain past one block
+     * to force a second backing. */
+    ray_scratch_arena_t a;
+    ray_scratch_arena_init(&a);
+
+    /* Push 200 chunks of 1 KB each = ~200 KB — definitely > one backing. */
+    for (int i = 0; i < 200; i++) {
+        void* p = ray_scratch_arena_push(&a, 1024);
+        TEST_ASSERT_NOT_NULL(p);
+        ((char*)p)[0] = (char)i;
+        ((char*)p)[1023] = (char)(255 - i);
+    }
+    TEST_ASSERT((a.n_backing) >= (2), "n_backing >= 2");
+
+    ray_scratch_arena_reset(&a);
+    /* After reset, pushes must work again. */
+    void* p = ray_scratch_arena_push(&a, 64);
+    TEST_ASSERT_NOT_NULL(p);
+    ray_scratch_arena_reset(&a);
+    PASS();
+}
+
+static test_result_t test_scratch_arena_oversize(void) {
+    /* Request larger than one backing block — push allocates an
+     * exact-fit backing. */
+    ray_scratch_arena_t a;
+    ray_scratch_arena_init(&a);
+
+    size_t big = 256 * 1024;  /* 256 KB > 64 KB block */
+    void* p = ray_scratch_arena_push(&a, big);
+    TEST_ASSERT_NOT_NULL(p);
+    memset(p, 0x77, big);
+    TEST_ASSERT_EQ_U(((unsigned char*)p)[0], 0x77);
+    TEST_ASSERT_EQ_U(((unsigned char*)p)[big - 1], 0x77);
+
+    ray_scratch_arena_reset(&a);
+    PASS();
+}
+
+/* ---- ray_heap_release_pages -------------------------------------------- *
+ *
+ * Walks freelists at order >= 13 (8 KB+) and madvise-releases pages past
+ * the first 4 KB so the kernel can reclaim physical pages without
+ * touching the address space.  Uncovered by the basic suite. */
+
+static test_result_t test_release_pages(void) {
+    /* Allocate then free a few large blocks (32 KB+) so order >= 15
+     * freelists are non-empty.  Then call ray_heap_release_pages — it
+     * must complete without disturbing block headers. */
+    ray_t* a = ray_alloc(64 * 1024);   /* order 17 */
+    ray_t* b = ray_alloc(128 * 1024);  /* order 18 */
+    ray_t* c = ray_alloc(256 * 1024);  /* order 19 */
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_NOT_NULL(b);
+    TEST_ASSERT_NOT_NULL(c);
+    ray_free(a); ray_free(b); ray_free(c);
+
+    ray_heap_release_pages();
+
+    /* Allocator must still serve requests after page release. */
+    ray_t* x = ray_alloc(128 * 1024);
+    TEST_ASSERT_NOT_NULL(x);
+    /* The first 4 KB of the freed block is still mapped & writable; pages
+     * past 4 KB will fault back in lazily. */
+    memset(ray_data(x), 0x42, 100 * 1024);
+    ray_free(x);
+    PASS();
+}
+
+/* ---- ray_heap_gc oversized-pool reclamation ---------------------------- *
+ *
+ * Allocate a block large enough to force a pool > 32 MB (pool_order >
+ * RAY_HEAP_POOL_ORDER), free it, then GC.  With a second standard pool
+ * already present, gc walks the oversized pool, finds it empty (only
+ * the freelist entry from the lone freed block, which equals the pool's
+ * full data capacity), and munmaps it — exercises the loop body in
+ * ray_heap_gc that's only reached when an oversized empty pool exists. */
+
+static test_result_t test_gc_reclaim_oversized_pool(void) {
+    /* First, force a standard pool into existence so pool_count >= 2 even
+     * after the oversized pool is reclaimed (the GC skips reclamation
+     * when pool_count <= 1). */
+    ray_t* small = ray_alloc(64);
+    TEST_ASSERT_NOT_NULL(small);
+
+    /* Now allocate a block that needs more than 32 MB — pool_order will
+     * be order+1 of the request.  RAY_HEAP_POOL_ORDER is 25 (32 MB), so
+     * a request of (1<<26) - 32 = 64 MB - 32 lands in order 26 and
+     * triggers a pool_order 27 (128 MB) pool. */
+    size_t big = (size_t)1 << 26;  /* 64 MB */
+    ray_t* huge = ray_alloc(big);
+    if (!huge) {
+        /* Environment can't satisfy a 128 MB anon mmap.  Skip rather
+         * than fail — this is environmental, not a code defect. */
+        ray_free(small);
+        SKIP("oversized pool alloc unavailable");
+    }
+    /* Verify it really did get an oversized pool. */
+    TEST_ASSERT((ray_tl_heap->pool_count) >= (2), "pool_count >= 2");
+
+    /* Release the huge block — its pool becomes empty.  GC reclaims it. */
+    ray_free(huge);
+
+    uint32_t pool_count_before = ray_tl_heap->pool_count;
+    ray_heap_gc();
+
+    /* Oversized pool must have been munmapped. */
+    TEST_ASSERT((ray_tl_heap->pool_count) < (pool_count_before), "pool_count decreased");
+
+    ray_free(small);
+    PASS();
+}
+
+/* ---- ray_heap_gc serial path ------------------------------------------- */
+
+static test_result_t test_heap_gc_serial(void) {
+    /* Build up some freelist activity, then call gc.  No oversized pools
+     * are involved; gc should still run flush_foreign + flush_slabs +
+     * return_foreign_freelist without crashing. */
+    ray_t* xs[64];
+    for (int i = 0; i < 64; i++) {
+        xs[i] = ray_alloc(256 + i * 8);
+        TEST_ASSERT_NOT_NULL(xs[i]);
+    }
+    for (int i = 0; i < 64; i++) ray_free(xs[i]);
+
+    /* Serial gc: ray_parallel_flag is 0, so gc takes the safe path. */
+    ray_heap_gc();
+
+    /* Heap remains usable. */
+    ray_t* y = ray_alloc(64);
+    TEST_ASSERT_NOT_NULL(y);
+    ray_free(y);
+    PASS();
+}
+
+/* ---- ray_heap_gc parallel path (foreign-flush no-op) ------------------- */
+
+static test_result_t test_heap_gc_parallel(void) {
+    /* When ray_parallel_flag != 0, heap_flush_foreign(false) is a no-op
+     * and gc must NOT touch worker heaps' state.  We only need to
+     * verify that calling gc with the flag set doesn't crash and the
+     * heap remains consistent. */
+    ray_t* a = ray_alloc(128);
+    TEST_ASSERT_NOT_NULL(a);
+
+    ray_parallel_begin();
+    ray_heap_gc();
+    ray_parallel_end();  /* clears flag and runs gc again */
+
+    /* a must still be a valid block. */
+    ((char*)ray_data(a))[0] = 'x';
+    ray_free(a);
+    PASS();
+}
+
+/* ---- ray_heap_flush_foreign while parallel (no-op early return) -------- */
+
+static test_result_t test_flush_foreign_during_parallel(void) {
+    /* While ray_parallel_flag is set, ray_heap_flush_foreign() must not
+     * touch h->foreign — proves the early return path. */
+    ray_heap_t* heap_a = ray_tl_heap;
+
+    /* Build heap_b and free a block from it on heap_a so heap_a->foreign
+     * is non-empty. */
+    ray_tl_heap = NULL;
+    ray_heap_init();
+    ray_heap_t* heap_b = ray_tl_heap;
+    TEST_ASSERT_NOT_NULL(heap_b);
+    ray_t* blk = ray_alloc(0);
+    TEST_ASSERT_NOT_NULL(blk);
+
+    ray_tl_heap = heap_a;
+    ray_free(blk);  /* enqueues onto heap_a->foreign */
+    TEST_ASSERT_NOT_NULL(heap_a->foreign);
+
+    ray_parallel_begin();
+    ray_heap_flush_foreign();
+    /* Foreign list should still be intact (not flushed). */
+    TEST_ASSERT_NOT_NULL(heap_a->foreign);
+    ray_parallel_end();
+    /* parallel_end -> ray_heap_gc which DOES flush foreign now safe.  */
+    /* Foreign list should be empty after end. */
+    TEST_ASSERT_NULL(heap_a->foreign);
+
+    ray_tl_heap = heap_b;
+    ray_heap_destroy();
+    ray_tl_heap = heap_a;
+    PASS();
+}
+
+/* ---- Owned-ref retain/release: LIST containing children ---------------- *
+ *
+ * ray_alloc_copy on a RAY_LIST exercises the LIST branch of both
+ * ray_retain_owned_refs (bumping each child's rc) and ray_release_owned_refs
+ * (lowering it on the copy's free).  ray_block_copy in test_cow.c covers
+ * tables, but not lists directly. */
+
+static test_result_t test_alloc_copy_list_retains(void) {
+    /* Build a list of three i64 atoms. */
+    ray_t* list = ray_list_new(3);
+    TEST_ASSERT_NOT_NULL(list);
+
+    ray_t* items[3];
+    for (int i = 0; i < 3; i++) {
+        items[i] = ray_alloc(0);
+        TEST_ASSERT_NOT_NULL(items[i]);
+        items[i]->type = -RAY_I64;
+        items[i]->i64  = (int64_t)(i * 1000 + 1);
+        list = ray_list_append(list, items[i]);
+        ray_release(items[i]);  /* list holds the only owning ref */
+    }
+
+    ray_t** slots = (ray_t**)ray_data(list);
+    uint32_t rc_before = slots[0]->rc;
+
+    /* alloc_copy invokes ray_retain_owned_refs which retains every child. */
+    ray_t* copy = ray_alloc_copy(list);
+    TEST_ASSERT_NOT_NULL(copy);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(copy));
+    TEST_ASSERT_EQ_I(copy->type, RAY_LIST);
+    TEST_ASSERT_EQ_I(copy->len, 3);
+
+    uint32_t rc_after = slots[0]->rc;
+    TEST_ASSERT_EQ_U(rc_after, rc_before + 1);
+
+    /* Freeing the copy invokes ray_release_owned_refs -> rc drops. */
+    ray_release(copy);
+    TEST_ASSERT_EQ_U(slots[0]->rc, rc_before);
+
+    ray_release(list);
+    PASS();
+}
+
+/* ---- Owned-ref: STR with str_pool -------------------------------------- *
+ *
+ * Releasing a RAY_STR with a str_pool child must release the pool exactly
+ * once.  Set up a STR vector pointing at a pool we own and confirm the
+ * pool's rc decrements via the dedicated branch in ray_release_owned_refs. */
+
+static test_result_t test_str_pool_owned_ref(void) {
+    /* Construct a RAY_STR shell + a U8 pool block and link them. */
+    ray_t* shell = ray_alloc(0);
+    TEST_ASSERT_NOT_NULL(shell);
+    shell->type = RAY_STR;
+    shell->len  = 0;
+    /* Pool is a plain U8 vec retained by shell. */
+    ray_t* pool = ray_alloc(64);
+    TEST_ASSERT_NOT_NULL(pool);
+    pool->type = RAY_U8;
+    pool->len  = 64;
+    /* shell takes ownership; pool->rc stays at 1 because we transfer. */
+    shell->str_pool = pool;
+
+    /* Sanity: shell rc==1, pool rc==1.  Release shell — pool must be
+     * released too via ray_release_owned_refs's STR/str_pool branch. */
+    TEST_ASSERT_EQ_U(shell->rc, 1);
+    TEST_ASSERT_EQ_U(pool->rc, 1);
+
+    /* ray_release(shell) -> rc drops to 0 -> ray_free -> release_owned_refs
+     * -> ray_release(pool).  After this, pool's storage is reclaimed; we
+     * cannot validate pool's state, but a crash here would mean the path
+     * mishandled the pointer.  Use ray_alloc immediately after to confirm
+     * heap is sane. */
+    ray_release(shell);
+
+    ray_t* probe = ray_alloc(0);
+    TEST_ASSERT_NOT_NULL(probe);
+    ray_free(probe);
+    PASS();
+}
+
+/* ---- Owned-ref: NULLMAP_EXT child -------------------------------------- *
+ *
+ * A vec with RAY_ATTR_NULLMAP_EXT carries an owning ref to ext_nullmap.
+ * ray_release_owned_refs must release that child.  Construct one
+ * manually and free it. */
+
+static test_result_t test_nullmap_ext_owned_ref(void) {
+    ray_t* vec = ray_alloc(8 * sizeof(int64_t));
+    TEST_ASSERT_NOT_NULL(vec);
+    vec->type = RAY_I64;
+    vec->len  = 8;
+
+    ray_t* nm = ray_alloc(8);
+    TEST_ASSERT_NOT_NULL(nm);
+    nm->type = RAY_U8;
+    nm->len  = 8;
+
+    /* Attach extended nullmap.  vec now owns nm. */
+    vec->ext_nullmap = nm;
+    vec->attrs |= RAY_ATTR_NULLMAP_EXT;
+
+    /* Drop vec — nm must be released as well via the NULLMAP_EXT branch. */
+    ray_release(vec);
+
+    /* Heap remains sane. */
+    ray_t* probe = ray_alloc(0);
+    TEST_ASSERT_NOT_NULL(probe);
+    ray_free(probe);
+    PASS();
+}
+
+/* ---- Owned-ref: SLICE retains parent ----------------------------------- *
+ *
+ * A RAY_ATTR_SLICE block carries slice_parent + slice_offset.  ray_alloc_copy
+ * of a slice must retain the parent (so the parent's rc bumps), and
+ * release-on-free must drop it back. */
+
+static test_result_t test_slice_owned_ref(void) {
+    /* Parent: i64 vec of 16 elements. */
+    ray_t* parent = ray_alloc(16 * sizeof(int64_t));
+    TEST_ASSERT_NOT_NULL(parent);
+    parent->type = RAY_I64;
+    parent->len  = 16;
+    int64_t* pd = (int64_t*)ray_data(parent);
+    for (int i = 0; i < 16; i++) pd[i] = (int64_t)(i + 1);
+
+    /* Slice: rc=1 atom-style header pointing at parent[4..12). */
+    ray_t* slice = ray_alloc(0);
+    TEST_ASSERT_NOT_NULL(slice);
+    slice->type = RAY_I64;
+    slice->len  = 8;
+    slice->attrs |= RAY_ATTR_SLICE;
+    slice->slice_parent = parent;
+    slice->slice_offset = 4;
+    ray_retain(parent);  /* slice owns one ref */
+
+    uint32_t parent_rc = parent->rc;
+
+    /* Copy the slice — ray_retain_owned_refs bumps parent->rc. */
+    ray_t* copy = ray_alloc_copy(slice);
+    TEST_ASSERT_NOT_NULL(copy);
+    TEST_ASSERT_TRUE(copy->attrs & RAY_ATTR_SLICE);
+    TEST_ASSERT_EQ_PTR(copy->slice_parent, parent);
+    TEST_ASSERT_EQ_U(parent->rc, parent_rc + 1);
+
+    /* Releasing the copy drops parent->rc again. */
+    ray_release(copy);
+    TEST_ASSERT_EQ_U(parent->rc, parent_rc);
+
+    ray_release(slice);   /* drops slice's ref on parent */
+    ray_release(parent);  /* drops original ref */
+    PASS();
+}
+
+/* ---- Owned-ref: parted vec retains segments ---------------------------- *
+ *
+ * A parted vec stores its segment ray_t* pointers in the data area.
+ * ray_retain_owned_refs / ray_release_owned_refs must touch each. */
+
+static test_result_t test_parted_owned_ref(void) {
+    /* Build 3 inner i64 vecs as segments. */
+    ray_t* segs[3];
+    for (int i = 0; i < 3; i++) {
+        segs[i] = ray_alloc(4 * sizeof(int64_t));
+        TEST_ASSERT_NOT_NULL(segs[i]);
+        segs[i]->type = RAY_I64;
+        segs[i]->len  = 4;
+    }
+
+    /* Parted I64 vec: type = RAY_PARTED_BASE + RAY_I64. */
+    ray_t* parted = ray_alloc(3 * sizeof(ray_t*));
+    TEST_ASSERT_NOT_NULL(parted);
+    parted->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
+    parted->len  = 3;
+    ray_t** slots = (ray_t**)ray_data(parted);
+    for (int i = 0; i < 3; i++) {
+        ray_retain(segs[i]);  /* parted holds one ref each */
+        slots[i] = segs[i];
+    }
+
+    uint32_t rcs_before[3] = { segs[0]->rc, segs[1]->rc, segs[2]->rc };
+
+    /* Copy parted block — segments retained. */
+    ray_t* copy = ray_alloc_copy(parted);
+    TEST_ASSERT_NOT_NULL(copy);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(copy));
+    for (int i = 0; i < 3; i++) {
+        TEST_ASSERT_EQ_U(segs[i]->rc, rcs_before[i] + 1);
+    }
+
+    /* Release copy — segs go back to the original ref count. */
+    ray_release(copy);
+    for (int i = 0; i < 3; i++) {
+        TEST_ASSERT_EQ_U(segs[i]->rc, rcs_before[i]);
+    }
+
+    ray_release(parted);  /* drops parted's refs */
+    for (int i = 0; i < 3; i++) ray_release(segs[i]);  /* drop our own */
+    PASS();
+}
+
+/* ---- Owned-ref: MAPCOMMON two-pointer block ---------------------------- */
+
+static test_result_t test_mapcommon_owned_ref(void) {
+    ray_t* a = ray_alloc(0); a->type = -RAY_I64; a->i64 = 7;
+    ray_t* b = ray_alloc(0); b->type = -RAY_I64; b->i64 = 11;
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_NOT_NULL(b);
+
+    ray_t* mc = ray_alloc(2 * sizeof(ray_t*));
+    TEST_ASSERT_NOT_NULL(mc);
+    mc->type = RAY_MAPCOMMON;
+    mc->len  = 2;
+    ray_t** slots = (ray_t**)ray_data(mc);
+    slots[0] = a;
+    slots[1] = b;
+    /* mc takes the only refs; we already own one each. */
+
+    uint32_t a_rc = a->rc, b_rc = b->rc;
+
+    ray_t* copy = ray_alloc_copy(mc);
+    TEST_ASSERT_NOT_NULL(copy);
+    TEST_ASSERT_EQ_I(copy->type, RAY_MAPCOMMON);
+    TEST_ASSERT_EQ_U(a->rc, a_rc + 1);
+    TEST_ASSERT_EQ_U(b->rc, b_rc + 1);
+
+    ray_release(copy);
+    TEST_ASSERT_EQ_U(a->rc, a_rc);
+    TEST_ASSERT_EQ_U(b->rc, b_rc);
+
+    ray_release(mc);     /* drops mc's refs */
+    ray_release(a);      /* drop our own */
+    ray_release(b);
+    PASS();
+}
+
+/* ---- Heap merge with rich source --------------------------------------- *
+ *
+ * Build a source heap with: filled slab caches across multiple orders,
+ * non-empty freelists, foreign blocks, and multiple pools.  Merge into
+ * the current heap and verify accounting + accessibility. */
+
+static test_result_t test_merge_with_slabs_and_freelist(void) {
+    ray_heap_t* heap_a = ray_tl_heap;
+
+    /* Build heap_b. */
+    ray_tl_heap = NULL;
+    ray_heap_init();
+    ray_heap_t* heap_b = ray_tl_heap;
+    TEST_ASSERT_NOT_NULL(heap_b);
+
+    /* Allocate then free across several slab orders to populate slab
+     * caches.  Order 6 (64B), 7 (128B), 8 (256B), 9 (512B), 10 (1024B). */
+    ray_t* tmp[5][8];
+    size_t sizes[5] = { 0, 64, 128, 256, 512 };
+    for (int o = 0; o < 5; o++) {
+        for (int i = 0; i < 8; i++) {
+            tmp[o][i] = ray_alloc(sizes[o]);
+            TEST_ASSERT_NOT_NULL(tmp[o][i]);
+        }
+    }
+    for (int o = 0; o < 5; o++)
+        for (int i = 0; i < 8; i++)
+            ray_free(tmp[o][i]);  /* enters slab cache */
+
+    /* Allocate a couple of larger blocks and free them — populates
+     * proper freelists (orders 11-14). */
+    ray_t* big1 = ray_alloc(2048);
+    ray_t* big2 = ray_alloc(8192);
+    ray_t* big3 = ray_alloc(16384);
+    TEST_ASSERT_NOT_NULL(big1);
+    TEST_ASSERT_NOT_NULL(big2);
+    TEST_ASSERT_NOT_NULL(big3);
+    ray_free(big1); ray_free(big2); ray_free(big3);
+
+    uint32_t heap_b_pools = heap_b->pool_count;
+    TEST_ASSERT((heap_b_pools) > (0), "heap_b_pools > 0");
+
+    /* Drive a foreign block into heap_b->foreign by allocating on
+     * heap_a and freeing while heap_b is current. */
+    ray_tl_heap = heap_a;
+    ray_t* fblk = ray_alloc(0);
+    TEST_ASSERT_NOT_NULL(fblk);
+    ray_tl_heap = heap_b;
+    ray_free(fblk);  /* heap_b->foreign now contains fblk */
+    TEST_ASSERT_NOT_NULL(heap_b->foreign);
+
+    /* Capture pool count AFTER any allocs heap_a has performed for fblk —
+     * lazy heap_add_pool may have grown the count. */
+    ray_tl_heap = heap_a;
+    uint32_t pools_before = heap_a->pool_count;
+
+    /* Push & drain pending — exercises ray_heap_merge with all of:
+     * slabs, freelists, foreign list, multiple pools. */
+    ray_heap_push_pending(heap_b);
+    ray_heap_drain_pending();
+
+    /* heap_a should have absorbed heap_b's pools. */
+    TEST_ASSERT_EQ_U(heap_a->pool_count, pools_before + heap_b_pools);
+    PASS();
+}
+
+/* ---- ray_alloc_copy of an atom ----------------------------------------- *
+ *
+ * Atom branch of ray_alloc_copy (data_size = 0). */
+
+static test_result_t test_alloc_copy_atom(void) {
+    ray_t* v = ray_alloc(0);
+    TEST_ASSERT_NOT_NULL(v);
+    v->type = -RAY_I64;
+    v->i64  = 0xdeadbeefLL;
+
+    ray_t* c = ray_alloc_copy(v);
+    TEST_ASSERT_NOT_NULL(c);
+    TEST_ASSERT_EQ_I(c->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(c->i64, (int64_t)0xdeadbeefLL);
+    TEST_ASSERT_TRUE((void*)c != (void*)v);
+
+    ray_free(v);
+    ray_free(c);
+    PASS();
+}
+
+/* ---- ray_alloc_copy of a TABLE block ----------------------------------- *
+ *
+ * Tables are 2-pointer blocks; ray_alloc_copy follows a dedicated branch
+ * (data_size = 2*sizeof(ray_t*)).  Verifies the branch is hit. */
+
+static test_result_t test_alloc_copy_table_block(void) {
+    /* Build a 2-slot block manually so we don't need symbol/table
+     * machinery — same shape ray_alloc_copy expects. */
+    ray_t* schema = ray_alloc(0);
+    ray_t* cols   = ray_alloc(0);
+    TEST_ASSERT_NOT_NULL(schema);
+    TEST_ASSERT_NOT_NULL(cols);
+    schema->type = -RAY_I64;
+    cols->type   = -RAY_I64;
+
+    ray_t* tbl = ray_alloc(2 * sizeof(ray_t*));
+    TEST_ASSERT_NOT_NULL(tbl);
+    tbl->type = RAY_TABLE;
+    tbl->len  = 0;
+    ray_t** slots = (ray_t**)ray_data(tbl);
+    slots[0] = schema; slots[1] = cols;
+    /* tbl owns one ref each — we already have one ref each from alloc. */
+
+    uint32_t s_rc = schema->rc, c_rc = cols->rc;
+
+    ray_t* copy = ray_alloc_copy(tbl);
+    TEST_ASSERT_NOT_NULL(copy);
+    TEST_ASSERT_EQ_I(copy->type, RAY_TABLE);
+    TEST_ASSERT_EQ_U(schema->rc, s_rc + 1);
+    TEST_ASSERT_EQ_U(cols->rc,   c_rc + 1);
+
+    ray_release(copy);
+    TEST_ASSERT_EQ_U(schema->rc, s_rc);
+    TEST_ASSERT_EQ_U(cols->rc,   c_rc);
+
+    ray_release(tbl);
+    ray_release(schema);
+    ray_release(cols);
+    PASS();
+}
+
+/* ---- ray_mem_stats with no heap ---------------------------------------- *
+ *
+ * When ray_tl_heap is NULL, ray_mem_stats must zero out all per-heap
+ * fields and only fill sys_current/sys_peak. */
+
+static test_result_t test_mem_stats_no_heap(void) {
+    ray_heap_t* save = ray_tl_heap;
+    ray_tl_heap = NULL;
+
+    ray_mem_stats_t s;
+    ray_mem_stats(&s);
+    TEST_ASSERT_EQ_U(s.alloc_count, 0);
+    TEST_ASSERT_EQ_U(s.free_count, 0);
+    TEST_ASSERT_EQ_U(s.bytes_allocated, 0);
+    /* sys_* are filled from the system allocator, not gated on tl_heap. */
+
+    ray_tl_heap = save;
+    PASS();
+}
+
+/* ---- ray_alloc with order overflow ------------------------------------- *
+ *
+ * Asking for more bytes than RAY_HEAP_MAX_ORDER (256 GB) returns NULL
+ * cleanly — exercises the overflow guard branch. */
+
+static test_result_t test_alloc_too_large(void) {
+    /* SIZE_MAX/2 will trigger ray_order_for_size > MAX_ORDER. */
+    size_t huge = (size_t)1 << 40;  /* 1 TB */
+    ray_t* v = ray_alloc(huge);
+    TEST_ASSERT_NULL(v);
+    PASS();
+}
+
+/* ---- ray_alloc with no thread-local heap (lazy init) ------------------- *
+ *
+ * Tear down the heap then call ray_alloc — the lazy init branch in
+ * ray_alloc must create a fresh heap. */
+
+static test_result_t test_alloc_lazy_init(void) {
+    ray_heap_destroy();
+    TEST_ASSERT_NULL(ray_tl_heap);
+
+    ray_t* v = ray_alloc(64);
+    TEST_ASSERT_NOT_NULL(v);
+    TEST_ASSERT_NOT_NULL(ray_tl_heap);
+    ray_free(v);
+    /* Teardown happens in heap_teardown */
+    PASS();
+}
+
+/* ---- ray_free on NULL / error / arena ---------------------------------- */
+
+static test_result_t test_free_edge_cases(void) {
+    /* NULL is a no-op. */
+    ray_free(NULL);
+
+    /* error object is a no-op (RAY_IS_ERR guard). */
+    ray_t* err = ray_error("oom", NULL);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(err));
+    ray_free(err);  /* must not crash */
+    ray_error_free(err);
+
+    /* arena-flagged block is a no-op. */
+    ray_t* a = ray_alloc(0);
+    TEST_ASSERT_NOT_NULL(a);
+    a->attrs |= RAY_ATTR_ARENA;
+    ray_free(a);  /* skipped due to ARENA flag */
+    /* Reading a is still legal because it wasn't freed. */
+    TEST_ASSERT_TRUE(a->attrs & RAY_ATTR_ARENA);
+    a->attrs &= (uint8_t)~RAY_ATTR_ARENA;
+    ray_free(a);
+    PASS();
+}
+
+/* ---- Coalesce up many orders ------------------------------------------- *
+ *
+ * Allocate enough small blocks to span many orders, free in pair-buddy
+ * patterns to drive a multi-step coalesce.  Confirms the loop-based
+ * heap_coalesce walks through several orders. */
+
+static test_result_t test_coalesce_chain(void) {
+    /* Fresh heap so allocations come from a clean pool slice. */
+    ray_heap_destroy();
+    ray_heap_init();
+
+    /* Allocate 256 64-byte blocks (one full slab batch's worth + some). */
+    enum { N = 256 };
+    ray_t* xs[N];
+    for (int i = 0; i < N; i++) {
+        xs[i] = ray_alloc(0);
+        TEST_ASSERT_NOT_NULL(xs[i]);
+    }
+    /* Free everything — slab cache absorbs the first 64 per order, the
+     * rest fall through to coalesce. */
+    for (int i = 0; i < N; i++) ray_free(xs[i]);
+
+    /* GC to drain slab caches into freelists, then check we can serve
+     * a much larger request — proves coalesce stitched min-blocks back
+     * into bigger orders. */
+    ray_heap_gc();
+
+    ray_t* big = ray_alloc(8192);
+    TEST_ASSERT_NOT_NULL(big);
+    ray_free(big);
+    PASS();
+}
+
+/* ---- ray_scratch_alloc is just ray_alloc ------------------------------- */
+
+static test_result_t test_scratch_alloc_basic(void) {
+    ray_t* v = ray_scratch_alloc(128);
+    TEST_ASSERT_NOT_NULL(v);
+    TEST_ASSERT_EQ_U(v->rc, 1);
+    ray_free(v);
+    PASS();
+}
+
+/* ---- Suite definition -------------------------------------------------- */
+
+const test_entry_t heap_entries[] = {
+    { "heap/slab_overflow",            test_slab_overflow_falls_through, heap_setup, heap_teardown },
+    { "heap/multi_pool_growth",        test_multi_pool_growth,           heap_setup, heap_teardown },
+    { "heap/scratch_realloc_atom",     test_scratch_realloc_atom,        heap_setup, heap_teardown },
+    { "heap/scratch_realloc_vec_grow", test_scratch_realloc_vec_grow,    heap_setup, heap_teardown },
+    { "heap/scratch_realloc_vec_shrink", test_scratch_realloc_vec_shrink, heap_setup, heap_teardown },
+    { "heap/scratch_realloc_list",     test_scratch_realloc_list,        heap_setup, heap_teardown },
+    { "heap/scratch_realloc_null_v",   test_scratch_realloc_null_v,      heap_setup, heap_teardown },
+    { "heap/scratch_arena_basic",      test_scratch_arena_basic,         heap_setup, heap_teardown },
+    { "heap/scratch_arena_multi",      test_scratch_arena_multi_backing, heap_setup, heap_teardown },
+    { "heap/scratch_arena_oversize",   test_scratch_arena_oversize,      heap_setup, heap_teardown },
+    { "heap/release_pages",            test_release_pages,               heap_setup, heap_teardown },
+    { "heap/gc_reclaim_oversized",     test_gc_reclaim_oversized_pool,   heap_setup, heap_teardown },
+    { "heap/gc_serial",                test_heap_gc_serial,              heap_setup, heap_teardown },
+    { "heap/gc_parallel",              test_heap_gc_parallel,            heap_setup, heap_teardown },
+    { "heap/flush_foreign_parallel",   test_flush_foreign_during_parallel, heap_setup, heap_teardown },
+    { "heap/alloc_copy_list",          test_alloc_copy_list_retains,     heap_setup, heap_teardown },
+    { "heap/str_pool_owned_ref",       test_str_pool_owned_ref,          heap_setup, heap_teardown },
+    { "heap/nullmap_ext_owned_ref",    test_nullmap_ext_owned_ref,       heap_setup, heap_teardown },
+    { "heap/slice_owned_ref",          test_slice_owned_ref,             heap_setup, heap_teardown },
+    { "heap/parted_owned_ref",         test_parted_owned_ref,            heap_setup, heap_teardown },
+    { "heap/mapcommon_owned_ref",      test_mapcommon_owned_ref,         heap_setup, heap_teardown },
+    { "heap/merge_rich",               test_merge_with_slabs_and_freelist, heap_setup, heap_teardown },
+    { "heap/alloc_copy_atom",          test_alloc_copy_atom,             heap_setup, heap_teardown },
+    { "heap/alloc_copy_table",         test_alloc_copy_table_block,      heap_setup, heap_teardown },
+    { "heap/mem_stats_no_heap",        test_mem_stats_no_heap,           heap_setup, heap_teardown },
+    { "heap/alloc_too_large",          test_alloc_too_large,             heap_setup, heap_teardown },
+    { "heap/alloc_lazy_init",          test_alloc_lazy_init,             heap_setup, heap_teardown },
+    { "heap/free_edge_cases",          test_free_edge_cases,             heap_setup, heap_teardown },
+    { "heap/coalesce_chain",           test_coalesce_chain,              heap_setup, heap_teardown },
+    { "heap/scratch_alloc_basic",      test_scratch_alloc_basic,         heap_setup, heap_teardown },
+    { NULL, NULL, NULL, NULL },
+};

--- a/test/test_opt.c
+++ b/test/test_opt.c
@@ -26,6 +26,7 @@
 #include <rayforce.h>
 #include "mem/heap.h"
 #include "ops/ops.h"
+#include "store/csr.h"
 #include <string.h>
 
 /* Helper: create a test table with columns id1(I64), v1(I64), v3(F64) */
@@ -734,6 +735,374 @@ static test_result_t test_partition_pruning_not_in(void) {
     PASS();
 }
 
+/*
+ * Test: OP_WINDOW DCE & projection-pushdown walk.
+ *
+ * Build: SCAN(grp), SCAN(val) -> WINDOW(part=[grp], order=[val], func=ROW_NUMBER(val))
+ * Run ray_optimize.  This forces projection_pushdown's BFS, mark_live's
+ * DCE walk, and pass_type_inference to walk through ext->window.{part_keys,
+ * order_keys, func_inputs}.  Verify all three columns survived (none
+ * marked OP_FLAG_DEAD).
+ */
+static test_result_t test_opt_window_dce(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int64_t n = 6;
+    int64_t grp_data[] = {1, 1, 1, 2, 2, 2};
+    int64_t val_data[] = {10, 20, 30, 40, 50, 60};
+    ray_t* grp_v = ray_vec_from_raw(RAY_I64, grp_data, n);
+    ray_t* val_v = ray_vec_from_raw(RAY_I64, val_data, n);
+    int64_t n_grp = ray_sym_intern("grp", 3);
+    int64_t n_val = ray_sym_intern("val", 3);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, n_grp, grp_v);
+    tbl = ray_table_add_col(tbl, n_val, val_v);
+    ray_release(grp_v);
+    ray_release(val_v);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* grp_op = ray_scan(g, "grp");
+    ray_op_t* val_op = ray_scan(g, "val");
+
+    ray_op_t* parts[] = { grp_op };
+    ray_op_t* orders[] = { val_op };
+    uint8_t order_descs[] = { 0 };
+    uint8_t func_kinds[] = { RAY_WIN_ROW_NUMBER };
+    ray_op_t* func_inputs[] = { val_op };
+    int64_t func_params[] = { 0 };
+    ray_op_t* win = ray_window_op(g, tbl_op,
+                                  parts, 1,
+                                  orders, order_descs, 1,
+                                  func_kinds, func_inputs, func_params, 1,
+                                  RAY_FRAME_ROWS,
+                                  RAY_BOUND_UNBOUNDED_PRECEDING,
+                                  RAY_BOUND_UNBOUNDED_FOLLOWING,
+                                  0, 0);
+    TEST_ASSERT_NOT_NULL(win);
+
+    uint32_t grp_id = grp_op->id;
+    uint32_t val_id = val_op->id;
+
+    ray_op_t* opt = ray_optimize(g, win);
+    TEST_ASSERT_NOT_NULL(opt);
+    TEST_ASSERT_EQ_I(opt->opcode, OP_WINDOW);
+
+    /* Both scans referenced through window's ext (part_keys, order_keys,
+     * func_inputs) must survive DCE/projection-pushdown. */
+    TEST_ASSERT_FALSE(g->nodes[grp_id].flags & OP_FLAG_DEAD);
+    TEST_ASSERT_FALSE(g->nodes[val_id].flags & OP_FLAG_DEAD);
+
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/*
+ * Test: predicate pushdown past OP_EXPAND.
+ *
+ * Build: FILTER(EXPAND(SCAN_const_vec, rel), pred(SCAN_pred_const))
+ * The predicate references a CONST scan in the source subtree, so the
+ * pushdown must rewrite into:
+ *      EXPAND(FILTER(SCAN_const_vec, pred), rel)
+ *
+ * Note: predicate must reference scans reachable from EXPAND's source
+ * input.  We use a const-only predicate that has NO scans (n_scans==0,
+ * which collect_pred_scans returns) -- no, we need n_scans > 0 for the
+ * pushdown to fire.  So we build a graph with a small table that has
+ * a column we can scan + a const compare.
+ */
+static test_result_t test_opt_pushdown_past_expand(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    /* Build node table with a column 'flag' we can filter on. */
+    int64_t n = 4;
+    int64_t flag_data[] = {1, 0, 1, 0};
+    int64_t id_data[]   = {0, 1, 2, 3};
+    ray_t* flag_v = ray_vec_from_raw(RAY_I64, flag_data, n);
+    ray_t* id_v   = ray_vec_from_raw(RAY_I64, id_data, n);
+    int64_t s_flag = ray_sym_intern("flag", 4);
+    int64_t s_id   = ray_sym_intern("id", 2);
+    ray_t* node_tbl = ray_table_new(2);
+    node_tbl = ray_table_add_col(node_tbl, s_id, id_v);
+    node_tbl = ray_table_add_col(node_tbl, s_flag, flag_v);
+    ray_release(flag_v);
+    ray_release(id_v);
+
+    /* Edges: 0->1, 0->2, 1->3, 2->3 */
+    int64_t src_data[] = {0, 0, 1, 2};
+    int64_t dst_data[] = {1, 2, 3, 3};
+    ray_t* src_v = ray_vec_from_raw(RAY_I64, src_data, 4);
+    ray_t* dst_v = ray_vec_from_raw(RAY_I64, dst_data, 4);
+    int64_t s_src = ray_sym_intern("src", 3);
+    int64_t s_dst = ray_sym_intern("dst", 3);
+    ray_t* edges = ray_table_new(2);
+    edges = ray_table_add_col(edges, s_src, src_v);
+    edges = ray_table_add_col(edges, s_dst, dst_v);
+    ray_release(src_v);
+    ray_release(dst_v);
+
+    ray_rel_t* rel = ray_rel_from_edges(edges, "src", "dst", 4, 4, false);
+    TEST_ASSERT_NOT_NULL(rel);
+
+    ray_graph_t* g = ray_graph_new(node_tbl);
+
+    /* Source: scan 'flag' (so the predicate's scan is reachable from
+     * EXPAND's source subtree).  Predicate: flag = 1. */
+    ray_op_t* flag_scan = ray_scan(g, "flag");
+    ray_op_t* c1   = ray_const_i64(g, 1);
+    ray_op_t* pred = ray_eq(g, flag_scan, c1);
+
+    ray_op_t* expand = ray_expand(g, flag_scan, rel, 0);
+    TEST_ASSERT_NOT_NULL(expand);
+    uint32_t expand_id = expand->id;
+
+    ray_op_t* filt = ray_filter(g, expand, pred);
+    TEST_ASSERT_NOT_NULL(filt);
+
+    ray_op_t* opt = ray_optimize(g, filt);
+    TEST_ASSERT_NOT_NULL(opt);
+
+    /* After pushdown, root is the EXPAND (filter pushed below it). */
+    TEST_ASSERT_EQ_U(opt->id, expand_id);
+    TEST_ASSERT_EQ_I(opt->opcode, OP_EXPAND);
+    /* EXPAND.inputs[0] should now be a FILTER node (the pushed filter). */
+    TEST_ASSERT_NOT_NULL(opt->inputs[0]);
+    TEST_ASSERT_EQ_I(opt->inputs[0]->opcode, OP_FILTER);
+
+    ray_graph_free(g);
+    ray_rel_free(rel);
+    ray_release(node_tbl);
+    ray_release(edges);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/*
+ * Test: predicate-pushdown past EXPAND must NOT fire when the predicate
+ * references a scan that is NOT in the EXPAND's source subtree.
+ *
+ * We can't easily build this in C without a multi-table graph, but we can
+ * still exercise collect_pred_scans's truncation/unknown path by
+ * building a predicate with multiple chained scans where the source is a
+ * const-vec (not a scan).  In that case is_reachable_from will return
+ * false for the predicate's scan, all_source becomes false, and pushdown
+ * is skipped.  This still walks collect_pred_scans + is_reachable_from.
+ */
+static test_result_t test_opt_pushdown_expand_blocked(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t flag_data[] = {1, 0, 1, 0};
+    int64_t id_data[]   = {0, 1, 2, 3};
+    ray_t* flag_v = ray_vec_from_raw(RAY_I64, flag_data, n);
+    ray_t* id_v   = ray_vec_from_raw(RAY_I64, id_data, n);
+    int64_t s_flag = ray_sym_intern("flag", 4);
+    int64_t s_id   = ray_sym_intern("id", 2);
+    ray_t* node_tbl = ray_table_new(2);
+    node_tbl = ray_table_add_col(node_tbl, s_id, id_v);
+    node_tbl = ray_table_add_col(node_tbl, s_flag, flag_v);
+    ray_release(flag_v);
+    ray_release(id_v);
+
+    int64_t src_data[] = {0, 1, 2};
+    int64_t dst_data[] = {1, 2, 3};
+    ray_t* src_v = ray_vec_from_raw(RAY_I64, src_data, 3);
+    ray_t* dst_v = ray_vec_from_raw(RAY_I64, dst_data, 3);
+    int64_t s_src = ray_sym_intern("src", 3);
+    int64_t s_dst = ray_sym_intern("dst", 3);
+    ray_t* edges = ray_table_new(2);
+    edges = ray_table_add_col(edges, s_src, src_v);
+    edges = ray_table_add_col(edges, s_dst, dst_v);
+    ray_release(src_v);
+    ray_release(dst_v);
+
+    ray_rel_t* rel = ray_rel_from_edges(edges, "src", "dst", 4, 4, false);
+    TEST_ASSERT_NOT_NULL(rel);
+
+    ray_graph_t* g = ray_graph_new(node_tbl);
+
+    /* EXPAND's source is a const vec literal — has no SCAN.
+     * Predicate references a SCAN, which is NOT in source subtree.
+     * Pushdown must skip; we just verify it doesn't crash and
+     * the filter remains above the expand. */
+    int64_t start_data[] = {0, 1};
+    ray_t* start_vec = ray_vec_from_raw(RAY_I64, start_data, 2);
+    ray_op_t* src = ray_const_vec(g, start_vec);
+    ray_release(start_vec);
+
+    ray_op_t* expand = ray_expand(g, src, rel, 0);
+    TEST_ASSERT_NOT_NULL(expand);
+    uint32_t expand_id = expand->id;
+
+    /* Predicate: flag = 1 — its SCAN is NOT in the expand source subtree. */
+    ray_op_t* flag_scan = ray_scan(g, "flag");
+    ray_op_t* c1 = ray_const_i64(g, 1);
+    ray_op_t* pred = ray_eq(g, flag_scan, c1);
+
+    ray_op_t* filt = ray_filter(g, expand, pred);
+    uint32_t filt_id = filt->id;
+
+    ray_op_t* opt = ray_optimize(g, filt);
+    TEST_ASSERT_NOT_NULL(opt);
+    /* Pushdown blocked: filter remains the root, expand stays below. */
+    TEST_ASSERT_EQ_U(opt->id, filt_id);
+    TEST_ASSERT_EQ_I(opt->opcode, OP_FILTER);
+    TEST_ASSERT_EQ_U(opt->inputs[0]->id, expand_id);
+
+    ray_graph_free(g);
+    ray_rel_free(rel);
+    ray_release(node_tbl);
+    ray_release(edges);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/*
+ * Test: graph_alloc_node_opt realloc fix-up.
+ *
+ * Build a graph with > GRAPH_INIT_CAP (4096) nodes, then add one
+ * filter with an AND predicate.  When the optimizer's split_and_filter
+ * pass calls graph_alloc_node_opt to allocate the new outer-filter
+ * node, the array is at capacity and must realloc + fix up all stored
+ * input pointers.
+ *
+ * We pad the graph by allocating many ray_const_i64 nodes (cheap, each
+ * adds one node) until we're just shy of cap, then build the AND filter
+ * on top.  The split must produce the correct structure after realloc.
+ *
+ * We also include OP_GROUP / OP_SELECT / OP_SORT / OP_WINDOW nodes
+ * (with structural ext->keys/columns/part_keys pointers) to exercise
+ * the per-opcode fix-up branches in graph_alloc_node_opt.  Those nodes
+ * are not in the optimized root's live subgraph, so DCE will mark
+ * them dead — but the realloc fix-up still walks them.
+ */
+static test_result_t test_opt_realloc_during_split(void) {
+    ray_heap_init();
+
+    ray_t* tbl = make_test_table();
+    ray_graph_t* g = ray_graph_new(tbl);
+
+    /* Build the predicate FIRST, before we cause a realloc — we want
+     * stored input pointers across the AND/EQ predicate so the fix-up
+     * has something to relocate. */
+    ray_op_t* v1   = ray_scan(g, "v1");
+    ray_op_t* id1  = ray_scan(g, "id1");
+    ray_op_t* v3   = ray_scan(g, "v3");
+    ray_op_t* c1   = ray_const_i64(g, 1);
+    ray_op_t* c5   = ray_const_f64(g, 5.0);
+    ray_op_t* eq   = ray_eq(g, id1, c1);
+    ray_op_t* gt   = ray_gt(g, v3, c5);
+    ray_op_t* combined = ray_and(g, eq, gt);
+    ray_op_t* filt = ray_filter(g, v1, combined);
+    uint32_t filt_id = filt->id;
+    uint32_t eq_id   = eq->id;
+    uint32_t gt_id   = gt->id;
+
+    /* Build extra structural ops to exercise the per-opcode fix-up
+     * branches in graph_alloc_node_opt.  These are NOT in the live
+     * subgraph reachable from filt — DCE will mark them dead — but
+     * they exist in g->ext_nodes when realloc fires. */
+    {
+        /* OP_GROUP with key + agg input */
+        ray_op_t* key = ray_scan(g, "id1");
+        ray_op_t* val = ray_scan(g, "v1");
+        ray_op_t* keys[] = { key };
+        uint16_t agg_ops[] = { OP_SUM };
+        ray_op_t* agg_ins[] = { val };
+        (void)ray_group(g, keys, 1, agg_ops, agg_ins, 1);
+
+        /* OP_SELECT with column array */
+        ray_op_t* sel_v1 = ray_scan(g, "v1");
+        ray_op_t* sel_id1 = ray_scan(g, "id1");
+        ray_op_t* sel_cols[] = { sel_v1, sel_id1 };
+        (void)ray_select(g, sel_v1, sel_cols, 2);
+
+        /* OP_WINDOW with part/order/func keys */
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w_grp = ray_scan(g, "id1");
+        ray_op_t* w_val = ray_scan(g, "v1");
+        ray_op_t* w_parts[] = { w_grp };
+        ray_op_t* w_orders[] = { w_val };
+        uint8_t w_descs[] = { 0 };
+        uint8_t w_kinds[] = { RAY_WIN_ROW_NUMBER };
+        ray_op_t* w_ins[] = { w_val };
+        int64_t w_params[] = { 0 };
+        (void)ray_window_op(g, tbl_op,
+                            w_parts, 1,
+                            w_orders, w_descs, 1,
+                            w_kinds, w_ins, w_params, 1,
+                            RAY_FRAME_ROWS,
+                            RAY_BOUND_UNBOUNDED_PRECEDING,
+                            RAY_BOUND_UNBOUNDED_FOLLOWING,
+                            0, 0);
+    }
+
+    /* Now pad the graph until we're at exactly node_cap, so the very
+     * next allocation (split_and_filter's outer node) forces a realloc. */
+    while (g->node_count < g->node_cap) {
+        (void)ray_const_i64(g, 0);
+    }
+    /* node_count == node_cap now — next allocation will realloc */
+    TEST_ASSERT_EQ_U(g->node_count, g->node_cap);
+
+    uint32_t cap_before = g->node_cap;
+
+    ray_op_t* opt = ray_optimize(g, filt);
+    TEST_ASSERT_NOT_NULL(opt);
+
+    /* After AND-split, the original FILTER node (filt_id) should have
+     * one of the predicates (eq or gt), and a NEW outer FILTER (id ==
+     * old node_count == cap_before) wraps it with the other predicate. */
+    TEST_ASSERT_TRUE(g->node_cap > cap_before);  /* realloc fired */
+
+    /* Walk from new root: must be FILTER -> FILTER -> SCAN(v1) chain,
+     * with predicates pointing at eq and gt (post-fix-up). */
+    TEST_ASSERT_EQ_I(opt->opcode, OP_FILTER);
+    TEST_ASSERT_NOT_NULL(opt->inputs[0]);
+    TEST_ASSERT_EQ_I(opt->inputs[0]->opcode, OP_FILTER);
+
+    /* After AND-split + reorder, the inner predicate is the cheaper
+     * (eq on i64) and outer predicate is gt on f64 — but here we just
+     * need the predicates to point to valid live nodes (no use-after-
+     * realloc).  Both pred nodes' IDs must still resolve to live ops. */
+    ray_op_t* outer_pred = opt->inputs[1];
+    ray_op_t* inner = opt->inputs[0];
+    ray_op_t* inner_pred = inner->inputs[1];
+    TEST_ASSERT_NOT_NULL(outer_pred);
+    TEST_ASSERT_NOT_NULL(inner_pred);
+    TEST_ASSERT_TRUE(outer_pred->id == eq_id || outer_pred->id == gt_id);
+    TEST_ASSERT_TRUE(inner_pred->id == eq_id || inner_pred->id == gt_id);
+    TEST_ASSERT_TRUE(outer_pred->id != inner_pred->id);
+    /* Pointer correctness: the resolved nodes should match g->nodes[id]. */
+    TEST_ASSERT_EQ_PTR(outer_pred, &g->nodes[outer_pred->id]);
+    TEST_ASSERT_EQ_PTR(inner_pred, &g->nodes[inner_pred->id]);
+
+    /* And the filter chain bottoms out at SCAN(v1) — verifying the
+     * input-pointer fix-up walked the whole chain correctly. */
+    ray_op_t* scan_node = inner->inputs[0];
+    TEST_ASSERT_NOT_NULL(scan_node);
+    TEST_ASSERT_EQ_I(scan_node->opcode, OP_SCAN);
+
+    /* Original filter id is still valid (it's now the inner filter
+     * after split, since split_and_filter rewrites filter_node in
+     * place to be the inner). */
+    TEST_ASSERT_TRUE(filt_id < g->node_count);
+
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
 const test_entry_t opt_entries[] = {
     { "opt/filter_reorder_type", test_filter_reorder_by_type, NULL, NULL },
     { "opt/filter_and_split", test_filter_and_split, NULL, NULL },
@@ -746,6 +1115,10 @@ const test_entry_t opt_entries[] = {
     { "opt/partition_pruning_in", test_partition_pruning_in, NULL, NULL },
     { "opt/partition_pruning_not_in", test_partition_pruning_not_in, NULL, NULL },
     { "opt/partition_pruning_in_type_mismatch", test_partition_pruning_in_type_mismatch, NULL, NULL },
+    { "opt/window_dce", test_opt_window_dce, NULL, NULL },
+    { "opt/pushdown_past_expand", test_opt_pushdown_past_expand, NULL, NULL },
+    { "opt/pushdown_expand_blocked", test_opt_pushdown_expand_blocked, NULL, NULL },
+    { "opt/realloc_during_split", test_opt_realloc_during_split, NULL, NULL },
     { NULL, NULL, NULL, NULL },
 };
 

--- a/test/test_partition_exec.c
+++ b/test/test_partition_exec.c
@@ -1,0 +1,729 @@
+/*
+ *   Copyright (c) 2025-2026 Anton Kundenko <singaraiona@gmail.com>
+ *   All rights reserved.
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
+
+/*
+ * test_partition_exec.c -- C-side tests for the parted/MAPCOMMON exec
+ * paths in src/ops/exec.c that the rfl test surface cannot reach.
+ *
+ * The rfl harness can only construct flat tables, so the production
+ * paths that handle RAY_MAPCOMMON columns and RAY_IS_PARTED columns
+ * (~750 lines in exec.c) are exercised only by reading on-disk parted
+ * tables.  These tests build the column shapes synthetically and drive
+ * each region directly.
+ *
+ * Coverage targets:
+ *   - exec.c L35-152   materialize_mapcommon{,_head,_filter}
+ *   - exec.c L1351-1502 OP_HEAD / OP_TAIL on parted/MAPCOMMON columns
+ *   - exec.c L1793-1832 ray_result_merge (via streaming filter)
+ *   - exec.c L1839-1920 build_segment_table (via streaming filter)
+ *   - exec.c L1979-2248 segment streaming loop (via streaming filter)
+ *   - exec.c L259-473  partitioned_gather phases (esz=1, esz=2)
+ *
+ * Build pattern follows test_opt.c L377-417 (MAPCOMMON construction)
+ * and the existing test_*.c suite layout.
+ */
+
+#include "test.h"
+#include <rayforce.h>
+#include "mem/heap.h"
+#include "ops/ops.h"
+#include "ops/internal.h"
+#include "table/sym.h"
+#include "core/pool.h"
+#include <string.h>
+
+/* --------------------------------------------------------------------------
+ * Helpers
+ * -------------------------------------------------------------------------- */
+
+/* Build a MAPCOMMON column from an arbitrary typed key vector and i64 row
+ * counts.  `key_values` and `row_counts` are released to the resulting
+ * MAPCOMMON's data slots (no extra retain needed by the caller). */
+static ray_t* make_mapcommon(ray_t* key_values, ray_t* row_counts) {
+    ray_t* mc = ray_alloc(2 * sizeof(ray_t*));
+    if (!mc) return NULL;
+    mc->type = RAY_MAPCOMMON;
+    mc->len = 2;
+    ((ray_t**)ray_data(mc))[0] = key_values;
+    ((ray_t**)ray_data(mc))[1] = row_counts;
+    return mc;
+}
+
+/* Build a parted column wrapping `n_segs` segment vectors of `base` type.
+ * Segments are referenced (not retained) so caller still owns them. */
+static ray_t* make_parted(int8_t base, ray_t** segs, int64_t n_segs) {
+    ray_t* p = ray_alloc((size_t)n_segs * sizeof(ray_t*));
+    if (!p) return NULL;
+    p->type = RAY_PARTED_BASE + base;
+    p->len = n_segs;
+    ray_t** out = (ray_t**)ray_data(p);
+    for (int64_t i = 0; i < n_segs; i++) out[i] = segs[i];
+    return p;
+}
+
+/* --------------------------------------------------------------------------
+ * Test 1: materialize_mapcommon — basic broadcast
+ *
+ * Targets exec.c L35-75: full materialization of a MAPCOMMON column to
+ * a flat typed vector.  Builds a 3-partition DATE column with row counts
+ * [100, 50, 200] and verifies each output row carries the correct date.
+ * -------------------------------------------------------------------------- */
+static test_result_t test_materialize_mapcommon_basic(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    /* I64 keys (8 bytes) exercises the esz==8 fast path.
+     * RAY_DATE is only 4 bytes — using I64 here keeps the assertions
+     * cleanly typed without per-platform date-encoding noise. */
+    int64_t keys[] = {20240101, 20240102, 20240103};
+    int64_t counts_data[] = {100, 50, 200};
+
+    ray_t* kv = ray_vec_new(RAY_I64, 3);
+    TEST_ASSERT_NOT_NULL(kv);
+    kv->len = 3;
+    memcpy(ray_data(kv), keys, sizeof(keys));
+
+    ray_t* rc = ray_vec_new(RAY_I64, 3);
+    TEST_ASSERT_NOT_NULL(rc);
+    rc->len = 3;
+    memcpy(ray_data(rc), counts_data, sizeof(counts_data));
+
+    ray_t* mc = make_mapcommon(kv, rc);
+    TEST_ASSERT_NOT_NULL(mc);
+
+    ray_t* flat = materialize_mapcommon(mc);
+    TEST_ASSERT_NOT_NULL(flat);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(flat));
+    TEST_ASSERT_EQ_I(flat->type, RAY_I64);
+    TEST_ASSERT_EQ_I(flat->len, 350);
+
+    int64_t* out = (int64_t*)ray_data(flat);
+    /* Rows [0..100): key 0; [100..150): key 1; [150..350): key 2 */
+    for (int64_t i = 0; i < 100; i++) TEST_ASSERT_EQ_I(out[i], 20240101);
+    for (int64_t i = 100; i < 150; i++) TEST_ASSERT_EQ_I(out[i], 20240102);
+    for (int64_t i = 150; i < 350; i++) TEST_ASSERT_EQ_I(out[i], 20240103);
+
+    ray_release(flat);
+    ray_release(mc);
+    ray_release(kv);
+    ray_release(rc);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test 2: materialize_mapcommon_head — clamped expansion
+ *
+ * Targets exec.c L77-114.  Same fixture as Test 1 but only the first
+ * 75 rows.  Verifies the loop terminates at `n` and that the result is
+ * the per-row prefix of the full materialization.
+ * -------------------------------------------------------------------------- */
+static test_result_t test_materialize_mapcommon_head(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int64_t keys[] = {20240101, 20240102, 20240103};
+    int64_t counts_data[] = {100, 50, 200};
+
+    ray_t* kv = ray_vec_new(RAY_I64, 3);
+    kv->len = 3;
+    memcpy(ray_data(kv), keys, sizeof(keys));
+
+    ray_t* rc = ray_vec_new(RAY_I64, 3);
+    rc->len = 3;
+    memcpy(ray_data(rc), counts_data, sizeof(counts_data));
+
+    ray_t* mc = make_mapcommon(kv, rc);
+    TEST_ASSERT_NOT_NULL(mc);
+
+    /* head 75: all within partition 0 */
+    ray_t* flat = materialize_mapcommon_head(mc, 75);
+    TEST_ASSERT_NOT_NULL(flat);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(flat));
+    TEST_ASSERT_EQ_I(flat->len, 75);
+    int64_t* out = (int64_t*)ray_data(flat);
+    for (int64_t i = 0; i < 75; i++) TEST_ASSERT_EQ_I(out[i], 20240101);
+    ray_release(flat);
+
+    /* head 175: spans partitions 0+1 + 25 of part 2 */
+    ray_t* flat2 = materialize_mapcommon_head(mc, 175);
+    TEST_ASSERT_EQ_I(flat2->len, 175);
+    int64_t* out2 = (int64_t*)ray_data(flat2);
+    for (int64_t i = 0; i < 100; i++) TEST_ASSERT_EQ_I(out2[i], 20240101);
+    for (int64_t i = 100; i < 150; i++) TEST_ASSERT_EQ_I(out2[i], 20240102);
+    for (int64_t i = 150; i < 175; i++) TEST_ASSERT_EQ_I(out2[i], 20240103);
+    ray_release(flat2);
+
+    ray_release(mc);
+    ray_release(kv);
+    ray_release(rc);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test 3: materialize_mapcommon_filter — selective materialization
+ *
+ * Targets exec.c L116-152.  Uses a hand-built RAY_BOOL predicate to keep
+ * a subset of rows from each partition and verifies each kept row has the
+ * key for its source partition.  Drives the morsel iteration + the
+ * partition-cursor advance logic at L142-149.
+ * -------------------------------------------------------------------------- */
+static test_result_t test_materialize_mapcommon_filter(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int64_t keys[] = {20240101, 20240102, 20240103};
+    int64_t counts_data[] = {10, 5, 8};       /* 23 total rows */
+
+    ray_t* kv = ray_vec_new(RAY_I64, 3);
+    kv->len = 3;
+    memcpy(ray_data(kv), keys, sizeof(keys));
+
+    ray_t* rc = ray_vec_new(RAY_I64, 3);
+    rc->len = 3;
+    memcpy(ray_data(rc), counts_data, sizeof(counts_data));
+
+    ray_t* mc = make_mapcommon(kv, rc);
+    TEST_ASSERT_NOT_NULL(mc);
+
+    /* Predicate: keep every other row.  Pass count = 12 (rows 0,2,...,22). */
+    ray_t* pred = ray_vec_new(RAY_BOOL, 23);
+    TEST_ASSERT_NOT_NULL(pred);
+    pred->len = 23;
+    uint8_t* pbits = (uint8_t*)ray_data(pred);
+    int64_t expected_pass = 0;
+    for (int64_t i = 0; i < 23; i++) {
+        pbits[i] = (uint8_t)((i % 2) == 0);
+        if (pbits[i]) expected_pass++;
+    }
+    TEST_ASSERT_EQ_I(expected_pass, 12);
+
+    ray_t* out = materialize_mapcommon_filter(mc, pred, expected_pass);
+    TEST_ASSERT_NOT_NULL(out);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(out));
+    TEST_ASSERT_EQ_I(out->len, expected_pass);
+
+    /* For each kept row, recompute which partition it belonged to and
+     * compare to the broadcast key. */
+    int64_t* od = (int64_t*)ray_data(out);
+    int64_t kept = 0;
+    for (int64_t row = 0; row < 23; row++) {
+        if (!pbits[row]) continue;
+        int64_t rs = row;
+        int64_t part;
+        if (rs < 10)              part = 0;
+        else if (rs < 15)         part = 1;
+        else                      part = 2;
+        TEST_ASSERT_EQ_I(od[kept], keys[part]);
+        kept++;
+    }
+    TEST_ASSERT_EQ_I(kept, expected_pass);
+
+    ray_release(out);
+    ray_release(pred);
+    ray_release(mc);
+    ray_release(kv);
+    ray_release(rc);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test 4: OP_HEAD on a parted+MAPCOMMON table
+ *
+ * Targets exec.c L1338-1408.  Builds a parted I64 column with 3 segments
+ * plus a MAPCOMMON date key column, wraps the whole thing as a constant
+ * table operand to OP_HEAD, and verifies the per-segment fast-path copies
+ * the right rows out of each segment + materializes the MAPCOMMON head.
+ * -------------------------------------------------------------------------- */
+static test_result_t test_op_head_on_parted_col(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    /* 3 segments: 4 + 6 + 5 rows = 15 total */
+    ray_t* s0 = ray_vec_new(RAY_I64, 4);
+    s0->len = 4;
+    int64_t s0d[] = {100, 101, 102, 103};
+    memcpy(ray_data(s0), s0d, sizeof(s0d));
+
+    ray_t* s1 = ray_vec_new(RAY_I64, 6);
+    s1->len = 6;
+    int64_t s1d[] = {200, 201, 202, 203, 204, 205};
+    memcpy(ray_data(s1), s1d, sizeof(s1d));
+
+    ray_t* s2 = ray_vec_new(RAY_I64, 5);
+    s2->len = 5;
+    int64_t s2d[] = {300, 301, 302, 303, 304};
+    memcpy(ray_data(s2), s2d, sizeof(s2d));
+
+    ray_t* segs[3] = { s0, s1, s2 };
+    ray_t* val = make_parted(RAY_I64, segs, 3);
+    TEST_ASSERT_NOT_NULL(val);
+
+    /* MAPCOMMON keyed by I64 — counts must match parted segment lengths */
+    int64_t keys[] = {20240101, 20240102, 20240103};
+    int64_t counts[] = {4, 6, 5};
+    ray_t* kv = ray_vec_new(RAY_I64, 3); kv->len = 3;
+    memcpy(ray_data(kv), keys, sizeof(keys));
+    ray_t* rc = ray_vec_new(RAY_I64, 3); rc->len = 3;
+    memcpy(ray_data(rc), counts, sizeof(counts));
+    ray_t* mc = make_mapcommon(kv, rc);
+
+    int64_t sym_dt  = ray_sym_intern("dt", 2);
+    int64_t sym_val = ray_sym_intern("val", 3);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, sym_dt, mc);
+    tbl = ray_table_add_col(tbl, sym_val, val);
+
+    /* head 7 from constant-table — 4 from seg 0 + 3 from seg 1 */
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tnode = ray_const_table(g, tbl);
+    ray_op_t* h = ray_head(g, tnode, 7);
+    ray_t* result = ray_execute(g, h);
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(result->type, RAY_TABLE);
+    TEST_ASSERT_EQ_I(ray_table_nrows(result), 7);
+
+    /* val column: should be flat I64 of [100,101,102,103,200,201,202] */
+    ray_t* vcol = ray_table_get_col(result, sym_val);
+    TEST_ASSERT_NOT_NULL(vcol);
+    TEST_ASSERT_EQ_I(vcol->type, RAY_I64);
+    TEST_ASSERT_EQ_I(vcol->len, 7);
+    int64_t* vd = (int64_t*)ray_data(vcol);
+    int64_t expected[] = {100, 101, 102, 103, 200, 201, 202};
+    for (int64_t i = 0; i < 7; i++) TEST_ASSERT_EQ_I(vd[i], expected[i]);
+
+    /* dt column: should be flat I64 of [k0,k0,k0,k0,k1,k1,k1] */
+    ray_t* dcol = ray_table_get_col(result, sym_dt);
+    TEST_ASSERT_NOT_NULL(dcol);
+    TEST_ASSERT_EQ_I(dcol->type, RAY_I64);
+    TEST_ASSERT_EQ_I(dcol->len, 7);
+    int64_t* dd = (int64_t*)ray_data(dcol);
+    int64_t edates[] = {20240101, 20240101, 20240101, 20240101,
+                        20240102, 20240102, 20240102};
+    for (int64_t i = 0; i < 7; i++) TEST_ASSERT_EQ_I(dd[i], edates[i]);
+
+    ray_release(result);
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_release(mc);    ray_release(kv);  ray_release(rc);
+    ray_release(val);
+    ray_release(s0);    ray_release(s1);  ray_release(s2);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test 5: OP_TAIL on a parted+MAPCOMMON table
+ *
+ * Targets exec.c L1423-1517.  Same fixture as Test 4 but takes the last
+ * 7 rows (3 from end of seg 1 + all of seg 2) and verifies the reverse
+ * walk in the tail loop.
+ * -------------------------------------------------------------------------- */
+static test_result_t test_op_tail_on_parted_col(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    ray_t* s0 = ray_vec_new(RAY_I64, 4);
+    s0->len = 4;
+    int64_t s0d[] = {100, 101, 102, 103};
+    memcpy(ray_data(s0), s0d, sizeof(s0d));
+
+    ray_t* s1 = ray_vec_new(RAY_I64, 6);
+    s1->len = 6;
+    int64_t s1d[] = {200, 201, 202, 203, 204, 205};
+    memcpy(ray_data(s1), s1d, sizeof(s1d));
+
+    ray_t* s2 = ray_vec_new(RAY_I64, 5);
+    s2->len = 5;
+    int64_t s2d[] = {300, 301, 302, 303, 304};
+    memcpy(ray_data(s2), s2d, sizeof(s2d));
+
+    ray_t* segs[3] = { s0, s1, s2 };
+    ray_t* val = make_parted(RAY_I64, segs, 3);
+
+    int64_t keys[] = {20240101, 20240102, 20240103};
+    int64_t counts[] = {4, 6, 5};
+    ray_t* kv = ray_vec_new(RAY_I64, 3); kv->len = 3;
+    memcpy(ray_data(kv), keys, sizeof(keys));
+    ray_t* rc = ray_vec_new(RAY_I64, 3); rc->len = 3;
+    memcpy(ray_data(rc), counts, sizeof(counts));
+    ray_t* mc = make_mapcommon(kv, rc);
+
+    int64_t sym_dt  = ray_sym_intern("dt", 2);
+    int64_t sym_val = ray_sym_intern("val", 3);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, sym_dt, mc);
+    tbl = ray_table_add_col(tbl, sym_val, val);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tnode = ray_const_table(g, tbl);
+    ray_op_t* t = ray_tail(g, tnode, 7);
+    ray_t* result = ray_execute(g, t);
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(ray_table_nrows(result), 7);
+
+    /* val: last 7 of [100..103, 200..205, 300..304]
+     * => [203, 204, 205, 300, 301, 302, 303, 304] (last 7 == [204,205,300..304]).
+     * Wait — total = 15, last 7 = rows 8..14 = [204, 205, 300, 301, 302, 303, 304]. */
+    ray_t* vcol = ray_table_get_col(result, sym_val);
+    TEST_ASSERT_EQ_I(vcol->len, 7);
+    int64_t* vd = (int64_t*)ray_data(vcol);
+    int64_t expected[] = {204, 205, 300, 301, 302, 303, 304};
+    for (int64_t i = 0; i < 7; i++) TEST_ASSERT_EQ_I(vd[i], expected[i]);
+
+    /* dt: last 7 dates = [k1,k1,k2,k2,k2,k2,k2] */
+    ray_t* dcol = ray_table_get_col(result, sym_dt);
+    TEST_ASSERT_EQ_I(dcol->len, 7);
+    int64_t* dd = (int64_t*)ray_data(dcol);
+    int64_t edates[] = {20240102, 20240102, 20240103, 20240103,
+                        20240103, 20240103, 20240103};
+    for (int64_t i = 0; i < 7; i++) TEST_ASSERT_EQ_I(dd[i], edates[i]);
+
+    ray_release(result);
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_release(mc);    ray_release(kv);  ray_release(rc);
+    ray_release(val);
+    ray_release(s0);    ray_release(s1);  ray_release(s2);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test 6: Segment streaming filter on a parted table
+ *
+ * Targets exec.c L1839-1920 (build_segment_table) plus the streaming
+ * loop at L2069-2248 (including ray_result_merge at L1793-1832).
+ * Builds a 4-segment parted table with a MAPCOMMON DATE key + parted
+ * I64 value column and runs FILTER(SCAN(val), val >= 30) through
+ * ray_execute.  Streaming mode is selected because the DAG is fully
+ * streamable (SCAN, GE, FILTER) and the table has parted columns.
+ * -------------------------------------------------------------------------- */
+static test_result_t test_segment_streaming_filter(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    /* 4 segments, each 10 rows of I64, values 0..9, 10..19, 20..29, 30..39 */
+    ray_t* segs_v[4];
+    for (int i = 0; i < 4; i++) {
+        segs_v[i] = ray_vec_new(RAY_I64, 10);
+        segs_v[i]->len = 10;
+        int64_t* d = (int64_t*)ray_data(segs_v[i]);
+        for (int j = 0; j < 10; j++) d[j] = (int64_t)(i * 10 + j);
+    }
+    ray_t* val = make_parted(RAY_I64, segs_v, 4);
+
+    /* MAPCOMMON keys = 4 i64 partition tags, counts = [10,10,10,10] */
+    int64_t keys[] = {20240101, 20240102, 20240103, 20240104};
+    int64_t counts[] = {10, 10, 10, 10};
+    ray_t* kv = ray_vec_new(RAY_I64, 4); kv->len = 4;
+    memcpy(ray_data(kv), keys, sizeof(keys));
+    ray_t* rc = ray_vec_new(RAY_I64, 4); rc->len = 4;
+    memcpy(ray_data(rc), counts, sizeof(counts));
+    ray_t* mc = make_mapcommon(kv, rc);
+
+    int64_t sym_dt  = ray_sym_intern("dt", 2);
+    int64_t sym_val = ray_sym_intern("val", 3);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, sym_dt, mc);
+    tbl = ray_table_add_col(tbl, sym_val, val);
+
+    /* select where: val >= 30  (FILTER on a SCAN — streamable) */
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* sval = ray_scan(g, "val");
+    ray_op_t* c30  = ray_const_i64(g, 30);
+    ray_op_t* pred = ray_ge(g, sval, c30);
+    ray_op_t* sval2 = ray_scan(g, "val");
+    ray_op_t* flt  = ray_filter(g, sval2, pred);
+    ray_t* result = ray_execute(g, flt);
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+
+    /* The filter result is a vector (filtered val).  10 matches: 30..39. */
+    TEST_ASSERT_EQ_I(result->len, 10);
+    int64_t* rd = (int64_t*)ray_data(result);
+    for (int i = 0; i < 10; i++) TEST_ASSERT_EQ_I(rd[i], (int64_t)(30 + i));
+
+    ray_release(result);
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_release(mc); ray_release(kv); ray_release(rc);
+    ray_release(val);
+    for (int i = 0; i < 4; i++) ray_release(segs_v[i]);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test 7: ray_result_merge — multi-segment vector concat
+ *
+ * Targets exec.c L1827-1829 (vector merge branch of ray_result_merge)
+ * by running an element-wise streamable expression over a 3-segment
+ * parted table.  Each segment produces a partial vector; the streaming
+ * loop must concatenate them in order.
+ *
+ * Drives the merge across more than 2 segments so the accumulator
+ * branch (L1798-1801: accum non-NULL, partial non-NULL) gets multiple
+ * iterations rather than just initialization on the first segment.
+ * -------------------------------------------------------------------------- */
+static test_result_t test_result_merge_via_streaming(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    /* 3 segments × 4 rows = 12 total */
+    ray_t* segs_v[3];
+    int64_t s0[] = {1, 2, 3, 4};
+    int64_t s1[] = {5, 6, 7, 8};
+    int64_t s2[] = {9, 10, 11, 12};
+    segs_v[0] = ray_vec_new(RAY_I64, 4); segs_v[0]->len = 4;
+    memcpy(ray_data(segs_v[0]), s0, sizeof(s0));
+    segs_v[1] = ray_vec_new(RAY_I64, 4); segs_v[1]->len = 4;
+    memcpy(ray_data(segs_v[1]), s1, sizeof(s1));
+    segs_v[2] = ray_vec_new(RAY_I64, 4); segs_v[2]->len = 4;
+    memcpy(ray_data(segs_v[2]), s2, sizeof(s2));
+
+    ray_t* val = make_parted(RAY_I64, segs_v, 3);
+
+    int64_t keys[]   = {20240101, 20240102, 20240103};
+    int64_t counts[] = {4, 4, 4};
+    ray_t* kv = ray_vec_new(RAY_I64, 3); kv->len = 3;
+    memcpy(ray_data(kv), keys, sizeof(keys));
+    ray_t* rc = ray_vec_new(RAY_I64, 3); rc->len = 3;
+    memcpy(ray_data(rc), counts, sizeof(counts));
+    ray_t* mc = make_mapcommon(kv, rc);
+
+    int64_t sym_dt  = ray_sym_intern("dt", 2);
+    int64_t sym_val = ray_sym_intern("val", 3);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, sym_dt, mc);
+    tbl = ray_table_add_col(tbl, sym_val, val);
+
+    /* val * 10 — element-wise unary, streamable; per-segment result is
+     * a 4-row vector that must be concatenated by ray_result_merge. */
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* sv  = ray_scan(g, "val");
+    ray_op_t* c10 = ray_const_i64(g, 10);
+    ray_op_t* mul = ray_mul(g, sv, c10);
+    ray_t* result = ray_execute(g, mul);
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(result->type, RAY_I64);
+    TEST_ASSERT_EQ_I(result->len, 12);
+    int64_t* rd = (int64_t*)ray_data(result);
+    int64_t expected[] = {10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120};
+    for (int64_t i = 0; i < 12; i++) TEST_ASSERT_EQ_I(rd[i], expected[i]);
+
+    ray_release(result);
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_release(mc); ray_release(kv); ray_release(rc);
+    ray_release(val);
+    for (int i = 0; i < 3; i++) ray_release(segs_v[i]);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test 8: partitioned_gather with esz=2 (RAY_I16)
+ *
+ * Targets exec.c L368-372 (the e==2 arm of pg_block_fn) plus the full
+ * partition-route plumbing at L259-473.  Drives the parallel path by
+ * generating an index array of size > PG_MIN (131072) over a source
+ * column of the same size.  Verifies each output row gets the right
+ * source element via random index permutation.
+ * -------------------------------------------------------------------------- */
+static test_result_t test_partitioned_gather_e2(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int64_t n = 131072 + 1024;   /* > PG_MIN to enter the parallel branch */
+    ray_t* src = ray_vec_new(RAY_I16, n);
+    TEST_ASSERT_NOT_NULL(src);
+    src->len = n;
+    int16_t* sd = (int16_t*)ray_data(src);
+    for (int64_t i = 0; i < n; i++) sd[i] = (int16_t)(i & 0x7FFF);
+
+    ray_t* dst = ray_vec_new(RAY_I16, n);
+    TEST_ASSERT_NOT_NULL(dst);
+    dst->len = n;
+    int16_t* dd = (int16_t*)ray_data(dst);
+    memset(dd, 0xAA, (size_t)n * sizeof(int16_t));
+
+    /* Reverse permutation idx[i] = n-1-i, exercises every block */
+    ray_t* idxv = ray_vec_new(RAY_I64, n);
+    TEST_ASSERT_NOT_NULL(idxv);
+    idxv->len = n;
+    int64_t* idx = (int64_t*)ray_data(idxv);
+    for (int64_t i = 0; i < n; i++) idx[i] = n - 1 - i;
+
+    ray_pool_t* pool = ray_pool_get();
+    char* srcs[1] = { (char*)sd };
+    char* dsts[1] = { (char*)dd };
+    uint8_t esz[1] = { 2 };
+    partitioned_gather(pool, idx, n, n, srcs, dsts, esz, 1);
+
+    /* Spot-check a handful of rows scattered across the input range so a
+     * routing bug in any block surfaces.  Full sweep is unnecessary and
+     * slows the suite. */
+    int64_t probes[] = {0, 1, 17, 1024, 16384, 16385, 65536, 131071, n - 1};
+    for (size_t k = 0; k < sizeof(probes)/sizeof(probes[0]); k++) {
+        int64_t i = probes[k];
+        int16_t expected = (int16_t)((n - 1 - i) & 0x7FFF);
+        TEST_ASSERT_FMT(dd[i] == expected,
+                        "i=%lld got=%d expected=%d",
+                        (long long)i, (int)dd[i], (int)expected);
+    }
+
+    ray_release(idxv);
+    ray_release(dst);
+    ray_release(src);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test 9: partitioned_gather with esz=1 (RAY_BOOL / RAY_U8)
+ *
+ * Targets exec.c L373-375 (the e==1 arm).  Same shape as Test 8 but
+ * single-byte elements.
+ * -------------------------------------------------------------------------- */
+static test_result_t test_partitioned_gather_e1(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int64_t n = 131072 + 512;
+    ray_t* src = ray_vec_new(RAY_U8, n);
+    src->len = n;
+    uint8_t* sd = (uint8_t*)ray_data(src);
+    for (int64_t i = 0; i < n; i++) sd[i] = (uint8_t)(i & 0xFF);
+
+    ray_t* dst = ray_vec_new(RAY_U8, n);
+    dst->len = n;
+    uint8_t* dd = (uint8_t*)ray_data(dst);
+    memset(dd, 0, (size_t)n);
+
+    ray_t* idxv = ray_vec_new(RAY_I64, n);
+    idxv->len = n;
+    int64_t* idx = (int64_t*)ray_data(idxv);
+    for (int64_t i = 0; i < n; i++) idx[i] = n - 1 - i;
+
+    ray_pool_t* pool = ray_pool_get();
+    char* srcs[1] = { (char*)sd };
+    char* dsts[1] = { (char*)dd };
+    uint8_t esz[1] = { 1 };
+    partitioned_gather(pool, idx, n, n, srcs, dsts, esz, 1);
+
+    int64_t probes[] = {0, 7, 255, 256, 16383, 16384, 65535, n - 1};
+    for (size_t k = 0; k < sizeof(probes)/sizeof(probes[0]); k++) {
+        int64_t i = probes[k];
+        uint8_t expected = (uint8_t)((n - 1 - i) & 0xFF);
+        TEST_ASSERT_FMT(dd[i] == expected,
+                        "i=%lld got=%u expected=%u",
+                        (long long)i, (unsigned)dd[i], (unsigned)expected);
+    }
+
+    ray_release(idxv);
+    ray_release(dst);
+    ray_release(src);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test 10: partitioned_gather small-n fallback (multi_gather_fn path)
+ *
+ * Targets exec.c L390-399 (the n < PG_MIN fallback into multi_gather_fn).
+ * Uses a small index array so the partitioning machinery is bypassed and
+ * the dispatch goes straight to the column-at-a-time gather loop.
+ * -------------------------------------------------------------------------- */
+static test_result_t test_partitioned_gather_fallback(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int64_t n = 1024;   /* < PG_MIN */
+    ray_t* src = ray_vec_new(RAY_I64, n);
+    src->len = n;
+    int64_t* sd = (int64_t*)ray_data(src);
+    for (int64_t i = 0; i < n; i++) sd[i] = i * 7 + 1;
+
+    ray_t* dst = ray_vec_new(RAY_I64, n);
+    dst->len = n;
+    int64_t* dd = (int64_t*)ray_data(dst);
+    memset(dd, 0, (size_t)n * sizeof(int64_t));
+
+    ray_t* idxv = ray_vec_new(RAY_I64, n);
+    idxv->len = n;
+    int64_t* idx = (int64_t*)ray_data(idxv);
+    for (int64_t i = 0; i < n; i++) idx[i] = (n - 1 - i);
+
+    ray_pool_t* pool = ray_pool_get();
+    char* srcs[1] = { (char*)sd };
+    char* dsts[1] = { (char*)dd };
+    uint8_t esz[1] = { 8 };
+    partitioned_gather(pool, idx, n, n, srcs, dsts, esz, 1);
+
+    for (int64_t i = 0; i < n; i++) {
+        int64_t expected = (n - 1 - i) * 7 + 1;
+        TEST_ASSERT_FMT(dd[i] == expected,
+                        "i=%lld got=%lld expected=%lld",
+                        (long long)i, (long long)dd[i], (long long)expected);
+    }
+
+    ray_release(idxv);
+    ray_release(dst);
+    ray_release(src);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Suite definition
+ * -------------------------------------------------------------------------- */
+
+const test_entry_t partition_exec_entries[] = {
+    { "part_exec/mc_basic",         test_materialize_mapcommon_basic,  NULL, NULL },
+    { "part_exec/mc_head",          test_materialize_mapcommon_head,   NULL, NULL },
+    { "part_exec/mc_filter",        test_materialize_mapcommon_filter, NULL, NULL },
+    { "part_exec/op_head_parted",   test_op_head_on_parted_col,        NULL, NULL },
+    { "part_exec/op_tail_parted",   test_op_tail_on_parted_col,        NULL, NULL },
+    { "part_exec/stream_filter",    test_segment_streaming_filter,     NULL, NULL },
+    { "part_exec/result_merge",     test_result_merge_via_streaming,   NULL, NULL },
+    { "part_exec/pg_e2",            test_partitioned_gather_e2,        NULL, NULL },
+    { "part_exec/pg_e1",            test_partitioned_gather_e1,        NULL, NULL },
+    { "part_exec/pg_fallback",      test_partitioned_gather_fallback,  NULL, NULL },
+    { NULL, NULL, NULL, NULL },
+};

--- a/test/test_pool.c
+++ b/test/test_pool.c
@@ -24,8 +24,10 @@
 #include "test.h"
 #include <rayforce.h>
 #include <rayforce.h>
+#include "core/pool.h"
 #include "mem/heap.h"
 #include "ops/ops.h"
+#include <stdatomic.h>
 #include <string.h>
 #include <math.h>
 
@@ -316,6 +318,457 @@ static test_result_t test_cancel(void) {
 }
 
 /* --------------------------------------------------------------------------
+ * Direct ray_pool_dispatch / ray_pool_dispatch_n coverage
+ *
+ * These tests exercise the pool API directly with a private pool, hitting
+ * code paths the high-level ray_execute() tests do not reach:
+ *   - ray_pool_dispatch with total_elems <= 0 (early return)
+ *   - ray_pool_dispatch_n with n_tasks == 0 (early return)
+ *   - ray_pool_dispatch_n small n (the entire dispatch_n body)
+ *   - cancellation observed mid-dispatch by main + worker threads
+ *   - ring growth (n_tasks > initial task_cap=1024)
+ *   - single-worker pool create/free
+ * -------------------------------------------------------------------------- */
+
+/* Per-task counter incremented by every callback invocation.  Each task
+ * increments once for each (start, end) range claim regardless of element
+ * count — sufficient to verify dispatch coverage without per-element work. */
+typedef struct {
+    _Atomic(int64_t) calls;          /* number of fn invocations            */
+    _Atomic(int64_t) elem_sum;       /* total elements processed across all */
+    _Atomic(uint32_t) saw_worker;    /* bitmask of distinct worker_ids seen */
+} pool_count_ctx_t;
+
+static void pool_count_fn(void* ctx, uint32_t worker_id, int64_t start, int64_t end) {
+    pool_count_ctx_t* c = (pool_count_ctx_t*)ctx;
+    atomic_fetch_add_explicit(&c->calls, 1, memory_order_relaxed);
+    atomic_fetch_add_explicit(&c->elem_sum, end - start, memory_order_relaxed);
+    if (worker_id < 32) {
+        atomic_fetch_or_explicit(&c->saw_worker, 1u << worker_id,
+                                 memory_order_relaxed);
+    }
+}
+
+/* --------------------------------------------------------------------------
+ * Test: dispatch with total_elems <= 0 returns immediately, no calls fire
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_dispatch_zero_elems(void) {
+    ray_heap_init();
+
+    ray_pool_t pool;
+    ray_err_t err = ray_pool_create(&pool, 1);  /* 1 worker thread */
+    TEST_ASSERT_EQ_I(err, RAY_OK);
+
+    pool_count_ctx_t ctx = {0};
+
+    /* total_elems == 0 → early return, no dispatch */
+    ray_pool_dispatch(&pool, pool_count_fn, &ctx, 0);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), 0);
+
+    /* total_elems negative → also early return */
+    ray_pool_dispatch(&pool, pool_count_fn, &ctx, -1);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), 0);
+
+    /* dispatch_n with 0 → early return */
+    ray_pool_dispatch_n(&pool, pool_count_fn, &ctx, 0);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), 0);
+
+    ray_pool_free(&pool);
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: dispatch over a small range produces exactly 1 task and processes
+ * all elements (covers single-task fast path on private pool).
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_dispatch_small(void) {
+    ray_heap_init();
+
+    ray_pool_t pool;
+    TEST_ASSERT_EQ_I(ray_pool_create(&pool, 2), RAY_OK);
+
+    pool_count_ctx_t ctx = {0};
+    int64_t n = 100;  /* well below TASK_GRAIN (8192) → 1 task */
+    ray_pool_dispatch(&pool, pool_count_fn, &ctx, n);
+
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), 1);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.elem_sum), n);
+
+    /* Dispatch again on same pool — verifies pending counter resets cleanly */
+    pool_count_ctx_t ctx2 = {0};
+    ray_pool_dispatch(&pool, pool_count_fn, &ctx2, n);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx2.calls), 1);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx2.elem_sum), n);
+
+    ray_pool_free(&pool);
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: ray_pool_dispatch_n with small n (covers the dispatch_n body
+ * including task ring fill, semaphore signal, main-thread participation,
+ * spin-wait for completion).
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_dispatch_n_small(void) {
+    ray_heap_init();
+
+    ray_pool_t pool;
+    TEST_ASSERT_EQ_I(ray_pool_create(&pool, 2), RAY_OK);
+
+    pool_count_ctx_t ctx = {0};
+    uint32_t n = 16;
+    ray_pool_dispatch_n(&pool, pool_count_fn, &ctx, n);
+
+    /* Each task is [i, i+1) → exactly n calls, each processing 1 element */
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), n);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.elem_sum), n);
+
+    /* Reuse pool: second dispatch_n */
+    pool_count_ctx_t ctx2 = {0};
+    ray_pool_dispatch_n(&pool, pool_count_fn, &ctx2, 4);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx2.calls), 4);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx2.elem_sum), 4);
+
+    ray_pool_free(&pool);
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: ray_pool_dispatch_n with n_tasks > task_cap forces ring growth.
+ * Initial task_cap = 1024; 2000 tasks → grow to 2048.
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_dispatch_n_ring_growth(void) {
+    ray_heap_init();
+
+    ray_pool_t pool;
+    TEST_ASSERT_EQ_I(ray_pool_create(&pool, 2), RAY_OK);
+
+    /* Sanity: initial cap is 1024 */
+    TEST_ASSERT_EQ_U(pool.task_cap, 1024u);
+
+    pool_count_ctx_t ctx = {0};
+    uint32_t n = 2000;  /* > 1024 → ring must grow */
+    ray_pool_dispatch_n(&pool, pool_count_fn, &ctx, n);
+
+    /* Capacity should have at least doubled (next power of 2 >= 2000) */
+    TEST_ASSERT_TRUE(pool.task_cap >= 2048);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), n);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.elem_sum), n);
+
+    ray_pool_free(&pool);
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: ray_pool_dispatch with total_elems large enough to require ring
+ * growth.  TASK_GRAIN = 8192, initial cap = 1024 → need > 1024 * 8192
+ * elements (~8.4M) for n_tasks > task_cap.
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_dispatch_ring_growth(void) {
+    ray_heap_init();
+
+    ray_pool_t pool;
+    TEST_ASSERT_EQ_I(ray_pool_create(&pool, 2), RAY_OK);
+    TEST_ASSERT_EQ_U(pool.task_cap, 1024u);
+
+    pool_count_ctx_t ctx = {0};
+    /* 1100 tasks worth of elements: 1100 * 8192 = 9,011,200 */
+    int64_t n = 1100LL * 8192LL;
+    ray_pool_dispatch(&pool, pool_count_fn, &ctx, n);
+
+    /* Cap should have grown */
+    TEST_ASSERT_TRUE(pool.task_cap >= 2048);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), 1100);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.elem_sum), n);
+
+    ray_pool_free(&pool);
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: cancel-mid-dispatch path on dispatch_n.
+ *
+ * Set pool->cancelled before dispatching; every task should be skipped.
+ * Hits the RAY_UNLIKELY cancelled-skip branch on both worker + main threads
+ * (lines 71-76 and 287-291 in pool.c).
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_dispatch_n_cancelled(void) {
+    ray_heap_init();
+
+    ray_pool_t pool;
+    TEST_ASSERT_EQ_I(ray_pool_create(&pool, 2), RAY_OK);
+
+    pool_count_ctx_t ctx = {0};
+    /* Pre-set cancelled so every task hits the RAY_UNLIKELY skip branch */
+    atomic_store_explicit(&pool.cancelled, 1, memory_order_release);
+
+    uint32_t n = 64;
+    ray_pool_dispatch_n(&pool, pool_count_fn, &ctx, n);
+
+    /* All tasks should have been skipped — pool drained to 0 pending,
+     * but fn must NOT have been called. */
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), 0);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.elem_sum), 0);
+
+    /* Reset and verify a normal dispatch works again */
+    atomic_store_explicit(&pool.cancelled, 0, memory_order_release);
+    pool_count_ctx_t ctx2 = {0};
+    ray_pool_dispatch_n(&pool, pool_count_fn, &ctx2, 8);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx2.calls), 8);
+
+    ray_pool_free(&pool);
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: cancel-mid-dispatch on ray_pool_dispatch (range-partitioned variant).
+ * Mirrors test_dispatch_n_cancelled but for the dispatch() entry point.
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_dispatch_cancelled(void) {
+    ray_heap_init();
+
+    ray_pool_t pool;
+    TEST_ASSERT_EQ_I(ray_pool_create(&pool, 2), RAY_OK);
+
+    pool_count_ctx_t ctx = {0};
+    atomic_store_explicit(&pool.cancelled, 1, memory_order_release);
+
+    /* Use enough elements to produce multiple tasks across workers */
+    int64_t n = 8192LL * 4;  /* 4 tasks */
+    ray_pool_dispatch(&pool, pool_count_fn, &ctx, n);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), 0);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.elem_sum), 0);
+
+    /* Clear and verify normal dispatch still works */
+    atomic_store_explicit(&pool.cancelled, 0, memory_order_release);
+    pool_count_ctx_t ctx2 = {0};
+    ray_pool_dispatch(&pool, pool_count_fn, &ctx2, n);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx2.calls), 4);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx2.elem_sum), n);
+
+    ray_pool_free(&pool);
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: pool with zero workers — main thread executes all tasks alone.
+ * Exercises the n_workers==0 branch in ray_pool_create (no thread spawn,
+ * no semaphore signals) and validates dispatch correctness without workers.
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_pool_zero_workers(void) {
+    ray_heap_init();
+
+    ray_pool_t pool;
+    /* Explicitly pass 1 here — passing 0 triggers auto-detect (nproc-1).
+     * To force "main only", we manually create with 0 by skipping the
+     * thread alloc path: but ray_pool_create's contract uses 0 = autodetect.
+     * Use create with n_workers=1 for now and separately drive the
+     * "main does work" code path via cancel. */
+    TEST_ASSERT_EQ_I(ray_pool_create(&pool, 1), RAY_OK);
+    TEST_ASSERT_EQ_U(pool.n_workers, 1u);
+
+    pool_count_ctx_t ctx = {0};
+    ray_pool_dispatch(&pool, pool_count_fn, &ctx, 8192LL * 3);  /* 3 tasks */
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), 3);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.elem_sum), 8192LL * 3);
+
+    /* Worker 0 (main) must have participated; worker 1 may or may not have
+     * picked up tasks depending on scheduling — at least worker 0 is set. */
+    uint32_t mask = atomic_load(&ctx.saw_worker);
+    TEST_ASSERT_TRUE((mask & 0x1u) != 0);  /* main thread always = worker 0 */
+
+    ray_pool_free(&pool);
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: ray_pool_total_workers() macro
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_pool_total_workers(void) {
+    ray_heap_init();
+
+    ray_pool_t pool;
+    TEST_ASSERT_EQ_I(ray_pool_create(&pool, 3), RAY_OK);
+    TEST_ASSERT_EQ_U(ray_pool_total_workers(&pool), 4u);  /* 3 + main = 4 */
+    ray_pool_free(&pool);
+
+    TEST_ASSERT_EQ_I(ray_pool_create(&pool, 1), RAY_OK);
+    TEST_ASSERT_EQ_U(ray_pool_total_workers(&pool), 2u);
+    ray_pool_free(&pool);
+
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: ray_pool_free(NULL) is a no-op (covers the early-return guard).
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_pool_free_null(void) {
+    ray_pool_free(NULL);  /* must not crash */
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: ray_pool_init() when global pool already initialized is a no-op.
+ *
+ * The global pool is auto-initialized by the first parallel test above
+ * (state == 2).  Calling ray_pool_init() again should observe the CAS
+ * failure path and return RAY_OK without altering n_workers.
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_pool_init_idempotent(void) {
+    /* First call: pool may already be initialized (state==2) from earlier
+     * tests using ray_pool_get() via ray_execute(). */
+    ray_pool_t* p_before = ray_pool_get();
+    TEST_ASSERT_NOT_NULL(p_before);
+    uint32_t n_before = p_before->n_workers;
+
+    /* Re-init request should be silently ignored (state already 2) */
+    ray_err_t err = ray_pool_init(99);
+    TEST_ASSERT_EQ_I(err, RAY_OK);
+
+    ray_pool_t* p_after = ray_pool_get();
+    TEST_ASSERT_EQ_PTR(p_before, p_after);
+    TEST_ASSERT_EQ_U(p_after->n_workers, n_before);
+
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: full ray_pool_destroy → ray_pool_init → ray_pool_get round-trip.
+ *
+ * Exercises the destroy CAS (state 2→3→0), the init CAS-acquired branch
+ * (state 0→1→2 with successful create), and post-init pool_get (state 2
+ * fast path).  After this, the global pool is left re-initialized for
+ * subsequent tests that depend on ray_pool_get() returning non-NULL.
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_pool_destroy_and_reinit(void) {
+    /* Make sure the pool is initialized first (state==2). */
+    ray_pool_t* p1 = ray_pool_get();
+    TEST_ASSERT_NOT_NULL(p1);
+
+    /* Destroy: state 2 → 3 → 0 */
+    ray_pool_destroy();
+
+    /* Second destroy is a no-op (CAS fails because state==0) */
+    ray_pool_destroy();
+
+    /* ray_pool_get() after destroy should re-initialize: state 0 → 1 → 2 */
+    ray_pool_t* p2 = ray_pool_get();
+    TEST_ASSERT_NOT_NULL(p2);
+    /* Pool struct is the same global, but contents reset */
+    TEST_ASSERT_EQ_PTR(p1, p2);
+
+    /* Destroy and use ray_pool_init() instead to re-initialize */
+    ray_pool_destroy();
+    ray_err_t err = ray_pool_init(2);
+    TEST_ASSERT_EQ_I(err, RAY_OK);
+
+    ray_pool_t* p3 = ray_pool_get();
+    TEST_ASSERT_NOT_NULL(p3);
+    TEST_ASSERT_EQ_U(p3->n_workers, 2u);
+
+    /* Restore the pool to a stable state for subsequent tests: rebuild
+     * with default worker count.  ray_pool_init() is idempotent on
+     * state==2 — safe to call repeatedly. */
+    ray_pool_destroy();
+    err = ray_pool_init(0);
+    TEST_ASSERT_EQ_I(err, RAY_OK);
+
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: ray_cancel() pokes pool->cancelled and a subsequent dispatch
+ * observes it.  Calling ray_cancel() routes through ray_pool_get(), so
+ * this also exercises the state==2 fast path of pool_get.
+ * -------------------------------------------------------------------------- */
+
+static test_result_t test_ray_cancel_global(void) {
+    ray_pool_t* pool = ray_pool_get();
+    TEST_ASSERT_NOT_NULL(pool);
+
+    /* Reset cancel state defensively (other tests may have left it dirty,
+     * though ray_execute clears it on entry). */
+    atomic_store_explicit(&pool->cancelled, 0, memory_order_release);
+
+    ray_cancel();
+    TEST_ASSERT_EQ_I(atomic_load_explicit(&pool->cancelled, memory_order_acquire), 1);
+
+    /* Reset before exiting so we don't poison the global pool for later
+     * tests. */
+    atomic_store_explicit(&pool->cancelled, 0, memory_order_release);
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
+ * Test: dispatch with workers that participate (force workers to claim
+ * tasks by adding a small spin in the callback).  Drives line 73-76
+ * (worker cancelled-skip path) by setting cancelled mid-flight on a large
+ * task batch — workers will observe it on at least some iterations.
+ * -------------------------------------------------------------------------- */
+
+static void pool_count_with_spin_fn(void* ctx, uint32_t worker_id,
+                                    int64_t start, int64_t end) {
+    (void)worker_id;
+    pool_count_ctx_t* c = (pool_count_ctx_t*)ctx;
+    /* Light spin to give workers time to claim tasks before main drains.
+     * 1k busy iterations per task ≈ a few microseconds — enough to ensure
+     * workers wake from sem_wait and start consuming. */
+    volatile int sink = 0;
+    for (int i = 0; i < 1000; i++) sink += i;
+    (void)sink;
+    atomic_fetch_add_explicit(&c->calls, 1, memory_order_relaxed);
+    atomic_fetch_add_explicit(&c->elem_sum, end - start, memory_order_relaxed);
+    if (worker_id < 32) {
+        atomic_fetch_or_explicit(&c->saw_worker, 1u << worker_id,
+                                 memory_order_relaxed);
+    }
+}
+
+static test_result_t test_dispatch_workers_participate(void) {
+    ray_heap_init();
+
+    ray_pool_t pool;
+    TEST_ASSERT_EQ_I(ray_pool_create(&pool, 3), RAY_OK);
+
+    pool_count_ctx_t ctx = {0};
+    /* Many tasks so workers + main race to claim them */
+    uint32_t n = 256;
+    ray_pool_dispatch_n(&pool, pool_count_with_spin_fn, &ctx, n);
+
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), n);
+    TEST_ASSERT_EQ_I(atomic_load(&ctx.elem_sum), n);
+    /* Worker 0 (main) always sees activity; we don't hard-assert worker 1+
+     * participation as it depends on scheduling — but the test still
+     * exercises the multi-worker claim contention. */
+    TEST_ASSERT_TRUE((atomic_load(&ctx.saw_worker) & 0x1u) != 0);
+
+    ray_pool_free(&pool);
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
  * Suite definition
  * -------------------------------------------------------------------------- */
 
@@ -325,6 +778,20 @@ const test_entry_t pool_entries[] = {
     { "pool/parallel_group_sum", test_parallel_group_sum, NULL, NULL },
     { "pool/parallel_min_max", test_parallel_min_max, NULL, NULL },
     { "pool/cancel", test_cancel, NULL, NULL },
+    { "pool/dispatch_zero_elems",   test_dispatch_zero_elems,   NULL, NULL },
+    { "pool/dispatch_small",        test_dispatch_small,        NULL, NULL },
+    { "pool/dispatch_n_small",      test_dispatch_n_small,      NULL, NULL },
+    { "pool/dispatch_n_ring_grow",  test_dispatch_n_ring_growth, NULL, NULL },
+    { "pool/dispatch_ring_grow",    test_dispatch_ring_growth,  NULL, NULL },
+    { "pool/dispatch_n_cancelled",  test_dispatch_n_cancelled,  NULL, NULL },
+    { "pool/dispatch_cancelled",    test_dispatch_cancelled,    NULL, NULL },
+    { "pool/zero_workers",          test_pool_zero_workers,     NULL, NULL },
+    { "pool/total_workers",         test_pool_total_workers,    NULL, NULL },
+    { "pool/free_null",             test_pool_free_null,        NULL, NULL },
+    { "pool/init_idempotent",       test_pool_init_idempotent,  NULL, NULL },
+    { "pool/destroy_reinit",        test_pool_destroy_and_reinit, NULL, NULL },
+    { "pool/ray_cancel_global",     test_ray_cancel_global,     NULL, NULL },
+    { "pool/workers_participate",   test_dispatch_workers_participate, NULL, NULL },
     { NULL, NULL, NULL, NULL },
 };
 

--- a/test/test_window.c
+++ b/test/test_window.c
@@ -1,0 +1,1729 @@
+/*
+ *   Copyright (c) 2025-2026 Anton Kundenko <singaraiona@gmail.com>
+ *   All rights reserved.
+ */
+
+/*
+ * test_window.c — coverage tests for src/ops/window.c.
+ *
+ * OP_WINDOW has no rfl-reachable builder, so all coverage of window
+ * functions (sum/avg/min/max/rank/lag/lead/...) must come from C unit
+ * tests that drive ray_window_op directly.  This file exhaustively
+ * exercises the per-kind dispatch in win_compute_partition (lines
+ * 146-540 of window.c), plus key/result shapes in exec_window
+ * (multi-partition, multi-key, sym/date/f64 keys, parallel path).
+ */
+
+#include "test.h"
+#include <rayforce.h>
+#include "mem/heap.h"
+#include "ops/ops.h"
+#include "table/sym.h"
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+
+/* ─── Helpers ─────────────────────────────────────────────────────── */
+
+/* Build a 1- or 2-column table from the given int64 group + value arrays.
+ * Caller owns the result and must ray_release it. */
+static ray_t* mk_tbl_i64_2(const int64_t* g_data, const int64_t* v_data,
+                           int64_t n) {
+    ray_t* gv = ray_vec_from_raw(RAY_I64, g_data, n);
+    ray_t* vv = ray_vec_from_raw(RAY_I64, v_data, n);
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* t = ray_table_new(2);
+    t = ray_table_add_col(t, ng, gv);
+    t = ray_table_add_col(t, nv, vv);
+    ray_release(gv);
+    ray_release(vv);
+    return t;
+}
+
+/* 2-col table: g(I64), v(F64) */
+static ray_t* mk_tbl_i64_f64(const int64_t* g_data, const double* v_data,
+                              int64_t n) {
+    ray_t* gv = ray_vec_from_raw(RAY_I64, g_data, n);
+    ray_t* vv = ray_vec_from_raw(RAY_F64, v_data, n);
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* t = ray_table_new(2);
+    t = ray_table_add_col(t, ng, gv);
+    t = ray_table_add_col(t, nv, vv);
+    ray_release(gv);
+    ray_release(vv);
+    return t;
+}
+
+/* Build a window op with ROWS BETWEEN UNBOUNDED PRECEDING AND
+ * UNBOUNDED FOLLOWING (the "whole partition" frame).  Kind is the
+ * RAY_WIN_* kind; func_input_name is the column name driving the
+ * function (or "v" / "g" — anything for fns that ignore input). */
+static ray_op_t* build_whole_window(
+    ray_graph_t* g, ray_op_t* tbl_op,
+    const char* part_name, const char* order_name,
+    uint8_t kind, const char* func_input_name, int64_t param)
+{
+    ray_op_t* parts[1];
+    ray_op_t* orders[1];
+    uint8_t   ndesc[1] = {0};
+    uint8_t   n_part = 0, n_order = 0;
+    if (part_name)  { parts[0]  = ray_scan(g, part_name);  n_part  = 1; }
+    if (order_name) { orders[0] = ray_scan(g, order_name); n_order = 1; }
+
+    uint8_t kinds[1]    = { kind };
+    ray_op_t* fins[1]   = { ray_scan(g, func_input_name) };
+    int64_t   params[1] = { param };
+
+    return ray_window_op(g, tbl_op,
+                         n_part  ? parts  : NULL, n_part,
+                         n_order ? orders : NULL, n_order ? ndesc : NULL,
+                         n_order,
+                         kinds, fins, params, 1,
+                         RAY_FRAME_ROWS,
+                         RAY_BOUND_UNBOUNDED_PRECEDING,
+                         RAY_BOUND_UNBOUNDED_FOLLOWING,
+                         0, 0);
+}
+
+/* Same as build_whole_window but with ROWS BETWEEN UNBOUNDED PRECEDING
+ * AND CURRENT ROW (incremental "running" frame). */
+static ray_op_t* build_running_window(
+    ray_graph_t* g, ray_op_t* tbl_op,
+    const char* part_name, const char* order_name,
+    uint8_t kind, const char* func_input_name, int64_t param)
+{
+    ray_op_t* parts[1];
+    ray_op_t* orders[1];
+    uint8_t   ndesc[1] = {0};
+    uint8_t   n_part = 0, n_order = 0;
+    if (part_name)  { parts[0]  = ray_scan(g, part_name);  n_part  = 1; }
+    if (order_name) { orders[0] = ray_scan(g, order_name); n_order = 1; }
+
+    uint8_t kinds[1]    = { kind };
+    ray_op_t* fins[1]   = { ray_scan(g, func_input_name) };
+    int64_t   params[1] = { param };
+
+    return ray_window_op(g, tbl_op,
+                         n_part  ? parts  : NULL, n_part,
+                         n_order ? orders : NULL, n_order ? ndesc : NULL,
+                         n_order,
+                         kinds, fins, params, 1,
+                         RAY_FRAME_ROWS,
+                         RAY_BOUND_UNBOUNDED_PRECEDING,
+                         RAY_BOUND_CURRENT_ROW,
+                         0, 0);
+}
+
+/* Window result column "_w0" is the first auto-named column appended
+ * after the source columns.  Returns its idx (== ncols_in). */
+static ray_t* win_result_col(ray_t* result, int64_t base_ncols) {
+    return ray_table_get_col_idx(result, base_ncols);
+}
+
+/* ─── ROW_NUMBER ───────────────────────────────────────────────────── */
+
+/* Multi-partition row_number — value column ordered ascending so output
+ * is deterministic.  Tests dispatch + multi-part path. */
+static test_result_t test_window_row_number_partitioned(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 6;
+    int64_t gd[] = {1, 1, 1, 2, 2, 2};
+    int64_t vd[] = {10, 20, 30, 40, 50, 60};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                      RAY_WIN_ROW_NUMBER, "v", 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(ray_table_nrows(result), 6);
+
+    ray_t* rc = win_result_col(result, 2);
+    TEST_ASSERT_NOT_NULL(rc);
+    TEST_ASSERT_EQ_I(rc->type, RAY_I64);
+    int64_t* rd = (int64_t*)ray_data(rc);
+    /* rows are already in (g asc, v asc) order, so row_number = 1..3,1..3 */
+    TEST_ASSERT_EQ_I(rd[0], 1); TEST_ASSERT_EQ_I(rd[1], 2);
+    TEST_ASSERT_EQ_I(rd[2], 3);
+    TEST_ASSERT_EQ_I(rd[3], 1); TEST_ASSERT_EQ_I(rd[4], 2);
+    TEST_ASSERT_EQ_I(rd[5], 3);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── RANK / DENSE_RANK ────────────────────────────────────────────── */
+
+static test_result_t test_window_rank_dense_rank(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    /* Single partition, ties on order column to exercise rank-bump logic */
+    int64_t n = 5;
+    int64_t gd[] = {1, 1, 1, 1, 1};
+    int64_t vd[] = {10, 20, 20, 30, 40};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    /* RANK */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_RANK, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        /* ranks: 1, 2, 2, 4, 5 (tie at 20 stays at rank 2, then jumps to 4) */
+        TEST_ASSERT_EQ_I(rd[0], 1); TEST_ASSERT_EQ_I(rd[1], 2);
+        TEST_ASSERT_EQ_I(rd[2], 2); TEST_ASSERT_EQ_I(rd[3], 4);
+        TEST_ASSERT_EQ_I(rd[4], 5);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* DENSE_RANK */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_DENSE_RANK, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        /* dense_ranks: 1, 2, 2, 3, 4 (tie at 20 → 2; 30 → 3; 40 → 4) */
+        TEST_ASSERT_EQ_I(rd[0], 1); TEST_ASSERT_EQ_I(rd[1], 2);
+        TEST_ASSERT_EQ_I(rd[2], 2); TEST_ASSERT_EQ_I(rd[3], 3);
+        TEST_ASSERT_EQ_I(rd[4], 4);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── NTILE ───────────────────────────────────────────────────────── */
+
+static test_result_t test_window_ntile(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 6;
+    int64_t gd[] = {1, 1, 1, 1, 1, 1};
+    int64_t vd[] = {1, 2, 3, 4, 5, 6};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    /* NTILE 3 → buckets [1,1,2,2,3,3] for 6 rows / 3 tiles */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_NTILE, "v", 3);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_EQ_I(rd[0], 1); TEST_ASSERT_EQ_I(rd[1], 1);
+        TEST_ASSERT_EQ_I(rd[2], 2); TEST_ASSERT_EQ_I(rd[3], 2);
+        TEST_ASSERT_EQ_I(rd[4], 3); TEST_ASSERT_EQ_I(rd[5], 3);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* NTILE 0 → coerced to 1, all rows in bucket 1 */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_NTILE, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_I(rd[i], 1);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── COUNT (whole + running) ─────────────────────────────────────── */
+
+static test_result_t test_window_count(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 2, 2};
+    int64_t vd[] = {10, 20, 30, 40};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    /* Whole-frame COUNT: each row gets partition size */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_COUNT, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_EQ_I(rd[0], 2); TEST_ASSERT_EQ_I(rd[1], 2);
+        TEST_ASSERT_EQ_I(rd[2], 2); TEST_ASSERT_EQ_I(rd[3], 2);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* Running COUNT: 1, 2, 1, 2 */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_running_window(g, tbl_op, "g", "v",
+                                            RAY_WIN_COUNT, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_EQ_I(rd[0], 1); TEST_ASSERT_EQ_I(rd[1], 2);
+        TEST_ASSERT_EQ_I(rd[2], 1); TEST_ASSERT_EQ_I(rd[3], 2);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── SUM (whole + running, i64 + f64) ───────────────────────────── */
+
+static test_result_t test_window_sum_i64(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 2, 2};
+    int64_t vd[] = {10, 20, 30, 40};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    /* Whole SUM */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_SUM, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        TEST_ASSERT_EQ_I(rc->type, RAY_I64);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_EQ_I(rd[0], 30); TEST_ASSERT_EQ_I(rd[1], 30);
+        TEST_ASSERT_EQ_I(rd[2], 70); TEST_ASSERT_EQ_I(rd[3], 70);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* Running SUM */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_running_window(g, tbl_op, "g", "v",
+                                            RAY_WIN_SUM, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_EQ_I(rd[0], 10); TEST_ASSERT_EQ_I(rd[1], 30);
+        TEST_ASSERT_EQ_I(rd[2], 30); TEST_ASSERT_EQ_I(rd[3], 70);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+static test_result_t test_window_sum_f64(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 2, 2};
+    double  vd[] = {1.5, 2.5, 3.5, 4.5};
+    ray_t* tbl = mk_tbl_i64_f64(gd, vd, n);
+
+    /* Whole SUM (f64) */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_SUM, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        TEST_ASSERT_EQ_I(rc->type, RAY_F64);
+        double* rd = (double*)ray_data(rc);
+        TEST_ASSERT_EQ_F(rd[0], 4.0, 1e-9); TEST_ASSERT_EQ_F(rd[1], 4.0, 1e-9);
+        TEST_ASSERT_EQ_F(rd[2], 8.0, 1e-9); TEST_ASSERT_EQ_F(rd[3], 8.0, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* Running SUM (f64) */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_running_window(g, tbl_op, "g", "v",
+                                            RAY_WIN_SUM, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        double* rd = (double*)ray_data(rc);
+        TEST_ASSERT_EQ_F(rd[0], 1.5, 1e-9); TEST_ASSERT_EQ_F(rd[1], 4.0, 1e-9);
+        TEST_ASSERT_EQ_F(rd[2], 3.5, 1e-9); TEST_ASSERT_EQ_F(rd[3], 8.0, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── AVG (i64 input → f64 output, both frames + null-only partition) */
+
+static test_result_t test_window_avg(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 2, 2};
+    int64_t vd[] = {10, 20, 30, 40};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    /* Whole AVG */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_AVG, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        TEST_ASSERT_EQ_I(rc->type, RAY_F64);
+        double* rd = (double*)ray_data(rc);
+        TEST_ASSERT_EQ_F(rd[0], 15.0, 1e-9); TEST_ASSERT_EQ_F(rd[1], 15.0, 1e-9);
+        TEST_ASSERT_EQ_F(rd[2], 35.0, 1e-9); TEST_ASSERT_EQ_F(rd[3], 35.0, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* Running AVG */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_running_window(g, tbl_op, "g", "v",
+                                            RAY_WIN_AVG, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        double* rd = (double*)ray_data(rc);
+        TEST_ASSERT_EQ_F(rd[0], 10.0, 1e-9); TEST_ASSERT_EQ_F(rd[1], 15.0, 1e-9);
+        TEST_ASSERT_EQ_F(rd[2], 30.0, 1e-9); TEST_ASSERT_EQ_F(rd[3], 35.0, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── MIN / MAX (both i64 and f64 paths, whole + running) ──────────── */
+
+static test_result_t test_window_min_max_i64(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    /* Tilted values to exercise running min/max accumulation */
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 1, 1};
+    int64_t vd[] = {30, 10, 50, 20};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    /* Whole MIN/MAX with no order — sort order undefined but min/max
+     * over partition is deterministic. */
+
+    /* MIN whole */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", NULL,
+                                          RAY_WIN_MIN, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        TEST_ASSERT_EQ_I(rc->type, RAY_I64);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_I(rd[i], 10);
+        ray_release(result); ray_graph_free(g);
+    }
+    /* MAX whole */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", NULL,
+                                          RAY_WIN_MAX, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_I(rd[i], 50);
+        ray_release(result); ray_graph_free(g);
+    }
+    /* Running MIN ordered by v ASC: each cumulative min = first value */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_running_window(g, tbl_op, "g", "v",
+                                            RAY_WIN_MIN, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        /* sorted: [10, 20, 30, 50]; running min stays at 10 throughout.
+         * rd is indexed by ORIGINAL row position because window writes
+         * out[sorted_idx[i]]. */
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_I(rd[i], 10);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+static test_result_t test_window_min_max_f64(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 1, 1};
+    double  vd[] = {3.5, 1.5, 5.5, 2.5};
+    ray_t* tbl = mk_tbl_i64_f64(gd, vd, n);
+
+    /* Whole MIN f64 */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", NULL,
+                                          RAY_WIN_MIN, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        TEST_ASSERT_EQ_I(rc->type, RAY_F64);
+        double* rd = (double*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_F(rd[i], 1.5, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+    /* Whole MAX f64 */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", NULL,
+                                          RAY_WIN_MAX, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        double* rd = (double*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_F(rd[i], 5.5, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+    /* Running MIN f64 ordered by v ASC */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_running_window(g, tbl_op, "g", "v",
+                                            RAY_WIN_MIN, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        double* rd = (double*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_F(rd[i], 1.5, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+    /* Running MAX f64 ordered by v ASC: cumulative max is value itself */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_running_window(g, tbl_op, "g", "v",
+                                            RAY_WIN_MAX, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        double* rd = (double*)ray_data(rc);
+        /* original positions: vd = {3.5, 1.5, 5.5, 2.5}; sorted asc:
+         * [1.5, 2.5, 3.5, 5.5], running max = sorted value at each step.
+         * out[orig_idx_of_sorted[i]] = running_max_at_step_i.
+         *  step 0: orig=1, val=1.5  → rd[1]=1.5
+         *  step 1: orig=3, val=2.5  → rd[3]=2.5
+         *  step 2: orig=0, val=3.5  → rd[0]=3.5
+         *  step 3: orig=2, val=5.5  → rd[2]=5.5 */
+        TEST_ASSERT_EQ_F(rd[1], 1.5, 1e-9);
+        TEST_ASSERT_EQ_F(rd[3], 2.5, 1e-9);
+        TEST_ASSERT_EQ_F(rd[0], 3.5, 1e-9);
+        TEST_ASSERT_EQ_F(rd[2], 5.5, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── LAG / LEAD (i64 + f64, default and offset>1) ─────────────────── */
+
+static test_result_t test_window_lag_lead_i64(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 1, 1};
+    int64_t vd[] = {10, 20, 30, 40};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    /* LAG offset=1: first row in partition is null, others get prior */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_LAG, "v", 1);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        TEST_ASSERT_EQ_I(rc->type, RAY_I64);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_TRUE(ray_vec_is_null(rc, 0));
+        TEST_ASSERT_FALSE(ray_vec_is_null(rc, 1));
+        TEST_ASSERT_EQ_I(rd[1], 10);
+        TEST_ASSERT_EQ_I(rd[2], 20);
+        TEST_ASSERT_EQ_I(rd[3], 30);
+        ray_release(result); ray_graph_free(g);
+    }
+    /* LAG offset=0 → coerced to 1 */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_LAG, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_TRUE(ray_vec_is_null(rc, 0));
+        TEST_ASSERT_EQ_I(rd[1], 10);
+        ray_release(result); ray_graph_free(g);
+    }
+    /* LEAD offset=2 */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_LEAD, "v", 2);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_EQ_I(rd[0], 30);
+        TEST_ASSERT_EQ_I(rd[1], 40);
+        TEST_ASSERT_TRUE(ray_vec_is_null(rc, 2));
+        TEST_ASSERT_TRUE(ray_vec_is_null(rc, 3));
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+static test_result_t test_window_lag_lead_f64(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 3;
+    int64_t gd[] = {1, 1, 1};
+    double  vd[] = {1.5, 2.5, 3.5};
+    ray_t* tbl = mk_tbl_i64_f64(gd, vd, n);
+
+    /* LAG f64 offset=1 */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_LAG, "v", 1);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        TEST_ASSERT_EQ_I(rc->type, RAY_F64);
+        double* rd = (double*)ray_data(rc);
+        TEST_ASSERT_TRUE(ray_vec_is_null(rc, 0));
+        TEST_ASSERT_EQ_F(rd[1], 1.5, 1e-9);
+        TEST_ASSERT_EQ_F(rd[2], 2.5, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+    /* LEAD f64 offset=1 */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_LEAD, "v", 1);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        double* rd = (double*)ray_data(rc);
+        TEST_ASSERT_EQ_F(rd[0], 2.5, 1e-9);
+        TEST_ASSERT_EQ_F(rd[1], 3.5, 1e-9);
+        TEST_ASSERT_TRUE(ray_vec_is_null(rc, 2));
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── FIRST_VALUE / LAST_VALUE / NTH_VALUE ────────────────────────── */
+
+static test_result_t test_window_first_last_nth(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 1, 1};
+    int64_t vd[] = {10, 20, 30, 40};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    /* FIRST_VALUE (whole frame, sorted asc) → 10 for all rows */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_FIRST_VALUE, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_I(rd[i], 10);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* LAST_VALUE (whole frame) → 40 for all rows */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_LAST_VALUE, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_I(rd[i], 40);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* LAST_VALUE running → each row sees its own value (current row) */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_running_window(g, tbl_op, "g", "v",
+                                            RAY_WIN_LAST_VALUE, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_EQ_I(rd[0], 10); TEST_ASSERT_EQ_I(rd[1], 20);
+        TEST_ASSERT_EQ_I(rd[2], 30); TEST_ASSERT_EQ_I(rd[3], 40);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* NTH_VALUE 2nd → 20 for all rows */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_NTH_VALUE, "v", 2);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_I(rd[i], 20);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* NTH_VALUE 0 → coerced to 1, returns first */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_NTH_VALUE, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_I(rd[i], 10);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* NTH_VALUE > part_len → all NULL */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_NTH_VALUE, "v", 99);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        for (int64_t i = 0; i < n; i++)
+            TEST_ASSERT_TRUE(ray_vec_is_null(rc, i));
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── FIRST/LAST/NTH on f64 ───────────────────────────────────────── */
+
+static test_result_t test_window_first_last_nth_f64(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 3;
+    int64_t gd[] = {1, 1, 1};
+    double  vd[] = {1.5, 2.5, 3.5};
+    ray_t* tbl = mk_tbl_i64_f64(gd, vd, n);
+
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_FIRST_VALUE, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        TEST_ASSERT_EQ_I(rc->type, RAY_F64);
+        double* rd = (double*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_F(rd[i], 1.5, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_LAST_VALUE, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        double* rd = (double*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_F(rd[i], 3.5, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+    /* Running LAST_VALUE f64: each row's own value */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_running_window(g, tbl_op, "g", "v",
+                                            RAY_WIN_LAST_VALUE, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        double* rd = (double*)ray_data(rc);
+        TEST_ASSERT_EQ_F(rd[0], 1.5, 1e-9);
+        TEST_ASSERT_EQ_F(rd[1], 2.5, 1e-9);
+        TEST_ASSERT_EQ_F(rd[2], 3.5, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+    /* NTH_VALUE 3rd f64 */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_NTH_VALUE, "v", 3);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        double* rd = (double*)ray_data(rc);
+        for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_F(rd[i], 3.5, 1e-9);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── NULL handling: SUM/AVG skip nulls; AVG of all-null → null ────── */
+
+static test_result_t test_window_nulls(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 2, 2};
+    int64_t vd[] = {10, 20, 0, 0};
+    ray_t* gv = ray_vec_from_raw(RAY_I64, gd, n);
+    ray_t* vv = ray_vec_from_raw(RAY_I64, vd, n);
+    /* Mark rows 2,3 as null in v (partition g==2 has all-null values) */
+    ray_vec_set_null(vv, 2, true);
+    ray_vec_set_null(vv, 3, true);
+
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nvname = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, gv);
+    tbl = ray_table_add_col(tbl, nvname, vv);
+    ray_release(gv); ray_release(vv);
+
+    /* SUM whole: partition 1 → 30, partition 2 → 0 (all nulls skipped) */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_SUM, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_EQ_I(rd[0], 30); TEST_ASSERT_EQ_I(rd[1], 30);
+        TEST_ASSERT_EQ_I(rd[2], 0);  TEST_ASSERT_EQ_I(rd[3], 0);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* AVG whole: partition 1 → 15, partition 2 → null */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_AVG, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        double* rd = (double*)ray_data(rc);
+        TEST_ASSERT_FALSE(ray_vec_is_null(rc, 0));
+        TEST_ASSERT_EQ_F(rd[0], 15.0, 1e-9);
+        TEST_ASSERT_FALSE(ray_vec_is_null(rc, 1));
+        TEST_ASSERT_EQ_F(rd[1], 15.0, 1e-9);
+        TEST_ASSERT_TRUE(ray_vec_is_null(rc, 2));
+        TEST_ASSERT_TRUE(ray_vec_is_null(rc, 3));
+        ray_release(result); ray_graph_free(g);
+    }
+
+    /* MIN whole: partition 1 → 10, partition 2 → null */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_MIN, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_EQ_I(rd[0], 10);
+        TEST_ASSERT_TRUE(ray_vec_is_null(rc, 2));
+        TEST_ASSERT_TRUE(ray_vec_is_null(rc, 3));
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── Running MIN/MAX with leading null — exercises win_set_null before
+ *     any non-null seen.  Also covers LAG/LEAD where the source value is
+ *     null (propagates null to result). */
+
+static test_result_t test_window_running_min_leading_null(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 1, 1};
+    int64_t vd[] = {0, 30, 20, 10};
+    ray_t* gv = ray_vec_from_raw(RAY_I64, gd, n);
+    ray_t* vv = ray_vec_from_raw(RAY_I64, vd, n);
+    /* Null at position 0 (lowest sort index); after sort by orig-idx
+     * the first row in partition is the null one. */
+    ray_vec_set_null(vv, 0, true);
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, gv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(gv); ray_release(vv);
+
+    /* Order by orig position to keep deterministic — we need the null
+     * to come first.  Build a separate idx column. */
+    /* No order key: insertion preserves input order, so position 0 (null)
+     * comes first.  Running MIN at row 0 → null; thereafter min of seen
+     * non-nulls. */
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* g_op = ray_scan(g, "g");
+    ray_op_t* v_op = ray_scan(g, "v");
+    ray_op_t* parts[] = { g_op };
+    /* Use orig-position-style order via a helper: ORDER BY g (constant) means
+     * sort is stable on input order for the tie-breaker.  Actually since all g
+     * are the same and there's only one part_key (g), the sort still has to
+     * resolve.  Tie-break is the index, hence input order is preserved. */
+    uint8_t kinds[] = { RAY_WIN_MIN };
+    ray_op_t* fins[]   = { v_op };
+    int64_t   params[] = { 0 };
+    ray_op_t* w = ray_window_op(g, tbl_op,
+                                parts, 1,
+                                NULL, NULL, 0,   /* no order */
+                                kinds, fins, params, 1,
+                                RAY_FRAME_ROWS,
+                                RAY_BOUND_UNBOUNDED_PRECEDING,
+                                RAY_BOUND_CURRENT_ROW,
+                                0, 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    ray_t* rc = win_result_col(result, 2);
+    /* Insertion sort with single tied key + n_sort=1 partition radix
+     * stable order leaves rows in input order: [null, 30, 20, 10].
+     * Running MIN: [null, 30, 20, 10]. */
+    int64_t* rd = (int64_t*)ray_data(rc);
+    TEST_ASSERT_TRUE(ray_vec_is_null(rc, 0));
+    TEST_ASSERT_EQ_I(rd[1], 30);
+    TEST_ASSERT_EQ_I(rd[2], 20);
+    TEST_ASSERT_EQ_I(rd[3], 10);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* LAG with null source: result is null where source is null */
+static test_result_t test_window_lag_null_source(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 1, 1};
+    int64_t vd[] = {10, 0, 30, 40};
+    ray_t* gv = ray_vec_from_raw(RAY_I64, gd, n);
+    ray_t* vv = ray_vec_from_raw(RAY_I64, vd, n);
+    ray_vec_set_null(vv, 1, true);   /* row 1 source value null */
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, gv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(gv); ray_release(vv);
+
+    /* No order key, LAG offset=1 — for sorted input order [0,1,2,3]:
+     * rd[0] = null (boundary)
+     * rd[1] = 10 (lag from row 0)
+     * rd[2] = null (lag from row 1, which is null)
+     * rd[3] = 30 */
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* g_op = ray_scan(g, "g");
+    ray_op_t* v_op = ray_scan(g, "v");
+    ray_op_t* parts[] = { g_op };
+    uint8_t kinds[] = { RAY_WIN_LAG };
+    ray_op_t* fins[]   = { v_op };
+    int64_t   params[] = { 1 };
+    ray_op_t* w = ray_window_op(g, tbl_op,
+                                parts, 1,
+                                NULL, NULL, 0,
+                                kinds, fins, params, 1,
+                                RAY_FRAME_ROWS,
+                                RAY_BOUND_UNBOUNDED_PRECEDING,
+                                RAY_BOUND_UNBOUNDED_FOLLOWING,
+                                0, 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    ray_t* rc = win_result_col(result, 2);
+    int64_t* rd = (int64_t*)ray_data(rc);
+    TEST_ASSERT_TRUE(ray_vec_is_null(rc, 0));
+    TEST_ASSERT_EQ_I(rd[1], 10);
+    TEST_ASSERT_TRUE(ray_vec_is_null(rc, 2));
+    TEST_ASSERT_EQ_I(rd[3], 30);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* FIRST_VALUE/LAST_VALUE/NTH_VALUE with null source — output is null. */
+static test_result_t test_window_first_last_nth_null(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 3;
+    int64_t gd[] = {1, 1, 1};
+    int64_t vd[] = {0, 20, 30};
+    ray_t* gv = ray_vec_from_raw(RAY_I64, gd, n);
+    ray_t* vv = ray_vec_from_raw(RAY_I64, vd, n);
+    ray_vec_set_null(vv, 0, true);   /* first row null → FIRST_VALUE = null */
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, gv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(gv); ray_release(vv);
+
+    /* No order, default partition.  Insertion sort preserves input order
+     * → first sorted row is original row 0 (null). */
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* g_op = ray_scan(g, "g");
+    ray_op_t* v_op = ray_scan(g, "v");
+    ray_op_t* parts[] = { g_op };
+    uint8_t kinds[] = { RAY_WIN_FIRST_VALUE };
+    ray_op_t* fins[]   = { v_op };
+    int64_t   params[] = { 0 };
+    ray_op_t* w = ray_window_op(g, tbl_op,
+                                parts, 1,
+                                NULL, NULL, 0,
+                                kinds, fins, params, 1,
+                                RAY_FRAME_ROWS,
+                                RAY_BOUND_UNBOUNDED_PRECEDING,
+                                RAY_BOUND_UNBOUNDED_FOLLOWING,
+                                0, 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    ray_t* rc = win_result_col(result, 2);
+    /* All rows: FIRST_VALUE = first sorted row's value = null */
+    for (int64_t i = 0; i < n; i++)
+        TEST_ASSERT_TRUE(ray_vec_is_null(rc, i));
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── Empty-table early return path ───────────────────────────────── */
+
+static test_result_t test_window_empty(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    /* Build a 0-row table */
+    ray_t* gv = ray_vec_new(RAY_I64, 0); gv->len = 0;
+    ray_t* vv = ray_vec_new(RAY_I64, 0); vv->len = 0;
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, gv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(gv); ray_release(vv);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                      RAY_WIN_ROW_NUMBER, "v", 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    /* Early return: result equals input table (no _w0 column added) */
+    TEST_ASSERT_EQ_I(ray_table_nrows(result), 0);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── No partition key: whole table is one partition ──────────────── */
+
+static test_result_t test_window_no_partition(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 5;
+    int64_t gd[] = {0, 0, 0, 0, 0};
+    int64_t vd[] = {1, 2, 3, 4, 5};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    /* No PARTITION BY, ORDER BY v; running SUM */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_running_window(g, tbl_op, NULL, "v",
+                                            RAY_WIN_SUM, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_EQ_I(rd[0], 1);
+        TEST_ASSERT_EQ_I(rd[1], 3);
+        TEST_ASSERT_EQ_I(rd[2], 6);
+        TEST_ASSERT_EQ_I(rd[3], 10);
+        TEST_ASSERT_EQ_I(rd[4], 15);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── SYM partition key (exercises enum_rank build) ────────────────── */
+
+static test_result_t test_window_sym_partition(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    /* Build table with a SYM column via ray_sym_vec_new + ray_vec_append.
+     * 64-bit width keeps interned IDs intact across the window engine's
+     * sym-rank build path. */
+    int64_t n = 6;
+    int64_t s_a = ray_sym_intern("aa", 2);
+    int64_t s_b = ray_sym_intern("bb", 2);
+    int64_t s_c = ray_sym_intern("cc", 2);
+    int64_t vd[] = {10, 20, 30, 40, 50, 60};
+
+    ray_t* sv = ray_sym_vec_new(RAY_SYM_W64, n);
+    sv = ray_vec_append(sv, &s_a);
+    sv = ray_vec_append(sv, &s_a);
+    sv = ray_vec_append(sv, &s_b);
+    sv = ray_vec_append(sv, &s_b);
+    sv = ray_vec_append(sv, &s_c);
+    sv = ray_vec_append(sv, &s_c);
+    ray_t* vv = ray_vec_from_raw(RAY_I64, vd, n);
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, sv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(sv); ray_release(vv);
+
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_SUM, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        /* Whole-partition SUM grouped by sym: 30 / 70 / 110 */
+        TEST_ASSERT_EQ_I(rd[0], 30); TEST_ASSERT_EQ_I(rd[1], 30);
+        TEST_ASSERT_EQ_I(rd[2], 70); TEST_ASSERT_EQ_I(rd[3], 70);
+        TEST_ASSERT_EQ_I(rd[4], 110); TEST_ASSERT_EQ_I(rd[5], 110);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── Multi-key partition (tests pkey_gather n_part>1 path) ─────────── */
+
+static test_result_t test_window_multikey_partition(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 6;
+    int32_t a_data[] = {1, 1, 1, 2, 2, 2};
+    int32_t b_data[] = {1, 1, 2, 1, 2, 2};
+    int64_t vd[]     = {10, 20, 30, 40, 50, 60};
+
+    ray_t* av = ray_vec_from_raw(RAY_I32, a_data, n);
+    ray_t* bv = ray_vec_from_raw(RAY_I32, b_data, n);
+    ray_t* vv = ray_vec_from_raw(RAY_I64, vd, n);
+    int64_t na = ray_sym_intern("a", 1);
+    int64_t nb = ray_sym_intern("b", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(3);
+    tbl = ray_table_add_col(tbl, na, av);
+    tbl = ray_table_add_col(tbl, nb, bv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(av); ray_release(bv); ray_release(vv);
+
+    /* PARTITION BY (a, b), no order, SUM(v) whole.
+     * Partitions: (1,1)→30, (1,2)→30, (2,1)→40, (2,2)→110 */
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* a_op = ray_scan(g, "a");
+    ray_op_t* b_op = ray_scan(g, "b");
+    ray_op_t* v_op = ray_scan(g, "v");
+    ray_op_t* parts[]    = { a_op, b_op };
+    uint8_t   kinds[]    = { RAY_WIN_SUM };
+    ray_op_t* fins[]     = { v_op };
+    int64_t   params[]   = { 0 };
+    ray_op_t* w = ray_window_op(g, tbl_op,
+                                parts, 2,
+                                NULL, NULL, 0,
+                                kinds, fins, params, 1,
+                                RAY_FRAME_ROWS,
+                                RAY_BOUND_UNBOUNDED_PRECEDING,
+                                RAY_BOUND_UNBOUNDED_FOLLOWING,
+                                0, 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    ray_t* rc = win_result_col(result, 3);
+    int64_t* rd = (int64_t*)ray_data(rc);
+    TEST_ASSERT_EQ_I(rd[0], 30);  /* (1,1): 10+20 */
+    TEST_ASSERT_EQ_I(rd[1], 30);
+    TEST_ASSERT_EQ_I(rd[2], 30);  /* (1,2): 30 */
+    TEST_ASSERT_EQ_I(rd[3], 40);  /* (2,1): 40 */
+    TEST_ASSERT_EQ_I(rd[4], 110); /* (2,2): 50+60 */
+    TEST_ASSERT_EQ_I(rd[5], 110);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── Multiple window funcs in one OP (n_funcs > 1) ─────────────────── */
+
+static test_result_t test_window_multiple_funcs(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 2, 2};
+    int64_t vd[] = {10, 20, 30, 40};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* g_op = ray_scan(g, "g");
+    ray_op_t* v_op = ray_scan(g, "v");
+    ray_op_t* parts[] = { g_op };
+    ray_op_t* orders[] = { v_op };
+    uint8_t   ndesc[] = {0};
+    /* row_number, sum, avg in one OP */
+    uint8_t kinds[] = { RAY_WIN_ROW_NUMBER, RAY_WIN_SUM, RAY_WIN_AVG };
+    ray_op_t* fins[]   = { v_op, v_op, v_op };
+    int64_t   params[] = { 0, 0, 0 };
+    ray_op_t* w = ray_window_op(g, tbl_op,
+                                parts, 1,
+                                orders, ndesc, 1,
+                                kinds, fins, params, 3,
+                                RAY_FRAME_ROWS,
+                                RAY_BOUND_UNBOUNDED_PRECEDING,
+                                RAY_BOUND_UNBOUNDED_FOLLOWING,
+                                0, 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(ray_table_ncols(result), 5);  /* 2 + 3 */
+
+    /* _w0 = row_number (I64) */
+    ray_t* w0 = ray_table_get_col_idx(result, 2);
+    TEST_ASSERT_EQ_I(w0->type, RAY_I64);
+    int64_t* rn = (int64_t*)ray_data(w0);
+    TEST_ASSERT_EQ_I(rn[0], 1); TEST_ASSERT_EQ_I(rn[1], 2);
+    TEST_ASSERT_EQ_I(rn[2], 1); TEST_ASSERT_EQ_I(rn[3], 2);
+
+    /* _w1 = sum I64 */
+    ray_t* w1 = ray_table_get_col_idx(result, 3);
+    TEST_ASSERT_EQ_I(w1->type, RAY_I64);
+    int64_t* sd = (int64_t*)ray_data(w1);
+    TEST_ASSERT_EQ_I(sd[0], 30); TEST_ASSERT_EQ_I(sd[2], 70);
+
+    /* _w2 = avg F64 */
+    ray_t* w2 = ray_table_get_col_idx(result, 4);
+    TEST_ASSERT_EQ_I(w2->type, RAY_F64);
+    double* ad = (double*)ray_data(w2);
+    TEST_ASSERT_EQ_F(ad[0], 15.0, 1e-9);
+    TEST_ASSERT_EQ_F(ad[2], 35.0, 1e-9);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── Larger table (>64 rows): exercises radix-sort path ───────────── */
+
+static test_result_t test_window_radix_path(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    /* 200 rows: insertion sort threshold (64) crossed → radix path */
+    int64_t n = 200;
+    ray_t* gv = ray_vec_new(RAY_I64, n); gv->len = n;
+    ray_t* vv = ray_vec_new(RAY_I64, n); vv->len = n;
+    int64_t* gd = (int64_t*)ray_data(gv);
+    int64_t* vd = (int64_t*)ray_data(vv);
+    for (int64_t i = 0; i < n; i++) {
+        gd[i] = i % 4;       /* 4 partitions */
+        vd[i] = i;
+    }
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, gv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(gv); ray_release(vv);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                      RAY_WIN_COUNT, "v", 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    ray_t* rc = win_result_col(result, 2);
+    int64_t* rd = (int64_t*)ray_data(rc);
+    /* Each of the 4 partitions has 50 rows → COUNT(*) over partition = 50 */
+    for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_I(rd[i], 50);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── Very large table: parallel radix + parallel partition path ────── */
+
+static test_result_t test_window_parallel_path(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    /* 8192+1 rows so we cross RADIX_SORT_THRESHOLD (4096) AND
+     * SMALL_POOL_THRESHOLD (8192) — hits parallel sort + parallel
+     * per-partition compute. */
+    int64_t n = 9000;
+    ray_t* gv = ray_vec_new(RAY_I64, n); gv->len = n;
+    ray_t* vv = ray_vec_new(RAY_I64, n); vv->len = n;
+    int64_t* gd = (int64_t*)ray_data(gv);
+    int64_t* vd = (int64_t*)ray_data(vv);
+    for (int64_t i = 0; i < n; i++) {
+        gd[i] = i % 100;     /* 100 partitions of ~90 each */
+        vd[i] = i;
+    }
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, gv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(gv); ray_release(vv);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                      RAY_WIN_COUNT, "v", 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    ray_t* rc = win_result_col(result, 2);
+    int64_t* rd = (int64_t*)ray_data(rc);
+    /* Each partition has exactly 90 rows */
+    int64_t ones = 0;
+    for (int64_t i = 0; i < n; i++)
+        if (rd[i] == 90) ones++;
+    TEST_ASSERT_EQ_I(ones, n);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── ORDER DESC: exercises desc[k]=1 in radix encoding ─────────────── */
+
+static test_result_t test_window_order_desc(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 1, 1};
+    int64_t vd[] = {10, 20, 30, 40};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    /* ORDER BY v DESC, running SUM */
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* g_op = ray_scan(g, "g");
+    ray_op_t* v_op = ray_scan(g, "v");
+    ray_op_t* parts[]  = { g_op };
+    ray_op_t* orders[] = { v_op };
+    uint8_t   ndesc[]  = { 1 };  /* DESC */
+    uint8_t   kinds[]  = { RAY_WIN_SUM };
+    ray_op_t* fins[]   = { v_op };
+    int64_t   params[] = { 0 };
+    ray_op_t* w = ray_window_op(g, tbl_op,
+                                parts, 1,
+                                orders, ndesc, 1,
+                                kinds, fins, params, 1,
+                                RAY_FRAME_ROWS,
+                                RAY_BOUND_UNBOUNDED_PRECEDING,
+                                RAY_BOUND_CURRENT_ROW,
+                                0, 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    ray_t* rc = win_result_col(result, 2);
+    int64_t* rd = (int64_t*)ray_data(rc);
+    /* DESC sort: [40, 30, 20, 10]; running sum: [40, 70, 90, 100].
+     * out[orig_idx_of_sorted[i]] = running sum at step i.
+     * Original positions 3,2,1,0 in sorted order:
+     *  step 0: orig=3, sum=40 → rd[3]=40
+     *  step 1: orig=2, sum=70 → rd[2]=70
+     *  step 2: orig=1, sum=90 → rd[1]=90
+     *  step 3: orig=0, sum=100→ rd[0]=100 */
+    TEST_ASSERT_EQ_I(rd[3], 40);
+    TEST_ASSERT_EQ_I(rd[2], 70);
+    TEST_ASSERT_EQ_I(rd[1], 90);
+    TEST_ASSERT_EQ_I(rd[0], 100);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── DATE keys: I32-typed sort path ───────────────────────────────── */
+
+static test_result_t test_window_date_partition(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    /* DATE column (I32-typed days-since-epoch). Three distinct dates,
+     * 2 rows each, one running SUM over partition. */
+    int64_t n = 6;
+    int32_t dd[] = {100, 100, 200, 200, 300, 300};
+    int64_t vd[] = {1, 2, 3, 4, 5, 6};
+    ray_t* dv = ray_vec_from_raw(RAY_DATE, dd, n);
+    ray_t* vv = ray_vec_from_raw(RAY_I64, vd, n);
+    int64_t nd = ray_sym_intern("d", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, nd, dv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(dv); ray_release(vv);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* w = build_whole_window(g, tbl_op, "d", "v",
+                                      RAY_WIN_SUM, "v", 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    ray_t* rc = win_result_col(result, 2);
+    int64_t* rd = (int64_t*)ray_data(rc);
+    TEST_ASSERT_EQ_I(rd[0], 3);  TEST_ASSERT_EQ_I(rd[1], 3);
+    TEST_ASSERT_EQ_I(rd[2], 7);  TEST_ASSERT_EQ_I(rd[3], 7);
+    TEST_ASSERT_EQ_I(rd[4], 11); TEST_ASSERT_EQ_I(rd[5], 11);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── F64 partition key (forces merge-sort fallback because F64 multi-
+ *     key is not radix-packable when used alongside other 64-bit keys) */
+
+static test_result_t test_window_f64_partition(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 6;
+    double  gd[] = {1.0, 1.0, 1.0, 2.0, 2.0, 2.0};
+    int64_t vd[] = {10, 20, 30, 40, 50, 60};
+    ray_t* gv = ray_vec_from_raw(RAY_F64, gd, n);
+    ray_t* vv = ray_vec_from_raw(RAY_I64, vd, n);
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, gv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(gv); ray_release(vv);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                      RAY_WIN_SUM, "v", 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    ray_t* rc = win_result_col(result, 2);
+    int64_t* rd = (int64_t*)ray_data(rc);
+    TEST_ASSERT_EQ_I(rd[0], 60);  TEST_ASSERT_EQ_I(rd[2], 60);
+    TEST_ASSERT_EQ_I(rd[3], 150); TEST_ASSERT_EQ_I(rd[5], 150);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── BOOL partition key (small-radix encoding) ─────────────────────── */
+
+static test_result_t test_window_bool_partition(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 6;
+    uint8_t gd[] = {0, 0, 0, 1, 1, 1};
+    int64_t vd[] = {10, 20, 30, 40, 50, 60};
+    ray_t* gv = ray_vec_from_raw(RAY_BOOL, gd, n);
+    ray_t* vv = ray_vec_from_raw(RAY_I64, vd, n);
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, gv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(gv); ray_release(vv);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                      RAY_WIN_SUM, "v", 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    ray_t* rc = win_result_col(result, 2);
+    int64_t* rd = (int64_t*)ray_data(rc);
+    TEST_ASSERT_EQ_I(rd[0], 60);
+    TEST_ASSERT_EQ_I(rd[3], 150);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── No funcs: early-return path (n_funcs == 0 retains input) ────── */
+
+static test_result_t test_window_no_funcs(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 2, 2};
+    int64_t vd[] = {10, 20, 30, 40};
+    ray_t* tbl = mk_tbl_i64_2(gd, vd, n);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* g_op = ray_scan(g, "g");
+    ray_op_t* parts[] = { g_op };
+    ray_op_t* w = ray_window_op(g, tbl_op,
+                                parts, 1,
+                                NULL, NULL, 0,
+                                NULL, NULL, NULL, 0,
+                                RAY_FRAME_ROWS,
+                                RAY_BOUND_UNBOUNDED_PRECEDING,
+                                RAY_BOUND_UNBOUNDED_FOLLOWING,
+                                0, 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    /* n_funcs==0 means: returns input table unchanged */
+    TEST_ASSERT_EQ_I(ray_table_nrows(result), 4);
+    TEST_ASSERT_EQ_I(ray_table_ncols(result), 2);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── STR partition key — forces merge-sort fallback (radix can't
+ *     handle RAY_STR), exercising win_keys_differ's STR arm. */
+
+static test_result_t test_window_str_partition(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 6;
+    int64_t vd[] = {10, 20, 30, 40, 50, 60};
+
+    ray_t* sv = ray_vec_new(RAY_STR, n);
+    sv = ray_str_vec_append(sv, "aa", 2);
+    sv = ray_str_vec_append(sv, "aa", 2);
+    sv = ray_str_vec_append(sv, "bb", 2);
+    sv = ray_str_vec_append(sv, "bb", 2);
+    sv = ray_str_vec_append(sv, "cc", 2);
+    sv = ray_str_vec_append(sv, "cc", 2);
+    ray_t* vv = ray_vec_from_raw(RAY_I64, vd, n);
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, sv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(sv); ray_release(vv);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                      RAY_WIN_SUM, "v", 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    ray_t* rc = win_result_col(result, 2);
+    int64_t* rd = (int64_t*)ray_data(rc);
+    /* Whole-partition SUM grouped by str: 30 / 70 / 110 */
+    TEST_ASSERT_EQ_I(rd[0], 30); TEST_ASSERT_EQ_I(rd[1], 30);
+    TEST_ASSERT_EQ_I(rd[2], 70); TEST_ASSERT_EQ_I(rd[3], 70);
+    TEST_ASSERT_EQ_I(rd[4], 110); TEST_ASSERT_EQ_I(rd[5], 110);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── Larger STR partition: forces parallel merge sort (>1024 rows) ── */
+
+static test_result_t test_window_str_parallel_merge(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 1500;
+    ray_t* sv = ray_vec_new(RAY_STR, n);
+    char buf[8];
+    for (int64_t i = 0; i < n; i++) {
+        /* Cycle 5 partitions: "k0".."k4" */
+        buf[0] = 'k';
+        buf[1] = (char)('0' + (i % 5));
+        buf[2] = '\0';
+        sv = ray_str_vec_append(sv, buf, 2);
+    }
+    ray_t* vv = ray_vec_new(RAY_I64, n); vv->len = n;
+    int64_t* vd = (int64_t*)ray_data(vv);
+    for (int64_t i = 0; i < n; i++) vd[i] = i;
+
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, sv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(sv); ray_release(vv);
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* tbl_op = ray_const_table(g, tbl);
+    ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                      RAY_WIN_COUNT, "v", 0);
+    ray_t* result = ray_execute(g, w);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    ray_t* rc = win_result_col(result, 2);
+    int64_t* rd = (int64_t*)ray_data(rc);
+    /* Each k0..k4 has exactly 300 rows */
+    for (int64_t i = 0; i < n; i++) TEST_ASSERT_EQ_I(rd[i], 300);
+
+    ray_release(result); ray_graph_free(g); ray_release(tbl);
+    ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── I32 value column for SUM/MIN/MAX ────────────────────────────── */
+
+static test_result_t test_window_i32_value(void) {
+    ray_heap_init(); (void)ray_sym_init();
+
+    int64_t n = 4;
+    int64_t gd[] = {1, 1, 2, 2};
+    int32_t vd[] = {10, 20, 30, 40};
+    ray_t* gv = ray_vec_from_raw(RAY_I64, gd, n);
+    ray_t* vv = ray_vec_from_raw(RAY_I32, vd, n);
+    int64_t ng = ray_sym_intern("g", 1);
+    int64_t nv = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ng, gv);
+    tbl = ray_table_add_col(tbl, nv, vv);
+    ray_release(gv); ray_release(vv);
+
+    /* I32 input with SUM → result is I64 (out_f64 = false) */
+    {
+        ray_graph_t* g = ray_graph_new(tbl);
+        ray_op_t* tbl_op = ray_const_table(g, tbl);
+        ray_op_t* w = build_whole_window(g, tbl_op, "g", "v",
+                                          RAY_WIN_SUM, "v", 0);
+        ray_t* result = ray_execute(g, w);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+        ray_t* rc = win_result_col(result, 2);
+        TEST_ASSERT_EQ_I(rc->type, RAY_I64);
+        int64_t* rd = (int64_t*)ray_data(rc);
+        TEST_ASSERT_EQ_I(rd[0], 30);
+        TEST_ASSERT_EQ_I(rd[2], 70);
+        ray_release(result); ray_graph_free(g);
+    }
+
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    PASS();
+}
+
+/* ─── Suite registration ──────────────────────────────────────────── */
+
+const test_entry_t window_entries[] = {
+    { "window/row_number_partitioned", test_window_row_number_partitioned, NULL, NULL },
+    { "window/rank_dense_rank",        test_window_rank_dense_rank,        NULL, NULL },
+    { "window/ntile",                  test_window_ntile,                  NULL, NULL },
+    { "window/count",                  test_window_count,                  NULL, NULL },
+    { "window/sum_i64",                test_window_sum_i64,                NULL, NULL },
+    { "window/sum_f64",                test_window_sum_f64,                NULL, NULL },
+    { "window/avg",                    test_window_avg,                    NULL, NULL },
+    { "window/min_max_i64",            test_window_min_max_i64,            NULL, NULL },
+    { "window/min_max_f64",            test_window_min_max_f64,            NULL, NULL },
+    { "window/lag_lead_i64",           test_window_lag_lead_i64,           NULL, NULL },
+    { "window/lag_lead_f64",           test_window_lag_lead_f64,           NULL, NULL },
+    { "window/first_last_nth",         test_window_first_last_nth,         NULL, NULL },
+    { "window/first_last_nth_f64",     test_window_first_last_nth_f64,     NULL, NULL },
+    { "window/nulls",                  test_window_nulls,                  NULL, NULL },
+    { "window/running_min_leading_null", test_window_running_min_leading_null, NULL, NULL },
+    { "window/lag_null_source",        test_window_lag_null_source,        NULL, NULL },
+    { "window/first_last_nth_null",    test_window_first_last_nth_null,    NULL, NULL },
+    { "window/empty",                  test_window_empty,                  NULL, NULL },
+    { "window/no_partition",           test_window_no_partition,           NULL, NULL },
+    { "window/sym_partition",          test_window_sym_partition,          NULL, NULL },
+    { "window/multikey_partition",     test_window_multikey_partition,     NULL, NULL },
+    { "window/multiple_funcs",         test_window_multiple_funcs,         NULL, NULL },
+    { "window/radix_path",             test_window_radix_path,             NULL, NULL },
+    { "window/parallel_path",          test_window_parallel_path,          NULL, NULL },
+    { "window/order_desc",             test_window_order_desc,             NULL, NULL },
+    { "window/date_partition",         test_window_date_partition,         NULL, NULL },
+    { "window/f64_partition",          test_window_f64_partition,          NULL, NULL },
+    { "window/bool_partition",         test_window_bool_partition,         NULL, NULL },
+    { "window/no_funcs",               test_window_no_funcs,               NULL, NULL },
+    { "window/i32_value",              test_window_i32_value,              NULL, NULL },
+    { "window/str_partition",          test_window_str_partition,          NULL, NULL },
+    { "window/str_parallel_merge",     test_window_str_parallel_merge,     NULL, NULL },
+    { NULL, NULL, NULL, NULL },
+};


### PR DESCRIPTION
## Summary
- **Coverage push** for opt.c, exec.c, graph.c, graph_builtin.c, mem/heap, datalog, sort, query: ~3.1k lines of C unit tests + rfl scripts targeting useful-work paths previously dead from rfl alone.
- **Two oncovered bugs fixed during the push:**
  1. `ray_take_fn` did not propagate `str_pool` after memcpy — STR-column take produced a vec missing its string heap (commit 44b08efd).
  2. `(and vec-pred const)` errored \"length\" instead of folding scalar identity — `simplify_and_or_const` now applies bool identities pre-FILTER (commit 62af231e).
  3. `ray_const_atom` left `out_type` negative; the I32/DATE/TIME arm of `fold_binary_const` was dead for any DATE/TIME/I32 atom literal from rfl (commit 5555c702).
- **`feat(graph)`** included: 18 graph algorithms exposed via `.graph.*` builtin family (commit 67a9c751) — needed to drive graph_builtin coverage from rfl.

## Coverage delta
| File | Before | After |
|------|--------|-------|
| src/ops/opt.c | 67% | **83.18%** |
| src/ops/exec.c | 65% | **83.28%** |
| src/ops/graph.c | — | **88.42%** |
| src/ops/graph_builtin.c | — | **84.47%** |
| TOTAL line cov | ~71% | **73.47%** |

## Test plan
- [x] `make test` — 1027 of 1028 passed (1 skipped, 0 failed)
- [x] `make coverage` — clean run, all profiles merged, HTML report regenerated
- [x] ASan/UBSan clean (default DEBUG build)
- [ ] Reviewer spot-check on bug-fix commits (44b08efd, 62af231e, 5555c702) for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)