### PR TITLE
feat(repl): remote REPL + server-only auto-detect + serde null fix

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -21,6 +21,7 @@
  *   SOFTWARE.
  */
 
+#define _POSIX_C_SOURCE 200809L
 #include "core/poll.h"
 #include "core/ipc.h"
 #include "core/pool.h"
@@ -33,6 +34,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <signal.h>
+#include <unistd.h>
 
 int main(int argc, char** argv) {
     ray_runtime_t* rt = ray_runtime_create(argc, argv);
@@ -54,7 +57,6 @@ int main(int argc, char** argv) {
      *   -p PORT          IPC listen port
      *   -c N             worker-pool size (0 = auto: ncpu - 1)
      *   -t N             enable timeit at startup (N != 0 turns on)
-     *   -r N             repl mode (1 = enabled, 0 = disabled)
      *   -i               interactive
      * Plus rayforce-specific:
      *   -u PW / -U PW    auth password (plain / restricted)
@@ -106,7 +108,17 @@ int main(int argc, char** argv) {
                 "  -U PW               set restricted auth password\n"
                 "  -l BASE             enable journal logging (BASE.log + BASE.qdb)\n"
                 "  -L BASE             enable journal logging with fsync per write\n"
-                "  -h, --help          show this message\n",
+                "  -h, --help          show this message\n"
+                "\nFor a remote REPL, start rayforce locally and call\n"
+                "(.repl.connect \"host:port\") inside the REPL.\n"
+                "\nRunning as a service:\n"
+                "  When stdin and stdout are both not a terminal (systemd\n"
+                "  Type=simple, Docker, nohup &, etc.), rayforce skips the\n"
+                "  REPL and runs only the IPC poll loop.  Redirect stdout\n"
+                "  and stderr to a file/journal — anything (println ...)\n"
+                "  prints from the server side goes there.  Example:\n"
+                "    nohup rayforce -p 5000 > rayforce.log 2>&1 &\n"
+                "    systemd:  StandardOutput=journal StandardError=journal\n",
                 argv[0]);
             ray_runtime_destroy(rt);
             return 0;
@@ -175,14 +187,52 @@ int main(int argc, char** argv) {
         if (!interactive && !(port > 0)) goto done;
     }
 
-    /* REPL or pure server mode */
-    {
+    /* REPL or pure server mode.
+     *
+     * Auto-detect server-only when launched as a daemon-style service:
+     * `-p` set, no script, no `-i`, and neither stdin nor stdout is a
+     * terminal.  In that case we skip ray_repl_create entirely and just
+     * drive the poll loop — which is the right shape for `nohup ... &`,
+     * systemd `Type=simple`, Docker without `-it`, etc.
+     *
+     * Without this guard the local REPL would enter run_piped() and
+     * block on fgets, starving the same poll loop the IPC listener is
+     * registered on — so connections get accepted by the kernel but
+     * never user-space handled.  Auto-detect fixes the deploy hole;
+     * `-i` overrides for the rare case of "I want REPL even with stdin
+     * piped". */
+    bool stdin_tty  = isatty(STDIN_FILENO);
+    bool stdout_tty = isatty(STDOUT_FILENO);
+    bool server_only = poll && port > 0 && !file && !interactive
+                       && !stdin_tty && !stdout_tty;
+
+    if (server_only) {
+        /* In service deployments stdout/stderr are typically pointed
+         * at a journal pipe or log file by the supervisor (systemd,
+         * docker, nohup).  Anything (println …) prints from the
+         * server side ends up there — see --help "Running as a
+         * service" for guidance.  We deliberately don't auto-create
+         * a log file: that would conflict with whatever the admin
+         * already configured. */
+        /* Suppress SIGPIPE so a write to a stdout/stderr pipe whose
+         * peer has gone away (journald restart, log rotator, etc.)
+         * doesn't kill the daemon.  Writes still fail with EPIPE,
+         * libc sets ferror(stdout), and the bytes are simply lost —
+         * which is the right behaviour for a service whose log sink
+         * is recoverable.  Only set in server-only mode; an
+         * interactive REPL with a broken pipe is genuinely fatal. */
+#ifndef RAY_OS_WINDOWS
+        signal(SIGPIPE, SIG_IGN);
+#endif
+        fprintf(stderr, "no terminal — running in server-only mode\n");
+        ray_poll_run(poll);
+    } else {
         ray_repl_t* repl = ray_repl_create(poll);
         if (repl) {
             ray_repl_run(repl);
             ray_repl_destroy(repl);
         } else if (poll && port > 0) {
-            /* No REPL possible — run pure server loop */
+            /* REPL create failed (OOM etc.) — fall back to pure poll. */
             ray_poll_run(poll);
         }
     }

--- a/src/app/repl.c
+++ b/src/app/repl.c
@@ -30,10 +30,12 @@
 #include "lang/format.h"
 #include "app/repl.h"
 #include "app/term.h"
+#include "core/ipc.h"
 #include "core/poll.h"
 #include "core/pool.h"
 #include "lang/env.h"
 #include "lang/eval.h"
+#include "lang/internal.h"
 #include "lang/nfo.h"
 #include "lang/parse.h"
 #include "lang/syscmd.h"
@@ -534,8 +536,156 @@ void ray_repl_destroy(ray_repl_t* repl) {
     ray_free(repl->_block);
 }
 
+/* ===== Remote-REPL session ==========================================
+ *
+ * (.repl.connect "host:port") routes subsequent local REPL inputs to a
+ * remote rayforce via ray_ipc_send_verbose() instead of ray_eval_str.
+ * This is a thin per-line redirect on top of the existing .ipc.* family
+ * — no new wire path, no separate event loop.  Single session at a
+ * time (matches kdb+'s remote-mode UX); reconnect to a different
+ * address closes the previous handle automatically.
+ *
+ * State lives in this file so eval_and_print can check it without
+ * pulling in another header or a new compile unit. */
+
+/* Pretty-print a ray_t to a stdio stream — defined in ops/builtins.c
+ * (used by `(println val)`).  Not in a public header. */
+extern void ray_lang_print(FILE* fp, ray_t* val);
+
+static int64_t      g_remote_handle    = -1;
+static char         g_remote_addr[128] = {0};
+/* The currently-running interactive REPL's terminal, set by
+ * ray_repl_run before entering the line loop.  Used by .repl.connect /
+ * .repl.disconnect to update the prompt prefix without pushing a
+ * pointer through the eval pipeline.  NULL in piped / file mode —
+ * connect still works (state is updated; eval_and_print_remote uses
+ * it), the prompt simply has no prefix to render. */
+static ray_term_t*  g_active_term      = NULL;
+
+bool ray_repl_remote_active(void) { return g_remote_handle >= 0; }
+int64_t ray_repl_remote_handle(void) { return g_remote_handle; }
+const char* ray_repl_remote_addr(void) {
+    return g_remote_handle >= 0 ? g_remote_addr : NULL;
+}
+
+ray_t* ray_repl_connect_fn(ray_t* host_port_str) {
+    if (!host_port_str || !ray_is_atom(host_port_str) ||
+        host_port_str->type != -RAY_STR)
+        return ray_error("type", "expected host:port string");
+
+    /* .ipc.open already handles the host:port[:user:password] split
+     * and the connect-error-to-rayfall-error mapping; reusing it
+     * keeps .repl.connect a one-line wrapper instead of a parallel
+     * implementation that drifts. */
+    ray_t* opened = ray_hopen_fn(host_port_str);
+    if (!opened || RAY_IS_ERR(opened)) return opened;
+    if (!ray_is_atom(opened) ||
+        (opened->type != -RAY_I64 && opened->type != -RAY_I32)) {
+        ray_release(opened);
+        return ray_error("io", "ipc.open returned non-handle");
+    }
+
+    int64_t h = (opened->type == -RAY_I64) ? opened->i64 : opened->i32;
+
+    /* Drop any prior session before swapping the handle — leaving the
+     * old socket open would leak the server-side connection slot. */
+    if (g_remote_handle >= 0 && g_remote_handle != h)
+        ray_ipc_close(g_remote_handle);
+    g_remote_handle = h;
+
+    size_t n = ray_str_len(host_port_str);
+    if (n >= sizeof(g_remote_addr)) n = sizeof(g_remote_addr) - 1;
+    memcpy(g_remote_addr, ray_str_ptr(host_port_str), n);
+    g_remote_addr[n] = '\0';
+
+    if (g_active_term) ray_term_set_prompt_prefix(g_active_term, g_remote_addr);
+    return opened;
+}
+
+ray_t* ray_repl_disconnect_fn(ray_t** args, int64_t n) {
+    (void)args; (void)n;
+    if (g_remote_handle < 0) return RAY_NULL_OBJ;
+    ray_ipc_close(g_remote_handle);
+    g_remote_handle    = -1;
+    g_remote_addr[0]   = '\0';
+    if (g_active_term) ray_term_set_prompt_prefix(g_active_term, NULL);
+    return RAY_NULL_OBJ;
+}
+
+/* eval_and_print's remote branch: send the raw input string to the
+ * connected server with RAY_IPC_FLAG_VERBOSE set so server-side
+ * stdout/stderr written during eval are captured and returned to us
+ * inside the response list.  Print captured output first, then the
+ * evaluated result (if any). */
+static void eval_and_print_remote(const char* input) {
+    ray_t* msg = ray_str(input, strlen(input));
+    if (!msg) {
+        fprintf(stderr, "error: oom building message\n");
+        return;
+    }
+
+    ray_t* resp = ray_ipc_send_verbose(g_remote_handle, msg);
+    ray_release(msg);
+
+    if (!resp) {
+        fprintf(stderr, "error: no response\n");
+        return;
+    }
+    if (RAY_IS_ERR(resp)) {
+        const char* what = (const char*)resp->sdata;
+        fprintf(stderr, "error: %s\n", what && *what ? what : "ipc");
+        /* Do NOT auto-disconnect on error — most rayfall errors (type,
+         * domain, parse, etc.) are recoverable at the REPL level.  The
+         * user can call (.repl.disconnect) explicitly if they prefer. */
+        return;
+    }
+
+    /* eval_payload's VERBOSE path produces [captured_str, result].
+     * If the server fell back to the no-capture path (tmpfile/dup
+     * failure on its side) it still wraps as a list with empty
+     * captured_str — clients can rely on the shape. */
+    ray_t* result = resp;
+    if (resp->type == RAY_LIST && resp->len >= 2) {
+        ray_t** items = (ray_t**)ray_data(resp);
+        ray_t*  cap   = items[0];
+        if (cap && cap->type == -RAY_STR) {
+            size_t cl = ray_str_len(cap);
+            if (cl > 0) fwrite(ray_str_ptr(cap), 1, cl, stdout);
+        }
+        result = items[1];
+    }
+    if (result && result != RAY_NULL_OBJ && !RAY_IS_ERR(result)) {
+        ray_lang_print(stdout, result);
+        fputc('\n', stdout);
+    } else if (result && RAY_IS_ERR(result)) {
+        fprintf(stderr, "error: %s\n", (const char*)result->sdata);
+    }
+    fflush(stdout);
+    ray_release(resp);
+}
+
 static void eval_and_print(ray_term_t* term, const char* input,
                            bool use_color, bool timeit) {
+    /* Remote-REPL redirect: when a session is active every input goes
+     * to the connected server.  Profiling/timing in remote mode is the
+     * server's responsibility (server-side -t setting), so we skip the
+     * local profiler scaffolding entirely and never touch ray_eval.
+     *
+     * Exception: `.repl.*` calls always evaluate locally — they manage
+     * the client-side session state, so forwarding them to the server
+     * would be a no-op (server's own session state is irrelevant) and
+     * would prevent the user from ever calling .repl.disconnect from
+     * inside a remote session. */
+    if (g_remote_handle >= 0) {
+        const char* p = input;
+        while (*p == ' ' || *p == '\t') p++;
+        bool is_repl_ctl = (strncmp(p, "(.repl.", 7) == 0);
+        if (!is_repl_ctl) {
+            eval_and_print_remote(input);
+            return;
+        }
+    }
+
     bool profiling = timeit && g_ray_profile.active;
 
     if (profiling) {
@@ -684,13 +834,37 @@ static ray_t* repl_read(ray_poll_t* poll, ray_selector_t* sel)
             fflush(stdout);
             return NULL;
         }
-        /* EOF */
+        /* EOF (Ctrl-D).  Inside a remote session, treat as
+         * "disconnect from remote, return to local prompt" rather
+         * than killing the whole REPL — matches ssh / mosh UX where
+         * the first Ctrl-D logs out of the remote and the second
+         * exits the local shell. */
+        if (ray_repl_remote_active()) {
+            ray_t* args = NULL;
+            ray_release(ray_repl_disconnect_fn(&args, 0));
+            term->buf_len = 0;
+            term->buf_pos = 0;
+            term->multiline_len = 0;
+            ray_term_prompt(term);
+            fflush(stdout);
+            return NULL;
+        }
         ray_poll_exit(poll, 0);
         return NULL;
     }
 
     ray_t* line = ray_term_feed(term);
     if (line == RAY_TERM_EOF) {
+        if (ray_repl_remote_active()) {
+            ray_t* args = NULL;
+            ray_release(ray_repl_disconnect_fn(&args, 0));
+            term->buf_len = 0;
+            term->buf_pos = 0;
+            term->multiline_len = 0;
+            ray_term_prompt(term);
+            fflush(stdout);
+            return NULL;
+        }
         ray_poll_exit(poll, 0);
         return NULL;
     }
@@ -973,11 +1147,15 @@ static void run_piped(ray_repl_t* repl) {
 }
 
 void ray_repl_run(ray_repl_t* repl) {
+    /* Publish the active term so .repl.connect / .repl.disconnect can
+     * adjust the prompt prefix without threading it through eval. */
+    g_active_term = repl->term;
     if (repl->term) {
         run_interactive(repl);
     } else {
         run_piped(repl);
     }
+    g_active_term = NULL;
 }
 
 int ray_repl_run_file(const char* path) {

--- a/src/app/repl.h
+++ b/src/app/repl.h
@@ -49,4 +49,17 @@ void       ray_repl_run(ray_repl_t* repl);
  * (errors are printed but do not terminate the loop). */
 int        ray_repl_run_file(const char* path);
 
+/* Remote-REPL session.  When active, ray_repl_run's eval pipeline
+ * sends each input string through ray_ipc_send_verbose() to the
+ * connected server instead of evaluating locally; the captured
+ * server-side stdout + result are printed on the local terminal.
+ * Toggled by the .repl.connect / .repl.disconnect builtins, which
+ * are wrappers over .ipc.open / .ipc.close — no new wire path. */
+bool        ray_repl_remote_active(void);
+int64_t     ray_repl_remote_handle(void);
+const char* ray_repl_remote_addr(void);
+
+ray_t* ray_repl_connect_fn(ray_t* host_port_str);
+ray_t* ray_repl_disconnect_fn(ray_t** args, int64_t n);
+
 #endif /* RAY_IO_REPL_H */

--- a/src/app/term.c
+++ b/src/app/term.c
@@ -1142,13 +1142,45 @@ int32_t ray_term_count_unmatched(ray_term_t* term) {
 #define CONT_PROMPT_VIS  2  /* visual: … + space */
 
 void ray_term_prompt(ray_term_t* term) {
+    if (term->prompt_prefix_len > 0)
+        term_write(term->prompt_prefix, (size_t)term->prompt_prefix_len);
     term_write(PROMPT_STR, PROMPT_LEN);
-    term->prompt_len = PROMPT_VIS;
+    term->prompt_len = term->prompt_prefix_vis + PROMPT_VIS;
 }
 
 void ray_term_continuation_prompt(ray_term_t* term) {
+    /* Continuation prompt mirrors the prefix so multi-line input
+     * stays visually aligned with the active session indicator. */
+    if (term->prompt_prefix_len > 0)
+        term_write(term->prompt_prefix, (size_t)term->prompt_prefix_len);
     term_write(CONT_PROMPT_STR, CONT_PROMPT_LEN);
-    term->prompt_len = CONT_PROMPT_VIS;
+    term->prompt_len = term->prompt_prefix_vis + CONT_PROMPT_VIS;
+}
+
+void ray_term_set_prompt_prefix(ray_term_t* term, const char* prefix) {
+    if (!term) return;
+    if (!prefix || !*prefix) {
+        term->prompt_prefix_len = 0;
+        term->prompt_prefix_vis = 0;
+        term->prompt_prefix[0]  = '\0';
+        return;
+    }
+    /* Wrap the user-visible bytes in a soft yellow ANSI tint so the
+     * remote prefix is visually distinct from local input.  The visual
+     * width is whatever ray_term_visual_width sees in the *plain*
+     * bytes — the ANSI escapes themselves don't take columns. */
+    int n = snprintf(term->prompt_prefix, sizeof(term->prompt_prefix),
+                     "\033[33m%s\033[0m ", prefix);
+    if (n < 0 || n >= (int)sizeof(term->prompt_prefix)) {
+        /* Fallback: prefix too long for the buffer — clear instead of
+         * truncating mid-escape, which would leak ANSI state on screen. */
+        term->prompt_prefix_len = 0;
+        term->prompt_prefix_vis = 0;
+        term->prompt_prefix[0]  = '\0';
+        return;
+    }
+    term->prompt_prefix_len = n;
+    term->prompt_prefix_vis = ray_term_visual_width(prefix, strlen(prefix)) + 1;
 }
 
 /* ===== Redraw ===== */
@@ -1179,12 +1211,25 @@ void ray_term_redraw(ray_term_t* term) {
         /* Each char can expand to ~15 bytes with ANSI escapes */
         char hlbuf[TERM_BUF_SIZE * 8];
         int32_t hlen = 0;
+        /* Prepend the prompt prefix (e.g. "host:port" in remote-REPL
+         * mode) so it stays visible across keystroke redraws.
+         * Without this, only ray_term_prompt's first render shows the
+         * prefix and the next keystroke wipes it, leaving the user
+         * unsure whether they're typing into the local or remote
+         * REPL.  The visual-width add-on for prompt_len is already
+         * computed by ray_term_prompt; we just have to keep the
+         * bytes flowing through every redraw. */
+        if (term->prompt_prefix_len > 0 &&
+            (int32_t)sizeof(hlbuf) > term->prompt_prefix_len) {
+            memcpy(hlbuf, term->prompt_prefix, (size_t)term->prompt_prefix_len);
+            hlen = term->prompt_prefix_len;
+        }
         if (term->multiline_len > 0) {
-            memcpy(hlbuf, CONT_PROMPT_STR, CONT_PROMPT_LEN);
-            hlen = CONT_PROMPT_LEN;
+            memcpy(hlbuf + hlen, CONT_PROMPT_STR, CONT_PROMPT_LEN);
+            hlen += CONT_PROMPT_LEN;
         } else {
-            memcpy(hlbuf, PROMPT_STR, PROMPT_LEN);
-            hlen = PROMPT_LEN;
+            memcpy(hlbuf + hlen, PROMPT_STR, PROMPT_LEN);
+            hlen += PROMPT_LEN;
         }
         if (term->buf_len > 0) {
             /* Find bracket match at cursor */
@@ -1588,12 +1633,23 @@ static ray_t* feed_normal(ray_term_t* term, int key) {
             printf("\r\033[J");
             char hlbuf[TERM_BUF_SIZE * 8];
             int32_t hlen = 0;
+            /* Mirror the redraw path: prepend the remote-REPL prefix
+             * so the line that's echoed on Enter (the final un-
+             * highlighted render before submitting to eval) keeps
+             * the host:port indicator instead of dropping back to
+             * the bare local prompt. */
+            if (term->prompt_prefix_len > 0 &&
+                (int32_t)sizeof(hlbuf) > term->prompt_prefix_len) {
+                memcpy(hlbuf, term->prompt_prefix,
+                       (size_t)term->prompt_prefix_len);
+                hlen = term->prompt_prefix_len;
+            }
             if (term->multiline_len > 0) {
-                memcpy(hlbuf, CONT_PROMPT_STR, CONT_PROMPT_LEN);
-                hlen = CONT_PROMPT_LEN;
+                memcpy(hlbuf + hlen, CONT_PROMPT_STR, CONT_PROMPT_LEN);
+                hlen += CONT_PROMPT_LEN;
             } else {
-                memcpy(hlbuf, PROMPT_STR, PROMPT_LEN);
-                hlen = PROMPT_LEN;
+                memcpy(hlbuf + hlen, PROMPT_STR, PROMPT_LEN);
+                hlen += PROMPT_LEN;
             }
             if (term->buf_len > 0)
                 hlen += term_highlight_into(hlbuf + hlen,

--- a/src/app/term.h
+++ b/src/app/term.h
@@ -89,6 +89,14 @@ typedef struct ray_term {
     int32_t  term_width;
     int32_t  term_height;
     int32_t  prompt_len;
+    /* Optional prefix shown before the standard `‣` prompt (e.g. the
+     * remote host:port when in remote-REPL mode).  Empty by default.
+     * Set via ray_term_set_prompt_prefix(); both the byte string and
+     * its rendered visual width must be in sync — visual is what the
+     * line editor uses for cursor math. */
+    char     prompt_prefix[80];
+    int32_t  prompt_prefix_len;
+    int32_t  prompt_prefix_vis;
     int32_t  last_total_rows;
     int32_t  last_cursor_row;
     ray_hist_t hist;
@@ -141,6 +149,13 @@ void    ray_term_goto_position(ray_term_t* term, int32_t from_pos, int32_t to_po
 ray_t*  ray_term_read(ray_term_t* term);
 void   ray_term_redraw(ray_term_t* term);
 void   ray_term_prompt(ray_term_t* term);
+
+/* Set (or clear, when prefix == NULL or empty) the prompt prefix.
+ * Used by the remote-REPL session to put the server address ahead
+ * of `‣` so the user can never mistake it for a local prompt.  The
+ * prefix bytes are copied into the term struct; caller may free
+ * after the call. */
+void   ray_term_set_prompt_prefix(ray_term_t* term, const char* prefix);
 
 /* Event-driven terminal API — split ray_term_read into begin + feed.
  * ray_term_begin: show prompt, reset line state.

--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -234,8 +234,12 @@ static void send_response(ray_sock_t fd, ray_t* result)
     if (payload) ray_sys_free(payload);
 }
 
-static ray_t* eval_payload(uint8_t* payload, size_t payload_len,
-                           ray_ipc_header_t* hdr)
+/* Run the actual decompress + de-serialize + ray_eval pipeline on a
+ * single inbound payload.  The wrapper eval_payload() below decides
+ * whether to capture stdout/stderr (RAY_IPC_FLAG_VERBOSE) and whether
+ * to wrap the result in a [captured_str, result] list. */
+static ray_t* eval_payload_core(uint8_t* payload, size_t payload_len,
+                                ray_ipc_header_t* hdr)
 {
     /* Journal hook: log every inbound SYNC message (state-mutation
      * channel in q's model) before evaluation, so a crash mid-handler
@@ -313,6 +317,88 @@ static ray_t* eval_payload(uint8_t* payload, size_t payload_len,
         }
     }
     return result ? result : RAY_NULL_OBJ;
+}
+
+/* eval_payload — outer wrapper.  When the client sets
+ * RAY_IPC_FLAG_VERBOSE on the request header, redirect stdout / stderr
+ * to a tmpfile for the duration of the eval, then return a 2-element
+ * RAY_LIST [captured_str, result] so the client can print the
+ * captured output on its own terminal.  Without the flag the bare
+ * result is returned (current behaviour, unchanged for existing
+ * clients).
+ *
+ * On any failure of the capture setup (tmpfile, dup, dup2) we fall
+ * back to the no-capture path: better to keep the eval running than
+ * to fail the whole request because /tmp is full.  The captured
+ * string is then empty, and the response shape is still the 2-elem
+ * list — clients can rely on that invariant. */
+static ray_t* eval_payload(uint8_t* payload, size_t payload_len,
+                           ray_ipc_header_t* hdr)
+{
+    if (!(hdr->flags & RAY_IPC_FLAG_VERBOSE))
+        return eval_payload_core(payload, payload_len, hdr);
+
+    FILE* cap = tmpfile();
+    int saved_out = -1, saved_err = -1;
+    bool capturing = false;
+
+    if (cap) {
+        fflush(stdout); fflush(stderr);
+        saved_out = dup(STDOUT_FILENO);
+        saved_err = dup(STDERR_FILENO);
+        if (saved_out >= 0 && saved_err >= 0) {
+            int capfd = fileno(cap);
+            if (dup2(capfd, STDOUT_FILENO) >= 0 &&
+                dup2(capfd, STDERR_FILENO) >= 0) {
+                capturing = true;
+            }
+        }
+    }
+
+    ray_t* result = eval_payload_core(payload, payload_len, hdr);
+
+    char* captured = NULL;
+    int   cap_len  = 0;
+    if (capturing) {
+        fflush(stdout); fflush(stderr);
+        dup2(saved_out, STDOUT_FILENO);
+        dup2(saved_err, STDERR_FILENO);
+        long pos = ftell(cap);
+        if (pos > 0) {
+            captured = (char*)ray_sys_alloc((size_t)pos + 1);
+            if (captured) {
+                fseek(cap, 0, SEEK_SET);
+                size_t got = fread(captured, 1, (size_t)pos, cap);
+                captured[got] = '\0';
+                cap_len = (int)got;
+            }
+        }
+    }
+    if (saved_out >= 0) close(saved_out);
+    if (saved_err >= 0) close(saved_err);
+    if (cap) fclose(cap);
+
+    /* Build [captured_str, result] list.  If the result is the
+     * "no result" sentinel (RAY_NULL_OBJ), keep it as-is; the
+     * client can distinguish via the second element's type. */
+    ray_t* cap_str = ray_str(captured ? captured : "", (size_t)cap_len);
+    if (captured) ray_sys_free(captured);
+    if (!cap_str) {
+        /* Allocator pressure on a tiny string is unlikely but possible. */
+        return result;
+    }
+
+    ray_t* response = ray_list_new(2);
+    if (!response) {
+        ray_release(cap_str);
+        return result;
+    }
+    ray_list_append(response, cap_str);
+    ray_list_append(response, result);
+    /* ray_list_append takes its own ref; release ours. */
+    ray_release(cap_str);
+    if (result != RAY_NULL_OBJ) ray_release(result);
+    return response;
 }
 
 /* ======================================================================
@@ -893,7 +979,8 @@ static int64_t recv_full(ray_sock_t fd, void* buf, size_t len) {
     return (int64_t)total;
 }
 
-static int64_t client_send_msg(int64_t handle, ray_t* msg, uint8_t msgtype)
+static int64_t client_send_msg(int64_t handle, ray_t* msg, uint8_t msgtype,
+                               uint8_t extra_flags)
 {
     if (handle < 0 || handle >= RAY_IPC_MAX_CONNS) return -2;
     ray_sock_t fd = g_client_fds[handle];
@@ -938,7 +1025,7 @@ static int64_t client_send_msg(int64_t handle, ray_t* msg, uint8_t msgtype)
     ray_ipc_header_t hdr = {
         .prefix  = RAY_SERDE_PREFIX,
         .version = RAY_SERDE_WIRE_VERSION,
-        .flags   = flags,
+        .flags   = (uint8_t)(flags | extra_flags),
         .endian  = 0,
         .msgtype = msgtype,
         .size    = (int64_t)send_len,
@@ -1047,7 +1134,7 @@ void ray_ipc_close(int64_t handle)
 
 ray_t* ray_ipc_send(int64_t handle, ray_t* msg)
 {
-    { int64_t sr = client_send_msg(handle, msg, RAY_IPC_MSG_SYNC);
+    { int64_t sr = client_send_msg(handle, msg, RAY_IPC_MSG_SYNC, 0);
       if (sr == -2) return ray_error("io", "connection closed");
       if (sr < 0) return ray_error("io", "ipc send failed"); }
 
@@ -1111,7 +1198,77 @@ ray_t* ray_ipc_send(int64_t handle, ray_t* msg)
 
 ray_err_t ray_ipc_send_async(int64_t handle, ray_t* msg)
 {
-    if (client_send_msg(handle, msg, RAY_IPC_MSG_ASYNC) < 0)
+    if (client_send_msg(handle, msg, RAY_IPC_MSG_ASYNC, 0) < 0)
         return RAY_ERR_IO;
     return RAY_OK;
+}
+
+/* Verbose-eval client send: sets RAY_IPC_FLAG_VERBOSE on the
+ * outbound header so the server captures whatever the eval writes
+ * to stdout/stderr and returns a 2-element list [captured_str,
+ * result] instead of bare result.  Same wire path as ray_ipc_send
+ * otherwise — sync, blocking until response. */
+ray_t* ray_ipc_send_verbose(int64_t handle, ray_t* msg)
+{
+    { int64_t sr = client_send_msg(handle, msg, RAY_IPC_MSG_SYNC,
+                                   RAY_IPC_FLAG_VERBOSE);
+      if (sr == -2) return ray_error("io", "connection closed");
+      if (sr < 0) return ray_error("io", "ipc send failed"); }
+
+    ray_sock_t fd = g_client_fds[handle];
+
+    ray_ipc_header_t hdr;
+    if (recv_full(fd, &hdr, sizeof(hdr)) < 0) {
+        ray_ipc_close(handle);
+        return ray_error("io", "ipc recv header failed");
+    }
+    if (hdr.prefix != RAY_SERDE_PREFIX || hdr.size <= 0) {
+        ray_ipc_close(handle);
+        return ray_error("io", "ipc bad response header");
+    }
+    if (hdr.version != RAY_SERDE_WIRE_VERSION) {
+        ray_ipc_close(handle);
+        return ray_error("version", "ipc peer wire version mismatch");
+    }
+    if (hdr.size > 256 * 1024 * 1024) {
+        ray_ipc_close(handle);
+        return ray_error("io", "ipc response too large");
+    }
+
+    uint8_t* payload = (uint8_t*)ray_sys_alloc((size_t)hdr.size);
+    if (!payload) return ray_error("oom", NULL);
+    if (recv_full(fd, payload, (size_t)hdr.size) < 0) {
+        ray_sys_free(payload);
+        ray_ipc_close(handle);
+        return ray_error("io", "ipc recv payload failed");
+    }
+
+    uint8_t* deser_buf    = payload;
+    size_t   deser_len    = (size_t)hdr.size;
+    uint8_t* decompressed = NULL;
+
+    if (hdr.flags & RAY_IPC_FLAG_COMPRESSED) {
+        if (deser_len < 4) { ray_sys_free(payload); return ray_error("io", "ipc compressed payload too short"); }
+        uint32_t uncomp_size;
+        memcpy(&uncomp_size, payload, 4);
+        decompressed = (uint8_t*)ray_sys_alloc(uncomp_size);
+        if (!decompressed) { ray_sys_free(payload); return ray_error("oom", NULL); }
+        size_t dlen = ray_ipc_decompress(payload + 4, deser_len - 4,
+                                         decompressed, uncomp_size);
+        if (dlen != uncomp_size) {
+            ray_sys_free(decompressed);
+            ray_sys_free(payload);
+            return ray_error("io", "ipc decompress failed");
+        }
+        deser_buf = decompressed;
+        deser_len = uncomp_size;
+    }
+
+    int64_t de_len = (int64_t)deser_len;
+    ray_t*  result = ray_de_raw(deser_buf, &de_len);
+
+    if (decompressed) ray_sys_free(decompressed);
+    ray_sys_free(payload);
+
+    return result ? result : RAY_NULL_OBJ;
 }

--- a/src/core/ipc.h
+++ b/src/core/ipc.h
@@ -53,6 +53,14 @@ size_t ray_ipc_decompress(const uint8_t* src, size_t clen,
  * crash + restart silently elevates restricted commands to full
  * privilege. */
 #define RAY_IPC_FLAG_RESTRICTED 0x02
+/* Set by clients that want a "verbose" eval response: the server
+ * captures whatever the eval wrote to stdout/stderr and returns a
+ * 2-element list [captured_str, result] instead of bare result.
+ * Used by the remote-REPL client wrapper so a `(println x)` from
+ * the connected client produces output on the *client's* terminal,
+ * not on the server's.  Default sync messages still get the bare
+ * result, so existing IPC clients are unaffected. */
+#define RAY_IPC_FLAG_VERBOSE    0x04
 #define RAY_IPC_MAX_CONNS 256
 
 /* ===== Poll-based IPC (new API) ===== */
@@ -92,5 +100,13 @@ int64_t   ray_ipc_connect(const char* host, uint16_t port,
 void      ray_ipc_close(int64_t handle);
 ray_t*    ray_ipc_send(int64_t handle, ray_t* msg);
 ray_err_t ray_ipc_send_async(int64_t handle, ray_t* msg);
+
+/* Remote-REPL helper: send a SYNC message with RAY_IPC_FLAG_VERBOSE
+ * set, returning a 2-element list [captured_str, result] where
+ * captured_str is whatever the server's eval wrote to stdout/stderr
+ * (combined) while running this request.  Used by the `-h` client
+ * loop in main.c so output produced by the remote eval is shown on
+ * the local user's terminal, not lost on the server. */
+ray_t*    ray_ipc_send_verbose(int64_t handle, ray_t* msg);
 
 #endif /* RAY_IPC_H */

--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -23,6 +23,7 @@
 
 #include "lang/eval.h"
 #include "lang/internal.h"
+#include "app/repl.h"
 #include "lang/env.h"
 #include "lang/nfo.h"
 #include "lang/parse.h"
@@ -2283,6 +2284,13 @@ static void ray_register_builtins(void) {
     register_unary( ".ipc.open",  RAY_FN_RESTRICTED,  ray_hopen_fn);
     register_unary( ".ipc.close", RAY_FN_RESTRICTED,  ray_hclose_fn);
     register_binary(".ipc.send",  RAY_FN_RESTRICTED,  ray_hsend_fn);
+
+    /* Remote-REPL session control under `.repl.*`.  Once .repl.connect
+     * succeeds, the local REPL line-loop reroutes each subsequent input
+     * through ray_ipc_send_verbose() until .repl.disconnect.  See
+     * src/app/repl_remote.c for the state model. */
+    register_unary(".repl.connect",    RAY_FN_RESTRICTED, ray_repl_connect_fn);
+    register_vary( ".repl.disconnect", RAY_FN_RESTRICTED, ray_repl_disconnect_fn);
 
     /* Transaction-log journaling under `.log.*` — q/kdb's -l/-L feature.
      * The CLI flags -l <base> / -L <base> call ray_journal_open() at

--- a/src/store/serde.c
+++ b/src/store/serde.c
@@ -255,6 +255,16 @@ int64_t ray_ser_raw(uint8_t* buf, ray_t* obj) {
         buf[8] = 0;
         return 1 + 8;
     }
+    /* RAY_NULL_OBJ — ray_serde_size mirrors this with `return 1`.
+     * Without this branch, ser_raw fell through to the vec path,
+     * wrote `obj->type` (= 126 = RAY_SERDE_NULL on the wire) plus
+     * vector-shape garbage, corrupting any frame that contained a
+     * null result (e.g. a list response from a `(println ...)`
+     * eval whose second element is the bare null sentinel). */
+    if (RAY_IS_NULL(obj)) {
+        buf[0] = RAY_SERDE_NULL;
+        return 1;
+    }
 
     int8_t type = obj->type;
     buf[0] = (uint8_t)type;
@@ -702,12 +712,24 @@ ray_t* ray_de_raw(uint8_t* buf, int64_t* len) {
         int64_t saved = *len;
         for (int64_t i = 0; i < l; i++) {
             elems[i] = ray_de_raw(buf + (saved - *len), len);
-            if (!elems[i] || RAY_IS_ERR(elems[i])) {
+            /* A NULL element is the in-band representation of
+             * RAY_NULL_OBJ on the wire (ray_ser_raw writes SERDE_NULL
+             * for the null singleton; ray_de_raw returns C NULL for
+             * that marker).  Lists must round-trip them — e.g. an IPC
+             * VERBOSE response is `[captured_str, result]` where
+             * `result` is RAY_NULL_OBJ for any (println ...) /
+             * (set ...) eval.  Rejecting NULL here would error the
+             * whole frame as "domain".  Substitute the singleton so
+             * downstream code (ray_lang_print, etc.) sees a valid
+             * pointer instead of a raw NULL. */
+            if (!elems[i]) {
+                elems[i] = RAY_NULL_OBJ;
+            } else if (RAY_IS_ERR(elems[i])) {
                 /* Clean up already-deserialized elements */
                 for (int64_t j = 0; j < i; j++) ray_release(elems[j]);
                 list->len = 0;
                 ray_release(list);
-                return elems[i] ? elems[i] : ray_error("domain", NULL);
+                return elems[i];
             }
         }
         return list;


### PR DESCRIPTION
## Summary

A **remote REPL** — the local Rayforce REPL talking to a different Rayforce over IPC, with full output capture and ssh-style UX.  Plus the server-only auto-detect that closes the deploy hole for systemd / Docker / nohup, and two serde bug-fixes that surfaced once null results started flying over the wire.

### Workflow
\`\`\`
‣ (.repl.connect \"127.0.0.1:5110\")
0
127.0.0.1:5110 ‣ (+ 1 2)
3
127.0.0.1:5110 ‣ (println \"hello from remote\")
hello from remote                  ← printed locally, not on server
127.0.0.1:5110 ‣ (.repl.disconnect)
‣
\`\`\`

### What's in the box

- New \`RAY_IPC_FLAG_VERBOSE\` bit; \`eval_payload\` captures server-side stdout/stderr via \`dup2\` + tmpfile and returns \`[captured_str, result]\`.
- New \`.repl.connect\` / \`.repl.disconnect\` builtins (thin wrappers over \`.ipc.open\` / \`.ipc.close\`).
- Dynamic prompt prefix in \`term.c\` so users can never confuse remote with local.
- Ctrl-D in a remote session disconnects (ssh / mosh style); second Ctrl-D exits.
- \`-p\` + neither stdin nor stdout a tty → run pure \`ray_poll_run\`, skip REPL.  Without this systemd/Docker deploys silently exited because \`run_piped\` blocked on fgets and starved the IPC listener.
- \`SIGPIPE\` ignored in service mode so a broken log-pipe doesn't kill the daemon.
- \`--help\` gains a "Running as a service" section.

### Bug fixes

- \`ray_ser_raw\` had no branch for \`RAY_IS_NULL(obj)\` — fell through to vec path and wrote garbage past the type byte.
- \`ray_de_raw\` list path treated NULL elements (the wire form of \`RAY_NULL_OBJ\`) as a fatal "domain" error, breaking every list with a null inside.

Both are independent of the feature — they would have surfaced for anyone serialising \`RAY_NULL_OBJ\` over IPC, even before this PR.

## Docs

Companion doc PR on branch \`docs/remote-repl\` (against \`mkdocs\`): #174.  The two PRs are independent — either can land first.

## Test plan

- [x] \`make test\` — 1154 of 1155 passed (1 pre-existing skip, 0 failed)
- [x] ASan/UBSan clean
- [x] Smoke test: server in service mode (stdin /dev/null, stdout > log) accepting remote-REPL clients
- [ ] Reviewer interactive smoke: connect, type, see prefix persist across keystrokes
- [ ] Reviewer Ctrl-D semantics check (disconnect + second exits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)