### PR TITLE
test: pass-7 coverage — progress + term + repl (+70 tests, 2 fixes)

### DIFF
--- a/src/app/repl.c
+++ b/src/app/repl.c
@@ -1186,6 +1186,26 @@ int ray_repl_run_file(const char* path) {
 
     if (nread == 0) { ray_release(block); return 0; }
 
+    /* Skip files whose entire content is whitespace and `;` line
+     * comments — `parse_source` raises a `parse` error for empty
+     * input, which is the wrong UX when running `rayforce file.rfl`
+     * on a comments-only file (a script header with no body should
+     * be a successful no-op).  Cheap single-pass scan; mirrors the
+     * lexer's whitespace/comment rule. */
+    {
+        const char* p = buf;
+        const char* end = buf + nread;
+        bool any_expr = false;
+        while (p < end) {
+            char c = *p;
+            if (c == ' ' || c == '\t' || c == '\n' || c == '\r') { p++; continue; }
+            if (c == ';') { while (p < end && *p != '\n') p++; continue; }
+            any_expr = true;
+            break;
+        }
+        if (!any_expr) { ray_release(block); return 0; }
+    }
+
     /* File mode matches eval_and_print's structure so -t 1 / :t 1
      * produces the same span layout (parse / eval / materialize) as
      * REPL input, not one opaque "eval" tick.  Colors are keyed per

--- a/src/app/term.c
+++ b/src/app/term.c
@@ -205,12 +205,28 @@ void ray_term_get_size(ray_term_t* term) {
 
 int32_t ray_term_visual_width(const char* str, int32_t len) {
     int32_t width = 0;
+    /* 0=normal, 1=just saw ESC (next byte is the CSI/SS3 introducer:
+     *   '[' or 'O', or rarely a 1-byte sequence), 2=in CSI parameter
+     *   bytes; terminate on final byte in [0x40,0x7E].  Without the
+     *   intermediate state the introducer '[' (0x5B) would itself be
+     *   mistaken for a final byte and end the escape one char early —
+     *   the SGR digits/`;`/`m` then leak into width counting. */
     int32_t in_escape = 0;
 
     for (int32_t i = 0; i < len; i++) {
         if (str[i] == '\033') {
             in_escape = 1;
-        } else if (in_escape) {
+        } else if (in_escape == 1) {
+            /* Introducer byte after ESC.  Standard CSI uses '[',
+             * SS3 uses 'O'; both transition to body state.  Any
+             * other byte is treated as a 2-byte ESC sequence and
+             * we exit the escape state immediately. */
+            if (str[i] == '[' || str[i] == 'O') {
+                in_escape = 2;
+            } else {
+                in_escape = 0;
+            }
+        } else if (in_escape == 2) {
             if (str[i] >= 0x40 && str[i] <= 0x7E) {
                 in_escape = 0;
             }

--- a/test/main.c
+++ b/test/main.c
@@ -122,6 +122,8 @@ extern const test_entry_t partition_exec_entries[];
 extern const test_entry_t pipe_entries[];
 extern const test_entry_t platform_entries[];
 extern const test_entry_t pool_entries[];
+extern const test_entry_t progress_entries[];
+extern const test_entry_t repl_entries[];
 extern const test_entry_t rowsel_entries[];
 extern const test_entry_t runtime_entries[];
 extern const test_entry_t sel_entries[];
@@ -130,6 +132,7 @@ extern const test_entry_t str_entries[];
 extern const test_entry_t sym_entries[];
 extern const test_entry_t sys_entries[];
 extern const test_entry_t table_entries[];
+extern const test_entry_t term_entries[];
 extern const test_entry_t types_entries[];
 extern const test_entry_t vec_entries[];
 extern const test_entry_t window_entries[];
@@ -146,9 +149,11 @@ static const test_entry_t* const compiled_groups[] = {
     lftj_entries,     list_entries,     meta_entries,     morsel_entries,
     numparse_entries, opt_entries,      partition_exec_entries,
     pipe_entries,     platform_entries,
-    pool_entries,
-    rowsel_entries,   runtime_entries,  sel_entries,      store_entries,
+    pool_entries,     progress_entries,
+    repl_entries,     rowsel_entries,   runtime_entries,  sel_entries,
+    store_entries,
     str_entries,      sym_entries,      sys_entries,      table_entries,
+    term_entries,
     types_entries,    vec_entries,      window_entries,
     NULL,
 };

--- a/test/test_progress.c
+++ b/test/test_progress.c
@@ -1,0 +1,559 @@
+/*
+ *   Copyright (c) 2025-2026 Anton Kundenko <singaraiona@gmail.com>
+ *   All rights reserved.
+
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
+
+/*
+ * Tests for src/core/progress.c — pull-based, main-thread-only progress
+ * reporting. The module's I/O is entirely through a user callback, so the
+ * tests record snapshots into a fixed-size buffer (no dynamic allocation —
+ * conforms to the "no libc malloc in tests" rule) and assert on the buffer
+ * after driving the public API.
+ *
+ * Timing: min_ms / tick_ms thresholds are exercised with millisecond-scale
+ * sleeps. The module reads CLOCK_MONOTONIC_COARSE which on Linux runs at
+ * jiffy resolution (~1–4 ms typical), so all timing tests use generous
+ * margins (min_ms ≥ 30 ms, sleeps ≥ ~2× the threshold) to stay reliable
+ * under load.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "test.h"
+#include <rayforce.h>
+#include "mem/heap.h"
+
+#include <string.h>
+#include <time.h>
+
+/* ---- Snapshot recorder -------------------------------------------------- */
+
+#define RECORDER_CAP 32
+
+typedef struct {
+    char        op_name[64];
+    char        phase[64];
+    uint64_t    rows_done;
+    uint64_t    rows_total;
+    double      elapsed_sec;
+    int64_t     mem_used;
+    int64_t     mem_budget;
+    bool        final;
+} recorded_t;
+
+typedef struct {
+    int        n;
+    recorded_t snaps[RECORDER_CAP];
+    int        magic;
+} recorder_t;
+
+static const int RECORDER_MAGIC = 0x5253474e; /* "RSGN" */
+
+static void recorder_reset(recorder_t* r) {
+    r->n = 0;
+    r->magic = RECORDER_MAGIC;
+    memset(r->snaps, 0, sizeof r->snaps);
+}
+
+static void record_cb(const ray_progress_t* snap, void* user) {
+    recorder_t* r = (recorder_t*)user;
+    if (r->n >= RECORDER_CAP) return;
+    recorded_t* s = &r->snaps[r->n++];
+    /* Defensive copy: snap->op_name / phase point at caller-owned storage,
+     * so we copy the bytes here. snprintf-with-precision-zero on NULL is UB,
+     * so guard explicitly. */
+    if (snap->op_name) {
+        size_t n = strlen(snap->op_name);
+        if (n >= sizeof s->op_name) n = sizeof s->op_name - 1;
+        memcpy(s->op_name, snap->op_name, n);
+        s->op_name[n] = '\0';
+    }
+    if (snap->phase) {
+        size_t n = strlen(snap->phase);
+        if (n >= sizeof s->phase) n = sizeof s->phase - 1;
+        memcpy(s->phase, snap->phase, n);
+        s->phase[n] = '\0';
+    }
+    s->rows_done   = snap->rows_done;
+    s->rows_total  = snap->rows_total;
+    s->elapsed_sec = snap->elapsed_sec;
+    s->mem_used    = snap->mem_used;
+    s->mem_budget  = snap->mem_budget;
+    s->final       = snap->final;
+}
+
+/* Sentinel callback that records nothing — used to verify magic-protected
+ * cells are not stomped when callback is intentionally cleared. */
+static void noop_cb(const ray_progress_t* snap, void* user) {
+    (void)snap;
+    (void)user;
+}
+
+static void sleep_ms(unsigned ms) {
+    struct timespec ts;
+    ts.tv_sec  = ms / 1000;
+    ts.tv_nsec = (long)(ms % 1000) * 1000000L;
+    nanosleep(&ts, NULL);
+}
+
+/* ---- Setup / Teardown --------------------------------------------------- */
+
+/* progress.c calls ray_mem_stats() / ray_mem_budget() inside fire(); both
+ * require the heap to be initialised. Every test does begin/end on the heap
+ * so callbacks can fire safely. */
+static void progress_setup(void) {
+    ray_heap_init();
+    /* Always reset module state from any prior test by clearing the
+     * callback then issuing an end with no callback (which clears the
+     * start_ns flag). */
+    ray_progress_set_callback(NULL, NULL, 0, 0);
+    ray_progress_end();
+}
+
+static void progress_teardown(void) {
+    /* Disconnect callback before the recorder (a stack object) goes out of
+     * scope. Any subsequent stray fire() would otherwise deref dead memory. */
+    ray_progress_set_callback(NULL, NULL, 0, 0);
+    ray_progress_end();
+    ray_heap_destroy();
+}
+
+/* ---- Tests -------------------------------------------------------------- */
+
+/* NULL callback path: every public entry is a no-op — no crash, no fire,
+ * no state change observable from outside. Drives the early-return
+ * branches in update / label / end. */
+static test_result_t test_progress_null_callback(void) {
+    /* Default state — no callback registered (setup cleared it). */
+    ray_progress_update("scan", "init", 5, 100);
+    ray_progress_update(NULL, NULL, 10, 100);
+    ray_progress_label("group", "dedupe");
+    ray_progress_end();
+    /* If we got here without crashing, the early-return paths held. */
+    PASS();
+}
+
+/* Callback fires on ray_progress_end only after enough time elapsed.
+ * Drives the 'g_showing' branch in ray_progress_end and the final=true
+ * snapshot field. */
+static test_result_t test_progress_end_fires_final(void) {
+    recorder_t r;
+    recorder_reset(&r);
+    /* Tiny min_ms / tick so we don't spend seconds in tests. */
+    ray_progress_set_callback(record_cb, &r, 30, 10);
+
+    ray_progress_update("scan", "rows", 0, 1000);
+    /* No fire yet — still inside min_ms window. */
+    TEST_ASSERT_EQ_I(r.n, 0);
+
+    sleep_ms(60);
+    ray_progress_update("scan", "rows", 500, 1000);
+    /* First fire passes both gates. */
+    TEST_ASSERT_EQ_I(r.n, 1);
+    TEST_ASSERT_FALSE(r.snaps[0].final);
+    TEST_ASSERT_STR_EQ(r.snaps[0].op_name, "scan");
+    TEST_ASSERT_STR_EQ(r.snaps[0].phase, "rows");
+    TEST_ASSERT_EQ_U(r.snaps[0].rows_done, 500);
+    TEST_ASSERT_EQ_U(r.snaps[0].rows_total, 1000);
+
+    ray_progress_end();
+    /* Final fire — should set final=true and bring rows_done up to total. */
+    TEST_ASSERT_EQ_I(r.n, 2);
+    TEST_ASSERT_TRUE(r.snaps[1].final);
+    TEST_ASSERT_EQ_U(r.snaps[1].rows_done, 1000);
+    TEST_ASSERT_EQ_U(r.snaps[1].rows_total, 1000);
+
+    PASS();
+}
+
+/* Short query (under min_ms) fires zero callbacks, including no final tick.
+ * Drives the 'g_showing == false' path in ray_progress_end. */
+static test_result_t test_progress_short_query_no_fire(void) {
+    recorder_t r;
+    recorder_reset(&r);
+    /* Set min_ms high enough that we cannot exceed it during this test. */
+    ray_progress_set_callback(record_cb, &r, 5000, 50);
+
+    ray_progress_update("scan", "rows", 0, 100);
+    sleep_ms(20);
+    ray_progress_update("scan", "rows", 100, 100);
+    ray_progress_end();
+
+    TEST_ASSERT_EQ_I(r.n, 0);
+    PASS();
+}
+
+/* tick_ms cadence: rapid updates shouldn't all fire — only those at least
+ * tick_ms apart. Drives the 'since_last < g_tick_ms' guard in
+ * ray_progress_update. */
+static test_result_t test_progress_tick_throttle(void) {
+    recorder_t r;
+    recorder_reset(&r);
+    ray_progress_set_callback(record_cb, &r, 30, 50);
+
+    ray_progress_update("scan", "rows", 0, 1000);
+    /* Cross min_ms — first update past it fires once. */
+    sleep_ms(60);
+    ray_progress_update("scan", "rows", 100, 1000);
+    TEST_ASSERT_EQ_I(r.n, 1);
+
+    /* Three rapid updates well under tick_ms — none should fire. */
+    ray_progress_update("scan", "rows", 200, 1000);
+    ray_progress_update("scan", "rows", 300, 1000);
+    ray_progress_update("scan", "rows", 400, 1000);
+    TEST_ASSERT_EQ_I(r.n, 1);
+
+    /* After tick_ms passes, next update fires. */
+    sleep_ms(70);
+    ray_progress_update("scan", "rows", 800, 1000);
+    TEST_ASSERT_EQ_I(r.n, 2);
+    TEST_ASSERT_EQ_U(r.snaps[1].rows_done, 800);
+
+    /* Final tick. */
+    ray_progress_end();
+    TEST_ASSERT_EQ_I(r.n, 3);
+    TEST_ASSERT_TRUE(r.snaps[2].final);
+
+    PASS();
+}
+
+/* op_name / phase NULL-keep semantics in ray_progress_update: a NULL keeps
+ * the previously stored value, while ray_progress_label always overwrites
+ * phase. Together these cover the "if op_name" / "if phase" guards in
+ * update vs the unconditional store in label. */
+static test_result_t test_progress_null_keep_semantics(void) {
+    recorder_t r;
+    recorder_reset(&r);
+    ray_progress_set_callback(record_cb, &r, 30, 10);
+
+    ray_progress_update("scan", "rows", 0, 100);
+    sleep_ms(60);
+    ray_progress_update("scan", "rows", 50, 100);
+    TEST_ASSERT_EQ_I(r.n, 1);
+    TEST_ASSERT_STR_EQ(r.snaps[0].op_name, "scan");
+    TEST_ASSERT_STR_EQ(r.snaps[0].phase, "rows");
+
+    /* NULL op_name and NULL phase — should keep "scan"/"rows". */
+    sleep_ms(20);
+    ray_progress_update(NULL, NULL, 70, 100);
+    TEST_ASSERT_EQ_I(r.n, 2);
+    TEST_ASSERT_STR_EQ(r.snaps[1].op_name, "scan");
+    TEST_ASSERT_STR_EQ(r.snaps[1].phase, "rows");
+    TEST_ASSERT_EQ_U(r.snaps[1].rows_done, 70);
+
+    ray_progress_end();
+    PASS();
+}
+
+/* ray_progress_label drops the previous phase when called with NULL phase
+ * (unlike update which keeps it) AND resets counters. Also fires if the
+ * gates pass. */
+static test_result_t test_progress_label_resets(void) {
+    recorder_t r;
+    recorder_reset(&r);
+    ray_progress_set_callback(record_cb, &r, 30, 10);
+
+    ray_progress_update("scan", "rows", 50, 100);
+    sleep_ms(60);
+    ray_progress_update(NULL, NULL, 60, 100);
+    TEST_ASSERT_EQ_I(r.n, 1);
+
+    /* label → new op, NULL phase clears stale phase, counters reset. */
+    sleep_ms(20);
+    ray_progress_label("group", NULL);
+    TEST_ASSERT_EQ_I(r.n, 2);
+    TEST_ASSERT_STR_EQ(r.snaps[1].op_name, "group");
+    TEST_ASSERT_STR_EQ(r.snaps[1].phase, "");          /* fmt'd from NULL */
+    TEST_ASSERT_EQ_U(r.snaps[1].rows_done, 0);
+    TEST_ASSERT_EQ_U(r.snaps[1].rows_total, 0);
+
+    ray_progress_end();
+    PASS();
+}
+
+/* min_ms = 0 / tick_ms = 0 in set_callback should preserve module defaults
+ * (2000 / 100 ms). Confirm by setting NON-default values, then "resetting"
+ * with zeros and observing that the previously set non-defaults are kept. */
+static test_result_t test_progress_set_callback_zero_keeps_existing(void) {
+    recorder_t r;
+    recorder_reset(&r);
+    /* Set explicit small thresholds. */
+    ray_progress_set_callback(record_cb, &r, 30, 10);
+    /* Now "update" the callback registration with zeros — should keep
+     * the previously-set 30 / 10 values, not snap back to defaults. */
+    ray_progress_set_callback(record_cb, &r, 0, 0);
+
+    ray_progress_update("scan", NULL, 0, 100);
+    sleep_ms(60);
+    ray_progress_update(NULL, NULL, 50, 100);
+    /* If thresholds had snapped back to 2000ms, no fire would happen here. */
+    TEST_ASSERT_EQ_I(r.n, 1);
+
+    ray_progress_end();
+    PASS();
+}
+
+/* Snapshot field plumbing: elapsed_sec strictly increases across fires;
+ * mem_used and mem_budget are populated. */
+static test_result_t test_progress_snapshot_fields(void) {
+    recorder_t r;
+    recorder_reset(&r);
+    ray_progress_set_callback(record_cb, &r, 30, 10);
+
+    ray_progress_update("op", "ph", 1, 10);
+    sleep_ms(60);
+    ray_progress_update(NULL, NULL, 5, 10);
+    sleep_ms(20);
+    ray_progress_update(NULL, NULL, 8, 10);
+    ray_progress_end();
+
+    /* At least 2 fires (one mid, one final). */
+    TEST_ASSERT_TRUE(r.n >= 2);
+
+    /* elapsed_sec is non-decreasing and non-negative. */
+    for (int i = 0; i < r.n; i++) {
+        TEST_ASSERT_TRUE(r.snaps[i].elapsed_sec >= 0.0);
+    }
+    for (int i = 1; i < r.n; i++) {
+        TEST_ASSERT_TRUE(r.snaps[i].elapsed_sec >= r.snaps[i-1].elapsed_sec);
+    }
+
+    /* mem_budget should match the live API result. */
+    int64_t budget_now = ray_mem_budget();
+    for (int i = 0; i < r.n; i++) {
+        TEST_ASSERT_EQ_I(r.snaps[i].mem_budget, budget_now);
+    }
+
+    /* mem_used non-negative — heap is initialized so stats are available. */
+    for (int i = 0; i < r.n; i++) {
+        TEST_ASSERT_TRUE(r.snaps[i].mem_used >= 0);
+    }
+
+    /* Last fire is final. */
+    TEST_ASSERT_TRUE(r.snaps[r.n - 1].final);
+
+    PASS();
+}
+
+/* Back-to-back begin/end pairs: state is fully reset, including g_showing,
+ * so a second short query under min_ms again fires nothing. */
+static test_result_t test_progress_state_reset_between_queries(void) {
+    recorder_t r;
+    recorder_reset(&r);
+    ray_progress_set_callback(record_cb, &r, 30, 10);
+
+    /* First query — long enough to fire. */
+    ray_progress_update("op1", "p1", 0, 10);
+    sleep_ms(60);
+    ray_progress_update(NULL, NULL, 5, 10);
+    ray_progress_end();
+    int after_first = r.n;
+    TEST_ASSERT_TRUE(after_first >= 2);
+
+    /* Second query — short enough to NOT fire. If state hadn't reset,
+     * g_showing would still be true and end() would emit a final tick. */
+    ray_progress_set_callback(record_cb, &r, 5000, 50);
+    ray_progress_update("op2", "p2", 0, 10);
+    sleep_ms(20);
+    ray_progress_update(NULL, NULL, 5, 10);
+    ray_progress_end();
+    TEST_ASSERT_EQ_I(r.n, after_first);
+
+    PASS();
+}
+
+/* End without callback hits the early-return branch that only clears
+ * g_start_ns. After a no-callback end, registering a callback and running
+ * a normal query still works (clock lazy-restarts on the next update). */
+static test_result_t test_progress_end_without_callback(void) {
+    recorder_t r;
+    recorder_reset(&r);
+
+    /* No callback yet — set one then drive a partial query. */
+    ray_progress_set_callback(record_cb, &r, 30, 10);
+    ray_progress_update("scan", "rows", 0, 10);
+    /* Detach callback BEFORE end. ray_progress_end with no callback hits
+     * the !g_cb early-return that only zeros g_start_ns. */
+    ray_progress_set_callback(NULL, NULL, 30, 10);
+    ray_progress_end();
+
+    /* Now register a fresh callback and drive a complete query. The lazy
+     * clock-start branch in update should kick in, since g_start_ns is 0. */
+    recorder_reset(&r);
+    ray_progress_set_callback(record_cb, &r, 30, 10);
+    ray_progress_update("op2", "p2", 0, 100);
+    sleep_ms(60);
+    ray_progress_update(NULL, NULL, 50, 100);
+    ray_progress_end();
+
+    TEST_ASSERT_TRUE(r.n >= 2);
+    TEST_ASSERT_STR_EQ(r.snaps[0].op_name, "op2");
+    TEST_ASSERT_TRUE(r.snaps[r.n - 1].final);
+    PASS();
+}
+
+/* End fires a "100% normalized" tick when rows_total > 0 — rows_done is
+ * forced up to rows_total even if it lagged. */
+static test_result_t test_progress_end_normalizes_rows_done(void) {
+    recorder_t r;
+    recorder_reset(&r);
+    ray_progress_set_callback(record_cb, &r, 30, 10);
+
+    ray_progress_update("scan", "rows", 0, 100);
+    sleep_ms(60);
+    /* Final mid-tick advances to a partial value, NOT 100. */
+    ray_progress_update(NULL, NULL, 70, 100);
+    TEST_ASSERT_EQ_I(r.n, 1);
+    TEST_ASSERT_EQ_U(r.snaps[0].rows_done, 70);
+
+    ray_progress_end();
+    /* end() should have promoted rows_done to rows_total. */
+    TEST_ASSERT_EQ_I(r.n, 2);
+    TEST_ASSERT_TRUE(r.snaps[1].final);
+    TEST_ASSERT_EQ_U(r.snaps[1].rows_done, 100);
+    TEST_ASSERT_EQ_U(r.snaps[1].rows_total, 100);
+
+    PASS();
+}
+
+/* End with rows_total = 0 (indeterminate progress): rows_done is left
+ * untouched in the final tick. Drives the 'if (g_rows_total)' guard in
+ * ray_progress_end. */
+static test_result_t test_progress_end_indeterminate(void) {
+    recorder_t r;
+    recorder_reset(&r);
+    ray_progress_set_callback(record_cb, &r, 30, 10);
+
+    ray_progress_update("scan", "rows", 0, 0);
+    sleep_ms(60);
+    ray_progress_update(NULL, NULL, 42, 0);
+    TEST_ASSERT_EQ_I(r.n, 1);
+
+    ray_progress_end();
+    TEST_ASSERT_EQ_I(r.n, 2);
+    TEST_ASSERT_TRUE(r.snaps[1].final);
+    /* rows_total stays 0; rows_done remains 42 (NOT promoted). */
+    TEST_ASSERT_EQ_U(r.snaps[1].rows_total, 0);
+    TEST_ASSERT_EQ_U(r.snaps[1].rows_done, 42);
+
+    PASS();
+}
+
+/* Lazy clock-start happens only on the first call after end (or first call
+ * ever). The label() entry should also lazy-start when g_start_ns == 0. */
+static test_result_t test_progress_label_lazy_start(void) {
+    recorder_t r;
+    recorder_reset(&r);
+    ray_progress_set_callback(record_cb, &r, 30, 10);
+
+    /* First call into the API after a clean end is a label() — should still
+     * lazy-start the clock without crashing or producing a bogus elapsed. */
+    ray_progress_label("scan", "init");
+    /* No fire yet — inside min_ms window. */
+    TEST_ASSERT_EQ_I(r.n, 0);
+
+    sleep_ms(60);
+    ray_progress_update(NULL, NULL, 5, 10);
+    TEST_ASSERT_EQ_I(r.n, 1);
+    /* The op_name from label() must have been preserved across the
+     * subsequent NULL-keep update. */
+    TEST_ASSERT_STR_EQ(r.snaps[0].op_name, "scan");
+    TEST_ASSERT_STR_EQ(r.snaps[0].phase, "init");
+    /* elapsed_sec is plausible: well above min_ms (~30 ms = 0.030 s) but
+     * well below absurd values (10s). This guards against a bug where the
+     * label-path lazy-start failed to set g_start_ns. */
+    TEST_ASSERT_TRUE(r.snaps[0].elapsed_sec >= 0.03);
+    TEST_ASSERT_TRUE(r.snaps[0].elapsed_sec < 10.0);
+
+    ray_progress_end();
+    PASS();
+}
+
+/* user pointer is plumbed through to the callback unchanged. */
+static test_result_t test_progress_user_pointer_plumbing(void) {
+    recorder_t r;
+    recorder_reset(&r);
+
+    ray_progress_set_callback(record_cb, &r, 30, 10);
+    ray_progress_update("op", "ph", 0, 100);
+    sleep_ms(60);
+    ray_progress_update(NULL, NULL, 1, 100);
+    TEST_ASSERT_EQ_I(r.n, 1);
+    /* magic was set in recorder_reset and must still be present, proving
+     * the callback received the real user pointer (not garbage). */
+    TEST_ASSERT_EQ_I(r.magic, RECORDER_MAGIC);
+
+    ray_progress_end();
+    PASS();
+}
+
+/* Setting a noop callback then end (mid-query, not under min_ms) takes the
+ * "showing == false" branch in end. */
+static test_result_t test_progress_end_branch_no_show(void) {
+    /* Use noop_cb so we don't pollute another recorder. */
+    ray_progress_set_callback(noop_cb, NULL, 5000, 50);
+
+    /* Drive an update that will NOT fire (under min_ms). */
+    ray_progress_update("op", "ph", 0, 10);
+    sleep_ms(5);
+    ray_progress_update(NULL, NULL, 1, 10);
+
+    /* End hits the !g_showing path — no fire, just state clear. Just ensure
+     * no crash. */
+    ray_progress_end();
+    PASS();
+}
+
+/* ---- Suite definition --------------------------------------------------- */
+
+const test_entry_t progress_entries[] = {
+    { "progress/null_callback",            test_progress_null_callback,
+      progress_setup, progress_teardown },
+    { "progress/end_fires_final",          test_progress_end_fires_final,
+      progress_setup, progress_teardown },
+    { "progress/short_query_no_fire",      test_progress_short_query_no_fire,
+      progress_setup, progress_teardown },
+    { "progress/tick_throttle",            test_progress_tick_throttle,
+      progress_setup, progress_teardown },
+    { "progress/null_keep_semantics",      test_progress_null_keep_semantics,
+      progress_setup, progress_teardown },
+    { "progress/label_resets",             test_progress_label_resets,
+      progress_setup, progress_teardown },
+    { "progress/set_callback_zero_keeps",  test_progress_set_callback_zero_keeps_existing,
+      progress_setup, progress_teardown },
+    { "progress/snapshot_fields",          test_progress_snapshot_fields,
+      progress_setup, progress_teardown },
+    { "progress/state_reset_between",      test_progress_state_reset_between_queries,
+      progress_setup, progress_teardown },
+    { "progress/end_without_callback",     test_progress_end_without_callback,
+      progress_setup, progress_teardown },
+    { "progress/end_normalizes_rows_done", test_progress_end_normalizes_rows_done,
+      progress_setup, progress_teardown },
+    { "progress/end_indeterminate",        test_progress_end_indeterminate,
+      progress_setup, progress_teardown },
+    { "progress/label_lazy_start",         test_progress_label_lazy_start,
+      progress_setup, progress_teardown },
+    { "progress/user_pointer_plumbing",    test_progress_user_pointer_plumbing,
+      progress_setup, progress_teardown },
+    { "progress/end_branch_no_show",       test_progress_end_branch_no_show,
+      progress_setup, progress_teardown },
+    { NULL, NULL, NULL, NULL },
+};

--- a/test/test_repl.c
+++ b/test/test_repl.c
@@ -1,0 +1,450 @@
+/*
+ *   Copyright (c) 2025-2026 Anton Kundenko <singaraiona@gmail.com>
+ *   All rights reserved.
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
+
+/*
+ * Unit tests for src/app/repl.c.
+ *
+ * The .rfl-driven harness in test/main.c uses ray_eval_str directly and
+ * never goes through repl.c, so without these tests repl.o sits at ~4%
+ * line coverage despite being linked.  These cases drive the file-batch
+ * entrypoint (ray_repl_run_file), the create/destroy lifecycle, and
+ * the bracket-balance helpers used by piped multi-line input.
+ *
+ * stdout/stderr are redirected to /dev/null around any call that
+ * prints results — keeps the test runner's progress output clean.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "test.h"
+#include <rayforce.h>
+#include "app/repl.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+/* Forward-declare runtime API — same pattern as test_lang.c. */
+struct ray_runtime_s;
+typedef struct ray_runtime_s ray_runtime_t;
+extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
+extern void           ray_runtime_destroy(ray_runtime_t* rt);
+extern ray_runtime_t* __RUNTIME;
+
+/* ─── Setup / Teardown ────────────────────────────────────────────── */
+
+static void repl_setup(void) {
+    ray_runtime_create(0, NULL);
+}
+
+static void repl_teardown(void) {
+    ray_runtime_destroy(__RUNTIME);
+}
+
+/* ─── stdio mute helper ───────────────────────────────────────────── */
+
+/* Redirect stdout+stderr to /dev/null for the duration of a call.
+ * Saves the original fds, restores on end_mute().  Keeps test output
+ * clean when ray_repl_run_file prints results / errors. */
+typedef struct {
+    int saved_out;
+    int saved_err;
+    int devnull;
+} mute_state_t;
+
+static void begin_mute(mute_state_t* m) {
+    fflush(stdout);
+    fflush(stderr);
+    m->saved_out = dup(fileno(stdout));
+    m->saved_err = dup(fileno(stderr));
+    m->devnull   = open("/dev/null", O_WRONLY);
+    if (m->devnull >= 0) {
+        dup2(m->devnull, fileno(stdout));
+        dup2(m->devnull, fileno(stderr));
+    }
+}
+
+static void end_mute(mute_state_t* m) {
+    fflush(stdout);
+    fflush(stderr);
+    if (m->saved_out >= 0) { dup2(m->saved_out, fileno(stdout)); close(m->saved_out); }
+    if (m->saved_err >= 0) { dup2(m->saved_err, fileno(stderr)); close(m->saved_err); }
+    if (m->devnull   >= 0) close(m->devnull);
+}
+
+/* Build a unique-per-pid tmp .rfl path; never returns NULL. */
+static const char* tmp_rfl_path(void) {
+    static char path[64];
+    if (!path[0])
+        snprintf(path, sizeof(path), "/tmp/ray_test_repl_%d.rfl", (int)getpid());
+    return path;
+}
+
+/* Write `body` to tmp .rfl path; returns 0 on success, -1 on I/O error. */
+static int write_rfl(const char* body) {
+    FILE* f = fopen(tmp_rfl_path(), "w");
+    if (!f) return -1;
+    if (body && *body) fwrite(body, 1, strlen(body), f);
+    fclose(f);
+    return 0;
+}
+
+static void unlink_rfl(void) { unlink(tmp_rfl_path()); }
+
+/* ─── ray_repl_run_file ──────────────────────────────────────────── */
+
+/* Happy path: simple arithmetic — evaluator returns a value, printer
+ * runs, ray_repl_run_file returns 0. */
+static test_result_t test_repl_run_file_happy(void) {
+    TEST_ASSERT_EQ_I(write_rfl("(+ 1 2)\n"), 0);
+
+    mute_state_t m;
+    begin_mute(&m);
+    int rc = ray_repl_run_file(tmp_rfl_path());
+    end_mute(&m);
+
+    unlink_rfl();
+    TEST_ASSERT_EQ_I(rc, 0);
+    PASS();
+}
+
+/* Multi-form file: each top-level form evaluated in order, last value
+ * is printed.  Should still return 0. */
+static test_result_t test_repl_run_file_multi_form(void) {
+    TEST_ASSERT_EQ_I(write_rfl(
+        "(set x 10)\n"
+        "(set y 20)\n"
+        "(+ x y)\n"), 0);
+
+    mute_state_t m;
+    begin_mute(&m);
+    int rc = ray_repl_run_file(tmp_rfl_path());
+    end_mute(&m);
+
+    unlink_rfl();
+    TEST_ASSERT_EQ_I(rc, 0);
+    PASS();
+}
+
+/* Parse error: malformed source — ray_parse_with_nfo returns an error,
+ * file mode prints it to stderr and returns 1. */
+static test_result_t test_repl_run_file_parse_error(void) {
+    /* Unmatched paren — definite parse error. */
+    TEST_ASSERT_EQ_I(write_rfl("(+ 1 2\n"), 0);
+
+    mute_state_t m;
+    begin_mute(&m);
+    int rc = ray_repl_run_file(tmp_rfl_path());
+    end_mute(&m);
+
+    unlink_rfl();
+    TEST_ASSERT_EQ_I(rc, 1);
+    PASS();
+}
+
+/* Eval error: parses fine but raises at eval (type error).  Should
+ * exit with rc=1, exercising the RAY_IS_ERR / repl_print_result branch
+ * on stderr including fmt_error_with_trace if a trace exists. */
+static test_result_t test_repl_run_file_eval_error(void) {
+    TEST_ASSERT_EQ_I(write_rfl("(+ \"abc\" 1)\n"), 0);
+
+    mute_state_t m;
+    begin_mute(&m);
+    int rc = ray_repl_run_file(tmp_rfl_path());
+    end_mute(&m);
+
+    unlink_rfl();
+    TEST_ASSERT_EQ_I(rc, 1);
+    PASS();
+}
+
+/* Empty file: ray_repl_run_file shortcircuits (nread == 0 path) and
+ * returns 0 without calling parse/eval. */
+static test_result_t test_repl_run_file_empty(void) {
+    TEST_ASSERT_EQ_I(write_rfl(""), 0);
+
+    mute_state_t m;
+    begin_mute(&m);
+    int rc = ray_repl_run_file(tmp_rfl_path());
+    end_mute(&m);
+
+    unlink_rfl();
+    TEST_ASSERT_EQ_I(rc, 0);
+    PASS();
+}
+
+/* File with only ;; comments: parses to nothing meaningful; the
+ * eval path may return null or void.  Either way, no error, rc=0. */
+static test_result_t test_repl_run_file_comments_only(void) {
+    TEST_ASSERT_EQ_I(write_rfl(
+        ";; first comment\n"
+        ";; second comment\n"
+        "\n"), 0);
+
+    mute_state_t m;
+    begin_mute(&m);
+    int rc = ray_repl_run_file(tmp_rfl_path());
+    end_mute(&m);
+
+    unlink_rfl();
+    TEST_ASSERT_EQ_I(rc, 0);
+    PASS();
+}
+
+/* Non-existent file: fopen fails, function prints "cannot open" to
+ * stderr and returns 1.  Covers the early-exit path. */
+static test_result_t test_repl_run_file_nonexistent(void) {
+    mute_state_t m;
+    begin_mute(&m);
+    int rc = ray_repl_run_file("/tmp/ray_test_repl_definitely_no_such_file_xyz.rfl");
+    end_mute(&m);
+
+    TEST_ASSERT_EQ_I(rc, 1);
+    PASS();
+}
+
+/* Multi-line expression in a file — parser accepts a single form
+ * spread across newlines.  Confirms file-mode reads the whole buffer
+ * before parsing (not a line-at-a-time stream).  `+` is binary, so we
+ * use a nested form to keep arity correct while spanning lines. */
+static test_result_t test_repl_run_file_multiline_expr(void) {
+    TEST_ASSERT_EQ_I(write_rfl(
+        "(+ (+ 1\n"
+        "       2)\n"
+        "   3)\n"), 0);
+
+    mute_state_t m;
+    begin_mute(&m);
+    int rc = ray_repl_run_file(tmp_rfl_path());
+    end_mute(&m);
+
+    unlink_rfl();
+    TEST_ASSERT_EQ_I(rc, 0);
+    PASS();
+}
+
+/* Lazy result path — produce a value that requires materialization.
+ * (count V) where V is a non-trivial vec exercises the lazy/materialize
+ * arm of ray_repl_run_file at line 1047. */
+static test_result_t test_repl_run_file_lazy_result(void) {
+    TEST_ASSERT_EQ_I(write_rfl(
+        "(set V (til 100))\n"
+        "(+ V 1)\n"), 0);
+
+    mute_state_t m;
+    begin_mute(&m);
+    int rc = ray_repl_run_file(tmp_rfl_path());
+    end_mute(&m);
+
+    unlink_rfl();
+    TEST_ASSERT_EQ_I(rc, 0);
+    PASS();
+}
+
+/* ─── ray_repl_create / ray_repl_destroy ─────────────────────────── */
+
+/* Create with NULL poll — the non-interactive path.  In tests stdin
+ * is unlikely to be a tty (and when it is, term creation may still
+ * succeed); either way, ray_repl_destroy must clean up correctly. */
+static test_result_t test_repl_create_destroy_null_poll(void) {
+    ray_repl_t* repl = ray_repl_create(NULL);
+    TEST_ASSERT_NOT_NULL(repl);
+    /* poll wired through faithfully */
+    TEST_ASSERT_EQ_PTR(repl->poll, NULL);
+    /* id starts at -1 (not yet registered with any poll) */
+    TEST_ASSERT_EQ_I(repl->id, -1);
+    ray_repl_destroy(repl);
+    PASS();
+}
+
+/* Destroy must be NULL-safe — main.c relies on this in error paths. */
+static test_result_t test_repl_destroy_null(void) {
+    ray_repl_destroy(NULL);   /* must not crash */
+    PASS();
+}
+
+/* ─── ray_repl_run (piped mode) ──────────────────────────────────── */
+
+/* Drive run_piped() by replacing stdin with a pipe pre-loaded with
+ * `script`, then calling ray_repl_run with poll=NULL.  Restores stdin
+ * before returning.  stdout/stderr are muted because run_piped prints
+ * results.  Returns 0 on success, -1 if the pipe wiring failed.
+ *
+ * NOTE: ray_repl_create() consults isatty(STDIN_FD) to decide whether
+ * to allocate a terminal — a pipe is not a tty, so the resulting
+ * ray_repl_t* has term==NULL and ray_repl_run picks the run_piped
+ * branch.  This is the only seam through which piped semantics are
+ * unit-testable without a child process. */
+static int run_piped_with_input(const char* script) {
+    int p[2];
+    if (pipe(p) != 0) return -1;
+
+    /* Pre-load the script and close the write end so fgets sees EOF. */
+    if (script && *script)
+        if (write(p[1], script, strlen(script)) < 0) { /* tolerate short writes for these tiny tests */ }
+    close(p[1]);
+
+    /* Swap stdin -> read end of pipe. */
+    fflush(stdin);
+    int saved_in = dup(fileno(stdin));
+    if (saved_in < 0) { close(p[0]); return -1; }
+    dup2(p[0], fileno(stdin));
+    close(p[0]);
+    /* fgets() in stdio buffers the underlying fd — clear the existing
+     * buffered state by reopening stdin so the pipe is read fresh. */
+    clearerr(stdin);
+
+    mute_state_t m;
+    begin_mute(&m);
+    ray_repl_t* repl = ray_repl_create(NULL);
+    if (repl) {
+        ray_repl_run(repl);
+        ray_repl_destroy(repl);
+    }
+    end_mute(&m);
+
+    /* Restore stdin. */
+    fflush(stdin);
+    dup2(saved_in, fileno(stdin));
+    close(saved_in);
+    clearerr(stdin);
+    return repl ? 0 : -1;
+}
+
+/* Single complete expression on one line. */
+static test_result_t test_repl_run_piped_single_line(void) {
+    TEST_ASSERT_EQ_I(run_piped_with_input("(+ 1 2)\n"), 0);
+    PASS();
+}
+
+/* Multi-line expression — the bracket-balance accumulator must hold
+ * input across two fgets() calls before evaluating. */
+static test_result_t test_repl_run_piped_multiline(void) {
+    TEST_ASSERT_EQ_I(run_piped_with_input(
+        "(+ 1\n"
+        "   2)\n"), 0);
+    PASS();
+}
+
+/* Multiple top-level expressions, each on its own line. */
+static test_result_t test_repl_run_piped_multi_form(void) {
+    TEST_ASSERT_EQ_I(run_piped_with_input(
+        "(set x 5)\n"
+        "(+ x 10)\n"), 0);
+    PASS();
+}
+
+/* Empty/blank input — fgets returns NULL straight away. */
+static test_result_t test_repl_run_piped_empty(void) {
+    TEST_ASSERT_EQ_I(run_piped_with_input(""), 0);
+    PASS();
+}
+
+/* Blank lines and `;;` comments between expressions — both must be
+ * tolerated by the piped accumulator without confusing bracket state. */
+static test_result_t test_repl_run_piped_comments_blank(void) {
+    TEST_ASSERT_EQ_I(run_piped_with_input(
+        ";; first\n"
+        "\n"
+        "(+ 1 2)\n"
+        "\n"
+        ";; trailing\n"), 0);
+    PASS();
+}
+
+/* Exit command `\\` terminates the loop immediately. */
+static test_result_t test_repl_run_piped_exit_backslash(void) {
+    TEST_ASSERT_EQ_I(run_piped_with_input(
+        "(+ 1 2)\n"
+        "\\\\\n"
+        "(+ 3 4)\n"   /* should never run */ ), 0);
+    PASS();
+}
+
+/* Exit command `exit` likewise. */
+static test_result_t test_repl_run_piped_exit_word(void) {
+    TEST_ASSERT_EQ_I(run_piped_with_input(
+        "exit\n"), 0);
+    PASS();
+}
+
+/* :q / :quit also exit; route through both early-exit branches. */
+static test_result_t test_repl_run_piped_colon_quit(void) {
+    TEST_ASSERT_EQ_I(run_piped_with_input(":q\n"),    0);
+    TEST_ASSERT_EQ_I(run_piped_with_input(":quit\n"), 0);
+    PASS();
+}
+
+/* :env / :? / :t — non-quitting commands should be dispatched and
+ * produce no error path that crashes; we only assert the loop survives. */
+static test_result_t test_repl_run_piped_command(void) {
+    TEST_ASSERT_EQ_I(run_piped_with_input(
+        ":?\n"
+        "(+ 1 2)\n"), 0);
+    PASS();
+}
+
+/* Eval error inside piped input — REPL semantics: error printed to
+ * stderr but loop continues to next line.  Final assertion is just
+ * that we make it to the end without crashing. */
+static test_result_t test_repl_run_piped_eval_error_continues(void) {
+    TEST_ASSERT_EQ_I(run_piped_with_input(
+        "(+ \"abc\" 1)\n"   /* type error */
+        "(+ 1 2)\n"          /* still runs */ ), 0);
+    PASS();
+}
+
+/* ─── Suite definition ───────────────────────────────────────────── */
+
+const test_entry_t repl_entries[] = {
+    /* file-batch entrypoint — ray_repl_run_file */
+    { "repl/run_file/happy",            test_repl_run_file_happy,            repl_setup, repl_teardown },
+    { "repl/run_file/multi_form",       test_repl_run_file_multi_form,       repl_setup, repl_teardown },
+    { "repl/run_file/parse_error",      test_repl_run_file_parse_error,      repl_setup, repl_teardown },
+    { "repl/run_file/eval_error",       test_repl_run_file_eval_error,       repl_setup, repl_teardown },
+    { "repl/run_file/empty",            test_repl_run_file_empty,            repl_setup, repl_teardown },
+    { "repl/run_file/comments_only",    test_repl_run_file_comments_only,    repl_setup, repl_teardown },
+    { "repl/run_file/nonexistent",      test_repl_run_file_nonexistent,      repl_setup, repl_teardown },
+    { "repl/run_file/multiline_expr",   test_repl_run_file_multiline_expr,   repl_setup, repl_teardown },
+    { "repl/run_file/lazy_result",      test_repl_run_file_lazy_result,      repl_setup, repl_teardown },
+
+    /* lifecycle */
+    { "repl/create_destroy/null_poll",  test_repl_create_destroy_null_poll,  repl_setup, repl_teardown },
+    { "repl/destroy/null",              test_repl_destroy_null,              NULL,       NULL          },
+
+    /* piped-mode loop — drives ray_repl_run via stdin pipe redirection */
+    { "repl/run/piped/single_line",     test_repl_run_piped_single_line,         repl_setup, repl_teardown },
+    { "repl/run/piped/multiline",       test_repl_run_piped_multiline,           repl_setup, repl_teardown },
+    { "repl/run/piped/multi_form",      test_repl_run_piped_multi_form,          repl_setup, repl_teardown },
+    { "repl/run/piped/empty",           test_repl_run_piped_empty,               repl_setup, repl_teardown },
+    { "repl/run/piped/comments_blank",  test_repl_run_piped_comments_blank,      repl_setup, repl_teardown },
+    { "repl/run/piped/exit_backslash",  test_repl_run_piped_exit_backslash,      repl_setup, repl_teardown },
+    { "repl/run/piped/exit_word",       test_repl_run_piped_exit_word,           repl_setup, repl_teardown },
+    { "repl/run/piped/colon_quit",      test_repl_run_piped_colon_quit,          repl_setup, repl_teardown },
+    { "repl/run/piped/command",         test_repl_run_piped_command,             repl_setup, repl_teardown },
+    { "repl/run/piped/eval_error",      test_repl_run_piped_eval_error_continues, repl_setup, repl_teardown },
+
+    { NULL, NULL, NULL, NULL },
+};

--- a/test/test_term.c
+++ b/test/test_term.c
@@ -1,0 +1,1102 @@
+/*
+ *   Copyright (c) 2025-2026 Anton Kundenko <singaraiona@gmail.com>
+ *   All rights reserved.
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in all
+ *   copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
+
+/*
+ * Coverage tests for src/app/term.c — the Rayforce REPL's terminal layer.
+ *
+ * Most of term.c is interactive (raw-mode reads, signal install, the
+ * keystroke loop) and not suitable for direct unit tests.  The pieces that
+ * ARE testable from a non-TTY context:
+ *
+ *   1. ray_hist_create / _destroy / _add / _prev / _next / _search /
+ *      _save / _load — the history buffer + on-disk persistence.
+ *   2. ray_term_visual_width — visual-column accounting that strips ANSI
+ *      escape sequences and counts UTF-8 code points.
+ *   3. ray_term_find_matching_paren — bracket matching with string-literal
+ *      handling.
+ *   4. ray_term_count_unmatched — multi-line continuation predicate.
+ *   5. ray_term_goto_position + the bare-printf cursor / line / hide-show
+ *      helpers — pure escape-code emitters; we redirect stdout to a
+ *      tempfile and assert on the captured bytes.
+ *   6. ray_term_collect_completions — pulls names from the global env
+ *      (under a real runtime), keywords, history words, and table
+ *      column names.
+ *
+ * Skipped (genuinely interactive / TTY-dependent and not worth a fragile
+ * harness):
+ *   - ray_term_create / _destroy (calls tcgetattr/tcsetattr on stdin)
+ *   - ray_term_getc, ray_term_read, ray_term_feed, ray_term_begin
+ *   - ray_term_prompt, ray_term_redraw, search-mode redraw
+ *   - signal handlers, atexit handler, eval_begin/end (termios mutation)
+ *
+ * History rules:
+ *   - All allocations use the project allocator (ray_alloc / ray_free
+ *     indirectly via ray_hist_*).  No libc malloc anywhere in this file.
+ *   - Test-temp files live under /tmp with a per-pid unique name and are
+ *     unlinked after the test (or on tearDown).
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "test.h"
+#include <rayforce.h>
+#include "mem/heap.h"
+#include "table/sym.h"
+#include "lang/env.h"
+#include "app/term.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+/* Forward declare the runtime API used by completion tests. */
+struct ray_runtime_s;
+typedef struct ray_runtime_s ray_runtime_t;
+extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
+extern void           ray_runtime_destroy(ray_runtime_t* rt);
+extern ray_runtime_t* __RUNTIME;
+
+/* ─── Setup / teardown ─────────────────────────────────────────────── */
+
+static void heap_setup(void)    { ray_heap_init(); (void)ray_sym_init(); }
+static void heap_teardown(void) { ray_sym_destroy(); ray_heap_destroy(); }
+
+static void runtime_setup(void)    { ray_runtime_create(0, NULL); }
+static void runtime_teardown(void) { ray_runtime_destroy(__RUNTIME); }
+
+/* ─── Stdout-capture plumbing ──────────────────────────────────────── */
+
+/* Redirect stdout to a freshly-truncated temp file under /tmp.  The fd
+ * returned must be passed to capture_end() — that closes the temp file,
+ * restores the original stdout, and copies up to cap-1 bytes of captured
+ * output into out.  Returns -1 on setup failure (test should bail). */
+static int capture_begin(char* tmppath, int32_t cap_path) {
+    fflush(stdout);
+    int saved = dup(fileno(stdout));
+    if (saved < 0) return -1;
+    snprintf(tmppath, (size_t)cap_path,
+             "/tmp/ray_term_test_cap_%d_%ld",
+             (int)getpid(), (long)saved);
+    int fd = open(tmppath, O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) { close(saved); return -1; }
+    if (dup2(fd, fileno(stdout)) < 0) {
+        close(fd); close(saved); unlink(tmppath); return -1;
+    }
+    close(fd);
+    return saved;
+}
+
+static int32_t capture_end(int saved_fd, const char* tmppath,
+                            char* out, int32_t cap) {
+    fflush(stdout);
+    if (saved_fd >= 0) {
+        dup2(saved_fd, fileno(stdout));
+        close(saved_fd);
+    }
+    int rfd = open(tmppath, O_RDONLY);
+    int32_t n = 0;
+    if (rfd >= 0) {
+        ssize_t r = read(rfd, out, (size_t)(cap - 1));
+        if (r > 0) n = (int32_t)r;
+        close(rfd);
+    }
+    out[n] = '\0';
+    unlink(tmppath);
+    return n;
+}
+
+/* ─── ray_term_get_size ────────────────────────────────────────────── */
+
+/* Calls ioctl(TIOCGWINSZ) on stdout.  Under a non-TTY runner stdout
+ * isn't a terminal, so the call fails and we get the documented fallback
+ * (80x24).  When run from an interactive shell ioctl succeeds and we
+ * just verify both fields are positive.  The point is to exercise the
+ * function and the fallback branch — not to assert exact dimensions. */
+static test_result_t test_term_get_size(void) {
+    ray_t* block = ray_alloc(sizeof(ray_term_t));
+    if (!block) FAIL("ray_alloc failed");
+    ray_term_t* t = (ray_term_t*)ray_data(block);
+    memset(t, 0, sizeof(*t));
+    t->_block = block;
+
+    ray_term_get_size(t);
+    TEST_ASSERT_FMT(t->term_width  > 0, "width=%d not positive",  t->term_width);
+    TEST_ASSERT_FMT(t->term_height > 0, "height=%d not positive", t->term_height);
+
+    ray_free(block);
+    PASS();
+}
+
+/* ─── Tests for the cursor/line escape printers ────────────────────── */
+
+static test_result_t test_term_cursor_move_basics(void) {
+    char path[256];
+    char buf[256];
+    int saved = capture_begin(path, sizeof path);
+    if (saved < 0) FAIL("capture setup failed");
+
+    /* All four directions with positive n */
+    ray_cursor_move_left(3);
+    ray_cursor_move_right(7);
+    ray_cursor_move_up(1);
+    ray_cursor_move_down(5);
+    /* n <= 0 is a no-op for left/right/up/down */
+    ray_cursor_move_left(0);
+    ray_cursor_move_right(-1);
+    ray_cursor_move_up(0);
+    ray_cursor_move_down(-2);
+    /* Move-start emits a CR */
+    ray_cursor_move_start();
+
+    int32_t n = capture_end(saved, path, buf, sizeof buf);
+    TEST_ASSERT_FMT(n > 0, "no bytes captured");
+    TEST_ASSERT_FMT(strstr(buf, "\033[3D") != NULL, "missing CSI 3D");
+    TEST_ASSERT_FMT(strstr(buf, "\033[7C") != NULL, "missing CSI 7C");
+    TEST_ASSERT_FMT(strstr(buf, "\033[1A") != NULL, "missing CSI 1A");
+    TEST_ASSERT_FMT(strstr(buf, "\033[5B") != NULL, "missing CSI 5B");
+    TEST_ASSERT_FMT(strchr(buf, '\r') != NULL, "missing CR from move_start");
+    /* No-op variants must not emit anything for those n values */
+    TEST_ASSERT_FMT(strstr(buf, "\033[0D") == NULL, "left(0) emitted CSI");
+    TEST_ASSERT_FMT(strstr(buf, "\033[-1C") == NULL, "right(-1) emitted CSI");
+    PASS();
+}
+
+static test_result_t test_term_line_clear_and_visibility(void) {
+    char path[256];
+    char buf[256];
+    int saved = capture_begin(path, sizeof path);
+    if (saved < 0) FAIL("capture setup failed");
+
+    ray_line_clear();        /* "\r\033[K" */
+    ray_line_clear_below();  /* "\033[J" */
+    ray_cursor_hide();       /* "\033[?25l" */
+    ray_cursor_show();       /* "\033[?25h" */
+
+    int32_t n = capture_end(saved, path, buf, sizeof buf);
+    TEST_ASSERT_FMT(n > 0, "no bytes captured");
+    TEST_ASSERT_FMT(strstr(buf, "\033[K")  != NULL, "missing line clear");
+    TEST_ASSERT_FMT(strstr(buf, "\033[J")  != NULL, "missing clear below");
+    TEST_ASSERT_FMT(strstr(buf, "\033[?25l") != NULL, "missing cursor hide");
+    TEST_ASSERT_FMT(strstr(buf, "\033[?25h") != NULL, "missing cursor show");
+    PASS();
+}
+
+/* ─── ray_term_visual_width ───────────────────────────────────────── */
+
+static test_result_t test_term_visual_width_ascii(void) {
+    TEST_ASSERT_EQ_I(ray_term_visual_width("",      0), 0);
+    TEST_ASSERT_EQ_I(ray_term_visual_width("hello", 5), 5);
+    TEST_ASSERT_EQ_I(ray_term_visual_width("a b",   3), 3);
+    PASS();
+}
+
+static test_result_t test_term_visual_width_strips_escapes(void) {
+    /* ANSI sequences contribute zero width, payload counts normally */
+    const char* s = "\033[31mred\033[0m!";
+    int32_t len = (int32_t)strlen(s);
+    TEST_ASSERT_EQ_I(ray_term_visual_width(s, len), 4);  /* "red!" */
+
+    /* Multi-parameter SGR */
+    const char* s2 = "\033[1;38;5;39mblue\033[0m";
+    TEST_ASSERT_EQ_I(ray_term_visual_width(s2, (int32_t)strlen(s2)), 4);
+    PASS();
+}
+
+static test_result_t test_term_visual_width_utf8(void) {
+    /* "‣" U+2023 is 3 bytes UTF-8 (E2 80 A3), 1 column wide */
+    const char* s = "\xe2\x80\xa3";
+    TEST_ASSERT_EQ_I(ray_term_visual_width(s, 3), 1);
+
+    /* Mixed ASCII + 2-byte UTF-8 (e.g. é = C3 A9) */
+    const char* s2 = "ca\xc3\xa9";
+    TEST_ASSERT_EQ_I(ray_term_visual_width(s2, (int32_t)strlen(s2)), 3);
+
+    /* 4-byte sequence (e.g. emoji) — counted as 2 columns */
+    const char* s3 = "\xf0\x9f\x98\x80";
+    TEST_ASSERT_EQ_I(ray_term_visual_width(s3, 4), 2);
+    PASS();
+}
+
+/* Bare ESC followed by a non-CSI byte — exits escape state immediately.
+ * Without the dedicated state-1 handling we'd over-count the bytes. */
+static test_result_t test_term_visual_width_bare_escape(void) {
+    /* "\033X" — the X is not '[' or 'O', so escape ends after consuming
+     * X.  Visual width = 0 (both bytes were part of the escape). */
+    const char* s = "\033X";
+    TEST_ASSERT_EQ_I(ray_term_visual_width(s, 2), 0);
+    /* "a\033Xb" — 'a' counts, "\033X" doesn't, 'b' counts. */
+    const char* s2 = "a\033Xb";
+    TEST_ASSERT_EQ_I(ray_term_visual_width(s2, 4), 2);
+    /* SS3 sequence "\033Of" — 'O' is the introducer, 'f' is final byte. */
+    const char* s3 = "\033Ofz";
+    TEST_ASSERT_EQ_I(ray_term_visual_width(s3, 4), 1); /* only 'z' */
+    PASS();
+}
+
+/* ─── ray_term_find_matching_paren ────────────────────────────────── */
+
+static test_result_t test_term_find_matching_paren_simple(void) {
+    const char* s = "(abc)";
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 5, 0), 4);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 5, 4), 0);
+
+    const char* s2 = "[ ( ) ]";
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s2, 7, 0), 6);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s2, 7, 6), 0);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s2, 7, 2), 4);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s2, 7, 4), 2);
+    PASS();
+}
+
+static test_result_t test_term_find_matching_paren_nested(void) {
+    const char* s = "((x)(y))";
+    /* Outer */
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 8, 0), 7);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 8, 7), 0);
+    /* Inner pair (x) at 1..3 */
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 8, 1), 3);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 8, 3), 1);
+    /* Inner pair (y) at 4..6 */
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 8, 4), 6);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 8, 6), 4);
+    PASS();
+}
+
+static test_result_t test_term_find_matching_paren_unmatched(void) {
+    /* No match -> -1.  Cursor on a non-bracket -> -1. */
+    const char* s = "(abc";
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 4, 0), -1);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 4, 2), -1); /* 'b' */
+    /* Out-of-range cursor */
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 4, 4), -1);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 4, -1), -1);
+    PASS();
+}
+
+static test_result_t test_term_find_matching_paren_braces_brackets(void) {
+    /* {} */
+    const char* s1 = "{a{b}c}";
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s1, 7, 0), 6);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s1, 7, 6), 0);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s1, 7, 2), 4);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s1, 7, 4), 2);
+    /* [] */
+    const char* s2 = "[1[2]3]";
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s2, 7, 0), 6);
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s2, 7, 6), 0);
+    /* Mismatched brace types: the outer counts depth on opens of one kind,
+     * but matching of '{' with '}' is local; an interleaved '(' inside
+     * doesn't close the brace. */
+    const char* s3 = "{ ( ) }";
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s3, 7, 0), 6);
+    PASS();
+}
+
+static test_result_t test_term_find_matching_paren_in_string(void) {
+    /* Bracket inside a "" literal should not be considered a real bracket. */
+    const char* s = "(\"(\")";  /* 5 chars: ( " ( " ) */
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 5, 0), 4);
+    /* Cursor on the bracket inside the string — flagged as in-string,
+     * returns -1. */
+    TEST_ASSERT_EQ_I(ray_term_find_matching_paren(s, 5, 2), -1);
+    PASS();
+}
+
+/* ─── History: create / add / nav / destroy ───────────────────────── */
+
+static test_result_t test_hist_create_destroy(void) {
+    ray_hist_t h;
+    ray_hist_create(&h);
+    TEST_ASSERT_NOT_NULL(h.entries);
+    TEST_ASSERT_EQ_I(h.count, 0);
+    TEST_ASSERT_EQ_I(h.capacity, HIST_DEFAULT_CAP);
+    TEST_ASSERT_EQ_I(h.index, 0);
+    TEST_ASSERT_EQ_I(h.curr_saved, 0);
+    ray_hist_destroy(&h);
+    TEST_ASSERT_NULL(h.entries);
+    TEST_ASSERT_EQ_I(h.count, 0);
+    /* Double-destroy must be a no-op */
+    ray_hist_destroy(&h);
+    PASS();
+}
+
+static test_result_t test_hist_add_basic(void) {
+    ray_hist_t h;
+    ray_hist_create(&h);
+
+    ray_hist_add(&h, "alpha", 5);
+    ray_hist_add(&h, "beta",  4);
+    ray_hist_add(&h, "gamma", 5);
+    TEST_ASSERT_EQ_I(h.count, 3);
+    TEST_ASSERT_STR_EQ(h.entries[0], "alpha");
+    TEST_ASSERT_STR_EQ(h.entries[1], "beta");
+    TEST_ASSERT_STR_EQ(h.entries[2], "gamma");
+    /* Index points past last */
+    TEST_ASSERT_EQ_I(h.index, 3);
+
+    /* len <= 0 must be ignored */
+    ray_hist_add(&h, "x", 0);
+    ray_hist_add(&h, "x", -1);
+    TEST_ASSERT_EQ_I(h.count, 3);
+
+    /* Consecutive duplicate must NOT be appended (still resets index) */
+    ray_hist_add(&h, "gamma", 5);
+    TEST_ASSERT_EQ_I(h.count, 3);
+    TEST_ASSERT_EQ_I(h.index, 3);
+
+    ray_hist_destroy(&h);
+    PASS();
+}
+
+static test_result_t test_hist_add_grows(void) {
+    ray_hist_t h;
+    ray_hist_create(&h);
+    int32_t initial_cap = h.capacity;
+
+    /* Push past initial capacity to exercise the grow path */
+    char buf[16];
+    for (int i = 0; i < initial_cap + 4; i++) {
+        snprintf(buf, sizeof buf, "e%05d", i);
+        ray_hist_add(&h, buf, (int32_t)strlen(buf));
+    }
+    TEST_ASSERT_EQ_I(h.count, initial_cap + 4);
+    TEST_ASSERT_TRUE(h.capacity > initial_cap);
+    /* Verify first and last entries still intact post-grow (memcpy path) */
+    TEST_ASSERT_STR_EQ(h.entries[0], "e00000");
+    snprintf(buf, sizeof buf, "e%05d", initial_cap + 3);
+    TEST_ASSERT_STR_EQ(h.entries[h.count - 1], buf);
+    ray_hist_destroy(&h);
+    PASS();
+}
+
+static test_result_t test_hist_prev_next(void) {
+    ray_hist_t h;
+    ray_hist_create(&h);
+    ray_hist_add(&h, "one",   3);
+    ray_hist_add(&h, "two",   3);
+    ray_hist_add(&h, "three", 5);
+
+    char buf[64];
+    /* Pre-set buf to simulate "user's current input". */
+    strcpy(buf, "draft");
+
+    /* prev moves index from 3 -> 2 -> 1 -> 0, returns matching len */
+    int32_t len = ray_hist_prev(&h, buf, 5);
+    TEST_ASSERT_EQ_I(len, 5);
+    TEST_ASSERT_STR_EQ(buf, "three");
+
+    len = ray_hist_prev(&h, buf, len);
+    TEST_ASSERT_EQ_I(len, 3);
+    TEST_ASSERT_STR_EQ(buf, "two");
+
+    len = ray_hist_prev(&h, buf, len);
+    TEST_ASSERT_EQ_I(len, 3);
+    TEST_ASSERT_STR_EQ(buf, "one");
+
+    /* Going past the start returns -1 */
+    TEST_ASSERT_EQ_I(ray_hist_prev(&h, buf, len), -1);
+
+    /* next: 0 -> 1 -> 2 -> 3 (restore saved current) */
+    len = ray_hist_next(&h, buf);
+    TEST_ASSERT_EQ_I(len, 3);
+    TEST_ASSERT_STR_EQ(buf, "two");
+
+    len = ray_hist_next(&h, buf);
+    TEST_ASSERT_EQ_I(len, 5);
+    TEST_ASSERT_STR_EQ(buf, "three");
+
+    /* Past last entry: restore saved "draft" */
+    len = ray_hist_next(&h, buf);
+    TEST_ASSERT_EQ_I(len, 5);
+    TEST_ASSERT_STR_EQ(buf, "draft");
+
+    /* Further next returns -1 (past end, nothing saved) */
+    TEST_ASSERT_EQ_I(ray_hist_next(&h, buf), -1);
+
+    ray_hist_destroy(&h);
+    PASS();
+}
+
+static test_result_t test_hist_prev_empty(void) {
+    ray_hist_t h;
+    ray_hist_create(&h);
+    char buf[8] = "x";
+    TEST_ASSERT_EQ_I(ray_hist_prev(&h, buf, 1), -1);
+    TEST_ASSERT_EQ_I(ray_hist_next(&h, buf), -1);
+    ray_hist_destroy(&h);
+    PASS();
+}
+
+/* ─── History search ──────────────────────────────────────────────── */
+
+static test_result_t test_hist_search(void) {
+    ray_hist_t h;
+    ray_hist_create(&h);
+    ray_hist_add(&h, "select * from foo",  17);
+    ray_hist_add(&h, "select count from bar", 21);
+    ray_hist_add(&h, "drop table baz",     14);
+
+    /* Search backward from end for "select" — finds index 1 first */
+    int32_t idx = ray_hist_search(&h, "select", 6, h.count - 1);
+    TEST_ASSERT_EQ_I(idx, 1);
+
+    /* Continue from idx-1 -> finds index 0 */
+    idx = ray_hist_search(&h, "select", 6, 0);
+    TEST_ASSERT_EQ_I(idx, 0);
+
+    /* No match */
+    TEST_ASSERT_EQ_I(ray_hist_search(&h, "xyzzy", 5, h.count - 1), -1);
+
+    /* Empty needle -> -1 */
+    TEST_ASSERT_EQ_I(ray_hist_search(&h, "", 0, h.count - 1), -1);
+
+    /* Negative start -> -1 */
+    TEST_ASSERT_EQ_I(ray_hist_search(&h, "select", 6, -1), -1);
+
+    /* Start beyond count gets clamped */
+    TEST_ASSERT_EQ_I(ray_hist_search(&h, "drop", 4, 999), 2);
+
+    /* Needle longer than entry — skips over short entries cleanly */
+    ray_hist_add(&h, "z", 1);
+    TEST_ASSERT_EQ_I(ray_hist_search(&h, "longneedle", 10, h.count - 1), -1);
+
+    ray_hist_destroy(&h);
+    PASS();
+}
+
+/* ─── History save/load round-trip ────────────────────────────────── */
+
+static void make_temp_path(char* out, int32_t cap, const char* tag) {
+    snprintf(out, (size_t)cap, "/tmp/ray_term_test_hist_%d_%s",
+             (int)getpid(), tag);
+    unlink(out);
+}
+
+static test_result_t test_hist_save_load_roundtrip(void) {
+    char path[256];
+    make_temp_path(path, sizeof path, "save_load");
+
+    /* Populate hist1, save */
+    ray_hist_t h1;
+    ray_hist_create(&h1);
+    ray_hist_add(&h1, "first",   5);
+    ray_hist_add(&h1, "second",  6);
+    ray_hist_add(&h1, "third",   5);
+    ray_hist_save(&h1, path);
+    ray_hist_destroy(&h1);
+
+    /* Confirm file exists and has nonzero size */
+    struct stat st;
+    if (stat(path, &st) != 0) { unlink(path); FAIL("save did not create file"); }
+    if (st.st_size <= 0)      { unlink(path); FAIL("save produced empty file"); }
+
+    /* Load into fresh hist2, verify */
+    ray_hist_t h2;
+    ray_hist_create(&h2);
+    ray_hist_load(&h2, path);
+    int32_t cnt = h2.count;
+    int loaded_match =
+        cnt == 3
+        && strcmp(h2.entries[0], "first")  == 0
+        && strcmp(h2.entries[1], "second") == 0
+        && strcmp(h2.entries[2], "third")  == 0;
+    ray_hist_destroy(&h2);
+    unlink(path);
+    if (!loaded_match)
+        FAILF("round-trip mismatch: count=%d", cnt);
+    PASS();
+}
+
+static test_result_t test_hist_save_empty_no_file(void) {
+    /* Empty hist => save is a no-op, file not created */
+    char path[256];
+    make_temp_path(path, sizeof path, "empty");
+
+    ray_hist_t h;
+    ray_hist_create(&h);
+    ray_hist_save(&h, path);
+    struct stat st;
+    int exists = (stat(path, &st) == 0);
+    ray_hist_destroy(&h);
+    unlink(path);
+    TEST_ASSERT_FMT(!exists, "save with empty hist created a file");
+    PASS();
+}
+
+static test_result_t test_hist_load_missing_file(void) {
+    /* Load from a path that doesn't exist — must be a no-op (and not crash) */
+    char path[256];
+    snprintf(path, sizeof path, "/tmp/ray_term_test_nope_%d", (int)getpid());
+    unlink(path); /* be sure */
+
+    ray_hist_t h;
+    ray_hist_create(&h);
+    ray_hist_load(&h, path);
+    TEST_ASSERT_EQ_I(h.count, 0);
+    ray_hist_destroy(&h);
+    PASS();
+}
+
+static test_result_t test_hist_load_empty_file(void) {
+    /* A 0-byte file should also be a no-op */
+    char path[256];
+    make_temp_path(path, sizeof path, "empty_file");
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) FAIL("could not create empty file");
+    close(fd);
+
+    ray_hist_t h;
+    ray_hist_create(&h);
+    ray_hist_load(&h, path);
+    int32_t cnt = h.count;
+    ray_hist_destroy(&h);
+    unlink(path);
+    TEST_ASSERT_EQ_I(cnt, 0);
+    PASS();
+}
+
+/* Verify load skips over consecutive null bytes (empty entries) and that
+ * entries written by save can also be loaded verbatim back. */
+static test_result_t test_hist_load_skips_empty_records(void) {
+    char path[256];
+    make_temp_path(path, sizeof path, "skip_empty");
+
+    /* Hand-craft a file: "a\0\0b\0" — load should yield {"a","b"}. */
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) FAIL("temp write failed");
+    const char raw[] = { 'a', '\0', '\0', 'b', '\0' };
+    ssize_t w = write(fd, raw, sizeof raw);
+    (void)w;
+    close(fd);
+
+    ray_hist_t h;
+    ray_hist_create(&h);
+    ray_hist_load(&h, path);
+    int matched = h.count == 2
+        && strcmp(h.entries[0], "a") == 0
+        && strcmp(h.entries[1], "b") == 0;
+    ray_hist_destroy(&h);
+    unlink(path);
+    TEST_ASSERT_FMT(matched, "expected 2 entries 'a','b'");
+    PASS();
+}
+
+/* ─── Multi-line bracket counting ─────────────────────────────────── */
+
+static test_result_t test_term_count_unmatched_basic(void) {
+    ray_t* block = ray_alloc(sizeof(ray_term_t));
+    if (!block) FAIL("ray_alloc failed");
+    ray_term_t* t = (ray_term_t*)ray_data(block);
+    memset(t, 0, sizeof(*t));
+    t->_block = block;
+
+    /* Empty buf => no unmatched */
+    TEST_ASSERT_EQ_I(ray_term_count_unmatched(t), 0);
+
+    /* Single open => 1 */
+    strcpy(t->buf, "(");
+    t->buf_len = 1;
+    TEST_ASSERT_EQ_I(ray_term_count_unmatched(t), 1);
+
+    /* Balanced => 0 */
+    strcpy(t->buf, "([{}])");
+    t->buf_len = 6;
+    TEST_ASSERT_EQ_I(ray_term_count_unmatched(t), 0);
+
+    /* Open bracket inside string is ignored */
+    strcpy(t->buf, "\"(\"");
+    t->buf_len = 3;
+    TEST_ASSERT_EQ_I(ray_term_count_unmatched(t), 0);
+
+    /* Comment to end-of-line skips trailing brackets */
+    strcpy(t->buf, "(); rest (((");
+    t->buf_len = (int32_t)strlen(t->buf);
+    TEST_ASSERT_EQ_I(ray_term_count_unmatched(t), 0);
+
+    /* Multiline — unmatched ( on first chunk, not yet closed in buf */
+    strcpy(t->multiline_buf, "(foo\n");
+    t->multiline_len = 5;
+    strcpy(t->buf, "bar");
+    t->buf_len = 3;
+    TEST_ASSERT_EQ_I(ray_term_count_unmatched(t), 1);
+
+    /* Closed across chunks */
+    strcpy(t->multiline_buf, "(foo\n");
+    t->multiline_len = 5;
+    strcpy(t->buf, "bar)");
+    t->buf_len = 4;
+    TEST_ASSERT_EQ_I(ray_term_count_unmatched(t), 0);
+
+    /* Escaped quote inside multiline string keeps state correct */
+    strcpy(t->multiline_buf, "\"a\\\"b\n");
+    t->multiline_len = 6;
+    strcpy(t->buf, "c\"(");
+    t->buf_len = 3;
+    TEST_ASSERT_EQ_I(ray_term_count_unmatched(t), 1);
+
+    ray_free(block);
+    PASS();
+}
+
+/* ─── ray_term_goto_position ─────────────────────────────────────── */
+
+static test_result_t test_term_goto_position_no_op_zero_width(void) {
+    /* term_width <= 0 -> early return, no output */
+    char path[256], buf[64];
+    int saved = capture_begin(path, sizeof path);
+    if (saved < 0) FAIL("capture setup failed");
+
+    ray_term_t t;
+    memset(&t, 0, sizeof t);
+    t.term_width = 0;
+    t.prompt_len = 2;
+    ray_term_goto_position(&t, 0, 5);
+
+    int32_t n = capture_end(saved, path, buf, sizeof buf);
+    TEST_ASSERT_EQ_I(n, 0);
+    PASS();
+}
+
+static test_result_t test_term_goto_position_emits_movements(void) {
+    char path[256], buf[256];
+    int saved = capture_begin(path, sizeof path);
+    if (saved < 0) FAIL("capture setup failed");
+
+    /* Term 80 cols, prompt visual = 2; buf = 10 ASCII chars, no newlines.
+     * Move from col 12 (pos=10) -> col 7 (pos=5): same row, 5 cols left. */
+    ray_term_t t;
+    memset(&t, 0, sizeof t);
+    t.term_width = 80;
+    t.prompt_len = 2;
+    strcpy(t.buf, "abcdefghij");
+    t.buf_len = 10;
+    ray_term_goto_position(&t, 10, 5);
+
+    int32_t n = capture_end(saved, path, buf, sizeof buf);
+    TEST_ASSERT_FMT(n > 0, "no output");
+    TEST_ASSERT_FMT(strstr(buf, "\033[5D") != NULL,
+                    "missing left-5 movement: %s", buf);
+    /* Same-row -> no up/down */
+    TEST_ASSERT_FMT(strstr(buf, "[A") == NULL && strstr(buf, "[B") == NULL,
+                    "unexpected vertical movement");
+    /* Recorded final row = (2+5)/80 = 0 */
+    TEST_ASSERT_EQ_I(t.last_cursor_row, 0);
+    PASS();
+}
+
+static test_result_t test_term_goto_position_wraps_rows(void) {
+    char path[256], buf[256];
+    int saved = capture_begin(path, sizeof path);
+    if (saved < 0) FAIL("capture setup failed");
+
+    /* Narrow terminal (10 cols) forces wrapping.  Prompt=2, buf=20 chars.
+     * From pos 0 (row 0, col 2) to pos 20 (col total=22 -> row 2, col 2):
+     * down 2, right 0. */
+    ray_term_t t;
+    memset(&t, 0, sizeof t);
+    t.term_width = 10;
+    t.prompt_len = 2;
+    memset(t.buf, 'a', 20);
+    t.buf[20] = '\0';
+    t.buf_len = 20;
+    ray_term_goto_position(&t, 0, 20);
+
+    int32_t n = capture_end(saved, path, buf, sizeof buf);
+    TEST_ASSERT_FMT(n > 0, "no output");
+    TEST_ASSERT_FMT(strstr(buf, "\033[2B") != NULL,
+                    "missing down-2 movement: %s", buf);
+    TEST_ASSERT_EQ_I(t.last_cursor_row, 2);
+    PASS();
+}
+
+static test_result_t test_term_goto_position_up_movement(void) {
+    char path[256], buf[256];
+    int saved = capture_begin(path, sizeof path);
+    if (saved < 0) FAIL("capture setup failed");
+
+    /* From pos 20 (row 2) back to pos 0 (row 0): up 2, right 0 (col-aligned)
+     * actually col_diff = 2-2 = 0 since prompt_len = 2. */
+    ray_term_t t;
+    memset(&t, 0, sizeof t);
+    t.term_width = 10;
+    t.prompt_len = 2;
+    memset(t.buf, 'a', 20);
+    t.buf[20] = '\0';
+    t.buf_len = 20;
+    ray_term_goto_position(&t, 20, 0);
+
+    int32_t n = capture_end(saved, path, buf, sizeof buf);
+    TEST_ASSERT_FMT(n > 0, "no output");
+    TEST_ASSERT_FMT(strstr(buf, "\033[2A") != NULL,
+                    "missing up-2 movement: %s", buf);
+    TEST_ASSERT_EQ_I(t.last_cursor_row, 0);
+    PASS();
+}
+
+/* ─── ray_term_redraw (exercises term_highlight_into + goto_position) ── */
+
+/* Redraw is a write-only function — it streams escape sequences and the
+ * highlighted buffer to stdout.  We only need it to *not crash* and to
+ * emit *something* with the bracket-match colour for a balanced "(x)".
+ * The runtime is required for env_has_name lookups inside the highlighter
+ * (the keyword green path). */
+static test_result_t test_term_redraw_smoke(void) {
+    ray_t* block = ray_alloc(sizeof(ray_term_t));
+    if (!block) FAIL("ray_alloc failed");
+    ray_term_t* t = (ray_term_t*)ray_data(block);
+    memset(t, 0, sizeof(*t));
+    t->_block = block;
+    t->term_width = 80;
+    t->term_height = 24;
+    t->prompt_len = 2;
+    t->last_total_rows = 1;
+    ray_hist_create(&t->hist);
+
+    /* Buffer with brackets, a string literal, a quoted symbol, a comment,
+     * and an operator — exercises every arm of term_highlight_into. */
+    const char* src = "(let 'x \"hi\" + 1) ; trailing comment";
+    int32_t slen = (int32_t)strlen(src);
+    memcpy(t->buf, src, (size_t)slen);
+    t->buf_len = slen;
+    t->buf_pos = 1;  /* On the '(' so bracket-match path engages */
+
+    char path[256], buf[8192];
+    int saved = capture_begin(path, sizeof path);
+    if (saved < 0) {
+        ray_hist_destroy(&t->hist);
+        ray_free(block);
+        FAIL("capture setup failed");
+    }
+    ray_term_redraw(t);
+    int32_t n = capture_end(saved, path, buf, sizeof buf);
+
+    int output_ok = n > 0;
+    /* Bracket-match highlight uses cyan-bg (CSI 46) */
+    int saw_match = strstr(buf, "\033[46m") != NULL;
+    /* Some color reset must appear */
+    int saw_reset = strstr(buf, "\033[0m") != NULL;
+
+    ray_hist_destroy(&t->hist);
+    ray_free(block);
+    TEST_ASSERT_FMT(output_ok, "no redraw output");
+    TEST_ASSERT_FMT(saw_match, "missing bracket-match highlight");
+    TEST_ASSERT_FMT(saw_reset, "missing color reset");
+    PASS();
+}
+
+/* Redraw with cursor BEFORE a closing bracket — the second branch in
+ * the cursor-vs-match check (cursor > 0 case) becomes live. */
+static test_result_t test_term_redraw_close_bracket(void) {
+    ray_t* block = ray_alloc(sizeof(ray_term_t));
+    if (!block) FAIL("ray_alloc failed");
+    ray_term_t* t = (ray_term_t*)ray_data(block);
+    memset(t, 0, sizeof(*t));
+    t->_block = block;
+    t->term_width = 80;
+    t->term_height = 24;
+    t->prompt_len = 2;
+    t->last_total_rows = 1;
+    ray_hist_create(&t->hist);
+
+    const char* src = "(abc)";
+    int32_t slen = (int32_t)strlen(src);
+    memcpy(t->buf, src, (size_t)slen);
+    t->buf_len = slen;
+    /* Position the cursor right after ')', so the cursor-1 path in
+     * ray_term_redraw is what triggers the bracket match. */
+    t->buf_pos = slen;
+
+    char path[256], buf[4096];
+    int saved = capture_begin(path, sizeof path);
+    if (saved < 0) {
+        ray_hist_destroy(&t->hist);
+        ray_free(block);
+        FAIL("capture setup failed");
+    }
+    ray_term_redraw(t);
+    int32_t n = capture_end(saved, path, buf, sizeof buf);
+    int saw_match = strstr(buf, "\033[46m") != NULL;
+    int output_ok = n > 0;
+
+    ray_hist_destroy(&t->hist);
+    ray_free(block);
+    TEST_ASSERT_FMT(output_ok, "no redraw output");
+    TEST_ASSERT_FMT(saw_match, "missing bracket-match for cursor-after-close");
+    PASS();
+}
+
+/* Redraw with a multiline buffer chooses the continuation prompt branch. */
+static test_result_t test_term_redraw_multiline_prompt(void) {
+    ray_t* block = ray_alloc(sizeof(ray_term_t));
+    if (!block) FAIL("ray_alloc failed");
+    ray_term_t* t = (ray_term_t*)ray_data(block);
+    memset(t, 0, sizeof(*t));
+    t->_block = block;
+    t->term_width = 80;
+    t->term_height = 24;
+    t->prompt_len = 2;
+    t->last_total_rows = 1;
+    ray_hist_create(&t->hist);
+
+    strcpy(t->multiline_buf, "(foo\n");
+    t->multiline_len = 5;
+    strcpy(t->buf, "bar");
+    t->buf_len = 3;
+    t->buf_pos = 3;
+
+    char path[256], buf[4096];
+    int saved = capture_begin(path, sizeof path);
+    if (saved < 0) {
+        ray_hist_destroy(&t->hist);
+        ray_free(block);
+        FAIL("capture setup failed");
+    }
+    ray_term_redraw(t);
+    int32_t n = capture_end(saved, path, buf, sizeof buf);
+    int output_ok = n > 0;
+    /* Continuation prompt uses gray fg \033[90m */
+    int saw_cont = strstr(buf, "\033[90m") != NULL;
+
+    ray_hist_destroy(&t->hist);
+    ray_free(block);
+    TEST_ASSERT_FMT(output_ok, "no redraw output");
+    TEST_ASSERT_FMT(saw_cont, "missing continuation prompt color");
+    PASS();
+}
+
+/* ─── ray_term_collect_completions (needs lang runtime) ────────────── */
+
+static test_result_t test_term_collect_completions_env(void) {
+    ray_t* block = ray_alloc(sizeof(ray_term_t));
+    if (!block) FAIL("ray_alloc failed");
+    ray_term_t* t = (ray_term_t*)ray_data(block);
+    memset(t, 0, sizeof(*t));
+    t->_block = block;
+    ray_hist_create(&t->hist);
+
+    /* Prefix "se" should match builtins like "select", "set" registered by
+     * the runtime.  We don't hard-code their names — just assert we see at
+     * least one match and no crash. */
+    ray_term_collect_completions(t, "se", 2);
+    TEST_ASSERT_FMT(t->comp_count > 0,
+                    "expected at least 1 completion for 'se'; got %d",
+                    t->comp_count);
+    /* All results must start with the prefix (prefix lookup contract) */
+    for (int32_t i = 0; i < t->comp_count; i++) {
+        TEST_ASSERT_FMT(t->comp_items[i] != NULL,
+                        "comp_items[%d] is NULL", i);
+        TEST_ASSERT_FMT(strncmp(t->comp_items[i], "se", 2) == 0,
+                        "comp_items[%d]='%s' doesn't start with 'se'",
+                        i, t->comp_items[i]);
+    }
+
+    /* Empty prefix => 0 results, fast path */
+    ray_term_collect_completions(t, "", 0);
+    TEST_ASSERT_EQ_I(t->comp_count, 0);
+
+    /* Prefix that nothing matches */
+    ray_term_collect_completions(t, "qzqzqzqz", 8);
+    TEST_ASSERT_EQ_I(t->comp_count, 0);
+
+    ray_hist_destroy(&t->hist);
+    ray_free(block);
+    PASS();
+}
+
+/* Verify the column-name source: when buf contains "from: NAME", and NAME
+ * is bound to a table in the env, completions include matching column
+ * names.  Exercises comp_find_from_table + the column iteration path. */
+static test_result_t test_term_collect_completions_table_columns(void) {
+    ray_t* block = ray_alloc(sizeof(ray_term_t));
+    if (!block) FAIL("ray_alloc failed");
+    ray_term_t* t = (ray_term_t*)ray_data(block);
+    memset(t, 0, sizeof(*t));
+    t->_block = block;
+    ray_hist_create(&t->hist);
+
+    /* Build a tiny table with columns ucol_alpha and ucol_beta, bind it
+     * under a unique name `ucol_table` so we don't collide with anything. */
+    int64_t n_alpha = ray_sym_intern("ucol_alpha", 10);
+    int64_t n_beta  = ray_sym_intern("ucol_beta",  9);
+    int64_t v[] = { 1 };
+    ray_t* col_a = ray_vec_from_raw(RAY_I64, v, 1);
+    ray_t* col_b = ray_vec_from_raw(RAY_I64, v, 1);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, n_alpha, col_a);
+    tbl = ray_table_add_col(tbl, n_beta,  col_b);
+    ray_release(col_a);
+    ray_release(col_b);
+    int64_t n_tbl = ray_sym_intern("ucol_table", 10);
+    ray_env_bind(n_tbl, tbl);
+
+    /* Buffer references the table via a `from: ucol_table` query.  The
+     * cursor's prefix is "ucol_a" — we should see ucol_alpha. */
+    const char* sql = "(select {from: ucol_table} ucol_a";
+    int32_t slen = (int32_t)strlen(sql);
+    memcpy(t->buf, sql, (size_t)slen);
+    t->buf_len = slen;
+
+    ray_term_collect_completions(t, "ucol_a", 6);
+    int seen_alpha = 0;
+    for (int32_t i = 0; i < t->comp_count; i++) {
+        if (strcmp(t->comp_items[i], "ucol_alpha") == 0) seen_alpha = 1;
+    }
+    /* Be tolerant: the column lookup is one of several sources, and any
+     * env-bound user name `ucol_alpha` would also surface — what matters
+     * is that the symbol shows up. */
+    TEST_ASSERT_FMT(seen_alpha,
+                    "expected 'ucol_alpha' in completions; got %d",
+                    t->comp_count);
+
+    ray_hist_destroy(&t->hist);
+    ray_free(block);
+    PASS();
+}
+
+static test_result_t test_term_collect_completions_history(void) {
+    ray_t* block = ray_alloc(sizeof(ray_term_t));
+    if (!block) FAIL("ray_alloc failed");
+    ray_term_t* t = (ray_term_t*)ray_data(block);
+    memset(t, 0, sizeof(*t));
+    t->_block = block;
+    ray_hist_create(&t->hist);
+
+    /* Add an entry containing a unique word — must surface in completions. */
+    ray_hist_add(&t->hist, "(define unicornword 42)", 23);
+    ray_term_collect_completions(t, "unicorn", 7);
+    int found = 0;
+    for (int32_t i = 0; i < t->comp_count; i++) {
+        if (strcmp(t->comp_items[i], "unicornword") == 0) { found = 1; break; }
+    }
+    TEST_ASSERT_FMT(found,
+                    "expected 'unicornword' in completions; got %d items",
+                    t->comp_count);
+
+    /* Adding a second history hit for the same word should NOT duplicate. */
+    ray_hist_add(&t->hist, "use unicornword again", 21);
+    ray_term_collect_completions(t, "unicorn", 7);
+    int dup_count = 0;
+    for (int32_t i = 0; i < t->comp_count; i++) {
+        if (strcmp(t->comp_items[i], "unicornword") == 0) dup_count++;
+    }
+    TEST_ASSERT_EQ_I(dup_count, 1);
+
+    ray_hist_destroy(&t->hist);
+    ray_free(block);
+    PASS();
+}
+
+/* ─── Suite ───────────────────────────────────────────────────────── */
+
+const test_entry_t term_entries[] = {
+    /* Terminal size + cursor / line escape printers (no runtime needed) */
+    { "term/get_size",                  test_term_get_size,
+      heap_setup, heap_teardown },
+    { "term/cursor_move_basics",        test_term_cursor_move_basics,
+      heap_setup, heap_teardown },
+    { "term/line_clear_visibility",     test_term_line_clear_and_visibility,
+      heap_setup, heap_teardown },
+
+    /* Visual width */
+    { "term/visual_width_ascii",        test_term_visual_width_ascii,
+      heap_setup, heap_teardown },
+    { "term/visual_width_strips_esc",   test_term_visual_width_strips_escapes,
+      heap_setup, heap_teardown },
+    { "term/visual_width_utf8",         test_term_visual_width_utf8,
+      heap_setup, heap_teardown },
+    { "term/visual_width_bare_escape",  test_term_visual_width_bare_escape,
+      heap_setup, heap_teardown },
+
+    /* Bracket matching */
+    { "term/find_paren_simple",         test_term_find_matching_paren_simple,
+      heap_setup, heap_teardown },
+    { "term/find_paren_nested",         test_term_find_matching_paren_nested,
+      heap_setup, heap_teardown },
+    { "term/find_paren_unmatched",      test_term_find_matching_paren_unmatched,
+      heap_setup, heap_teardown },
+    { "term/find_paren_braces",         test_term_find_matching_paren_braces_brackets,
+      heap_setup, heap_teardown },
+    { "term/find_paren_in_string",      test_term_find_matching_paren_in_string,
+      heap_setup, heap_teardown },
+
+    /* History core */
+    { "term/hist_create_destroy",       test_hist_create_destroy,
+      heap_setup, heap_teardown },
+    { "term/hist_add_basic",            test_hist_add_basic,
+      heap_setup, heap_teardown },
+    { "term/hist_add_grows",            test_hist_add_grows,
+      heap_setup, heap_teardown },
+    { "term/hist_prev_next",            test_hist_prev_next,
+      heap_setup, heap_teardown },
+    { "term/hist_prev_empty",           test_hist_prev_empty,
+      heap_setup, heap_teardown },
+
+    /* History search + persistence */
+    { "term/hist_search",               test_hist_search,
+      heap_setup, heap_teardown },
+    { "term/hist_save_load_roundtrip",  test_hist_save_load_roundtrip,
+      heap_setup, heap_teardown },
+    { "term/hist_save_empty_no_file",   test_hist_save_empty_no_file,
+      heap_setup, heap_teardown },
+    { "term/hist_load_missing",         test_hist_load_missing_file,
+      heap_setup, heap_teardown },
+    { "term/hist_load_empty",           test_hist_load_empty_file,
+      heap_setup, heap_teardown },
+    { "term/hist_load_skip_empty_recs", test_hist_load_skips_empty_records,
+      heap_setup, heap_teardown },
+
+    /* Multi-line bracket counting */
+    { "term/count_unmatched",           test_term_count_unmatched_basic,
+      heap_setup, heap_teardown },
+
+    /* Cursor positioning math */
+    { "term/goto_pos_zero_width",       test_term_goto_position_no_op_zero_width,
+      heap_setup, heap_teardown },
+    { "term/goto_pos_movements",        test_term_goto_position_emits_movements,
+      heap_setup, heap_teardown },
+    { "term/goto_pos_wraps",            test_term_goto_position_wraps_rows,
+      heap_setup, heap_teardown },
+    { "term/goto_pos_up",               test_term_goto_position_up_movement,
+      heap_setup, heap_teardown },
+
+    /* Redraw + highlight (needs runtime for keyword highlighting + comp_count) */
+    { "term/redraw_smoke",              test_term_redraw_smoke,
+      runtime_setup, runtime_teardown },
+    { "term/redraw_close_bracket",      test_term_redraw_close_bracket,
+      runtime_setup, runtime_teardown },
+    { "term/redraw_multiline_prompt",   test_term_redraw_multiline_prompt,
+      runtime_setup, runtime_teardown },
+
+    /* Completions (need the full runtime — env, sym, keywords, table) */
+    { "term/completions_env",           test_term_collect_completions_env,
+      runtime_setup, runtime_teardown },
+    { "term/completions_table_cols",    test_term_collect_completions_table_columns,
+      runtime_setup, runtime_teardown },
+    { "term/completions_history",       test_term_collect_completions_history,
+      runtime_setup, runtime_teardown },
+
+    { NULL, NULL, NULL, NULL },
+};


### PR DESCRIPTION
## Summary

Three C-side test suites driving REPL-adjacent files that the rfl harness can't reach (the harness calls \`ray_eval_str\` directly, bypassing both the line-edit terminal and the repl wrapper).  Plus two latent bug fixes that the new tests surfaced.

### Bug fixes

1. **\`ray_term_visual_width\` ANSI escape state machine** (\`src/app/term.c\`).  Single-state machine treated the CSI introducer \`[\` (0x5B) as the final byte because 0x5B sits in the [0x40, 0x7E] "final byte" range.  Result: every CSI sequence (SGR colors, cursor moves) terminated one byte early, and the digits/\`;\`/\`m\` characters that followed leaked into the visual-width count.  For \`"\\033[31mred\\033[0m!"\` the function returned 9 instead of 4.  The REPL under-counted rows on multi-line input and mis-positioned the cursor whenever syntax highlighting was active.  Fix: 3-state machine.

2. **Comments-only file in \`ray_repl_run_file\`** (\`src/app/repl.c\`).  A file containing only \`;;\` line comments would cause \`parse_source\` to error with "parse" because it expected at least one expression — but every Lisp/shell-style language treats a header-only file as a successful no-op.  Fix: single-pass whitespace+comment scan that short-circuits to \`return 0\`.

### Coverage delta

| File | Before | After | Δ |
|------|-------:|------:|--:|
| \`src/core/progress.c\` | 10.84% | **100.00%** | +89.16pp |
| \`src/app/term.c\` | 0.00% | **46.28%** | +46.28pp |
| \`src/app/repl.c\` | 0.00% | **26.89%** | +26.89pp |
| **TOTAL line coverage** | 75.18% | **76.96%** | +1.78pp |

\`term.c\` and \`repl.c\` were both at 0% — the rfl harness goes through \`ray_eval_str\`, never the line-edit code or the repl wrapper, so without dedicated C tests these files had no direct coverage.  46% / 27% reflects the testable subsets (history, cursor math, ANSI escape printers; \`ray_repl_run_file\` + piped-mode loop); the remaining ~50% / ~70% is interactive raw-mode keystroke handling that needs a real PTY to exercise — out of scope here.

### Suites added

- \`test_progress.c\` (15 tests): callback fires after \`min_ms\`, \`tick_ms\` throttle, label/end semantics, snapshot fields, lazy start, user-pointer plumbing, end-without-callback.
- \`test_term.c\` (34 tests): cursor + line escape printers, \`ray_term_get_size\` ioctl + 80x24 fallback, \`ray_term_visual_width\` (ASCII / ANSI / 1..4-byte UTF-8 / SS3 / bare ESC), paren-match, history (create/add/nav/search/save+load round-trip), bracket-balance state across chunks, \`ray_term_redraw\` (bracket-match + multiline cont prompt), \`ray_term_collect_completions\` (env + \`from:\` table cols + history words).
- \`test_repl.c\` (21 tests): \`ray_repl_run_file\` happy / multi-form / parse-error / eval-error / empty / comments-only / nonexistent / multiline / lazy result; lifecycle (\`create\` null-poll, \`destroy\` null); piped-mode loop via stdin pipe redirection (single, multi-line, multi-form, empty, comments-blank, \`\\\` exit, \`exit\` word, \`:quit\`, command, error-continue).

## Test plan

- [x] \`make test\` — 1224 of 1225 passed (1 pre-existing skip, 0 failed)
- [x] ASan/UBSan clean
- [x] Coverage measured both with and without pass-7 to compute the delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)