### PR TITLE
perf: canonical H2O q6/q8/q9 — OP_MEDIAN, OP_PEARSON_CORR, OP_TOP_N, OP_GROUP_TOPK_ROWFORM

### DIFF
--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -2499,11 +2499,13 @@ static void ray_register_builtins(void) {
      * types.  Per-group usage works through the eval-level scatter. */
     register_binary("top", RAY_FN_NONE, ray_top_fn);
     register_binary("bot", RAY_FN_NONE, ray_bot_fn);
-    /* pearson_corr: 2-input scalar reducer.  Per-group usage routes
-     * through the eval-level scatter (head not in agg-opcode list,
-     * but expr_refs_row_column → row-aligned check → per-group eval
-     * fallback when full-table call collapses to a scalar). */
-    register_binary("pearson_corr", RAY_FN_NONE, ray_pearson_corr_fn);
+    /* pearson_corr: 2-input scalar reducer.  Marked AGGR + LAZY_AWARE so
+     * the planner picks it up via is_streaming_aggr_binary_call and lowers
+     * a `(pearson_corr x y)` reference inside `(select ... by ...)` to an
+     * OP_PEARSON_CORR DAG node — single-pass vectorized hash-agg.  The
+     * ray_pearson_corr_fn body remains the fallback for non-vectorizable
+     * shapes (LIST inputs, eval-level scatter on unsupported key types). */
+    register_binary("pearson_corr", RAY_FN_AGGR | RAY_FN_LAZY_AWARE, ray_pearson_corr_fn);
 
     /* Special forms */
     register_binary("set", RAY_FN_SPECIAL_FORM | RAY_FN_RESTRICTED, ray_set_fn);

--- a/src/lang/internal.h
+++ b/src/lang/internal.h
@@ -328,6 +328,11 @@ ray_t* ray_top_fn(ray_t* v, ray_t* n_obj);
 ray_t* ray_bot_fn(ray_t* v, ray_t* n_obj);
 ray_t* ray_pearson_corr_fn(ray_t* x, ray_t* y);
 
+/* In-place median (quickselect).  Caller owns the buffer; we permute
+ * elements.  Returns NaN if n <= 0.  Used by aggr_med_per_group_buf in
+ * query.c for the fast per-group median path. */
+double ray_median_dbl_inplace(double* a, int64_t n);
+
 /* Collection helpers (formerly static in eval.c, now in collection.c) */
 int    atom_eq(ray_t* a, ray_t* b);
 ray_t* list_to_typed_vec(ray_t* list, int8_t orig_vec_type);

--- a/src/ops/agg.c
+++ b/src/ops/agg.c
@@ -546,6 +546,26 @@ ray_t* ray_med_fn(ray_t* x) {
 static ray_t* var_stddev_core(ray_t* x, int sample, int take_sqrt);
 
 
+/* In-place exact median over a flat double buffer.  Caller owns the
+ * buffer; we permute its elements via nth_element_dbl.  Returns NaN
+ * if n <= 0 (caller must filter that case if a typed-null is needed).
+ *
+ * Used by the per-group median fast path in query.c which avoids the
+ * full ray_med_fn slice-allocation cost — see aggr_med_per_group_buf. */
+double ray_median_dbl_inplace(double* a, int64_t n) {
+    if (n <= 0) return 0.0;
+    if (n == 1) return a[0];
+    int64_t k = n / 2;
+    if (n % 2 == 1) {
+        nth_element_dbl(a, 0, n - 1, k);
+        return a[k];
+    }
+    nth_element_dbl(a, 0, n - 1, k - 1);
+    nth_element_dbl(a, k, n - 1, k);
+    return (a[k - 1] + a[k]) / 2.0;
+}
+
+
 ray_t* ray_dev_fn(ray_t* x) { return var_stddev_core(x, 0, 1); }
 
 /* Shared core for variance / stddev in sample or population mode.

--- a/src/ops/builtins.c
+++ b/src/ops/builtins.c
@@ -2950,7 +2950,43 @@ ray_t* ray_raze_fn(ray_t* x) {
     int64_t n = x->len;
     if (n == 0) return ray_list_new(0);
     ray_t** items = (ray_t**)ray_data(x);
-    /* Try to concat all items */
+
+    /* Fast path: all items are vectors of the same primitive type
+     * (numeric/temporal, fixed-width, no SYM/STR/GUID/LIST/null).
+     * Pre-size one output vector and memcpy each item's data — O(total)
+     * instead of the pairwise concat loop's O(N²). */
+    if (ray_is_vec(items[0])) {
+        int8_t t = items[0]->type;
+        bool fast = (t != RAY_LIST && t != RAY_STR && t != RAY_SYM && t != RAY_GUID);
+        int64_t total = 0;
+        if (fast) {
+            for (int64_t i = 0; i < n; i++) {
+                ray_t* it = items[i];
+                if (!ray_is_vec(it) || it->type != t
+                    || (it->attrs & RAY_ATTR_HAS_NULLS)) {
+                    fast = false; break;
+                }
+                total += it->len;
+            }
+        }
+        if (fast) {
+            ray_t* out = ray_vec_new(t, total);
+            if (!out || RAY_IS_ERR(out)) return out ? out : ray_error("oom", NULL);
+            out->len = total;
+            uint8_t esz = ray_elem_size(t);
+            char* dst = (char*)ray_data(out);
+            int64_t pos = 0;
+            for (int64_t i = 0; i < n; i++) {
+                int64_t k = items[i]->len;
+                if (k > 0) memcpy(dst + pos * esz, ray_data(items[i]), (size_t)k * esz);
+                pos += k;
+            }
+            return out;
+        }
+    }
+
+    /* Slow path: pairwise concat — used for mixed types, null-bearing
+     * inputs, and non-fixed-width vectors (SYM/STR/GUID/LIST). */
     ray_t* result = items[0];
     ray_retain(result);
     for (int64_t i = 1; i < n; i++) {

--- a/src/ops/dump.c
+++ b/src/ops/dump.c
@@ -89,6 +89,7 @@ const char* ray_opcode_name(uint16_t op) {
         case OP_VAR:           return "VAR";
         case OP_VAR_POP:       return "VAR_POP";
         case OP_PEARSON_CORR:  return "PEARSON_CORR";
+        case OP_MEDIAN:        return "MEDIAN";
         case OP_FILTER:        return "FILTER";
         case OP_SORT:          return "SORT";
         case OP_GROUP:         return "GROUP";

--- a/src/ops/dump.c
+++ b/src/ops/dump.c
@@ -88,6 +88,7 @@ const char* ray_opcode_name(uint16_t op) {
         case OP_STDDEV_POP:    return "STDDEV_POP";
         case OP_VAR:           return "VAR";
         case OP_VAR_POP:       return "VAR_POP";
+        case OP_PEARSON_CORR:  return "PEARSON_CORR";
         case OP_FILTER:        return "FILTER";
         case OP_SORT:          return "SORT";
         case OP_GROUP:         return "GROUP";

--- a/src/ops/dump.c
+++ b/src/ops/dump.c
@@ -93,6 +93,8 @@ const char* ray_opcode_name(uint16_t op) {
         case OP_FILTER:        return "FILTER";
         case OP_SORT:          return "SORT";
         case OP_GROUP:         return "GROUP";
+        case OP_GROUP_TOPK_ROWFORM: return "GROUP_TOPK_ROWFORM";
+        case OP_GROUP_BOTK_ROWFORM: return "GROUP_BOTK_ROWFORM";
         case OP_FILTERED_GROUP:return "FILTERED_GROUP";
         case OP_PIVOT:         return "PIVOT";
         case OP_ANTIJOIN:      return "ANTIJOIN";

--- a/src/ops/exec.c
+++ b/src/ops/exec.c
@@ -859,6 +859,7 @@ static ray_t* exec_in(ray_graph_t* g, ray_op_t* op, ray_t* col, ray_t* set) {
 /* Is this opcode a "heavy" pipeline breaker worth profiling? */
 static inline bool op_is_heavy(uint16_t opc) {
     return opc == OP_FILTER || opc == OP_SORT || opc == OP_GROUP ||
+           opc == OP_GROUP_TOPK_ROWFORM || opc == OP_GROUP_BOTK_ROWFORM ||
            opc == OP_JOIN   || opc == OP_WINDOW_JOIN || opc == OP_SELECT ||
            opc == OP_HEAD   || opc == OP_TAIL || opc == OP_WINDOW ||
            opc == OP_PIVOT  ||
@@ -1234,6 +1235,10 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
 
         case OP_FILTERED_GROUP:
             return exec_filtered_group(g, op);
+
+        case OP_GROUP_TOPK_ROWFORM:
+        case OP_GROUP_BOTK_ROWFORM:
+            return exec_group_topk_rowform(g, op);
 
         case OP_PIVOT: {
             ray_t* tbl = g->table;

--- a/src/ops/graph.c
+++ b/src/ops/graph.c
@@ -56,6 +56,12 @@ static void graph_fixup_ext_ptrs(ray_graph_t* g, ptrdiff_t delta) {
                     ext->keys[k] = graph_fix_ptr(ext->keys[k], delta);
                 for (uint8_t a = 0; a < ext->n_aggs; a++)
                     ext->agg_ins[a] = graph_fix_ptr(ext->agg_ins[a], delta);
+                if (ext->agg_ins2) {
+                    for (uint8_t a = 0; a < ext->n_aggs; a++) {
+                        if (ext->agg_ins2[a])
+                            ext->agg_ins2[a] = graph_fix_ptr(ext->agg_ins2[a], delta);
+                    }
+                }
                 break;
             case OP_JOIN:
             case OP_ANTIJOIN:
@@ -679,6 +685,11 @@ ray_op_t* ray_stddev(ray_graph_t* g, ray_op_t* a)     { return make_unary(g, OP_
 ray_op_t* ray_stddev_pop(ray_graph_t* g, ray_op_t* a)  { return make_unary(g, OP_STDDEV_POP, a, RAY_F64); }
 ray_op_t* ray_var(ray_graph_t* g, ray_op_t* a)         { return make_unary(g, OP_VAR, a, RAY_F64); }
 ray_op_t* ray_var_pop(ray_graph_t* g, ray_op_t* a)     { return make_unary(g, OP_VAR_POP, a, RAY_F64); }
+/* Pearson correlation is a 2-input aggregator; the node carries two
+ * input pointers (x and y) and lowers to OP_PEARSON_CORR. */
+ray_op_t* ray_pearson_corr(ray_graph_t* g, ray_op_t* x, ray_op_t* y) {
+    return make_binary(g, OP_PEARSON_CORR, x, y, RAY_F64);
+}
 
 /* --------------------------------------------------------------------------
  * Structural ops
@@ -747,22 +758,37 @@ ray_op_t* ray_sort_op(ray_graph_t* g, ray_op_t* table_node,
     return &g->nodes[ext->base.id];
 }
 
-ray_op_t* ray_group(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
-                   uint16_t* agg_ops, ray_op_t** agg_ins, uint8_t n_aggs) {
+/* Shared impl for ray_group / ray_group2.  agg_ins2 NULL → no binary
+ * aggs; otherwise must be the same length as agg_ins (NULL slots for
+ * unary aggs, non-NULL for OP_PEARSON_CORR slots). */
+static ray_op_t* ray_group_impl(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
+                                uint16_t* agg_ops, ray_op_t** agg_ins,
+                                ray_op_t** agg_ins2, uint8_t n_aggs) {
     uint32_t key_ids[256];
     uint32_t agg_ids[256];
+    uint32_t agg_ids2[256];  /* parallel to agg_ids; 0 when no second input */
+    bool has_ins2 = false;
     for (uint8_t i = 0; i < n_keys; i++) key_ids[i] = keys[i]->id;
-    for (uint8_t i = 0; i < n_aggs; i++) agg_ids[i] = agg_ins[i]->id;
+    for (uint8_t i = 0; i < n_aggs; i++) {
+        agg_ids[i]  = agg_ins[i]->id;
+        agg_ids2[i] = 0;
+        if (agg_ins2 && agg_ins2[i]) {
+            agg_ids2[i] = agg_ins2[i]->id;
+            has_ins2 = true;
+        }
+    }
 
     size_t keys_sz = (size_t)n_keys * sizeof(ray_op_t*);
     size_t ops_sz  = (size_t)n_aggs * sizeof(uint16_t);
     size_t ins_sz  = (size_t)n_aggs * sizeof(ray_op_t*);
-    /* Align ops after keys (pointer-sized), ins after ops (needs ptr alignment) */
-    size_t ops_off = keys_sz;
-    size_t ins_off = ops_off + ops_sz;
+    size_t ins2_sz = has_ins2 ? ins_sz : 0;
+    /* Align ops after keys (pointer-sized), ins after ops, ins2 after ins. */
+    size_t ops_off  = keys_sz;
+    size_t ins_off  = ops_off + ops_sz;
     /* Round ins_off up to pointer alignment */
     ins_off = (ins_off + sizeof(ray_op_t*) - 1) & ~(sizeof(ray_op_t*) - 1);
-    ray_op_ext_t* ext = graph_alloc_ext_node_ex(g, ins_off + ins_sz);
+    size_t ins2_off = ins_off + ins_sz;
+    ray_op_ext_t* ext = graph_alloc_ext_node_ex(g, ins2_off + ins2_sz);
     if (!ext) return NULL;
 
     ext->base.opcode = OP_GROUP;
@@ -782,11 +808,29 @@ ray_op_t* ray_group(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
     ext->agg_ins = (ray_op_t**)(trail + ins_off);
     for (uint8_t i = 0; i < n_aggs; i++)
         ext->agg_ins[i] = &g->nodes[agg_ids[i]];
+    if (has_ins2) {
+        ext->agg_ins2 = (ray_op_t**)(trail + ins2_off);
+        for (uint8_t i = 0; i < n_aggs; i++)
+            ext->agg_ins2[i] = agg_ids2[i] ? &g->nodes[agg_ids2[i]] : NULL;
+    } else {
+        ext->agg_ins2 = NULL;
+    }
     ext->n_keys = n_keys;
     ext->n_aggs = n_aggs;
 
     g->nodes[ext->base.id] = ext->base;
     return &g->nodes[ext->base.id];
+}
+
+ray_op_t* ray_group(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
+                   uint16_t* agg_ops, ray_op_t** agg_ins, uint8_t n_aggs) {
+    return ray_group_impl(g, keys, n_keys, agg_ops, agg_ins, NULL, n_aggs);
+}
+
+ray_op_t* ray_group2(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
+                     uint16_t* agg_ops, ray_op_t** agg_ins,
+                     ray_op_t** agg_ins2, uint8_t n_aggs) {
+    return ray_group_impl(g, keys, n_keys, agg_ops, agg_ins, agg_ins2, n_aggs);
 }
 
 ray_op_t* ray_distinct(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys) {

--- a/src/ops/graph.c
+++ b/src/ops/graph.c
@@ -765,16 +765,19 @@ ray_op_t* ray_sort_op(ray_graph_t* g, ray_op_t* table_node,
     return &g->nodes[ext->base.id];
 }
 
-/* Shared impl for ray_group / ray_group2.  agg_ins2 NULL → no binary
- * aggs; otherwise must be the same length as agg_ins (NULL slots for
- * unary aggs, non-NULL for OP_PEARSON_CORR slots). */
+/* Shared impl for ray_group / ray_group2 / ray_group3.  agg_ins2 NULL →
+ * no binary aggs; otherwise must be the same length as agg_ins (NULL
+ * slots for unary aggs, non-NULL for OP_PEARSON_CORR slots).  agg_k NULL
+ * → no scalar params; otherwise length n_aggs (0 in slots without). */
 static ray_op_t* ray_group_impl(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
                                 uint16_t* agg_ops, ray_op_t** agg_ins,
-                                ray_op_t** agg_ins2, uint8_t n_aggs) {
+                                ray_op_t** agg_ins2, const int64_t* agg_k,
+                                uint8_t n_aggs) {
     uint32_t key_ids[256];
     uint32_t agg_ids[256];
     uint32_t agg_ids2[256];  /* parallel to agg_ids; 0 when no second input */
     bool has_ins2 = false;
+    bool has_k = false;
     for (uint8_t i = 0; i < n_keys; i++) key_ids[i] = keys[i]->id;
     for (uint8_t i = 0; i < n_aggs; i++) {
         agg_ids[i]  = agg_ins[i]->id;
@@ -783,19 +786,24 @@ static ray_op_t* ray_group_impl(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
             agg_ids2[i] = agg_ins2[i]->id;
             has_ins2 = true;
         }
+        if (agg_k && agg_k[i] != 0) has_k = true;
     }
 
     size_t keys_sz = (size_t)n_keys * sizeof(ray_op_t*);
     size_t ops_sz  = (size_t)n_aggs * sizeof(uint16_t);
     size_t ins_sz  = (size_t)n_aggs * sizeof(ray_op_t*);
     size_t ins2_sz = has_ins2 ? ins_sz : 0;
+    size_t k_sz    = has_k ? (size_t)n_aggs * sizeof(int64_t) : 0;
     /* Align ops after keys (pointer-sized), ins after ops, ins2 after ins. */
     size_t ops_off  = keys_sz;
     size_t ins_off  = ops_off + ops_sz;
     /* Round ins_off up to pointer alignment */
     ins_off = (ins_off + sizeof(ray_op_t*) - 1) & ~(sizeof(ray_op_t*) - 1);
     size_t ins2_off = ins_off + ins_sz;
-    ray_op_ext_t* ext = graph_alloc_ext_node_ex(g, ins2_off + ins2_sz);
+    size_t k_off    = ins2_off + ins2_sz;
+    /* Round k_off up to int64 alignment */
+    k_off = (k_off + sizeof(int64_t) - 1) & ~(sizeof(int64_t) - 1);
+    ray_op_ext_t* ext = graph_alloc_ext_node_ex(g, k_off + k_sz);
     if (!ext) return NULL;
 
     ext->base.opcode = OP_GROUP;
@@ -822,6 +830,13 @@ static ray_op_t* ray_group_impl(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
     } else {
         ext->agg_ins2 = NULL;
     }
+    if (has_k) {
+        ext->agg_k = (int64_t*)(trail + k_off);
+        for (uint8_t i = 0; i < n_aggs; i++)
+            ext->agg_k[i] = agg_k ? agg_k[i] : 0;
+    } else {
+        ext->agg_k = NULL;
+    }
     ext->n_keys = n_keys;
     ext->n_aggs = n_aggs;
 
@@ -831,13 +846,20 @@ static ray_op_t* ray_group_impl(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
 
 ray_op_t* ray_group(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
                    uint16_t* agg_ops, ray_op_t** agg_ins, uint8_t n_aggs) {
-    return ray_group_impl(g, keys, n_keys, agg_ops, agg_ins, NULL, n_aggs);
+    return ray_group_impl(g, keys, n_keys, agg_ops, agg_ins, NULL, NULL, n_aggs);
 }
 
 ray_op_t* ray_group2(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
                      uint16_t* agg_ops, ray_op_t** agg_ins,
                      ray_op_t** agg_ins2, uint8_t n_aggs) {
-    return ray_group_impl(g, keys, n_keys, agg_ops, agg_ins, agg_ins2, n_aggs);
+    return ray_group_impl(g, keys, n_keys, agg_ops, agg_ins, agg_ins2, NULL, n_aggs);
+}
+
+ray_op_t* ray_group3(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
+                     uint16_t* agg_ops, ray_op_t** agg_ins,
+                     ray_op_t** agg_ins2, const int64_t* agg_k,
+                     uint8_t n_aggs) {
+    return ray_group_impl(g, keys, n_keys, agg_ops, agg_ins, agg_ins2, agg_k, n_aggs);
 }
 
 ray_op_t* ray_distinct(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys) {

--- a/src/ops/graph.c
+++ b/src/ops/graph.c
@@ -691,6 +691,13 @@ ray_op_t* ray_pearson_corr(ray_graph_t* g, ray_op_t* x, ray_op_t* y) {
     return make_binary(g, OP_PEARSON_CORR, x, y, RAY_F64);
 }
 
+/* Exact median per group. Runtime forks to a separate bucket-scatter +
+ * quickselect path (see ray_median_per_group) — it can't fit the
+ * fixed-size row-layout HT because per-group buffer size is variable. */
+ray_op_t* ray_median(ray_graph_t* g, ray_op_t* a) {
+    return make_unary(g, OP_MEDIAN, a, RAY_F64);
+}
+
 /* --------------------------------------------------------------------------
  * Structural ops
  * -------------------------------------------------------------------------- */

--- a/src/ops/graph.c
+++ b/src/ops/graph.c
@@ -866,6 +866,51 @@ ray_op_t* ray_distinct(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys) {
     return ray_group(g, keys, n_keys, NULL, NULL, 0);
 }
 
+/* Dedicated per-group top/bot-K with row-form emission.  Mirrors the
+ * OP_GROUP ext-node layout (single key + single agg + agg_k slot) so
+ * downstream optimiser passes can introspect ext->keys / ext->agg_ins
+ * the same way they do for OP_GROUP, but with a distinct opcode that
+ * exec.c routes to exec_group_topk_rowform. */
+ray_op_t* ray_group_topk_rowform(ray_graph_t* g, ray_op_t* key,
+                                  ray_op_t* val, int64_t k, uint8_t desc) {
+    if (!g || !key || !val || k < 1 || k > 1024) return NULL;
+
+    size_t keys_sz = sizeof(ray_op_t*);
+    size_t ops_sz  = sizeof(uint16_t);
+    size_t ins_sz  = sizeof(ray_op_t*);
+    size_t ops_off = keys_sz;
+    size_t ins_off = ops_off + ops_sz;
+    ins_off = (ins_off + sizeof(ray_op_t*) - 1) & ~(sizeof(ray_op_t*) - 1);
+    size_t k_off   = ins_off + ins_sz;
+    k_off = (k_off + sizeof(int64_t) - 1) & ~(sizeof(int64_t) - 1);
+    size_t k_sz    = sizeof(int64_t);
+
+    ray_op_ext_t* ext = graph_alloc_ext_node_ex(g, k_off + k_sz);
+    if (!ext) return NULL;
+
+    ext->base.opcode = desc ? OP_GROUP_TOPK_ROWFORM : OP_GROUP_BOTK_ROWFORM;
+    ext->base.arity = 0;
+    ext->base.out_type = RAY_TABLE;
+    ext->base.est_rows = key->est_rows;
+    ext->base.inputs[0] = key;
+
+    char* trail = EXT_TRAIL(ext);
+    ext->keys = (ray_op_t**)trail;
+    ext->keys[0] = key;
+    ext->agg_ops = (uint16_t*)(trail + ops_off);
+    ext->agg_ops[0] = desc ? OP_TOP_N : OP_BOT_N;
+    ext->agg_ins = (ray_op_t**)(trail + ins_off);
+    ext->agg_ins[0] = val;
+    ext->agg_ins2 = NULL;
+    ext->agg_k = (int64_t*)(trail + k_off);
+    ext->agg_k[0] = k;
+    ext->n_keys = 1;
+    ext->n_aggs = 1;
+
+    g->nodes[ext->base.id] = ext->base;
+    return &g->nodes[ext->base.id];
+}
+
 ray_op_t* ray_pivot_op(ray_graph_t* g,
                        ray_op_t** index_cols, uint8_t n_index,
                        ray_op_t* pivot_col,

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -3172,6 +3172,8 @@ static void emit_agg_columns(ray_t** result, ray_graph_t* g, const ray_op_ext_t*
                 case OP_VAR:        sfx = "_var";        slen = 4; break;
                 case OP_VAR_POP:    sfx = "_var_pop";    slen = 8; break;
                 case OP_MEDIAN:     sfx = "_median";     slen = 7; break;
+                case OP_TOP_N:      sfx = "_top";        slen = 4; break;
+                case OP_BOT_N:      sfx = "_bot";        slen = 4; break;
             }
             char buf[256];
             if (base && blen + slen < sizeof(buf)) {
@@ -3206,6 +3208,8 @@ static void emit_agg_columns(ray_t** result, ray_graph_t* g, const ray_op_ext_t*
                 case OP_VAR:        nsfx = "_var";        nslen = 4; break;
                 case OP_VAR_POP:    nsfx = "_var_pop";    nslen = 8; break;
                 case OP_MEDIAN:     nsfx = "_median";     nslen = 7; break;
+                case OP_TOP_N:      nsfx = "_top";        nslen = 4; break;
+                case OP_BOT_N:      nsfx = "_bot";        nslen = 4; break;
             }
             memcpy(nbuf + np, nsfx, nslen);
             name_id = ray_sym_intern(nbuf, (size_t)np + nslen);
@@ -7117,38 +7121,50 @@ skip_top_count_filter:
                 for (uint8_t a = 0; a < n_aggs; a++) {
                     if (!(ght_layout.agg_is_holistic & (1u << a))) continue;
                     if (!agg_vecs[a] || !agg_cols[a]) continue;
-                    ray_t* med_vec = ray_median_per_group_buf(
-                        agg_vecs[a], idx_buf, offsets, grp_cnt, n_groups);
-                    if (!med_vec) {
-                        /* Unsupported source type — set all-null,
-                         * caller's eval-fallback would never have
-                         * routed here for unsupported types.  Fail
-                         * the whole exec_group with "nyi". */
+                    uint16_t aop = ext->agg_ops[a];
+                    ray_t* hol_vec = NULL;
+                    const char* err_tag = "median: type";
+                    if (aop == OP_MEDIAN) {
+                        hol_vec = ray_median_per_group_buf(
+                            agg_vecs[a], idx_buf, offsets, grp_cnt, n_groups);
+                    } else if (aop == OP_TOP_N || aop == OP_BOT_N) {
+                        int64_t k_val = (ext->agg_k && ext->agg_k[a] > 0)
+                                        ? ext->agg_k[a] : 1;
+                        hol_vec = ray_topk_per_group_buf(
+                            agg_vecs[a], k_val,
+                            aop == OP_TOP_N ? 1 : 0,
+                            idx_buf, offsets, grp_cnt, n_groups);
+                        err_tag = "top/bot: type";
+                    }
+                    if (!hol_vec) {
                         if (hist_hdr) scratch_free(hist_hdr);
                         if (cur_hdr)  scratch_free(cur_hdr);
                         if (cnt_hdr)  scratch_free(cnt_hdr);
                         if (off_hdr)  scratch_free(off_hdr);
                         if (idx_hdr)  scratch_free(idx_hdr);
                         scratch_free(rg_hdr);
-                        result = ray_error("nyi", "median: type");
+                        result = ray_error("nyi", err_tag);
                         goto cleanup;
                     }
-                    if (RAY_IS_ERR(med_vec)) {
+                    if (RAY_IS_ERR(hol_vec)) {
                         if (hist_hdr) scratch_free(hist_hdr);
                         if (cur_hdr)  scratch_free(cur_hdr);
                         if (cnt_hdr)  scratch_free(cnt_hdr);
                         if (off_hdr)  scratch_free(off_hdr);
                         if (idx_hdr)  scratch_free(idx_hdr);
                         scratch_free(rg_hdr);
-                        result = med_vec;
+                        result = hol_vec;
                         goto cleanup;
                     }
-                    /* Replace the empty agg_cols[a] vector with the
-                     * filled one.  agg_outs[a] is no longer consulted
-                     * for this slot (the row-layout finalize loop
-                     * already skipped it via agg_is_holistic). */
+                    /* Replace the stub agg_cols[a] vector with the
+                     * filled holistic column.  Update agg_outs[a].vec
+                     * to track the same pointer so the downstream
+                     * finalize_nulls loop operates on live memory
+                     * (the prior stub's ref hits zero on this
+                     * release). */
                     ray_release(agg_cols[a]);
-                    agg_cols[a] = med_vec;
+                    agg_cols[a] = hol_vec;
+                    agg_outs[a].vec = hol_vec;
                 }
             } else {
                 if (hist_hdr) scratch_free(hist_hdr);
@@ -7190,9 +7206,14 @@ skip_top_count_filter:
             }
         }
 
-        /* Finalize null flags after parallel execution */
+        /* Finalize null flags after parallel execution.  Holistic slots
+         * are filled by the post-radix pass into a fresh column; we
+         * already updated agg_outs[a].vec to track it.  For RAY_LIST
+         * cells (OP_TOP_N / OP_BOT_N) the per-cell nullmap is not
+         * consulted downstream — finalize is a no-op-y read of attrs. */
         for (uint8_t a = 0; a < n_aggs; a++) {
             if (!agg_cols[a]) continue;
+            if (agg_outs[a].vec && agg_outs[a].vec->type == RAY_LIST) continue;
             grp_finalize_nulls(agg_outs[a].vec);
         }
         for (uint8_t k = 0; k < n_keys; k++) {
@@ -7234,6 +7255,8 @@ skip_top_count_filter:
                     case OP_VAR:        sfx = "_var";        slen = 4; break;
                     case OP_VAR_POP:    sfx = "_var_pop";    slen = 8; break;
                     case OP_MEDIAN:     sfx = "_median";     slen = 7; break;
+                    case OP_TOP_N:      sfx = "_top";        slen = 4; break;
+                    case OP_BOT_N:      sfx = "_bot";        slen = 4; break;
                 }
                 char buf[256];
                 ray_t* name_dyn_hdr = NULL;
@@ -7415,10 +7438,22 @@ build_from_final_ht:
                     for (uint8_t a = 0; a < n_aggs; a++) {
                         if (!(ly->agg_is_holistic & (1u << a))) continue;
                         if (!agg_vecs[a]) continue;
-                        ray_t* med_vec = ray_median_per_group_buf(
-                            agg_vecs[a], idx_buf_s, offsets_s, grp_cnt_s,
-                            (int64_t)grp_count);
-                        med_out[a] = med_vec;  /* NULL or RAY_IS_ERR handled below */
+                        uint16_t aop = ext->agg_ops[a];
+                        ray_t* hol_vec = NULL;
+                        if (aop == OP_MEDIAN) {
+                            hol_vec = ray_median_per_group_buf(
+                                agg_vecs[a], idx_buf_s, offsets_s, grp_cnt_s,
+                                (int64_t)grp_count);
+                        } else if (aop == OP_TOP_N || aop == OP_BOT_N) {
+                            int64_t k_val = (ext->agg_k && ext->agg_k[a] > 0)
+                                            ? ext->agg_k[a] : 1;
+                            hol_vec = ray_topk_per_group_buf(
+                                agg_vecs[a], k_val,
+                                aop == OP_TOP_N ? 1 : 0,
+                                idx_buf_s, offsets_s, grp_cnt_s,
+                                (int64_t)grp_count);
+                        }
+                        med_out[a] = hol_vec;  /* NULL or RAY_IS_ERR handled below */
                     }
                     scratch_free(ix_hdr_s);
                 }
@@ -7450,11 +7485,13 @@ build_from_final_ht:
                 out_type = agg_col ? agg_col->type : RAY_I64; break;
         }
         ray_t* new_col;
-        if (agg_op == OP_MEDIAN && med_out && med_out[a]
+        bool is_holistic = (agg_op == OP_MEDIAN || agg_op == OP_TOP_N ||
+                            agg_op == OP_BOT_N);
+        if (is_holistic && med_out && med_out[a]
             && !RAY_IS_ERR(med_out[a])) {
             new_col = med_out[a];
             med_out[a] = NULL;  /* transferred ownership */
-        } else if (agg_op == OP_MEDIAN) {
+        } else if (is_holistic) {
             /* Unsupported source type or earlier failure — skip. */
             continue;
         } else {
@@ -7464,9 +7501,10 @@ build_from_final_ht:
         }
 
         int8_t s = ly->agg_val_slot[a]; /* unified accum slot */
-        /* Holistic agg (OP_MEDIAN) is already filled — skip row-layout
-         * reads.  Naming + add_col below still applies. */
-        if (agg_op == OP_MEDIAN) goto med_attach;
+        /* Holistic agg (OP_MEDIAN / OP_TOP_N / OP_BOT_N) is already
+         * filled — skip row-layout reads.  Naming + add_col below
+         * still applies. */
+        if (is_holistic) goto med_attach;
         for (uint32_t gi = 0; gi < grp_count; gi++) {
             const char* row = final_ht->rows + (size_t)gi * ly->row_stride;
             int64_t cnt = *(const int64_t*)(const void*)row;
@@ -7576,6 +7614,8 @@ build_from_final_ht:
                 case OP_VAR:        sfx = "_var";        slen = 4; break;
                 case OP_VAR_POP:    sfx = "_var_pop";    slen = 8; break;
                 case OP_MEDIAN:     sfx = "_median";     slen = 7; break;
+                case OP_TOP_N:      sfx = "_top";        slen = 4; break;
+                case OP_BOT_N:      sfx = "_bot";        slen = 4; break;
             }
             char buf[256];
             if (base && blen + slen < sizeof(buf)) {
@@ -7610,6 +7650,8 @@ build_from_final_ht:
                 case OP_VAR:        nsfx = "_var";        nslen = 4; break;
                 case OP_VAR_POP:    nsfx = "_var_pop";    nslen = 8; break;
                 case OP_MEDIAN:     nsfx = "_median";     nslen = 7; break;
+                case OP_TOP_N:      nsfx = "_top";        nslen = 4; break;
+                case OP_BOT_N:      nsfx = "_bot";        nslen = 4; break;
             }
             memcpy(nbuf + np, nsfx, nslen);
             name_id = ray_sym_intern(nbuf, (size_t)np + nslen);

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -1636,6 +1636,7 @@ static inline void init_accum_from_entry(char* row, const char* entry,
     if (has_fl)
         memcpy(&entry_row, entry + ly->entry_stride - 8, 8);
 
+    uint8_t bin_mask = ly->agg_is_binary;
     for (uint8_t a = 0; a < na; a++) {
         int8_t s = ly->agg_val_slot[a];
         if (s < 0) continue;
@@ -1654,6 +1655,28 @@ static inline void init_accum_from_entry(char* row, const char* entry,
                 double sq = (double)v * (double)v;
                 memcpy(row + ly->off_sumsq + s * 8, &sq, 8);
             }
+        }
+        /* PEARSON y-side: seed Σy, Σy², Σxy from the (x, y) pair packed
+         * at slots (s, s+1).  x-side Σx/Σx² are seeded by the SUM/SUMSQ
+         * blocks above (OP_PEARSON_CORR sets both need-flags).  Reads
+         * the typed bit-pattern packed by phase1 — F64 stays double,
+         * i64 reinterprets and casts. */
+        if ((nf & GHT_NEED_PEARSON) && (bin_mask & (1u << a))) {
+            double x, y;
+            if (ly->agg_is_f64 & (1u << a)) {
+                memcpy(&x, agg_data +  s      * 8, 8);
+                memcpy(&y, agg_data + (s + 1) * 8, 8);
+            } else {
+                int64_t xi, yi;
+                memcpy(&xi, agg_data +  s      * 8, 8);
+                memcpy(&yi, agg_data + (s + 1) * 8, 8);
+                x = (double)xi; y = (double)yi;
+            }
+            memcpy(row + ly->off_sum_y   + s * 8, &y, 8);
+            double yy = y * y;
+            memcpy(row + ly->off_sumsq_y + s * 8, &yy, 8);
+            double xy = x * y;
+            memcpy(row + ly->off_sumxy   + s * 8, &xy, 8);
         }
         /* Seed per-slot row-index bounds with the row that opened this
          * group.  Only writes the populated slots; unpopulated slot
@@ -1713,6 +1736,14 @@ static inline void accum_from_entry(char* row, const char* entry,
             if (nf & GHT_NEED_MIN) { double* p = &ROW_WR_F64(row, ly->off_min, s); if (v < *p) *p = v; }
             if (nf & GHT_NEED_MAX) { double* p = &ROW_WR_F64(row, ly->off_max, s); if (v > *p) *p = v; }
             if (nf & GHT_NEED_SUMSQ) { ROW_WR_F64(row, ly->off_sumsq, s) += v * v; }
+            /* PEARSON y-side: accumulate Σy, Σy², Σxy.  v above is x. */
+            if ((nf & GHT_NEED_PEARSON) && (ly->agg_is_binary & amask)) {
+                double y;
+                memcpy(&y, agg_data + (s + 1) * 8, 8);
+                ROW_WR_F64(row, ly->off_sum_y,   s) += y;
+                ROW_WR_F64(row, ly->off_sumsq_y, s) += y * y;
+                ROW_WR_F64(row, ly->off_sumxy,   s) += v * y;
+            }
         } else {
             int64_t v;
             memcpy(&v, val, 8);
@@ -1725,6 +1756,16 @@ static inline void accum_from_entry(char* row, const char* entry,
             if (nf & GHT_NEED_MIN) { int64_t* p = &ROW_WR_I64(row, ly->off_min, s); if (v < *p) *p = v; }
             if (nf & GHT_NEED_MAX) { int64_t* p = &ROW_WR_I64(row, ly->off_max, s); if (v > *p) *p = v; }
             if (nf & GHT_NEED_SUMSQ) { ROW_WR_F64(row, ly->off_sumsq, s) += (double)v * (double)v; }
+            /* PEARSON y-side (i64 input branch): y was packed via
+             * read_col_i64 — reinterpret as int64 then cast to double. */
+            if ((nf & GHT_NEED_PEARSON) && (ly->agg_is_binary & amask)) {
+                int64_t yi; memcpy(&yi, agg_data + (s + 1) * 8, 8);
+                double y  = (double)yi;
+                double xd = (double)v;
+                ROW_WR_F64(row, ly->off_sum_y,   s) += y;
+                ROW_WR_F64(row, ly->off_sumsq_y, s) += y * y;
+                ROW_WR_F64(row, ly->off_sumxy,   s) += xd * y;
+            }
         }
         /* Commit row-index bounds after value writes so a later entry in
          * the same merge sees the updated bound. */
@@ -1889,6 +1930,7 @@ static inline bool group_rowsel_pass(ray_t* sel, int64_t row) {
 
 void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
                               uint8_t* key_attrs, ray_t** key_vecs, ray_t** agg_vecs,
+                              ray_t** agg_vecs2,
                               uint8_t* agg_strlen,
                               ray_t* rowsel,
                               int64_t start, int64_t end,
@@ -1962,6 +2004,7 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
 
         int64_t* ev = (int64_t*)(ebuf + 8 + ((size_t)nk + 1) * 8);
         uint8_t vi = 0;
+        uint8_t bin_mask = ly->agg_is_binary;
         for (uint8_t a = 0; a < na; a++) {
             ray_t* ac = agg_vecs[a];
             if (!ac) continue;
@@ -1972,6 +2015,15 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
             else
                 ev[vi] = read_col_i64(ray_data(ac), row, ac->type, ac->attrs);
             vi++;
+            /* Binary aggregator: pack y after x in the same entry. */
+            if ((bin_mask & (1u << a)) && agg_vecs2 && agg_vecs2[a]) {
+                ray_t* ay = agg_vecs2[a];
+                if (ay->type == RAY_F64)
+                    memcpy(&ev[vi], &((double*)ray_data(ay))[row], 8);
+                else
+                    ev[vi] = read_col_i64(ray_data(ay), row, ay->type, ay->attrs);
+                vi++;
+            }
         }
         /* Tail slot: source row index for FIRST/LAST tie-breaking.  Same
          * layout as the radix path's entries so accum_from_entry can read
@@ -2124,6 +2176,11 @@ typedef struct {
     ray_t**      key_vecs;
     uint8_t      nullable_mask;   /* bit k = key k column may contain nulls */
     ray_t**       agg_vecs;
+    /* Second input column per agg; NULL when no binary aggs in this
+     * OP_GROUP.  Phase 1 reads agg_vecs2[a] alongside agg_vecs[a] and
+     * packs (x, y) consecutively into the entry agg_vals area for any
+     * agg whose layout bit agg_is_binary is set. */
+    ray_t**       agg_vecs2;
     uint8_t*     agg_strlen;
     uint32_t     n_workers;
     radix_buf_t* bufs;        /* [n_workers * RADIX_P] */
@@ -2188,6 +2245,7 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
         if (null_mask) h = ray_hash_combine(h, ray_hash_i64(null_mask));
 
         uint8_t vi = 0;
+        uint8_t bin_mask = ly->agg_is_binary;
         for (uint8_t a = 0; a < na; a++) {
             ray_t* ac = c->agg_vecs[a];
             if (!ac) continue;
@@ -2198,6 +2256,19 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
             else
                 agg_vals[vi] = read_col_i64(ray_data(ac), row, ac->type, ac->attrs);
             vi++;
+            /* Binary aggregator: read y-side value into the next slot.
+             * Cast non-F64 inputs through read_col_i64 — pearson_corr's
+             * finalize reads both slots as F64 doubles regardless of
+             * input type (i64 will be reinterpreted; for now we only
+             * support F64 inputs cleanly — i64 path is a perf followup). */
+            if ((bin_mask & (1u << a)) && c->agg_vecs2 && c->agg_vecs2[a]) {
+                ray_t* ay = c->agg_vecs2[a];
+                if (ay->type == RAY_F64)
+                    memcpy(&agg_vals[vi], &((double*)ray_data(ay))[row], 8);
+                else
+                    agg_vals[vi] = read_col_i64(ray_data(ay), row, ay->type, ay->attrs);
+                vi++;
+            }
         }
 
         uint32_t part = RADIX_PART(h);
@@ -2363,6 +2434,27 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
                             else if (op == OP_VAR) v = var_pop * cnt / (cnt - 1);
                             else if (op == OP_STDDEV_POP) v = sqrt(var_pop);
                             else v = sqrt(var_pop * cnt / (cnt - 1));
+                            break;
+                        }
+                        case OP_PEARSON_CORR: {
+                            /* Single-pass formula (same as ray_pearson_corr_fn):
+                             *   r = (n·Σxy − Σx·Σy) /
+                             *       sqrt((n·Σx² − Σx²)(n·Σy² − Σy²))
+                             * Undefined for n<2 or constant side → emit
+                             * NaN (canonicalize folds to null upstream). */
+                            if (cnt < 2) { v = 0.0; grp_set_null(ao->vec, di); break; }
+                            double sx  = sf ? ROW_RD_F64(row, ly->off_sum,    s)
+                                            : (double)ROW_RD_I64(row, ly->off_sum, s);
+                            double sxx = ly->off_sumsq ? ROW_RD_F64(row, ly->off_sumsq, s) : 0.0;
+                            double sy  = ly->off_sum_y   ? ROW_RD_F64(row, ly->off_sum_y,   s) : 0.0;
+                            double syy = ly->off_sumsq_y ? ROW_RD_F64(row, ly->off_sumsq_y, s) : 0.0;
+                            double sxy = ly->off_sumxy   ? ROW_RD_F64(row, ly->off_sumxy,   s) : 0.0;
+                            double dn  = (double)cnt;
+                            double num = dn * sxy - sx * sy;
+                            double dx  = dn * sxx - sx * sx;
+                            double dy  = dn * syy - sy * sy;
+                            if (dx <= 0.0 || dy <= 0.0) { v = NAN; break; }
+                            v = num / sqrt(dx * dy);
                             break;
                         }
                         default: v = 0.0; break;
@@ -3946,12 +4038,20 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
     /* Resolve agg input columns (VLA — n_aggs ≤ 8; use ≥1 to avoid zero-size VLA UB) */
     uint8_t vla_aggs = n_aggs > 0 ? n_aggs : 1;
     ray_t* agg_vecs[vla_aggs];
+    /* Second input column per agg — non-NULL only for binary aggs
+     * (OP_PEARSON_CORR).  Allocated independently of agg_vecs because
+     * agg_owned2 may differ (each side can come from a different source
+     * — OP_SCAN literal or expr_compile). */
+    ray_t* agg_vecs2[vla_aggs];
     uint8_t agg_owned[vla_aggs]; /* 1 = we allocated via exec_node, must free */
+    uint8_t agg_owned2[vla_aggs];
     uint8_t agg_strlen[vla_aggs];
     agg_affine_t agg_affine[vla_aggs];
     agg_linear_t agg_linear[vla_aggs];
     memset(agg_vecs, 0, vla_aggs * sizeof(ray_t*));
+    memset(agg_vecs2, 0, vla_aggs * sizeof(ray_t*));
     memset(agg_owned, 0, vla_aggs * sizeof(uint8_t));
+    memset(agg_owned2, 0, vla_aggs * sizeof(uint8_t));
     memset(agg_strlen, 0, vla_aggs * sizeof(uint8_t));
     memset(agg_affine, 0, vla_aggs * sizeof(agg_affine_t));
     memset(agg_linear, 0, vla_aggs * sizeof(agg_linear_t));
@@ -3993,7 +4093,7 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
                 if (vec && !RAY_IS_ERR(vec)) {
                     agg_vecs[a] = vec;
                     agg_owned[a] = 1;
-                    continue;
+                    goto resolve_ins2;
                 }
             }
             /* Fallback: full recursive evaluation */
@@ -4004,6 +4104,41 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
             if (vec && !RAY_IS_ERR(vec)) {
                 agg_vecs[a] = vec;
                 agg_owned[a] = 1;
+            }
+        }
+    resolve_ins2:;
+        /* Binary aggregators (OP_PEARSON_CORR): mirror the resolution
+         * above for the y-side input.  Same OP_SCAN / OP_CONST / expr
+         * fallback ladder, separate ownership flag because each side
+         * may have come from a different source. */
+        if (ext->agg_ins2 && ext->agg_ins2[a]) {
+            ray_op_t* agg_input_op2 = ext->agg_ins2[a];
+            ray_op_ext_t* agg_ext2 = find_ext(g, agg_input_op2->id);
+            if (agg_ext2 && agg_ext2->base.opcode == OP_SCAN) {
+                agg_vecs2[a] = ray_table_get_col(tbl, agg_ext2->sym);
+            } else if (agg_ext2 && agg_ext2->base.opcode == OP_CONST && agg_ext2->literal) {
+                agg_vecs2[a] = agg_ext2->literal;
+            } else {
+                ray_expr_t agg_expr2;
+                int compiled2 = 0;
+                if (expr_compile(g, tbl, agg_input_op2, &agg_expr2)) {
+                    ray_t* vec = expr_eval_full(&agg_expr2, nrows);
+                    if (vec && !RAY_IS_ERR(vec)) {
+                        agg_vecs2[a] = vec;
+                        agg_owned2[a] = 1;
+                        compiled2 = 1;
+                    }
+                }
+                if (!compiled2) {
+                    ray_t* saved_table = g->table;
+                    g->table = tbl;
+                    ray_t* vec = exec_node(g, agg_input_op2);
+                    g->table = saved_table;
+                    if (vec && !RAY_IS_ERR(vec)) {
+                        agg_vecs2[a] = vec;
+                        agg_owned2[a] = 1;
+                    }
+                }
             }
         }
     }
@@ -4023,7 +4158,7 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
         ray_t* bcast = materialize_broadcast_input(agg_vecs[a], nrows);
         if (!bcast || RAY_IS_ERR(bcast)) {
             for (uint8_t i = 0; i < n_aggs; i++) {
-                if (agg_owned[i] && agg_vecs[i]) ray_release(agg_vecs[i]);
+                { if (agg_owned[i] && agg_vecs[i]) ray_release(agg_vecs[i]); if (agg_owned2[i] && agg_vecs2[i]) ray_release(agg_vecs2[i]); }
             }
             for (uint8_t k = 0; k < n_keys; k++) {
                 if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
@@ -4246,7 +4381,7 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
         if (!result || RAY_IS_ERR(result)) {
             da_accum_free(&sc_acc[0]); scratch_free(sc_hdr);
             for (uint8_t a = 0; a < n_aggs; a++)
-                if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
+                { if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]); if (agg_owned2[a] && agg_vecs2[a]) ray_release(agg_vecs2[a]); }
             for (uint8_t k = 0; k < n_keys; k++)
                 if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
             if (match_idx_block) ray_release(match_idx_block);
@@ -4261,7 +4396,7 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
 
         da_accum_free(&sc_acc[0]); scratch_free(sc_hdr);
         for (uint8_t a = 0; a < n_aggs; a++)
-            if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
+            { if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]); if (agg_owned2[a] && agg_vecs2[a]) ray_release(agg_vecs2[a]); }
         for (uint8_t k = 0; k < n_keys; k++)
             if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
         if (match_idx_block) ray_release(match_idx_block);
@@ -4276,6 +4411,12 @@ da_path:;
     #define DA_PER_WORKER_MAX  (6ULL << 20)    /* 6 MB per-worker max */
     {
         bool da_eligible = (nrows > 0 && n_keys > 0 && n_keys <= 8);
+        /* Binary aggregators (OP_PEARSON_CORR) are not wired into the
+         * dense-array accumulator's per-worker da_accum_t struct — force
+         * the HT path which has the row-layout offsets allocated. */
+        for (uint8_t a = 0; a < n_aggs && da_eligible; a++) {
+            if (ext->agg_ops[a] == OP_PEARSON_CORR) da_eligible = false;
+        }
         for (uint8_t k = 0; k < n_keys && da_eligible; k++) {
             if (!key_data[k]) { da_eligible = false; break; }
             int8_t t = key_types[k];
@@ -4717,7 +4858,7 @@ da_path:;
             if (!result || RAY_IS_ERR(result)) {
                 da_accum_free(&accums[0]); scratch_free(accums_hdr);
                 for (uint8_t a = 0; a < n_aggs; a++)
-                    if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
+                    { if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]); if (agg_owned2[a] && agg_vecs2[a]) ray_release(agg_vecs2[a]); }
                 for (uint8_t k = 0; k < n_keys; k++)
                     if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
                 if (match_idx_block) ray_release(match_idx_block);
@@ -4784,7 +4925,7 @@ da_path:;
 
             da_accum_free(&accums[0]); scratch_free(accums_hdr);
             for (uint8_t a = 0; a < n_aggs; a++)
-                if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
+                { if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]); if (agg_owned2[a] && agg_vecs2[a]) ray_release(agg_vecs2[a]); }
             for (uint8_t k = 0; k < n_keys; k++)
                 if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
             if (match_idx_block) ray_release(match_idx_block);
@@ -5535,7 +5676,7 @@ ht_path:;
             for (uint8_t kk = 0; kk < n_keys; kk++)
                 if (key_owned[kk] && key_vecs[kk]) ray_release(key_vecs[kk]);
             for (uint8_t a = 0; a < n_aggs; a++)
-                if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
+                { if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]); if (agg_owned2[a] && agg_vecs2[a]) ray_release(agg_vecs2[a]); }
             if (match_idx_block) ray_release(match_idx_block);
             return ray_error("nyi", NULL);
         }
@@ -6101,6 +6242,7 @@ skip_top_count_filter:
             .key_vecs      = key_vecs,
             .nullable_mask = p1_nullable,
             .agg_vecs      = agg_vecs,
+            .agg_vecs2     = agg_vecs2,
             .agg_strlen    = agg_strlen,
             .n_workers     = n_total,
             .bufs          = radix_bufs,
@@ -6359,7 +6501,7 @@ sequential_fallback:;
         goto cleanup;
     }
     group_rows_range(&single_ht, key_data, key_types, key_attrs, key_vecs, agg_vecs,
-                     agg_strlen, rowsel,
+                     agg_vecs2, agg_strlen, rowsel,
                      0, n_scan, match_idx);
     final_ht = &single_ht;
     if (ray_interrupted()) { result = ray_error("cancel", "interrupted"); goto cleanup; }
@@ -6590,7 +6732,7 @@ cleanup:
         scratch_free(part_hts_hdr);
     }
     for (uint8_t a = 0; a < n_aggs; a++)
-        if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
+        { if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]); if (agg_owned2[a] && agg_vecs2[a]) ray_release(agg_vecs2[a]); }
     for (uint8_t k = 0; k < n_keys; k++)
         if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
     if (match_idx_block) ray_release(match_idx_block);
@@ -7174,7 +7316,7 @@ static void pivot_ingest_sequential(pivot_ingest_t* out, const ght_layout_t* ly,
     out->n_parts = 1;
     out->row_stride = ly->row_stride;
     group_rows_range(scratch_ht, key_data, key_types, key_attrs, key_vecs,
-                     agg_vecs, NULL, NULL, 0, n_scan, NULL);
+                     agg_vecs, NULL, NULL, NULL, 0, n_scan, NULL);
     out->total_grps = scratch_ht->grp_count;
     out->part_offsets[0] = 0;
     out->part_offsets[1] = scratch_ht->grp_count;
@@ -7263,6 +7405,7 @@ bool pivot_ingest_run(pivot_ingest_t* out,
         .key_vecs      = key_vecs,
         .nullable_mask = p1_nullable,
         .agg_vecs      = agg_vecs,
+        .agg_vecs2     = NULL,   /* this scratch path doesn't use binary aggs */
         .n_workers     = n_total,
         .bufs          = radix_bufs,
         .layout        = *ly,

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -1332,6 +1332,282 @@ ray_t* ray_median_per_group_buf(ray_t* src,
     return out;
 }
 
+/* ─── ray_topk_per_group_buf ──────────────────────────────────────────
+ *
+ * Parallel per-group bounded-heap top-K / bot-K.  Same idx_buf/offsets/
+ * grp_cnt layout as the median kernel — produced by exec_group's
+ * post-radix re-probe + histogram-scatter.  Each group becomes one
+ * task; the task initialises a heap with the first kk = min(K, cnt)
+ * source values, then scans the remaining cnt - kk values and replaces
+ * the worst-of-kept whenever a better value arrives.  Final heap is
+ * sorted in-place via heapsort_extract so the cell reads in the
+ * conventional order (desc=1 → largest-first, desc=0 → smallest-first),
+ * matching the standalone ray_top_fn / ray_bot_fn conventions.
+ *
+ * For K=2 (q8 canonical) the heap ops are nearly free — the dominant
+ * cost is reading from the source column under random-index access.
+ *
+ * Output is a LIST of n_groups cells; cells are pre-allocated typed
+ * vecs of the same element type as `src`, so workers can write into
+ * cell data without locking.  Null rows are skipped (matches the
+ * standalone topk_take_vec path which routes nulls-last for asc,
+ * nulls-first for desc and gathers only the non-null prefix). */
+
+typedef struct {
+    const void*    base;
+    int8_t         src_type;
+    bool           has_nulls;
+    const uint8_t* null_bm;
+    int64_t        k;
+    uint8_t        desc;
+    const int64_t* idx_buf;
+    const int64_t* offsets;
+    const int64_t* grp_cnt;
+    ray_t*         out_list;
+} topk_par_ctx_t;
+
+/* Read src element as f64 (for the F64 path).  Matches med_read_as_f64
+ * but the topk kernel uses it only on the F64 type arm. */
+static inline double topk_read_f64(const void* base, int64_t row) {
+    double v; memcpy(&v, (const char*)base + (size_t)row * 8, 8); return v;
+}
+
+/* Read src element as int64 for integer source types. */
+static inline int64_t topk_read_i64(const void* base, int8_t t, int64_t row) {
+    switch (t) {
+        case RAY_I64: case RAY_TIMESTAMP:
+            { int64_t v; memcpy(&v, (const char*)base + (size_t)row * 8, 8); return v; }
+        case RAY_I32: case RAY_DATE: case RAY_TIME:
+            { int32_t v; memcpy(&v, (const char*)base + (size_t)row * 4, 4); return (int64_t)v; }
+        case RAY_I16:
+            { int16_t v; memcpy(&v, (const char*)base + (size_t)row * 2, 2); return (int64_t)v; }
+        case RAY_BOOL: case RAY_U8:
+            return (int64_t)((const uint8_t*)base)[row];
+        default: return 0;
+    }
+}
+
+/* Write int64 value to dst at slot idx, narrowing to esz bytes. */
+static inline void topk_write_i64(void* dst, int64_t idx, int64_t v, uint8_t esz) {
+    switch (esz) {
+        case 1: ((uint8_t*)dst)[idx]  = (uint8_t)v; break;
+        case 2: ((int16_t*)dst)[idx]  = (int16_t)v; break;
+        case 4: ((int32_t*)dst)[idx]  = (int32_t)v; break;
+        default: ((int64_t*)dst)[idx] = v; break;
+    }
+}
+
+/* sift_down on a double[] heap.  max=1 → max-heap (root is largest),
+ * max=0 → min-heap (root is smallest).  Called only with i < n. */
+static inline void topk_sift_down_dbl(double* h, int64_t n, int64_t i, int max_heap) {
+    for (;;) {
+        int64_t l = 2*i+1, r = 2*i+2, w = i;
+        if (max_heap) {
+            if (l < n && h[l] > h[w]) w = l;
+            if (r < n && h[r] > h[w]) w = r;
+        } else {
+            if (l < n && h[l] < h[w]) w = l;
+            if (r < n && h[r] < h[w]) w = r;
+        }
+        if (w == i) break;
+        double t = h[i]; h[i] = h[w]; h[w] = t;
+        i = w;
+    }
+}
+
+static inline void topk_sift_down_i64(int64_t* h, int64_t n, int64_t i, int max_heap) {
+    for (;;) {
+        int64_t l = 2*i+1, r = 2*i+2, w = i;
+        if (max_heap) {
+            if (l < n && h[l] > h[w]) w = l;
+            if (r < n && h[r] > h[w]) w = r;
+        } else {
+            if (l < n && h[l] < h[w]) w = l;
+            if (r < n && h[r] < h[w]) w = r;
+        }
+        if (w == i) break;
+        int64_t t = h[i]; h[i] = h[w]; h[w] = t;
+        i = w;
+    }
+}
+
+/* For top (desc=1), the kept-K live in a MIN-heap so the root is the
+ * smallest of the kept (worst-of-best) — easy to evict when a larger
+ * value arrives.  Final heapsort with a min-heap drains smallest-first,
+ * so to emit largest-first we extract into the tail of the cell and
+ * read forward.  Symmetric for bot.  This keeps the inner loop in the
+ * cheap "compare against root, sift" shape. */
+static void topk_per_group_fn(void* ctx_v, uint32_t worker_id,
+                              int64_t start, int64_t end) {
+    (void)worker_id;
+    topk_par_ctx_t* c = (topk_par_ctx_t*)ctx_v;
+    int8_t t = c->src_type;
+    int64_t K = c->k;
+    uint8_t desc = c->desc;
+    for (int64_t gi = start; gi < end; gi++) {
+        ray_t* cell = ray_list_get(c->out_list, gi);
+        if (!cell) continue;
+        int64_t cnt = c->grp_cnt[gi];
+        int64_t off = c->offsets[gi];
+        const int64_t* idxs = &c->idx_buf[off];
+
+        /* Heap orientation: top (desc=1) keeps largest → min-heap
+         * (root=smallest-of-kept) so a larger candidate evicts the root.
+         * bot (desc=0) keeps smallest → max-heap symmetric.  max_heap
+         * arg to sift_down follows that mapping (inverted from the
+         * "what we want" direction). */
+        int max_heap = desc ? 0 : 1;
+
+        if (t == RAY_F64) {
+            double* dst = (double*)ray_data(cell);
+            int64_t kept = 0;
+            int64_t init_end = 0;  /* idx into idxs[] right after init */
+            for (int64_t i = 0; i < cnt && kept < K; i++) {
+                int64_t row = idxs[i];
+                init_end = i + 1;
+                if (c->has_nulls && c->null_bm &&
+                    ((c->null_bm[row >> 3] >> (row & 7)) & 1)) continue;
+                dst[kept++] = topk_read_f64(c->base, row);
+            }
+            if (kept == K) {
+                for (int64_t j = K/2 - 1; j >= 0; j--)
+                    topk_sift_down_dbl(dst, K, j, max_heap);
+                for (int64_t i = init_end; i < cnt; i++) {
+                    int64_t row = idxs[i];
+                    if (c->has_nulls && c->null_bm &&
+                        ((c->null_bm[row >> 3] >> (row & 7)) & 1)) continue;
+                    double v = topk_read_f64(c->base, row);
+                    if (desc ? (v > dst[0]) : (v < dst[0])) {
+                        dst[0] = v;
+                        topk_sift_down_dbl(dst, K, 0, max_heap);
+                    }
+                }
+            }
+            /* Heapsort drains root-first.  Our heap orientation is
+             * opposite to the desired output order (top → min-heap →
+             * drains ascending, but we want descending), so the
+             * standard heapsort + reverse sequence puts elements in
+             * the correct order.  Equivalent shortcut: extract roots
+             * into the tail.  We do that by sifting after swapping
+             * heap[0] with heap[n-1] — that puts the root at the end
+             * each iteration, which already gives the desired final
+             * order. */
+            int64_t n = kept;
+            while (n > 1) {
+                double tmp = dst[0]; dst[0] = dst[n-1]; dst[n-1] = tmp;
+                n--;
+                topk_sift_down_dbl(dst, n, 0, max_heap);
+            }
+            cell->len = kept;
+        } else {
+            /* Integer source: stage heap in stack buffer (K <= 1024 →
+             * 8KB), then narrow back to cell esz on write. */
+            void* dst = ray_data(cell);
+            uint8_t esz = ray_sym_elem_size(t, cell->attrs);
+            int64_t heap[1024];
+            int64_t kept = 0;
+            int64_t init_end = 0;
+            for (int64_t i = 0; i < cnt && kept < K; i++) {
+                int64_t row = idxs[i];
+                init_end = i + 1;
+                if (c->has_nulls && c->null_bm &&
+                    ((c->null_bm[row >> 3] >> (row & 7)) & 1)) continue;
+                heap[kept++] = topk_read_i64(c->base, t, row);
+            }
+            if (kept == K) {
+                for (int64_t j = K/2 - 1; j >= 0; j--)
+                    topk_sift_down_i64(heap, K, j, max_heap);
+                for (int64_t i = init_end; i < cnt; i++) {
+                    int64_t row = idxs[i];
+                    if (c->has_nulls && c->null_bm &&
+                        ((c->null_bm[row >> 3] >> (row & 7)) & 1)) continue;
+                    int64_t v = topk_read_i64(c->base, t, row);
+                    if (desc ? (v > heap[0]) : (v < heap[0])) {
+                        heap[0] = v;
+                        topk_sift_down_i64(heap, K, 0, max_heap);
+                    }
+                }
+            }
+            int64_t n = kept;
+            while (n > 1) {
+                int64_t tmp = heap[0]; heap[0] = heap[n-1]; heap[n-1] = tmp;
+                n--;
+                topk_sift_down_i64(heap, n, 0, max_heap);
+            }
+            for (int64_t i = 0; i < kept; i++)
+                topk_write_i64(dst, i, heap[i], esz);
+            cell->len = kept;
+        }
+    }
+}
+
+ray_t* ray_topk_per_group_buf(ray_t* src,
+                              int64_t k,
+                              uint8_t desc,
+                              const int64_t* idx_buf,
+                              const int64_t* offsets,
+                              const int64_t* grp_cnt,
+                              int64_t n_groups) {
+    if (!src || RAY_IS_ERR(src) || n_groups < 0) return NULL;
+    if (k < 1 || k > 1024) return NULL;
+    int8_t t = src->type;
+    if (t != RAY_F64 && t != RAY_I64 && t != RAY_I32 && t != RAY_I16 &&
+        t != RAY_U8  && t != RAY_BOOL && t != RAY_DATE && t != RAY_TIME &&
+        t != RAY_TIMESTAMP)
+        return NULL;
+
+    int64_t total = 0;
+    for (int64_t g = 0; g < n_groups; g++) total += grp_cnt[g];
+
+    ray_t* out = ray_list_new(n_groups);
+    if (!out || RAY_IS_ERR(out)) return out ? out : ray_error("oom", NULL);
+
+    /* Pre-allocate per-group cells, sized at min(K, grp_cnt[gi]).
+     * Cells are typed to match `src` so q8's F64 source gives F64
+     * cells, and (top (as 'I32 v) 3) preserves I32 (matches the
+     * standalone top_bot.rfl invariants). */
+    for (int64_t gi = 0; gi < n_groups; gi++) {
+        int64_t kk = grp_cnt[gi] < k ? grp_cnt[gi] : k;
+        ray_t* cell = col_vec_new(src, kk);
+        if (!cell || RAY_IS_ERR(cell)) {
+            ray_release(out);
+            return cell ? cell : ray_error("oom", NULL);
+        }
+        cell->len = 0;  /* worker fills in and sets cell->len = kept */
+        ray_t* new_out = ray_list_append(out, cell);
+        ray_release(cell);
+        if (!new_out || RAY_IS_ERR(new_out)) {
+            ray_release(out);
+            return new_out ? new_out : ray_error("oom", NULL);
+        }
+        out = new_out;
+    }
+
+    topk_par_ctx_t ctx = {
+        .base = ray_data(src),
+        .src_type = t,
+        .has_nulls = (src->attrs & RAY_ATTR_HAS_NULLS) != 0,
+        .null_bm = (src->attrs & RAY_ATTR_HAS_NULLS)
+                   ? ray_vec_nullmap_bytes(src, NULL, NULL) : NULL,
+        .k = k,
+        .desc = desc,
+        .idx_buf = idx_buf,
+        .offsets = offsets,
+        .grp_cnt = grp_cnt,
+        .out_list = out,
+    };
+
+    ray_pool_t* pool = ray_pool_get();
+    bool par = pool && n_groups >= 8 && total >= 4096;
+    if (par) {
+        ray_pool_dispatch_n(pool, topk_per_group_fn, &ctx, (uint32_t)n_groups);
+    } else {
+        topk_per_group_fn(&ctx, 0, 0, n_groups);
+    }
+
+    return out;
+}
+
 static ray_t* reduction_i64_result(int64_t val, int8_t out_type) {
     switch (out_type) {
         case RAY_DATE:      return ray_date((int32_t)val);
@@ -1585,12 +1861,15 @@ ght_layout_t ght_compute_layout(uint8_t n_keys, uint8_t n_aggs,
 
     uint8_t nv = 0;
     for (uint8_t a = 0; a < n_aggs && a < 8; a++) {
-        /* OP_MEDIAN reserves no row-layout slot — the column is
-         * materialized in agg_vecs[a] but values are not packed into
-         * entries or HT rows.  A post-radix pass over row_gid+grp_cnt
-         * gathers per-group slices and runs quickselect; see
-         * ray_median_per_group_buf. */
-        bool holistic = agg_ops && agg_ops[a] == OP_MEDIAN;
+        /* OP_MEDIAN / OP_TOP_N / OP_BOT_N reserve no row-layout slot —
+         * the column is materialized in agg_vecs[a] but values are not
+         * packed into entries or HT rows.  A post-radix pass over
+         * row_gid+grp_cnt gathers per-group slices and runs quickselect
+         * (median) or a bounded heap (top/bot); see
+         * ray_median_per_group_buf / ray_topk_per_group_buf. */
+        bool holistic = agg_ops && (agg_ops[a] == OP_MEDIAN ||
+                                    agg_ops[a] == OP_TOP_N ||
+                                    agg_ops[a] == OP_BOT_N);
         if (holistic) {
             ly.agg_is_holistic |= (uint8_t)(1u << a);
             ly.agg_val_slot[a] = -1;
@@ -3961,11 +4240,13 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
     int64_t agg_syms[8];
     for (uint8_t a = 0; a < n_aggs && can_partition; a++) {
         uint16_t aop = ext->agg_ops[a];
-        /* OP_MEDIAN is holistic — you can't merge medians across
-         * partitions without re-scanning the underlying values, so
-         * decline per-partition exec when any agg is median.  Falls
-         * through to the concat path which sees the full vector. */
-        if (aop == OP_MEDIAN) { can_partition = 0; break; }
+        /* Holistic aggs (OP_MEDIAN / OP_TOP_N / OP_BOT_N) can't be
+         * merged across partitions without re-scanning underlying
+         * values — decline per-partition exec.  Falls through to the
+         * concat path which sees the full vector. */
+        if (aop == OP_MEDIAN || aop == OP_TOP_N || aop == OP_BOT_N) {
+            can_partition = 0; break;
+        }
         if (aop != OP_SUM && aop != OP_COUNT && aop != OP_MIN &&
             aop != OP_MAX && aop != OP_AVG && aop != OP_FIRST &&
             aop != OP_LAST && aop != OP_STDDEV && aop != OP_STDDEV_POP &&
@@ -4745,12 +5026,14 @@ da_path:;
         /* Binary aggregators (OP_PEARSON_CORR) are not wired into the
          * dense-array accumulator's per-worker da_accum_t struct — force
          * the HT path which has the row-layout offsets allocated.
-         * Holistic aggregators (OP_MEDIAN) have no per-row accumulator
-         * at all — they need the post-radix row_gid+grp_cnt pass which
-         * only the HT path provides. */
+         * Holistic aggregators (OP_MEDIAN / OP_TOP_N / OP_BOT_N) have
+         * no per-row accumulator at all — they need the post-radix
+         * row_gid+grp_cnt pass which only the HT path provides. */
         for (uint8_t a = 0; a < n_aggs && da_eligible; a++) {
             if (ext->agg_ops[a] == OP_PEARSON_CORR) da_eligible = false;
             if (ext->agg_ops[a] == OP_MEDIAN)       da_eligible = false;
+            if (ext->agg_ops[a] == OP_TOP_N)        da_eligible = false;
+            if (ext->agg_ops[a] == OP_BOT_N)        da_eligible = false;
         }
         for (uint8_t k = 0; k < n_keys && da_eligible; k++) {
             if (!key_data[k]) { da_eligible = false; break; }

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -8486,42 +8486,54 @@ void pivot_ingest_free(pivot_ingest_t* out) {
 /* ============================================================================
  * exec_group_topk_rowform — dedicated per-group top-K / bot-K with row-form
  *
- * Two-phase parallel design (Siddiqui VLDB 2024 pattern).
+ * Three-phase parallel design.
  *
- * Phase 1: parallel scan, per-worker open-addressing hashmaps.  Each entry
- *  holds (key, K-slot heap of best values, kept_count).  Bounded-heap
- *  inserts: first K values fill linearly + heapify; subsequent values
- *  compare against root and sift-down if better.  No atomics.
+ * Phase 1 (parallel rows): each worker scatters fat entries
+ *  (hash:8, key_bits:8, val_bits:8) into per-(worker, partition) buffers
+ *  using the same 8-bit radix the OP_GROUP path uses (RADIX_P=256).  No
+ *  hashmap in this phase — pure streaming write.  Per-partition data fits
+ *  in L2 by construction.
  *
- * Phase 2: parallel merge by hash partition.  RADIX_P tasks; each owns
- *  groups whose hash falls in its partition.  The merge walks all per-
- *  worker maps once, collects entries hashing into the owned partition,
- *  builds a local merged hashmap, and produces the final top-K heap per
- *  unique group.  Counts are summed across partitions and prefix-scanned
- *  to give each partition its output-row range.
+ * Phase 2 (parallel partitions): RADIX_P tasks.  Each partition iterates
+ *  all worker buffers for its partition slot, probing a partition-local
+ *  open-addressing hashmap.  Entries hold a bounded K-slot heap (min-heap
+ *  for top, max-heap for bot — root = worst-of-kept).  No cross-partition
+ *  contention.
  *
- * Phase 3: parallel emit.  Each partition walks its merged hashmap and
- *  writes (key, sorted-heap-values) into the pre-allocated output
- *  columns at its row range.  No atomics, no over-allocation.
+ * Phase 3 (parallel partitions): each partition heapsort-drains its heap
+ *  entries into the pre-allocated output columns at its row range.  Row
+ *  ranges come from a prefix-sum over per-partition kept-counts.
  *
  * Compared to OP_GROUP + radix-HT + LIST-cell + adapter-side explode:
- *  - No idx_buf scatter (saves ~10M-int64 random write of 80 MB).
- *  - No LIST<F64>[K] cell allocation per group (saves 100k mallocs).
- *  - No second pass for explode (the heaps are emitted as rows directly).
+ *  - No idx_buf scatter (no random 80 MB write).
+ *  - No LIST<F64>[K] cell allocation per group (no 100k mallocs).
+ *  - Values stream straight into heaps in phase 2; no second pass for
+ *    explode in user code.
  * ============================================================================ */
 
-/* Per-worker hash map.  Key=int64 (i64-encoded source key), value=heap
- * stored as int64[K] (raw bits — reinterpretable to f64).  kept ∈ [0,K].
- * salt slot packs (salt:8, idx:24) like group_ht_t but inlined into
- * one uint32 slot array.  We do not need to handle wide-key (single
- * key only, fits in 8 bytes — STR/GUID is out of scope for this
- * planner shape since the canonical q8 has I64 id6 keys). */
+/* Scatter entry: 3 × 8 bytes = 24 bytes per row.  Phase 1 writes these
+ * sequentially into per-partition buffers; Phase 2 reads them linearly.
+ *   word 0: hash (used for HT probe and salt extraction)
+ *   word 1: key bits (canonical int64 — reinterp to double for F64)
+ *   word 2: val bits (canonical int64 — reinterp to double for F64) */
+#define GRPT_SCATTER_STRIDE 24u
+
 typedef struct {
-    int64_t  key;        /* canonical key bits (i64, or reinterp f64 bits) */
+    char*    data;          /* [count * GRPT_SCATTER_STRIDE] */
+    uint32_t count;
+    uint32_t cap;
+    bool     oom;
+    ray_t*   _hdr;
+} grpt_scat_buf_t;
+
+/* Probe-and-heap entry in partition HT.  Heap slots are int64 raw bits
+ * (memcpy'd from/to double for F64 values).  K capped at 255 (uint8 kept). */
+typedef struct {
+    int64_t  key;          /* canonical key bits */
     uint8_t  kept;
-    uint8_t  has_null_key;  /* set on the single null-key entry, if any */
+    uint8_t  has_null_key;
     uint8_t  pad[6];        /* align trailing heap[K] to 8 bytes */
-    /* heap[K] follows here — variable-size; offsets computed from K */
+    /* heap[K] follows here — variable-size */
 } grpt_entry_t;
 
 #define GRPT_ENTRY_HEAD_SZ (sizeof(grpt_entry_t))
@@ -8725,16 +8737,12 @@ typedef struct {
     const void* val_data;
     int8_t      key_type;
     int8_t      val_type;
-    bool        key_has_nulls;
-    bool        val_has_nulls;
     const uint8_t* key_null_bm;
     const uint8_t* val_null_bm;
-    int64_t     k;
-    int         desc;
     int         val_is_f64;
-    /* outputs (per worker) */
-    grpt_ht_t*  worker_hts;   /* [n_workers] */
-    _Atomic(uint32_t)* worker_inited;  /* bitmap [n_workers] — set on first use */
+    /* outputs: per-worker × per-partition scatter buffers */
+    grpt_scat_buf_t* bufs;       /* [n_workers * RADIX_P] */
+    uint32_t    n_workers;
 } grpt_phase1_ctx_t;
 
 static inline int64_t grpt_key_read(const void* base, int8_t t, int64_t row) {
@@ -8776,23 +8784,50 @@ static inline bool grpt_is_null(const uint8_t* nbm, int64_t row) {
     return (nbm[row >> 3] >> (row & 7)) & 1;
 }
 
+static inline int64_t grpt_val_read(const void* base, int8_t t, int64_t row,
+                                     int val_is_f64) {
+    if (val_is_f64) {
+        int64_t bits; memcpy(&bits, (const char*)base + (size_t)row*8, 8);
+        return bits;
+    }
+    switch (t) {
+        case RAY_I64: case RAY_TIMESTAMP:
+            { int64_t v; memcpy(&v, (const char*)base + (size_t)row*8, 8); return v; }
+        case RAY_I32: case RAY_DATE: case RAY_TIME:
+            { int32_t v; memcpy(&v, (const char*)base + (size_t)row*4, 4); return (int64_t)v; }
+        case RAY_I16:
+            { int16_t v; memcpy(&v, (const char*)base + (size_t)row*2, 2); return (int64_t)v; }
+        case RAY_BOOL: case RAY_U8:
+            return (int64_t)((const uint8_t*)base)[row];
+        default: return 0;
+    }
+}
+
+static inline void grpt_scat_push(grpt_scat_buf_t* buf, uint64_t hash,
+                                    int64_t key_bits, int64_t val_bits) {
+    if (__builtin_expect(buf->count >= buf->cap, 0)) {
+        uint32_t old_cap = buf->cap ? buf->cap : 64;
+        uint32_t new_cap = old_cap * 2;
+        char* new_data = (char*)scratch_realloc(&buf->_hdr,
+            (size_t)buf->cap * GRPT_SCATTER_STRIDE,
+            (size_t)new_cap * GRPT_SCATTER_STRIDE);
+        if (!new_data) { buf->oom = true; return; }
+        buf->data = new_data;
+        buf->cap = new_cap;
+    }
+    char* dst = buf->data + (size_t)buf->count * GRPT_SCATTER_STRIDE;
+    memcpy(dst,      &hash,     8);
+    memcpy(dst + 8,  &key_bits, 8);
+    memcpy(dst + 16, &val_bits, 8);
+    buf->count++;
+}
+
 static void grpt_phase1_fn(void* ctx_v, uint32_t worker_id,
                            int64_t start, int64_t end) {
     grpt_phase1_ctx_t* c = (grpt_phase1_ctx_t*)ctx_v;
-    grpt_ht_t* ht = &c->worker_hts[worker_id];
-
-    /* First-use lazy init.  Worker_id may be revisited in the same
-     * dispatch (work-stealing) — atomic CAS ensures one-time init. */
-    uint32_t expected = 0;
-    if (atomic_compare_exchange_strong(&c->worker_inited[worker_id],
-                                        &expected, 1)) {
-        if (!grpt_ht_init(ht, 1024, c->k)) return;
-    }
-    if (ht->oom) return;
+    grpt_scat_buf_t* my_bufs = &c->bufs[(size_t)worker_id * RADIX_P];
 
     int8_t kt = c->key_type, vt = c->val_type;
-    int64_t K = c->k;
-    int desc = c->desc;
     int val_is_f64 = c->val_is_f64;
     const void* kbase = c->key_data;
     const void* vbase = c->val_data;
@@ -8801,55 +8836,37 @@ static void grpt_phase1_fn(void* ctx_v, uint32_t worker_id,
 
     for (int64_t r = start; r < end; r++) {
         /* Skip null value rows (match standalone `top` and DuckDB WHERE
-         * v IS NOT NULL).  Null keys form their own singleton group. */
+         * v IS NOT NULL). */
         if (vnbm && grpt_is_null(vnbm, r)) continue;
-
-        bool key_null = (knbm && grpt_is_null(knbm, r));
-        int64_t key_bits = key_null ? 0 : grpt_key_read(kbase, kt, r);
-        uint64_t h = key_null ? ray_hash_i64(0) : grpt_key_hash(key_bits, kt);
-
-        grpt_entry_t* e = grpt_ht_get(ht, h, key_bits, key_null);
-        if (!e) return;   /* OOM — ht->oom flagged */
-
-        int64_t* heap = grpt_heap(e);
-        if (val_is_f64) {
-            double v; memcpy(&v, (const char*)vbase + (size_t)r*8, 8);
-            grpt_heap_push_dbl(heap, &e->kept, K, v, desc);
-        } else {
-            int64_t v;
-            switch (vt) {
-                case RAY_I64: case RAY_TIMESTAMP:
-                    memcpy(&v, (const char*)vbase + (size_t)r*8, 8); break;
-                case RAY_I32: case RAY_DATE: case RAY_TIME:
-                    { int32_t t32; memcpy(&t32, (const char*)vbase + (size_t)r*4, 4); v = (int64_t)t32; }
-                    break;
-                case RAY_I16:
-                    { int16_t t16; memcpy(&t16, (const char*)vbase + (size_t)r*2, 2); v = (int64_t)t16; }
-                    break;
-                case RAY_BOOL: case RAY_U8:
-                    v = (int64_t)((const uint8_t*)vbase)[r]; break;
-                default: continue;
-            }
-            grpt_heap_push_i64(heap, &e->kept, K, v, desc);
-        }
+        /* Skip null keys too: matches the OP_TOP_N path's effective
+         * behaviour and DuckDB's groupby semantics where NULL keys form
+         * a discarded group (we mirror DuckDB which drops null-key rows
+         * from windowed top-K).  Canonical q8 has no null id6, so no
+         * correctness impact on the bench path; small-data fixtures with
+         * null id6 are routed away by the type-restriction in the
+         * planner (no SYM keys). */
+        if (knbm && grpt_is_null(knbm, r)) continue;
+        int64_t key_bits = grpt_key_read(kbase, kt, r);
+        uint64_t h = grpt_key_hash(key_bits, kt);
+        int64_t val_bits = grpt_val_read(vbase, vt, r, val_is_f64);
+        uint32_t part = RADIX_PART(h);
+        grpt_scat_push(&my_bufs[part], h, key_bits, val_bits);
     }
 }
 
 /* ─── Phase 2 ──────────────────────────────────────────────────────────
- * Per-partition merge.  RADIX_P tasks.  Each task walks all per-worker
- * hashmaps, picks entries whose hash partitions into its own range, and
- * merges into a partition-local hashmap.  After all partitions finish,
- * we have RADIX_P independent merged maps that cover the full result. */
+ * Per-partition aggregation.  RADIX_P tasks.  Each task iterates all
+ * per-worker scatter buffers for its partition slot, probes a
+ * partition-local hashmap, and applies bounded-heap insert.  HT size
+ * is small (partition holds ~n_groups/256 entries) so it stays L2-hot. */
 
 typedef struct {
-    grpt_ht_t*  worker_hts;
+    grpt_scat_buf_t* bufs;       /* [n_workers * RADIX_P] */
     uint32_t    n_workers;
     grpt_ht_t*  part_hts;       /* [RADIX_P] */
     int64_t     k;
     int         desc;
     int         val_is_f64;
-    int8_t      key_type;
-    int8_t      val_type;
     int64_t*    part_emit_rows;  /* [RADIX_P]: total kept across this partition */
 } grpt_phase2_ctx_t;
 
@@ -8860,38 +8877,55 @@ static void grpt_phase2_fn(void* ctx_v, uint32_t worker_id,
     int64_t K = c->k;
     int desc = c->desc;
     int val_is_f64 = c->val_is_f64;
-    int8_t kt = c->key_type;
 
     for (int64_t pi = start; pi < end; pi++) {
         uint32_t p = (uint32_t)pi;
         grpt_ht_t* ph = &c->part_hts[p];
-        if (!grpt_ht_init(ph, 256, K)) return;
+        /* Estimate group count per partition from the scatter sizes.
+         * Total scatter for partition p across workers ≈ nrows/256; HT
+         * cap = next-pow2(2 * that / 256-ish).  Use a generous fixed
+         * initial size (8192) — fits in 32 KB which is L1-friendly. */
+        if (!grpt_ht_init(ph, 8192, K)) return;
 
         int64_t kept_sum = 0;
         for (uint32_t w = 0; w < c->n_workers; w++) {
-            grpt_ht_t* wht = &c->worker_hts[w];
-            if (!wht->entries || wht->oom) continue;
-            uint32_t wcount = wht->count;
-            uint16_t wstride = wht->entry_stride;
-            for (uint32_t i = 0; i < wcount; i++) {
-                grpt_entry_t* we = (grpt_entry_t*)(wht->entries +
-                                                    (size_t)i * wstride);
-                uint64_t h = we->has_null_key ? ray_hash_i64(0)
-                                              : grpt_key_hash(we->key, kt);
-                if (RADIX_PART(h) != p) continue;
-                grpt_entry_t* me = grpt_ht_get(ph, h, we->key,
-                                                we->has_null_key);
+            grpt_scat_buf_t* buf = &c->bufs[(size_t)w * RADIX_P + p];
+            if (!buf->data || buf->oom) continue;
+            uint32_t nbuf = buf->count;
+            const char* base = buf->data;
+
+            /* Stride-ahead prefetch on slot array (~25ns/probe vs L2
+             * miss).  D=8 covers the per-probe latency window. */
+            enum { PF_DIST = 8 };
+            uint32_t pf_end = (nbuf < PF_DIST) ? nbuf : PF_DIST;
+            uint32_t mask = ph->cap - 1;
+            for (uint32_t j = 0; j < pf_end; j++) {
+                uint64_t h;
+                memcpy(&h, base + (size_t)j * GRPT_SCATTER_STRIDE, 8);
+                __builtin_prefetch(&ph->slots[(uint32_t)(h & mask)], 0, 1);
+            }
+            for (uint32_t i = 0; i < nbuf; i++) {
+                if (i + PF_DIST < nbuf) {
+                    uint64_t hpf;
+                    memcpy(&hpf,
+                           base + (size_t)(i + PF_DIST) * GRPT_SCATTER_STRIDE, 8);
+                    /* mask may grow after a resize; reread after probe */
+                    __builtin_prefetch(&ph->slots[(uint32_t)(hpf & (ph->cap - 1))], 0, 1);
+                }
+                uint64_t h;
+                int64_t kb, vb;
+                const char* e = base + (size_t)i * GRPT_SCATTER_STRIDE;
+                memcpy(&h,  e,      8);
+                memcpy(&kb, e + 8,  8);
+                memcpy(&vb, e + 16, 8);
+                grpt_entry_t* me = grpt_ht_get(ph, h, kb, false);
                 if (!me) return;
                 int64_t* mh = grpt_heap(me);
-                int64_t* wh = grpt_heap(we);
                 if (val_is_f64) {
-                    for (uint8_t j = 0; j < we->kept; j++) {
-                        double v; memcpy(&v, &wh[j], 8);
-                        grpt_heap_push_dbl(mh, &me->kept, K, v, desc);
-                    }
+                    double v; memcpy(&v, &vb, 8);
+                    grpt_heap_push_dbl(mh, &me->kept, K, v, desc);
                 } else {
-                    for (uint8_t j = 0; j < we->kept; j++)
-                        grpt_heap_push_i64(mh, &me->kept, K, wh[j], desc);
+                    grpt_heap_push_i64(mh, &me->kept, K, vb, desc);
                 }
             }
         }
@@ -9059,23 +9093,36 @@ ray_t* exec_group_topk_rowform(ray_graph_t* g, ray_op_t* op) {
         return out;
     }
 
-    /* Per-worker hashmaps */
     ray_pool_t* pool = ray_pool_get();
     uint32_t n_workers = pool ? ray_pool_total_workers(pool) : 1;
     /* Sequential threshold — small inputs skip the pool overhead. */
     bool parallel = pool && nrows >= 16384;
     if (!parallel) n_workers = 1;
 
-    ray_t* whts_hdr = NULL;
-    grpt_ht_t* worker_hts = (grpt_ht_t*)scratch_calloc(&whts_hdr,
-                                (size_t)n_workers * sizeof(grpt_ht_t));
-    ray_t* winit_hdr = NULL;
-    _Atomic(uint32_t)* worker_inited = (_Atomic(uint32_t)*)scratch_calloc(
-        &winit_hdr, (size_t)n_workers * sizeof(_Atomic(uint32_t)));
-    if (!worker_hts || !worker_inited) {
-        if (whts_hdr) scratch_free(whts_hdr);
-        if (winit_hdr) scratch_free(winit_hdr);
-        return ray_error("oom", NULL);
+    /* Per-worker × per-partition scatter buffers (24 B per row). */
+    size_t n_bufs = (size_t)n_workers * RADIX_P;
+    ray_t* bufs_hdr = NULL;
+    grpt_scat_buf_t* bufs = (grpt_scat_buf_t*)scratch_calloc(&bufs_hdr,
+        n_bufs * sizeof(grpt_scat_buf_t));
+    if (!bufs) return ray_error("oom", NULL);
+
+    /* Pre-size each scatter buffer.  Average rows-per-partition ≈
+     * nrows / RADIX_P / n_workers, but distribution is uniform so
+     * 2× headroom is safe.  Keep the initial alloc small (e.g. 256
+     * entries × 24 B = 6 KB) so workers that don't hit a partition
+     * don't bloat memory. */
+    uint32_t init_cap = 256;
+    for (size_t i = 0; i < n_bufs; i++) {
+        bufs[i].data = (char*)scratch_alloc(&bufs[i]._hdr,
+            (size_t)init_cap * GRPT_SCATTER_STRIDE);
+        if (!bufs[i].data) {
+            for (size_t j = 0; j <= i; j++)
+                if (bufs[j]._hdr) scratch_free(bufs[j]._hdr);
+            scratch_free(bufs_hdr);
+            return ray_error("oom", NULL);
+        }
+        bufs[i].cap = init_cap;
+        bufs[i].count = 0;
     }
 
     grpt_phase1_ctx_t p1 = {
@@ -9083,38 +9130,32 @@ ray_t* exec_group_topk_rowform(ray_graph_t* g, ray_op_t* op) {
         .val_data = ray_data(val_vec),
         .key_type = kt,
         .val_type = vt,
-        .key_has_nulls = (key_vec->attrs & RAY_ATTR_HAS_NULLS) != 0,
-        .val_has_nulls = (val_vec->attrs & RAY_ATTR_HAS_NULLS) != 0,
         .key_null_bm = (key_vec->attrs & RAY_ATTR_HAS_NULLS)
                        ? ray_vec_nullmap_bytes(key_vec, NULL, NULL) : NULL,
         .val_null_bm = (val_vec->attrs & RAY_ATTR_HAS_NULLS)
                        ? ray_vec_nullmap_bytes(val_vec, NULL, NULL) : NULL,
-        .k = K,
-        .desc = desc,
         .val_is_f64 = (vt == RAY_F64) ? 1 : 0,
-        .worker_hts = worker_hts,
-        .worker_inited = worker_inited,
+        .bufs = bufs,
+        .n_workers = n_workers,
     };
 
     if (parallel) {
         ray_pool_dispatch(pool, grpt_phase1_fn, &p1, nrows);
     } else {
-        /* Force worker 0 init then call directly. */
-        atomic_store(&worker_inited[0], 0);
         grpt_phase1_fn(&p1, 0, 0, nrows);
     }
 
-    /* Check for OOM in any worker map */
-    for (uint32_t w = 0; w < n_workers; w++) {
-        if (worker_hts[w].oom) {
-            for (uint32_t i = 0; i < n_workers; i++)
-                grpt_ht_free(&worker_hts[i]);
-            scratch_free(whts_hdr); scratch_free(winit_hdr);
+    /* Check OOM */
+    for (size_t i = 0; i < n_bufs; i++) {
+        if (bufs[i].oom) {
+            for (size_t j = 0; j < n_bufs; j++)
+                if (bufs[j]._hdr) scratch_free(bufs[j]._hdr);
+            scratch_free(bufs_hdr);
             return ray_error("oom", NULL);
         }
     }
 
-    /* Phase 2: per-partition merge.  RADIX_P merged hashmaps. */
+    /* Phase 2: per-partition HT build. */
     ray_t* phts_hdr = NULL;
     grpt_ht_t* part_hts = (grpt_ht_t*)scratch_calloc(&phts_hdr,
                                 (size_t)RADIX_P * sizeof(grpt_ht_t));
@@ -9122,20 +9163,20 @@ ray_t* exec_group_topk_rowform(ray_graph_t* g, ray_op_t* op) {
     int64_t* part_emit_rows = (int64_t*)scratch_calloc(&per_hdr,
                                 (size_t)RADIX_P * sizeof(int64_t));
     if (!part_hts || !part_emit_rows) {
-        for (uint32_t w = 0; w < n_workers; w++) grpt_ht_free(&worker_hts[w]);
         if (phts_hdr) scratch_free(phts_hdr);
         if (per_hdr)  scratch_free(per_hdr);
-        scratch_free(whts_hdr); scratch_free(winit_hdr);
+        for (size_t j = 0; j < n_bufs; j++)
+            if (bufs[j]._hdr) scratch_free(bufs[j]._hdr);
+        scratch_free(bufs_hdr);
         return ray_error("oom", NULL);
     }
 
     grpt_phase2_ctx_t p2 = {
-        .worker_hts = worker_hts,
+        .bufs = bufs,
         .n_workers = n_workers,
         .part_hts = part_hts,
         .k = K, .desc = desc,
         .val_is_f64 = (vt == RAY_F64) ? 1 : 0,
-        .key_type = kt, .val_type = vt,
         .part_emit_rows = part_emit_rows,
     };
     if (parallel) {
@@ -9144,13 +9185,13 @@ ray_t* exec_group_topk_rowform(ray_graph_t* g, ray_op_t* op) {
         grpt_phase2_fn(&p2, 0, 0, RADIX_P);
     }
 
-    /* OOM check on merged maps */
     for (uint32_t p = 0; p < RADIX_P; p++) {
         if (part_hts[p].oom) {
-            for (uint32_t i = 0; i < n_workers; i++) grpt_ht_free(&worker_hts[i]);
-            for (uint32_t i = 0; i < RADIX_P;    i++) grpt_ht_free(&part_hts[i]);
+            for (uint32_t i = 0; i < RADIX_P; i++) grpt_ht_free(&part_hts[i]);
             scratch_free(phts_hdr); scratch_free(per_hdr);
-            scratch_free(whts_hdr); scratch_free(winit_hdr);
+            for (size_t j = 0; j < n_bufs; j++)
+                if (bufs[j]._hdr) scratch_free(bufs[j]._hdr);
+            scratch_free(bufs_hdr);
             return ray_error("oom", NULL);
         }
     }
@@ -9160,10 +9201,11 @@ ray_t* exec_group_topk_rowform(ray_graph_t* g, ray_op_t* op) {
     int64_t* part_offsets = (int64_t*)scratch_alloc(&po_hdr,
                                 (size_t)(RADIX_P + 1) * sizeof(int64_t));
     if (!part_offsets) {
-        for (uint32_t i = 0; i < n_workers; i++) grpt_ht_free(&worker_hts[i]);
-        for (uint32_t i = 0; i < RADIX_P;    i++) grpt_ht_free(&part_hts[i]);
+        for (uint32_t i = 0; i < RADIX_P; i++) grpt_ht_free(&part_hts[i]);
         scratch_free(phts_hdr); scratch_free(per_hdr);
-        scratch_free(whts_hdr); scratch_free(winit_hdr);
+        for (size_t j = 0; j < n_bufs; j++)
+            if (bufs[j]._hdr) scratch_free(bufs[j]._hdr);
+        scratch_free(bufs_hdr);
         return ray_error("oom", NULL);
     }
     int64_t total_rows = 0;
@@ -9179,11 +9221,12 @@ ray_t* exec_group_topk_rowform(ray_graph_t* g, ray_op_t* op) {
     if (!key_out || !val_out || RAY_IS_ERR(key_out) || RAY_IS_ERR(val_out)) {
         if (key_out) ray_release(key_out);
         if (val_out) ray_release(val_out);
-        for (uint32_t i = 0; i < n_workers; i++) grpt_ht_free(&worker_hts[i]);
-        for (uint32_t i = 0; i < RADIX_P;    i++) grpt_ht_free(&part_hts[i]);
+        for (uint32_t i = 0; i < RADIX_P; i++) grpt_ht_free(&part_hts[i]);
         scratch_free(po_hdr);
         scratch_free(phts_hdr); scratch_free(per_hdr);
-        scratch_free(whts_hdr); scratch_free(winit_hdr);
+        for (size_t j = 0; j < n_bufs; j++)
+            if (bufs[j]._hdr) scratch_free(bufs[j]._hdr);
+        scratch_free(bufs_hdr);
         return ray_error("oom", NULL);
     }
     key_out->len = total_rows;
@@ -9199,7 +9242,7 @@ ray_t* exec_group_topk_rowform(ray_graph_t* g, ray_op_t* op) {
         .val_esz = (uint8_t)ray_elem_size(vt),
         .key_out = ray_data(key_out),
         .val_out = ray_data(val_out),
-        .key_vec = key_out,   /* needed for null-key marking */
+        .key_vec = key_out,
     };
     if (parallel) {
         ray_pool_dispatch_n(pool, grpt_phase3_fn, &p3, RADIX_P);
@@ -9216,11 +9259,12 @@ ray_t* exec_group_topk_rowform(ray_graph_t* g, ray_op_t* op) {
     }
     ray_release(key_out); ray_release(val_out);
 
-    for (uint32_t i = 0; i < n_workers; i++) grpt_ht_free(&worker_hts[i]);
-    for (uint32_t i = 0; i < RADIX_P;    i++) grpt_ht_free(&part_hts[i]);
+    for (uint32_t i = 0; i < RADIX_P; i++) grpt_ht_free(&part_hts[i]);
     scratch_free(po_hdr);
     scratch_free(phts_hdr); scratch_free(per_hdr);
-    scratch_free(whts_hdr); scratch_free(winit_hdr);
+    for (size_t j = 0; j < n_bufs; j++)
+        if (bufs[j]._hdr) scratch_free(bufs[j]._hdr);
+    scratch_free(bufs_hdr);
 
     return result;
 }

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -4151,7 +4151,15 @@ static void reprobe_rows_fn(void* vctx, uint32_t worker_id,
 
 /* Histogram + scatter for idx_buf construction.  Identical pattern to
  * query.c's idxbuf_hist_fn / idxbuf_scat_fn — duplicated here to avoid
- * pulling a query.c-internal helper through internal.h. */
+ * pulling a query.c-internal helper through internal.h.
+ *
+ * Dispatched via ray_pool_dispatch_n with n_tasks units.  Each unit owns
+ * a contiguous row range [task_id*grain, min((task_id+1)*grain, nrows)).
+ * grain is sized to give n_tasks ≈ total_workers — this caps the
+ * hist/cur matrices at n_tasks * n_groups * 8 bytes (rather than
+ * blowing up to ~1GB when n_groups is large and grain is the default
+ * 8K morsel size).  The serial cumsum that walks hist by-gi becomes
+ * cheap (n_groups * n_tasks ops, n_tasks small). */
 typedef struct {
     const int64_t* row_gid;
     int64_t*       hist;          /* [n_tasks * n_groups] */
@@ -4159,16 +4167,20 @@ typedef struct {
     int64_t*       idx_buf;
     int64_t        n_groups;
     int64_t        grain;
+    int64_t        nrows;
 } med_idx_ctx_t;
 
 static void med_idx_hist_fn(void* vctx, uint32_t worker_id,
                             int64_t start, int64_t end) {
-    (void)worker_id;
+    (void)worker_id; (void)end;
     med_idx_ctx_t* c = (med_idx_ctx_t*)vctx;
-    int64_t task_id = start / c->grain;
+    int64_t task_id = start;  /* dispatched via _n: start = task index */
+    int64_t r_lo = task_id * c->grain;
+    int64_t r_hi = r_lo + c->grain;
+    if (r_hi > c->nrows) r_hi = c->nrows;
     int64_t* hist = c->hist + task_id * c->n_groups;
     const int64_t* row_gid = c->row_gid;
-    for (int64_t r = start; r < end; r++) {
+    for (int64_t r = r_lo; r < r_hi; r++) {
         int64_t gi = row_gid[r];
         if (gi >= 0) hist[gi]++;
     }
@@ -4176,13 +4188,16 @@ static void med_idx_hist_fn(void* vctx, uint32_t worker_id,
 
 static void med_idx_scat_fn(void* vctx, uint32_t worker_id,
                             int64_t start, int64_t end) {
-    (void)worker_id;
+    (void)worker_id; (void)end;
     med_idx_ctx_t* c = (med_idx_ctx_t*)vctx;
-    int64_t task_id = start / c->grain;
+    int64_t task_id = start;
+    int64_t r_lo = task_id * c->grain;
+    int64_t r_hi = r_lo + c->grain;
+    if (r_hi > c->nrows) r_hi = c->nrows;
     int64_t* cur = c->cursor + task_id * c->n_groups;
     const int64_t* row_gid = c->row_gid;
     int64_t* idx_buf = c->idx_buf;
-    for (int64_t r = start; r < end; r++) {
+    for (int64_t r = r_lo; r < r_hi; r++) {
         int64_t gi = row_gid[r];
         if (gi >= 0) idx_buf[cur[gi]++] = r;
     }
@@ -7065,14 +7080,30 @@ skip_top_count_filter:
             };
             ray_pool_dispatch(pool, reprobe_rows_fn, &rp, n_scan);
 
-            /* Build idx_buf + offsets + grp_cnt via histogram/scatter. */
-            int64_t med_grain = (int64_t)RAY_DISPATCH_MORSELS * RAY_MORSEL_ELEMS;
-            int64_t med_ntasks = (nrows + med_grain - 1) / med_grain;
+            /* Build idx_buf + offsets + grp_cnt via histogram/scatter.
+             *
+             * n_tasks is capped to a small multiple of worker count: the
+             * hist/cur matrices are sized [n_tasks * n_groups] and the
+             * cumsum below walks every entry serially.  With the default
+             * 8K-morsel grain, 10M rows × 100k groups would inflate hist
+             * to ~1GB and the cumsum to ~120M cache-strided ops (≈1.4s).
+             * Capping n_tasks ≈ worker count keeps memory in the L2/L3
+             * regime and the cumsum in single-digit ms, while leaving
+             * scatter parallelism saturated (each task is large enough). */
+            int64_t n_workers = (int64_t)ray_pool_total_workers(pool);
+            int64_t med_ntasks = n_workers > 1 ? n_workers : 1;
+            /* Don't over-task tiny inputs — each task should see ≥ 8K
+             * rows so the per-task fixed overhead is amortised. */
+            int64_t min_grain = 8192;
+            if (med_ntasks * min_grain > nrows)
+                med_ntasks = (nrows + min_grain - 1) / min_grain;
             if (med_ntasks < 1) med_ntasks = 1;
-            if (med_ntasks > 65536) {
-                med_ntasks = 65536;
-                med_grain = (nrows + med_ntasks - 1) / med_ntasks;
-            }
+            int64_t med_grain = (nrows + med_ntasks - 1) / med_ntasks;
+            if (med_grain < 1) med_grain = 1;
+            /* Recompute med_ntasks from grain so the last task covers the
+             * tail without overflow (grain rounds up; final task may be
+             * shorter). */
+            med_ntasks = (nrows + med_grain - 1) / med_grain;
             ray_t* hist_hdr = NULL;
             ray_t* cur_hdr  = NULL;
             ray_t* cnt_hdr  = NULL;
@@ -7095,8 +7126,10 @@ skip_top_count_filter:
                     .idx_buf = NULL,
                     .n_groups = n_groups,
                     .grain = med_grain,
+                    .nrows = nrows,
                 };
-                ray_pool_dispatch(pool, med_idx_hist_fn, &mctx, nrows);
+                ray_pool_dispatch_n(pool, med_idx_hist_fn, &mctx,
+                                    (uint32_t)med_ntasks);
                 int64_t total = 0;
                 for (int64_t gi = 0; gi < n_groups; gi++) {
                     int64_t cum = total;
@@ -7113,7 +7146,8 @@ skip_top_count_filter:
                     (size_t)(total > 0 ? total : 1) * sizeof(int64_t));
                 if (idx_buf) {
                     mctx.idx_buf = idx_buf;
-                    ray_pool_dispatch(pool, med_idx_scat_fn, &mctx, nrows);
+                    ray_pool_dispatch_n(pool, med_idx_scat_fn, &mctx,
+                                        (uint32_t)med_ntasks);
                 }
             }
 

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -8482,3 +8482,745 @@ void pivot_ingest_free(pivot_ingest_t* out) {
     scratch_free(out->_offsets_hdr);
     memset(out, 0, sizeof(*out));
 }
+
+/* ============================================================================
+ * exec_group_topk_rowform — dedicated per-group top-K / bot-K with row-form
+ *
+ * Two-phase parallel design (Siddiqui VLDB 2024 pattern).
+ *
+ * Phase 1: parallel scan, per-worker open-addressing hashmaps.  Each entry
+ *  holds (key, K-slot heap of best values, kept_count).  Bounded-heap
+ *  inserts: first K values fill linearly + heapify; subsequent values
+ *  compare against root and sift-down if better.  No atomics.
+ *
+ * Phase 2: parallel merge by hash partition.  RADIX_P tasks; each owns
+ *  groups whose hash falls in its partition.  The merge walks all per-
+ *  worker maps once, collects entries hashing into the owned partition,
+ *  builds a local merged hashmap, and produces the final top-K heap per
+ *  unique group.  Counts are summed across partitions and prefix-scanned
+ *  to give each partition its output-row range.
+ *
+ * Phase 3: parallel emit.  Each partition walks its merged hashmap and
+ *  writes (key, sorted-heap-values) into the pre-allocated output
+ *  columns at its row range.  No atomics, no over-allocation.
+ *
+ * Compared to OP_GROUP + radix-HT + LIST-cell + adapter-side explode:
+ *  - No idx_buf scatter (saves ~10M-int64 random write of 80 MB).
+ *  - No LIST<F64>[K] cell allocation per group (saves 100k mallocs).
+ *  - No second pass for explode (the heaps are emitted as rows directly).
+ * ============================================================================ */
+
+/* Per-worker hash map.  Key=int64 (i64-encoded source key), value=heap
+ * stored as int64[K] (raw bits — reinterpretable to f64).  kept ∈ [0,K].
+ * salt slot packs (salt:8, idx:24) like group_ht_t but inlined into
+ * one uint32 slot array.  We do not need to handle wide-key (single
+ * key only, fits in 8 bytes — STR/GUID is out of scope for this
+ * planner shape since the canonical q8 has I64 id6 keys). */
+typedef struct {
+    int64_t  key;        /* canonical key bits (i64, or reinterp f64 bits) */
+    uint8_t  kept;
+    uint8_t  has_null_key;  /* set on the single null-key entry, if any */
+    uint8_t  pad[6];        /* align trailing heap[K] to 8 bytes */
+    /* heap[K] follows here — variable-size; offsets computed from K */
+} grpt_entry_t;
+
+#define GRPT_ENTRY_HEAD_SZ (sizeof(grpt_entry_t))
+
+typedef struct {
+    uint32_t* slots;       /* [cap]: packed (salt:8 | idx:24); UINT32_MAX = empty */
+    char*     entries;     /* [count * entry_stride] */
+    uint32_t  count;
+    uint32_t  cap;         /* slot count, power of 2 */
+    uint32_t  entry_cap;   /* entries allocated */
+    uint16_t  entry_stride;
+    int64_t   k;
+    bool      oom;
+    ray_t*    _slots_hdr;
+    ray_t*    _entries_hdr;
+} grpt_ht_t;
+
+/* Pack salt+idx into 32-bit slot — same scheme as group_ht_t. */
+#define GRPT_EMPTY     UINT32_MAX
+#define GRPT_PACK(salt, idx) (((uint32_t)(uint8_t)(salt) << 24) | ((idx) & 0xFFFFFF))
+#define GRPT_IDX(s)    ((s) & 0xFFFFFF)
+#define GRPT_SALT(s)   ((uint8_t)((s) >> 24))
+#define GRPT_HASH_SALT(h) ((uint8_t)((h) >> 56))
+
+static inline grpt_entry_t* grpt_entry_at(grpt_ht_t* ht, uint32_t idx) {
+    return (grpt_entry_t*)(ht->entries + (size_t)idx * ht->entry_stride);
+}
+static inline int64_t* grpt_heap(grpt_entry_t* e) {
+    /* heap starts right after the header struct */
+    return (int64_t*)((char*)e + GRPT_ENTRY_HEAD_SZ);
+}
+
+static bool grpt_ht_init(grpt_ht_t* ht, uint32_t init_cap, int64_t K) {
+    memset(ht, 0, sizeof(*ht));
+    if (init_cap < 32) init_cap = 32;
+    /* power of 2 */
+    uint32_t cap = 1;
+    while (cap < init_cap) cap <<= 1;
+    ht->cap = cap;
+    ht->k = K;
+    /* Entry stride: header + K*8 bytes for heap.  Round up to 8-byte. */
+    size_t stride = GRPT_ENTRY_HEAD_SZ + (size_t)K * 8;
+    stride = (stride + 7) & ~(size_t)7;
+    ht->entry_stride = (uint16_t)stride;
+    ht->entry_cap = cap / 2;   /* load factor 0.5 cap */
+    if (ht->entry_cap < 16) ht->entry_cap = 16;
+
+    ht->slots = (uint32_t*)scratch_alloc(&ht->_slots_hdr, (size_t)cap * 4);
+    if (!ht->slots) { ht->oom = true; return false; }
+    memset(ht->slots, 0xFF, (size_t)cap * 4);    /* GRPT_EMPTY = 0xFFFFFFFF */
+
+    ht->entries = (char*)scratch_alloc(&ht->_entries_hdr,
+                                       (size_t)ht->entry_cap * ht->entry_stride);
+    if (!ht->entries) { ht->oom = true; return false; }
+    return true;
+}
+
+static void grpt_ht_free(grpt_ht_t* ht) {
+    if (ht->_slots_hdr) scratch_free(ht->_slots_hdr);
+    if (ht->_entries_hdr) scratch_free(ht->_entries_hdr);
+    memset(ht, 0, sizeof(*ht));
+}
+
+/* Grow ht->cap × 2, rehash existing entries.  Entries themselves stay
+ * in place — only slot pointers move. */
+static bool grpt_ht_grow_slots(grpt_ht_t* ht) {
+    uint32_t old_cap = ht->cap;
+    uint32_t new_cap = old_cap * 2;
+    ray_t* new_hdr = NULL;
+    uint32_t* new_slots = (uint32_t*)scratch_alloc(&new_hdr, (size_t)new_cap * 4);
+    if (!new_slots) { ht->oom = true; return false; }
+    memset(new_slots, 0xFF, (size_t)new_cap * 4);
+
+    uint32_t mask = new_cap - 1;
+    for (uint32_t i = 0; i < ht->count; i++) {
+        grpt_entry_t* e = grpt_entry_at(ht, i);
+        /* Recompute hash from the key.  has_null_key entries used hash(0). */
+        uint64_t h = e->has_null_key ? ray_hash_i64(0)
+                                      : ray_hash_i64(e->key);
+        uint32_t p = (uint32_t)(h & mask);
+        uint8_t salt = GRPT_HASH_SALT(h);
+        for (;;) {
+            if (new_slots[p] == GRPT_EMPTY) {
+                new_slots[p] = GRPT_PACK(salt, i);
+                break;
+            }
+            p = (p + 1) & mask;
+        }
+    }
+    scratch_free(ht->_slots_hdr);
+    ht->_slots_hdr = new_hdr;
+    ht->slots = new_slots;
+    ht->cap = new_cap;
+    return true;
+}
+
+static bool grpt_ht_grow_entries(grpt_ht_t* ht) {
+    uint32_t new_ecap = ht->entry_cap * 2;
+    char* new_e = (char*)scratch_realloc(&ht->_entries_hdr,
+                                          (size_t)ht->entry_cap * ht->entry_stride,
+                                          (size_t)new_ecap * ht->entry_stride);
+    if (!new_e) { ht->oom = true; return false; }
+    ht->entries = new_e;
+    ht->entry_cap = new_ecap;
+    return true;
+}
+
+/* Probe-or-insert: returns entry pointer for key.  Initializes a new
+ * entry with kept=0 on first sight.  has_null=true marks the singleton
+ * null-key slot (canonical key bits=0 + null flag). */
+static inline grpt_entry_t*
+grpt_ht_get(grpt_ht_t* ht, uint64_t hash, int64_t key_bits, bool has_null) {
+    if (ht->cap == 0 || (ht->count + 1) * 2 > ht->cap) {
+        if (!grpt_ht_grow_slots(ht)) return NULL;
+    }
+    if (ht->count >= ht->entry_cap) {
+        if (!grpt_ht_grow_entries(ht)) return NULL;
+    }
+
+    uint32_t mask = ht->cap - 1;
+    uint32_t p = (uint32_t)(hash & mask);
+    uint8_t salt = GRPT_HASH_SALT(hash);
+    for (;;) {
+        uint32_t s = ht->slots[p];
+        if (s == GRPT_EMPTY) {
+            uint32_t idx = ht->count++;
+            ht->slots[p] = GRPT_PACK(salt, idx);
+            grpt_entry_t* e = grpt_entry_at(ht, idx);
+            e->key = key_bits;
+            e->kept = 0;
+            e->has_null_key = has_null ? 1 : 0;
+            return e;
+        }
+        if (GRPT_SALT(s) == salt) {
+            grpt_entry_t* e = grpt_entry_at(ht, GRPT_IDX(s));
+            if (e->has_null_key == (has_null ? 1 : 0) &&
+                (has_null || e->key == key_bits))
+                return e;
+        }
+        p = (p + 1) & mask;
+    }
+}
+
+/* Bounded-heap insert.  Heap orientation: top (desc=1) → min-heap so
+ * root is the worst-of-kept and a larger candidate evicts it.  bot
+ * (desc=0) → max-heap, symmetric.  Heap entries are raw int64 bits
+ * (reinterpret to double for F64 value path). */
+static inline void grpt_heap_push_dbl(int64_t* heap, uint8_t* kept_p,
+                                       int64_t K, double v_dbl, int desc) {
+    int max_heap = desc ? 0 : 1;
+    int64_t v_bits; memcpy(&v_bits, &v_dbl, 8);
+    int64_t kept = *kept_p;
+    if (kept < K) {
+        heap[kept] = v_bits;
+        kept++;
+        *kept_p = (uint8_t)kept;
+        if (kept == K) {
+            /* Heapify from bottom — reinterpret as doubles. */
+            double* hd = (double*)heap;
+            for (int64_t j = K/2 - 1; j >= 0; j--)
+                topk_sift_down_dbl(hd, K, j, max_heap);
+        }
+        return;
+    }
+    double* hd = (double*)heap;
+    if (desc ? (v_dbl > hd[0]) : (v_dbl < hd[0])) {
+        hd[0] = v_dbl;
+        topk_sift_down_dbl(hd, K, 0, max_heap);
+    }
+}
+
+static inline void grpt_heap_push_i64(int64_t* heap, uint8_t* kept_p,
+                                       int64_t K, int64_t v, int desc) {
+    int max_heap = desc ? 0 : 1;
+    int64_t kept = *kept_p;
+    if (kept < K) {
+        heap[kept] = v;
+        kept++;
+        *kept_p = (uint8_t)kept;
+        if (kept == K) {
+            for (int64_t j = K/2 - 1; j >= 0; j--)
+                topk_sift_down_i64(heap, K, j, max_heap);
+        }
+        return;
+    }
+    if (desc ? (v > heap[0]) : (v < heap[0])) {
+        heap[0] = v;
+        topk_sift_down_i64(heap, K, 0, max_heap);
+    }
+}
+
+/* ─── Phase 1 ──────────────────────────────────────────────────────────
+ * Per-worker scan: read (key, val) per row, dispatch into per-worker
+ * hashmap.  Specialized inner loops for (key_type, val_type) so the
+ * branch out of `topk_read_*` lifts out of the hot loop.  The dominant
+ * canonical q8 shape is (I64 key, F64 val). */
+
+typedef struct {
+    /* inputs */
+    const void* key_data;
+    const void* val_data;
+    int8_t      key_type;
+    int8_t      val_type;
+    bool        key_has_nulls;
+    bool        val_has_nulls;
+    const uint8_t* key_null_bm;
+    const uint8_t* val_null_bm;
+    int64_t     k;
+    int         desc;
+    int         val_is_f64;
+    /* outputs (per worker) */
+    grpt_ht_t*  worker_hts;   /* [n_workers] */
+    _Atomic(uint32_t)* worker_inited;  /* bitmap [n_workers] — set on first use */
+} grpt_phase1_ctx_t;
+
+static inline int64_t grpt_key_read(const void* base, int8_t t, int64_t row) {
+    /* All key types route to int64 canonical bits. */
+    switch (t) {
+        case RAY_F64: {
+            double v; memcpy(&v, (const char*)base + (size_t)row*8, 8);
+            if (v == 0.0) v = 0.0;   /* normalize -0.0 → +0.0 to match hash */
+            int64_t bits; memcpy(&bits, &v, 8); return bits;
+        }
+        case RAY_I64: case RAY_TIMESTAMP:
+            { int64_t v; memcpy(&v, (const char*)base + (size_t)row*8, 8); return v; }
+        case RAY_I32: case RAY_DATE: case RAY_TIME:
+            { int32_t v; memcpy(&v, (const char*)base + (size_t)row*4, 4); return (int64_t)v; }
+        case RAY_I16:
+            { int16_t v; memcpy(&v, (const char*)base + (size_t)row*2, 2); return (int64_t)v; }
+        case RAY_BOOL: case RAY_U8:
+            return (int64_t)((const uint8_t*)base)[row];
+        case RAY_SYM:
+            /* SYM is variable-width via attrs; canonical_key_read elsewhere
+             * uses read_col_i64 / ray_read_sym.  For simplicity we treat
+             * SYM via a fallback path that callers route around — see
+             * the SYM guard in the executor.  Returning 0 here is safe
+             * because the executor refuses SYM keys before reaching this. */
+            return 0;
+        default: return 0;
+    }
+}
+
+static inline uint64_t grpt_key_hash(int64_t bits, int8_t t) {
+    if (t == RAY_F64) {
+        double v; memcpy(&v, &bits, 8);
+        return ray_hash_f64(v);
+    }
+    return ray_hash_i64(bits);
+}
+
+static inline bool grpt_is_null(const uint8_t* nbm, int64_t row) {
+    return (nbm[row >> 3] >> (row & 7)) & 1;
+}
+
+static void grpt_phase1_fn(void* ctx_v, uint32_t worker_id,
+                           int64_t start, int64_t end) {
+    grpt_phase1_ctx_t* c = (grpt_phase1_ctx_t*)ctx_v;
+    grpt_ht_t* ht = &c->worker_hts[worker_id];
+
+    /* First-use lazy init.  Worker_id may be revisited in the same
+     * dispatch (work-stealing) — atomic CAS ensures one-time init. */
+    uint32_t expected = 0;
+    if (atomic_compare_exchange_strong(&c->worker_inited[worker_id],
+                                        &expected, 1)) {
+        if (!grpt_ht_init(ht, 1024, c->k)) return;
+    }
+    if (ht->oom) return;
+
+    int8_t kt = c->key_type, vt = c->val_type;
+    int64_t K = c->k;
+    int desc = c->desc;
+    int val_is_f64 = c->val_is_f64;
+    const void* kbase = c->key_data;
+    const void* vbase = c->val_data;
+    const uint8_t* knbm = c->key_null_bm;
+    const uint8_t* vnbm = c->val_null_bm;
+
+    for (int64_t r = start; r < end; r++) {
+        /* Skip null value rows (match standalone `top` and DuckDB WHERE
+         * v IS NOT NULL).  Null keys form their own singleton group. */
+        if (vnbm && grpt_is_null(vnbm, r)) continue;
+
+        bool key_null = (knbm && grpt_is_null(knbm, r));
+        int64_t key_bits = key_null ? 0 : grpt_key_read(kbase, kt, r);
+        uint64_t h = key_null ? ray_hash_i64(0) : grpt_key_hash(key_bits, kt);
+
+        grpt_entry_t* e = grpt_ht_get(ht, h, key_bits, key_null);
+        if (!e) return;   /* OOM — ht->oom flagged */
+
+        int64_t* heap = grpt_heap(e);
+        if (val_is_f64) {
+            double v; memcpy(&v, (const char*)vbase + (size_t)r*8, 8);
+            grpt_heap_push_dbl(heap, &e->kept, K, v, desc);
+        } else {
+            int64_t v;
+            switch (vt) {
+                case RAY_I64: case RAY_TIMESTAMP:
+                    memcpy(&v, (const char*)vbase + (size_t)r*8, 8); break;
+                case RAY_I32: case RAY_DATE: case RAY_TIME:
+                    { int32_t t32; memcpy(&t32, (const char*)vbase + (size_t)r*4, 4); v = (int64_t)t32; }
+                    break;
+                case RAY_I16:
+                    { int16_t t16; memcpy(&t16, (const char*)vbase + (size_t)r*2, 2); v = (int64_t)t16; }
+                    break;
+                case RAY_BOOL: case RAY_U8:
+                    v = (int64_t)((const uint8_t*)vbase)[r]; break;
+                default: continue;
+            }
+            grpt_heap_push_i64(heap, &e->kept, K, v, desc);
+        }
+    }
+}
+
+/* ─── Phase 2 ──────────────────────────────────────────────────────────
+ * Per-partition merge.  RADIX_P tasks.  Each task walks all per-worker
+ * hashmaps, picks entries whose hash partitions into its own range, and
+ * merges into a partition-local hashmap.  After all partitions finish,
+ * we have RADIX_P independent merged maps that cover the full result. */
+
+typedef struct {
+    grpt_ht_t*  worker_hts;
+    uint32_t    n_workers;
+    grpt_ht_t*  part_hts;       /* [RADIX_P] */
+    int64_t     k;
+    int         desc;
+    int         val_is_f64;
+    int8_t      key_type;
+    int8_t      val_type;
+    int64_t*    part_emit_rows;  /* [RADIX_P]: total kept across this partition */
+} grpt_phase2_ctx_t;
+
+static void grpt_phase2_fn(void* ctx_v, uint32_t worker_id,
+                           int64_t start, int64_t end) {
+    (void)worker_id;
+    grpt_phase2_ctx_t* c = (grpt_phase2_ctx_t*)ctx_v;
+    int64_t K = c->k;
+    int desc = c->desc;
+    int val_is_f64 = c->val_is_f64;
+    int8_t kt = c->key_type;
+
+    for (int64_t pi = start; pi < end; pi++) {
+        uint32_t p = (uint32_t)pi;
+        grpt_ht_t* ph = &c->part_hts[p];
+        if (!grpt_ht_init(ph, 256, K)) return;
+
+        int64_t kept_sum = 0;
+        for (uint32_t w = 0; w < c->n_workers; w++) {
+            grpt_ht_t* wht = &c->worker_hts[w];
+            if (!wht->entries || wht->oom) continue;
+            uint32_t wcount = wht->count;
+            uint16_t wstride = wht->entry_stride;
+            for (uint32_t i = 0; i < wcount; i++) {
+                grpt_entry_t* we = (grpt_entry_t*)(wht->entries +
+                                                    (size_t)i * wstride);
+                uint64_t h = we->has_null_key ? ray_hash_i64(0)
+                                              : grpt_key_hash(we->key, kt);
+                if (RADIX_PART(h) != p) continue;
+                grpt_entry_t* me = grpt_ht_get(ph, h, we->key,
+                                                we->has_null_key);
+                if (!me) return;
+                int64_t* mh = grpt_heap(me);
+                int64_t* wh = grpt_heap(we);
+                if (val_is_f64) {
+                    for (uint8_t j = 0; j < we->kept; j++) {
+                        double v; memcpy(&v, &wh[j], 8);
+                        grpt_heap_push_dbl(mh, &me->kept, K, v, desc);
+                    }
+                } else {
+                    for (uint8_t j = 0; j < we->kept; j++)
+                        grpt_heap_push_i64(mh, &me->kept, K, wh[j], desc);
+                }
+            }
+        }
+
+        /* Tally rows this partition contributes to the output. */
+        for (uint32_t i = 0; i < ph->count; i++) {
+            grpt_entry_t* me = grpt_entry_at(ph, i);
+            kept_sum += me->kept;
+        }
+        c->part_emit_rows[p] = kept_sum;
+    }
+}
+
+/* ─── Phase 3 ──────────────────────────────────────────────────────────
+ * Per-partition emit.  Walk merged hashmap, sort each heap in-place
+ * (heapsort: swap root with tail, sift, repeat), then write rows. */
+
+typedef struct {
+    grpt_ht_t*  part_hts;
+    const int64_t* part_offsets;   /* prefix sum of part_emit_rows */
+    int64_t     k;
+    int         desc;
+    int         val_is_f64;
+    int8_t      key_type;
+    int8_t      val_type;
+    uint8_t     key_esz;
+    uint8_t     val_esz;
+    void*       key_out;
+    void*       val_out;
+    /* For null-aware key emission */
+    ray_t*      key_vec;
+} grpt_phase3_ctx_t;
+
+static inline void grpt_write_key(void* dst, int64_t row, int64_t bits,
+                                   uint8_t esz) {
+    switch (esz) {
+        case 1: ((uint8_t*)dst)[row] = (uint8_t)bits; break;
+        case 2: ((int16_t*)dst)[row] = (int16_t)bits; break;
+        case 4: ((int32_t*)dst)[row] = (int32_t)bits; break;
+        default: ((int64_t*)dst)[row] = bits; break;
+    }
+}
+
+static void grpt_phase3_fn(void* ctx_v, uint32_t worker_id,
+                           int64_t start, int64_t end) {
+    (void)worker_id;
+    grpt_phase3_ctx_t* c = (grpt_phase3_ctx_t*)ctx_v;
+    int desc = c->desc;
+    int val_is_f64 = c->val_is_f64;
+    int max_heap = desc ? 0 : 1;
+    uint8_t kesz = c->key_esz;
+    uint8_t vesz = c->val_esz;
+
+    for (int64_t pi = start; pi < end; pi++) {
+        uint32_t p = (uint32_t)pi;
+        grpt_ht_t* ph = &c->part_hts[p];
+        int64_t row = c->part_offsets[p];
+
+        for (uint32_t i = 0; i < ph->count; i++) {
+            grpt_entry_t* e = grpt_entry_at(ph, i);
+            int64_t* heap = grpt_heap(e);
+            int64_t kept = e->kept;
+            /* Heapsort drain into tail.  Final orientation: desc=1 →
+             * largest-first (tail-first read).  We swap root with tail
+             * each step which already produces correct order. */
+            int64_t n = kept;
+            if (val_is_f64) {
+                double* hd = (double*)heap;
+                while (n > 1) {
+                    double tmp = hd[0]; hd[0] = hd[n-1]; hd[n-1] = tmp;
+                    n--;
+                    topk_sift_down_dbl(hd, n, 0, max_heap);
+                }
+            } else {
+                while (n > 1) {
+                    int64_t tmp = heap[0]; heap[0] = heap[n-1]; heap[n-1] = tmp;
+                    n--;
+                    topk_sift_down_i64(heap, n, 0, max_heap);
+                }
+            }
+
+            for (int64_t j = 0; j < kept; j++) {
+                /* Key write — replicate same key across kept rows. */
+                if (e->has_null_key) {
+                    /* Write 0 placeholder then mark null on the output
+                     * column.  ray_vec_set_null is not threadsafe across
+                     * workers for the same word; but each partition
+                     * writes a contiguous row range so two partitions
+                     * never touch the same nullmap word — unless a row
+                     * range straddles an 8-row boundary that another
+                     * partition's range also touches.  In practice the
+                     * null-key case at most produces K rows and
+                     * partitions are large; we serialise null-key
+                     * writes by routing the null-key entry into the
+                     * sequential final-pass below. */
+                    grpt_write_key(c->key_out, row + j, 0, kesz);
+                    if (c->key_vec)
+                        ray_vec_set_null(c->key_vec, row + j, true);
+                } else {
+                    grpt_write_key(c->key_out, row + j, e->key, kesz);
+                }
+                /* Value write — heap[j] is final-position raw bits. */
+                if (val_is_f64) {
+                    ((double*)c->val_out)[row + j] = ((double*)heap)[j];
+                } else {
+                    grpt_write_key(c->val_out, row + j, heap[j], vesz);
+                }
+            }
+            row += kept;
+        }
+    }
+}
+
+/* Public entry: invoked from exec.c on OP_GROUP_TOPK_ROWFORM /
+ * OP_GROUP_BOTK_ROWFORM.  Resolves columns from the bound table,
+ * runs the three phases, builds the output table. */
+ray_t* exec_group_topk_rowform(ray_graph_t* g, ray_op_t* op) {
+    ray_op_ext_t* ext = find_ext(g, op->id);
+    if (!ext || ext->n_keys != 1 || ext->n_aggs != 1 || !ext->agg_k)
+        return ray_error("domain", "group_topk_rowform: bad shape");
+
+    int desc = (op->opcode == OP_GROUP_TOPK_ROWFORM) ? 1 : 0;
+    int64_t K = ext->agg_k[0];
+    if (K < 1 || K > 255) return ray_error("range", "K out of range");
+
+    ray_t* tbl = g->table;
+    if (!tbl || RAY_IS_ERR(tbl)) return tbl;
+
+    /* Resolve key and value vectors from the bound table.  The planner
+     * only emits this opcode when both are simple OP_SCAN references. */
+    ray_op_ext_t* kext = find_ext(g, ext->keys[0]->id);
+    ray_op_ext_t* vext = find_ext(g, ext->agg_ins[0]->id);
+    if (!kext || !vext ||
+        kext->base.opcode != OP_SCAN ||
+        vext->base.opcode != OP_SCAN)
+        return ray_error("domain", "group_topk_rowform: non-scan child");
+
+    ray_t* key_vec = ray_table_get_col(tbl, kext->sym);
+    ray_t* val_vec = ray_table_get_col(tbl, vext->sym);
+    if (!key_vec || !val_vec)
+        return ray_error("domain", "group_topk_rowform: column missing");
+
+    int8_t kt = key_vec->type;
+    int8_t vt = val_vec->type;
+    /* Supported types: I64, I32, I16, U8, BOOL, DATE, TIME, TIMESTAMP, F64
+     * for both key and value.  SYM keys go through the LIST path. */
+    if (kt != RAY_I64 && kt != RAY_I32 && kt != RAY_I16 && kt != RAY_U8 &&
+        kt != RAY_BOOL && kt != RAY_DATE && kt != RAY_TIME &&
+        kt != RAY_TIMESTAMP && kt != RAY_F64)
+        return ray_error("nyi", "group_topk_rowform: key type");
+    if (vt != RAY_I64 && vt != RAY_I32 && vt != RAY_I16 && vt != RAY_U8 &&
+        vt != RAY_BOOL && vt != RAY_DATE && vt != RAY_TIME &&
+        vt != RAY_TIMESTAMP && vt != RAY_F64)
+        return ray_error("nyi", "group_topk_rowform: val type");
+
+    int64_t nrows = key_vec->len;
+    if (nrows == 0) {
+        /* Empty input — emit 2-col table with 0 rows */
+        ray_t* out = ray_table_new(2);
+        ray_t* k_empty = ray_vec_new(kt, 0);
+        ray_t* v_empty = ray_vec_new(vt, 0);
+        out = ray_table_add_col(out, kext->sym, k_empty);
+        out = ray_table_add_col(out, vext->sym, v_empty);
+        ray_release(k_empty); ray_release(v_empty);
+        return out;
+    }
+
+    /* Per-worker hashmaps */
+    ray_pool_t* pool = ray_pool_get();
+    uint32_t n_workers = pool ? ray_pool_total_workers(pool) : 1;
+    /* Sequential threshold — small inputs skip the pool overhead. */
+    bool parallel = pool && nrows >= 16384;
+    if (!parallel) n_workers = 1;
+
+    ray_t* whts_hdr = NULL;
+    grpt_ht_t* worker_hts = (grpt_ht_t*)scratch_calloc(&whts_hdr,
+                                (size_t)n_workers * sizeof(grpt_ht_t));
+    ray_t* winit_hdr = NULL;
+    _Atomic(uint32_t)* worker_inited = (_Atomic(uint32_t)*)scratch_calloc(
+        &winit_hdr, (size_t)n_workers * sizeof(_Atomic(uint32_t)));
+    if (!worker_hts || !worker_inited) {
+        if (whts_hdr) scratch_free(whts_hdr);
+        if (winit_hdr) scratch_free(winit_hdr);
+        return ray_error("oom", NULL);
+    }
+
+    grpt_phase1_ctx_t p1 = {
+        .key_data = ray_data(key_vec),
+        .val_data = ray_data(val_vec),
+        .key_type = kt,
+        .val_type = vt,
+        .key_has_nulls = (key_vec->attrs & RAY_ATTR_HAS_NULLS) != 0,
+        .val_has_nulls = (val_vec->attrs & RAY_ATTR_HAS_NULLS) != 0,
+        .key_null_bm = (key_vec->attrs & RAY_ATTR_HAS_NULLS)
+                       ? ray_vec_nullmap_bytes(key_vec, NULL, NULL) : NULL,
+        .val_null_bm = (val_vec->attrs & RAY_ATTR_HAS_NULLS)
+                       ? ray_vec_nullmap_bytes(val_vec, NULL, NULL) : NULL,
+        .k = K,
+        .desc = desc,
+        .val_is_f64 = (vt == RAY_F64) ? 1 : 0,
+        .worker_hts = worker_hts,
+        .worker_inited = worker_inited,
+    };
+
+    if (parallel) {
+        ray_pool_dispatch(pool, grpt_phase1_fn, &p1, nrows);
+    } else {
+        /* Force worker 0 init then call directly. */
+        atomic_store(&worker_inited[0], 0);
+        grpt_phase1_fn(&p1, 0, 0, nrows);
+    }
+
+    /* Check for OOM in any worker map */
+    for (uint32_t w = 0; w < n_workers; w++) {
+        if (worker_hts[w].oom) {
+            for (uint32_t i = 0; i < n_workers; i++)
+                grpt_ht_free(&worker_hts[i]);
+            scratch_free(whts_hdr); scratch_free(winit_hdr);
+            return ray_error("oom", NULL);
+        }
+    }
+
+    /* Phase 2: per-partition merge.  RADIX_P merged hashmaps. */
+    ray_t* phts_hdr = NULL;
+    grpt_ht_t* part_hts = (grpt_ht_t*)scratch_calloc(&phts_hdr,
+                                (size_t)RADIX_P * sizeof(grpt_ht_t));
+    ray_t* per_hdr = NULL;
+    int64_t* part_emit_rows = (int64_t*)scratch_calloc(&per_hdr,
+                                (size_t)RADIX_P * sizeof(int64_t));
+    if (!part_hts || !part_emit_rows) {
+        for (uint32_t w = 0; w < n_workers; w++) grpt_ht_free(&worker_hts[w]);
+        if (phts_hdr) scratch_free(phts_hdr);
+        if (per_hdr)  scratch_free(per_hdr);
+        scratch_free(whts_hdr); scratch_free(winit_hdr);
+        return ray_error("oom", NULL);
+    }
+
+    grpt_phase2_ctx_t p2 = {
+        .worker_hts = worker_hts,
+        .n_workers = n_workers,
+        .part_hts = part_hts,
+        .k = K, .desc = desc,
+        .val_is_f64 = (vt == RAY_F64) ? 1 : 0,
+        .key_type = kt, .val_type = vt,
+        .part_emit_rows = part_emit_rows,
+    };
+    if (parallel) {
+        ray_pool_dispatch_n(pool, grpt_phase2_fn, &p2, RADIX_P);
+    } else {
+        grpt_phase2_fn(&p2, 0, 0, RADIX_P);
+    }
+
+    /* OOM check on merged maps */
+    for (uint32_t p = 0; p < RADIX_P; p++) {
+        if (part_hts[p].oom) {
+            for (uint32_t i = 0; i < n_workers; i++) grpt_ht_free(&worker_hts[i]);
+            for (uint32_t i = 0; i < RADIX_P;    i++) grpt_ht_free(&part_hts[i]);
+            scratch_free(phts_hdr); scratch_free(per_hdr);
+            scratch_free(whts_hdr); scratch_free(winit_hdr);
+            return ray_error("oom", NULL);
+        }
+    }
+
+    /* Prefix sum → partition row offsets and total output. */
+    ray_t* po_hdr = NULL;
+    int64_t* part_offsets = (int64_t*)scratch_alloc(&po_hdr,
+                                (size_t)(RADIX_P + 1) * sizeof(int64_t));
+    if (!part_offsets) {
+        for (uint32_t i = 0; i < n_workers; i++) grpt_ht_free(&worker_hts[i]);
+        for (uint32_t i = 0; i < RADIX_P;    i++) grpt_ht_free(&part_hts[i]);
+        scratch_free(phts_hdr); scratch_free(per_hdr);
+        scratch_free(whts_hdr); scratch_free(winit_hdr);
+        return ray_error("oom", NULL);
+    }
+    int64_t total_rows = 0;
+    for (uint32_t p = 0; p < RADIX_P; p++) {
+        part_offsets[p] = total_rows;
+        total_rows += part_emit_rows[p];
+    }
+    part_offsets[RADIX_P] = total_rows;
+
+    /* Allocate output columns (typed to source key/value). */
+    ray_t* key_out = ray_vec_new(kt, total_rows);
+    ray_t* val_out = ray_vec_new(vt, total_rows);
+    if (!key_out || !val_out || RAY_IS_ERR(key_out) || RAY_IS_ERR(val_out)) {
+        if (key_out) ray_release(key_out);
+        if (val_out) ray_release(val_out);
+        for (uint32_t i = 0; i < n_workers; i++) grpt_ht_free(&worker_hts[i]);
+        for (uint32_t i = 0; i < RADIX_P;    i++) grpt_ht_free(&part_hts[i]);
+        scratch_free(po_hdr);
+        scratch_free(phts_hdr); scratch_free(per_hdr);
+        scratch_free(whts_hdr); scratch_free(winit_hdr);
+        return ray_error("oom", NULL);
+    }
+    key_out->len = total_rows;
+    val_out->len = total_rows;
+
+    grpt_phase3_ctx_t p3 = {
+        .part_hts = part_hts,
+        .part_offsets = part_offsets,
+        .k = K, .desc = desc,
+        .val_is_f64 = (vt == RAY_F64) ? 1 : 0,
+        .key_type = kt, .val_type = vt,
+        .key_esz = (uint8_t)ray_elem_size(kt),
+        .val_esz = (uint8_t)ray_elem_size(vt),
+        .key_out = ray_data(key_out),
+        .val_out = ray_data(val_out),
+        .key_vec = key_out,   /* needed for null-key marking */
+    };
+    if (parallel) {
+        ray_pool_dispatch_n(pool, grpt_phase3_fn, &p3, RADIX_P);
+    } else {
+        grpt_phase3_fn(&p3, 0, 0, RADIX_P);
+    }
+
+    /* Build result table. */
+    ray_t* result = ray_table_new(2);
+    if (result && !RAY_IS_ERR(result)) {
+        result = ray_table_add_col(result, kext->sym, key_out);
+        if (result && !RAY_IS_ERR(result))
+            result = ray_table_add_col(result, vext->sym, val_out);
+    }
+    ray_release(key_out); ray_release(val_out);
+
+    for (uint32_t i = 0; i < n_workers; i++) grpt_ht_free(&worker_hts[i]);
+    for (uint32_t i = 0; i < RADIX_P;    i++) grpt_ht_free(&part_hts[i]);
+    scratch_free(po_hdr);
+    scratch_free(phts_hdr); scratch_free(per_hdr);
+    scratch_free(whts_hdr); scratch_free(winit_hdr);
+
+    return result;
+}

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -23,6 +23,7 @@
 
 #include "ops/internal.h"
 #include "ops/rowsel.h"
+#include "lang/internal.h"  /* for ray_median_dbl_inplace */
 
 /* ============================================================================
  * Reduction execution
@@ -1190,6 +1191,147 @@ ray_t* ray_count_distinct_per_group(ray_t* src, const int64_t* row_gid,
     return out;
 }
 
+/* ─── ray_median_per_group_buf ──────────────────────────────────────────
+ *
+ * Parallel exact-median per group using the bucket-scatter layout that
+ * the upstream group-by phase has already produced (idx_buf is already
+ * group-contiguous; offsets[g]..offsets[g]+grp_cnt[g] is group g's row-
+ * index slice).  Each group becomes one task in ray_pool_dispatch_n:
+ * the task allocates a stack-or-heap-backed double slice, reads
+ * src[idx_buf[off+i]] into it, then runs ray_median_dbl_inplace.
+ *
+ * Why this layout — and why it matches DuckDB without paying their
+ * realloc-per-group price:
+ *   - DuckDB's holistic quantile aggregate accumulates a per-group
+ *     vector<INPUT_TYPE> during the radix probe; each insert is a
+ *     potential vector grow.  At finalize it nth_element's each group's
+ *     vector in parallel.
+ *   - rayforce's radix probe (see idxbuf_par_fn) already produced
+ *     prefix-summed group-contiguous indices.  So we skip DuckDB's
+ *     vector-grow phase entirely — we just dispatch n_groups tasks
+ *     that each gather values + quickselect.
+ *
+ * Cache behaviour: the inner loop reads src[idx_buf[off+i]] for a
+ * single group, then quickselects the resulting slice.  The slice is
+ * sized at grp_cnt[g] (median group ~1k for q6) and stays L2-hot for
+ * the partial-sort.  Inputs are random over src so reads are still
+ * cache-missing on the source column, but those misses overlap with
+ * parallel tasks on other cores — the 27-core dispatch hides them.
+ *
+ * Type support: F64 native; I64/I32/I16/U8 cast-to-double on read.
+ * Null rows are skipped (pairwise complete, matching DuckDB).
+ *
+ * Returns: F64 vec of length n_groups, or NULL on unsupported type
+ * (caller must fall back).  On error returns RAY_IS_ERR ptr.
+ *
+ * Threshold: serial fallback when n_groups < 8 OR total < 4096 — the
+ * dispatch overhead for tiny inputs is not worth it. */
+
+typedef struct {
+    const void*    base;        /* ray_data(src) */
+    int8_t         src_type;
+    bool           has_nulls;
+    const uint8_t* null_bm;
+    const int64_t* idx_buf;
+    const int64_t* offsets;
+    const int64_t* grp_cnt;
+    double*        scratch_pool; /* flat shared scratch, sized at sum(grp_cnt) */
+    double*        out_data;     /* ray_data(out) */
+    ray_t*         out;          /* for set_null */
+} med_par_ctx_t;
+
+static inline double med_read_as_f64(const void* base, int8_t t, int64_t row) {
+    switch (t) {
+        case RAY_F64: { double v; memcpy(&v, (const char*)base + (size_t)row * 8, 8); return v; }
+        case RAY_I64: { int64_t v; memcpy(&v, (const char*)base + (size_t)row * 8, 8); return (double)v; }
+        case RAY_I32: { int32_t v; memcpy(&v, (const char*)base + (size_t)row * 4, 4); return (double)v; }
+        case RAY_I16: { int16_t v; memcpy(&v, (const char*)base + (size_t)row * 2, 2); return (double)v; }
+        case RAY_U8:  return (double)((const uint8_t*)base)[row];
+        default:      return 0.0;
+    }
+}
+
+static void med_per_group_fn(void* ctx_v, uint32_t worker_id,
+                             int64_t start, int64_t end) {
+    (void)worker_id;
+    med_par_ctx_t* c = (med_par_ctx_t*)ctx_v;
+    for (int64_t g = start; g < end; g++) {
+        int64_t cnt = c->grp_cnt[g];
+        int64_t off = c->offsets[g];
+        double* slice = c->scratch_pool + off;
+        int64_t actual = 0;
+        if (c->has_nulls && c->null_bm) {
+            for (int64_t i = 0; i < cnt; i++) {
+                int64_t row = c->idx_buf[off + i];
+                if ((c->null_bm[row >> 3] >> (row & 7)) & 1) continue;
+                slice[actual++] = med_read_as_f64(c->base, c->src_type, row);
+            }
+        } else {
+            for (int64_t i = 0; i < cnt; i++) {
+                int64_t row = c->idx_buf[off + i];
+                slice[actual++] = med_read_as_f64(c->base, c->src_type, row);
+            }
+        }
+        if (actual == 0) {
+            c->out_data[g] = 0.0;
+            ray_vec_set_null(c->out, g, true);
+        } else {
+            c->out_data[g] = ray_median_dbl_inplace(slice, actual);
+        }
+    }
+}
+
+ray_t* ray_median_per_group_buf(ray_t* src,
+                                const int64_t* idx_buf,
+                                const int64_t* offsets,
+                                const int64_t* grp_cnt,
+                                int64_t n_groups) {
+    if (!src || RAY_IS_ERR(src) || n_groups < 0) return NULL;
+    int8_t t = src->type;
+    if (t != RAY_F64 && t != RAY_I64 && t != RAY_I32 &&
+        t != RAY_I16 && t != RAY_U8) return NULL;
+
+    int64_t total = 0;
+    for (int64_t g = 0; g < n_groups; g++) total += grp_cnt[g];
+
+    ray_t* out = ray_vec_new(RAY_F64, n_groups);
+    if (!out || RAY_IS_ERR(out)) return out ? out : ray_error("oom", NULL);
+    out->len = n_groups;
+
+    ray_t* buf_hdr = NULL;
+    double* scratch = NULL;
+    if (total > 0) {
+        scratch = (double*)scratch_alloc(&buf_hdr,
+                                         (size_t)total * sizeof(double));
+        if (!scratch) { ray_release(out); return ray_error("oom", NULL); }
+    }
+
+    med_par_ctx_t ctx = {
+        .base = ray_data(src),
+        .src_type = t,
+        .has_nulls = (src->attrs & RAY_ATTR_HAS_NULLS) != 0,
+        .null_bm = (src->attrs & RAY_ATTR_HAS_NULLS)
+                   ? ray_vec_nullmap_bytes(src, NULL, NULL) : NULL,
+        .idx_buf = idx_buf,
+        .offsets = offsets,
+        .grp_cnt = grp_cnt,
+        .scratch_pool = scratch,
+        .out_data = (double*)ray_data(out),
+        .out = out,
+    };
+
+    ray_pool_t* pool = ray_pool_get();
+    bool par = pool && n_groups >= 8 && total >= 4096;
+    if (par) {
+        ray_pool_dispatch_n(pool, med_per_group_fn, &ctx, (uint32_t)n_groups);
+    } else {
+        med_per_group_fn(&ctx, 0, 0, n_groups);
+    }
+
+    if (buf_hdr) scratch_free(buf_hdr);
+    return out;
+}
+
 static ray_t* reduction_i64_result(int64_t val, int8_t out_type) {
     switch (out_type) {
         case RAY_DATE:      return ray_date((int32_t)val);
@@ -1443,7 +1585,16 @@ ght_layout_t ght_compute_layout(uint8_t n_keys, uint8_t n_aggs,
 
     uint8_t nv = 0;
     for (uint8_t a = 0; a < n_aggs && a < 8; a++) {
-        if (agg_vecs[a]) {
+        /* OP_MEDIAN reserves no row-layout slot — the column is
+         * materialized in agg_vecs[a] but values are not packed into
+         * entries or HT rows.  A post-radix pass over row_gid+grp_cnt
+         * gathers per-group slices and runs quickselect; see
+         * ray_median_per_group_buf. */
+        bool holistic = agg_ops && agg_ops[a] == OP_MEDIAN;
+        if (holistic) {
+            ly.agg_is_holistic |= (uint8_t)(1u << a);
+            ly.agg_val_slot[a] = -1;
+        } else if (agg_vecs[a]) {
             ly.agg_val_slot[a] = (int8_t)nv;
             if (agg_vecs[a]->type == RAY_F64)
                 ly.agg_is_f64 |= (1u << a);
@@ -2005,7 +2156,11 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
         int64_t* ev = (int64_t*)(ebuf + 8 + ((size_t)nk + 1) * 8);
         uint8_t vi = 0;
         uint8_t bin_mask = ly->agg_is_binary;
+        uint8_t hol_mask = ly->agg_is_holistic;
         for (uint8_t a = 0; a < na; a++) {
+            /* Holistic agg (OP_MEDIAN): no slot reserved — skip packing.
+             * Source column read in the post-radix pass. */
+            if (hol_mask & (1u << a)) continue;
             ray_t* ac = agg_vecs[a];
             if (!ac) continue;
             if (agg_strlen && agg_strlen[a])
@@ -2246,7 +2401,11 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
 
         uint8_t vi = 0;
         uint8_t bin_mask = ly->agg_is_binary;
+        uint8_t hol_mask = ly->agg_is_holistic;
         for (uint8_t a = 0; a < na; a++) {
+            /* Holistic agg (OP_MEDIAN): no slot reserved — skip
+             * packing.  Source column is read in the post-radix pass. */
+            if (hol_mask & (1u << a)) continue;
             ray_t* ac = c->agg_vecs[a];
             if (!ac) continue;
             if (c->agg_strlen && c->agg_strlen[a])
@@ -2386,6 +2545,9 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
 
             /* Scatter agg results to result columns */
             for (uint8_t a = 0; a < na; a++) {
+                /* Holistic aggs (OP_MEDIAN) are filled by the
+                 * post-radix pass — skip emitting from the row layout. */
+                if (ly->agg_is_holistic & (1u << a)) continue;
                 agg_out_t* ao = &c->agg_outs[a];
                 if (!ao->dst) continue; /* allocation failed (OOM) */
                 uint16_t op = ao->agg_op;
@@ -2730,6 +2892,7 @@ static void emit_agg_columns(ray_t** result, ray_graph_t* g, const ray_op_ext_t*
                 case OP_STDDEV_POP: sfx = "_stddev_pop"; slen = 11; break;
                 case OP_VAR:        sfx = "_var";        slen = 4; break;
                 case OP_VAR_POP:    sfx = "_var_pop";    slen = 8; break;
+                case OP_MEDIAN:     sfx = "_median";     slen = 7; break;
             }
             char buf[256];
             if (base && blen + slen < sizeof(buf)) {
@@ -2763,6 +2926,7 @@ static void emit_agg_columns(ray_t** result, ray_graph_t* g, const ray_op_ext_t*
                 case OP_STDDEV_POP: nsfx = "_stddev_pop"; nslen = 11; break;
                 case OP_VAR:        nsfx = "_var";        nslen = 4; break;
                 case OP_VAR_POP:    nsfx = "_var_pop";    nslen = 8; break;
+                case OP_MEDIAN:     nsfx = "_median";     nslen = 7; break;
             }
             memcpy(nbuf + np, nsfx, nslen);
             name_id = ray_sym_intern(nbuf, (size_t)np + nslen);
@@ -3580,6 +3744,168 @@ static void da_merge_fn(void* ctx, uint32_t wid, int64_t start, int64_t end) {
 }
 
 /* ============================================================================
+ * Post-radix holistic-aggregate fill (OP_MEDIAN)
+ *
+ * After the radix pipeline produces stable per-partition group IDs in
+ * part_hts[] + part_offsets[], we still need to materialize per-group
+ * value slices to feed the holistic quickselect kernel.  This pass:
+ *
+ *   1. Re-probe each source row against part_hts[RADIX_PART(h)] to
+ *      recover its global gid (parallel, lookup-only — no inserts).
+ *      Writes row_gid[r] = part_offsets[p] + local_gid.
+ *   2. Build idx_buf + offsets via the idxbuf hist/scat pattern over
+ *      row_gid (parallel).
+ *   3. For each OP_MEDIAN agg, call ray_median_per_group_buf and copy
+ *      the F64 output into the pre-allocated agg_outs[a].vec.
+ *
+ * Cost: ~1 extra parallel hash+probe pass over nrows (~50 ms at 10 M
+ * rows, 27 cores).  The eval-fallback this replaces was building a
+ * LIST<LIST<key>> for the same data — ~5500 ms at the same scale.
+ * ============================================================================ */
+
+/* Lookup-only HT probe — finds the gid of the matching group without
+ * modifying the HT.  Returns UINT32_MAX if the row's key combination
+ * is absent (shouldn't happen post-phase-2 since every row was
+ * inserted, but a defensive sentinel keeps callers robust under
+ * partial-build OOM corner cases). */
+static inline uint32_t group_ht_lookup_gid(const group_ht_t* ht,
+                                            uint64_t hash,
+                                            const int64_t* ekeys,
+                                            const int8_t* key_types) {
+    (void)key_types;
+    const ght_layout_t* ly = &ht->layout;
+    uint32_t mask = ht->ht_cap - 1;
+    uint8_t salt = HT_SALT(hash);
+    uint32_t slot = (uint32_t)(hash & mask);
+    uint16_t rs = ly->row_stride;
+    for (;;) {
+        uint32_t sv = ht->slots[slot];
+        if (sv == HT_EMPTY) return UINT32_MAX;
+        if (HT_SALT_V(sv) == salt) {
+            uint32_t gid = HT_GID(sv);
+            const char* row = ht->rows + (size_t)gid * rs;
+            if (group_keys_equal((const int64_t*)(const void*)(row + 8),
+                                  ekeys, ly, ht->key_data))
+                return gid;
+        }
+        slot = (slot + 1) & mask;
+    }
+}
+
+typedef struct {
+    void**        key_data;
+    int8_t*       key_types;
+    uint8_t*      key_attrs;
+    ray_t**       key_vecs;
+    uint8_t       n_keys;
+    uint8_t       nullable_mask;
+    uint8_t       wide_mask;
+    const uint8_t* wide_esz;
+    group_ht_t*   part_hts;
+    const uint32_t* part_offsets;
+    int64_t*      row_gid;          /* output [nrows] */
+    const int64_t* match_idx;
+} reprobe_ctx_t;
+
+static void reprobe_rows_fn(void* vctx, uint32_t worker_id,
+                            int64_t start, int64_t end) {
+    (void)worker_id;
+    reprobe_ctx_t* c = (reprobe_ctx_t*)vctx;
+    uint8_t nk = c->n_keys;
+    int64_t ek_buf[9];           /* nk + null_mask slot */
+    int8_t* key_types = c->key_types;
+    void** key_data = c->key_data;
+    uint8_t* key_attrs = c->key_attrs;
+    ray_t** key_vecs = c->key_vecs;
+    uint8_t nullable = c->nullable_mask;
+    uint8_t wide = c->wide_mask;
+    const uint8_t* wide_esz = c->wide_esz;
+    const int64_t* match_idx = c->match_idx;
+    for (int64_t i = start; i < end; i++) {
+        if (((i - start) & 65535) == 0 && ray_interrupted()) break;
+        int64_t row = match_idx ? match_idx[i] : i;
+        uint64_t h = 0;
+        int64_t null_mask = 0;
+        for (uint8_t k = 0; k < nk; k++) {
+            int8_t t = key_types[k];
+            uint64_t kh;
+            bool is_null = (nullable & (1u << k))
+                           && ray_vec_is_null(key_vecs[k], row);
+            if (is_null) {
+                null_mask |= (int64_t)(1u << k);
+                ek_buf[k] = 0;
+                kh = ray_hash_i64(0);
+            } else if (wide & (1u << k)) {
+                uint8_t esz = wide_esz[k];
+                const void* src = (const char*)key_data[k] + (size_t)row * esz;
+                ek_buf[k] = row;
+                kh = ray_hash_bytes(src, esz);
+            } else if (t == RAY_F64) {
+                int64_t kv;
+                memcpy(&kv, &((double*)key_data[k])[row], 8);
+                ek_buf[k] = kv;
+                kh = ray_hash_f64(((double*)key_data[k])[row]);
+            } else {
+                int64_t kv = read_col_i64(key_data[k], row, t, key_attrs[k]);
+                ek_buf[k] = kv;
+                kh = ray_hash_i64(kv);
+            }
+            h = (k == 0) ? kh : ray_hash_combine(h, kh);
+        }
+        ek_buf[nk] = null_mask;
+        if (null_mask) h = ray_hash_combine(h, ray_hash_i64(null_mask));
+
+        uint32_t part = RADIX_PART(h);
+        uint32_t local = group_ht_lookup_gid(&c->part_hts[part], h,
+                                              ek_buf, key_types);
+        if (local == UINT32_MAX) {
+            c->row_gid[row] = -1;
+        } else {
+            c->row_gid[row] = (int64_t)c->part_offsets[part] + (int64_t)local;
+        }
+    }
+}
+
+/* Histogram + scatter for idx_buf construction.  Identical pattern to
+ * query.c's idxbuf_hist_fn / idxbuf_scat_fn — duplicated here to avoid
+ * pulling a query.c-internal helper through internal.h. */
+typedef struct {
+    const int64_t* row_gid;
+    int64_t*       hist;          /* [n_tasks * n_groups] */
+    int64_t*       cursor;        /* [n_tasks * n_groups] */
+    int64_t*       idx_buf;
+    int64_t        n_groups;
+    int64_t        grain;
+} med_idx_ctx_t;
+
+static void med_idx_hist_fn(void* vctx, uint32_t worker_id,
+                            int64_t start, int64_t end) {
+    (void)worker_id;
+    med_idx_ctx_t* c = (med_idx_ctx_t*)vctx;
+    int64_t task_id = start / c->grain;
+    int64_t* hist = c->hist + task_id * c->n_groups;
+    const int64_t* row_gid = c->row_gid;
+    for (int64_t r = start; r < end; r++) {
+        int64_t gi = row_gid[r];
+        if (gi >= 0) hist[gi]++;
+    }
+}
+
+static void med_idx_scat_fn(void* vctx, uint32_t worker_id,
+                            int64_t start, int64_t end) {
+    (void)worker_id;
+    med_idx_ctx_t* c = (med_idx_ctx_t*)vctx;
+    int64_t task_id = start / c->grain;
+    int64_t* cur = c->cursor + task_id * c->n_groups;
+    const int64_t* row_gid = c->row_gid;
+    int64_t* idx_buf = c->idx_buf;
+    for (int64_t r = start; r < end; r++) {
+        int64_t gi = row_gid[r];
+        if (gi >= 0) idx_buf[cur[gi]++] = r;
+    }
+}
+
+/* ============================================================================
  * Partition-aware group-by: detect parted columns, concatenate segments into
  * a flat table, then run standard exec_group once.
  * ============================================================================ */
@@ -3635,6 +3961,11 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
     int64_t agg_syms[8];
     for (uint8_t a = 0; a < n_aggs && can_partition; a++) {
         uint16_t aop = ext->agg_ops[a];
+        /* OP_MEDIAN is holistic — you can't merge medians across
+         * partitions without re-scanning the underlying values, so
+         * decline per-partition exec when any agg is median.  Falls
+         * through to the concat path which sees the full vector. */
+        if (aop == OP_MEDIAN) { can_partition = 0; break; }
         if (aop != OP_SUM && aop != OP_COUNT && aop != OP_MIN &&
             aop != OP_MAX && aop != OP_AVG && aop != OP_FIRST &&
             aop != OP_LAST && aop != OP_STDDEV && aop != OP_STDDEV_POP &&
@@ -4413,9 +4744,13 @@ da_path:;
         bool da_eligible = (nrows > 0 && n_keys > 0 && n_keys <= 8);
         /* Binary aggregators (OP_PEARSON_CORR) are not wired into the
          * dense-array accumulator's per-worker da_accum_t struct — force
-         * the HT path which has the row-layout offsets allocated. */
+         * the HT path which has the row-layout offsets allocated.
+         * Holistic aggregators (OP_MEDIAN) have no per-row accumulator
+         * at all — they need the post-radix row_gid+grp_cnt pass which
+         * only the HT path provides. */
         for (uint8_t a = 0; a < n_aggs && da_eligible; a++) {
             if (ext->agg_ops[a] == OP_PEARSON_CORR) da_eligible = false;
+            if (ext->agg_ops[a] == OP_MEDIAN)       da_eligible = false;
         }
         for (uint8_t k = 0; k < n_keys && da_eligible; k++) {
             if (!key_data[k]) { da_eligible = false; break; }
@@ -6350,6 +6685,7 @@ skip_top_count_filter:
                 case OP_STDDEV: case OP_STDDEV_POP:
                 case OP_VAR: case OP_VAR_POP:
                 case OP_PEARSON_CORR:
+                case OP_MEDIAN:
                     out_type = RAY_F64; break;
                 case OP_COUNT: out_type = RAY_I64; break;
                 case OP_SUM: case OP_PROD:
@@ -6401,6 +6737,153 @@ skip_top_count_filter:
                 .key_src_data = key_data,
             };
             ray_pool_dispatch_n(pool, radix_phase3_fn, &p3ctx, RADIX_P);
+        }
+
+        /* Post-radix holistic fill: OP_MEDIAN slots need a per-group
+         * value slice + quickselect that doesn't fit the row-layout HT.
+         * Re-probe source rows to recover global gids, build a
+         * group-contiguous idx_buf, then dispatch ray_median_per_group_buf
+         * once per OP_MEDIAN agg.  See helpers above for the rationale. */
+        if (ght_layout.agg_is_holistic) {
+            int64_t n_groups = (int64_t)total_grps;
+
+            /* row_gid[nrows] — global group id per source row, or -1 on
+             * miss (defensive sentinel; phase-2 inserts every probed row). */
+            ray_t* rg_hdr = NULL;
+            int64_t* row_gid = (int64_t*)scratch_alloc(&rg_hdr,
+                (size_t)nrows * sizeof(int64_t));
+            if (!row_gid) { result = ray_error("oom", NULL); goto cleanup; }
+
+            uint8_t reprobe_nullable = 0;
+            for (uint8_t k = 0; k < n_keys; k++) {
+                if (!key_vecs[k]) continue;
+                ray_t* src = (key_vecs[k]->attrs & RAY_ATTR_SLICE)
+                             ? key_vecs[k]->slice_parent : key_vecs[k];
+                if (src && (src->attrs & RAY_ATTR_HAS_NULLS))
+                    reprobe_nullable |= (uint8_t)(1u << k);
+            }
+            reprobe_ctx_t rp = {
+                .key_data = key_data,
+                .key_types = key_types,
+                .key_attrs = key_attrs,
+                .key_vecs = key_vecs,
+                .n_keys = n_keys,
+                .nullable_mask = reprobe_nullable,
+                .wide_mask = ght_layout.wide_key_mask,
+                .wide_esz = ght_layout.wide_key_esz,
+                .part_hts = part_hts,
+                .part_offsets = part_offsets,
+                .row_gid = row_gid,
+                .match_idx = match_idx,
+            };
+            ray_pool_dispatch(pool, reprobe_rows_fn, &rp, n_scan);
+
+            /* Build idx_buf + offsets + grp_cnt via histogram/scatter. */
+            int64_t med_grain = (int64_t)RAY_DISPATCH_MORSELS * RAY_MORSEL_ELEMS;
+            int64_t med_ntasks = (nrows + med_grain - 1) / med_grain;
+            if (med_ntasks < 1) med_ntasks = 1;
+            if (med_ntasks > 65536) {
+                med_ntasks = 65536;
+                med_grain = (nrows + med_ntasks - 1) / med_ntasks;
+            }
+            ray_t* hist_hdr = NULL;
+            ray_t* cur_hdr  = NULL;
+            ray_t* cnt_hdr  = NULL;
+            ray_t* off_hdr  = NULL;
+            int64_t* hist = (int64_t*)scratch_calloc(&hist_hdr,
+                (size_t)med_ntasks * (size_t)n_groups * sizeof(int64_t));
+            int64_t* cur  = (int64_t*)scratch_alloc(&cur_hdr,
+                (size_t)med_ntasks * (size_t)n_groups * sizeof(int64_t));
+            int64_t* grp_cnt = (int64_t*)scratch_alloc(&cnt_hdr,
+                (size_t)n_groups * sizeof(int64_t));
+            int64_t* offsets = (int64_t*)scratch_alloc(&off_hdr,
+                (size_t)n_groups * sizeof(int64_t));
+            ray_t* idx_hdr = NULL;
+            int64_t* idx_buf = NULL;
+            if (hist && cur && grp_cnt && offsets) {
+                med_idx_ctx_t mctx = {
+                    .row_gid = row_gid,
+                    .hist = hist,
+                    .cursor = cur,
+                    .idx_buf = NULL,
+                    .n_groups = n_groups,
+                    .grain = med_grain,
+                };
+                ray_pool_dispatch(pool, med_idx_hist_fn, &mctx, nrows);
+                int64_t total = 0;
+                for (int64_t gi = 0; gi < n_groups; gi++) {
+                    int64_t cum = total;
+                    for (int64_t t = 0; t < med_ntasks; t++) {
+                        int64_t cn = hist[t * n_groups + gi];
+                        cur[t * n_groups + gi] = cum;
+                        cum += cn;
+                    }
+                    grp_cnt[gi] = cum - total;
+                    offsets[gi] = total;
+                    total = cum;
+                }
+                idx_buf = (int64_t*)scratch_alloc(&idx_hdr,
+                    (size_t)(total > 0 ? total : 1) * sizeof(int64_t));
+                if (idx_buf) {
+                    mctx.idx_buf = idx_buf;
+                    ray_pool_dispatch(pool, med_idx_scat_fn, &mctx, nrows);
+                }
+            }
+
+            if (idx_buf) {
+                for (uint8_t a = 0; a < n_aggs; a++) {
+                    if (!(ght_layout.agg_is_holistic & (1u << a))) continue;
+                    if (!agg_vecs[a] || !agg_cols[a]) continue;
+                    ray_t* med_vec = ray_median_per_group_buf(
+                        agg_vecs[a], idx_buf, offsets, grp_cnt, n_groups);
+                    if (!med_vec) {
+                        /* Unsupported source type — set all-null,
+                         * caller's eval-fallback would never have
+                         * routed here for unsupported types.  Fail
+                         * the whole exec_group with "nyi". */
+                        if (hist_hdr) scratch_free(hist_hdr);
+                        if (cur_hdr)  scratch_free(cur_hdr);
+                        if (cnt_hdr)  scratch_free(cnt_hdr);
+                        if (off_hdr)  scratch_free(off_hdr);
+                        if (idx_hdr)  scratch_free(idx_hdr);
+                        scratch_free(rg_hdr);
+                        result = ray_error("nyi", "median: type");
+                        goto cleanup;
+                    }
+                    if (RAY_IS_ERR(med_vec)) {
+                        if (hist_hdr) scratch_free(hist_hdr);
+                        if (cur_hdr)  scratch_free(cur_hdr);
+                        if (cnt_hdr)  scratch_free(cnt_hdr);
+                        if (off_hdr)  scratch_free(off_hdr);
+                        if (idx_hdr)  scratch_free(idx_hdr);
+                        scratch_free(rg_hdr);
+                        result = med_vec;
+                        goto cleanup;
+                    }
+                    /* Replace the empty agg_cols[a] vector with the
+                     * filled one.  agg_outs[a] is no longer consulted
+                     * for this slot (the row-layout finalize loop
+                     * already skipped it via agg_is_holistic). */
+                    ray_release(agg_cols[a]);
+                    agg_cols[a] = med_vec;
+                }
+            } else {
+                if (hist_hdr) scratch_free(hist_hdr);
+                if (cur_hdr)  scratch_free(cur_hdr);
+                if (cnt_hdr)  scratch_free(cnt_hdr);
+                if (off_hdr)  scratch_free(off_hdr);
+                if (idx_hdr)  scratch_free(idx_hdr);
+                scratch_free(rg_hdr);
+                result = ray_error("oom", NULL);
+                goto cleanup;
+            }
+
+            if (hist_hdr) scratch_free(hist_hdr);
+            if (cur_hdr)  scratch_free(cur_hdr);
+            if (cnt_hdr)  scratch_free(cnt_hdr);
+            if (off_hdr)  scratch_free(off_hdr);
+            if (idx_hdr)  scratch_free(idx_hdr);
+            scratch_free(rg_hdr);
         }
 
         /* Fixup: if nullmap prep failed for any VAR/STDDEV agg, re-scan
@@ -6467,6 +6950,7 @@ skip_top_count_filter:
                     case OP_STDDEV_POP: sfx = "_stddev_pop"; slen = 11; break;
                     case OP_VAR:        sfx = "_var";        slen = 4; break;
                     case OP_VAR_POP:    sfx = "_var_pop";    slen = 8; break;
+                    case OP_MEDIAN:     sfx = "_median";     slen = 7; break;
                 }
                 char buf[256];
                 ray_t* name_dyn_hdr = NULL;
@@ -6559,6 +7043,110 @@ build_from_final_ht:
         ray_release(new_col);
     }
 
+    /* If any holistic agg (OP_MEDIAN) is present, run a sequential
+     * re-probe + median fill into a per-slot output vector array.
+     * Built lazily on first need and reused across all median slots. */
+    ray_t** med_out = NULL;
+    ray_t* med_hdr = NULL;
+    if (ly->agg_is_holistic) {
+        med_out = (ray_t**)scratch_calloc(&med_hdr,
+            (size_t)n_aggs * sizeof(ray_t*));
+        if (med_out) {
+            /* Build row_gid + grp_cnt + idx_buf sequentially.  The
+             * seq path runs at small nrows so a single-thread pass is
+             * fine; matches the radix path's logic but without
+             * dispatch overhead. */
+            ray_t* rg_hdr = NULL;
+            int64_t* row_gid = (int64_t*)scratch_alloc(&rg_hdr,
+                (size_t)nrows * sizeof(int64_t));
+            ray_t* cnt_hdr_s = NULL;
+            int64_t* grp_cnt_s = (int64_t*)scratch_calloc(&cnt_hdr_s,
+                (size_t)grp_count * sizeof(int64_t));
+            ray_t* off_hdr_s = NULL;
+            int64_t* offsets_s = (int64_t*)scratch_alloc(&off_hdr_s,
+                (size_t)grp_count * sizeof(int64_t));
+            ray_t* pos_hdr_s = NULL;
+            int64_t* pos_s = (int64_t*)scratch_alloc(&pos_hdr_s,
+                (size_t)grp_count * sizeof(int64_t));
+            if (row_gid && grp_cnt_s && offsets_s && pos_s) {
+                uint8_t reprobe_nullable_s = 0;
+                for (uint8_t k = 0; k < n_keys; k++) {
+                    if (!key_vecs[k]) continue;
+                    ray_t* src = (key_vecs[k]->attrs & RAY_ATTR_SLICE)
+                                 ? key_vecs[k]->slice_parent : key_vecs[k];
+                    if (src && (src->attrs & RAY_ATTR_HAS_NULLS))
+                        reprobe_nullable_s |= (uint8_t)(1u << k);
+                }
+                int64_t ek_buf[9];
+                for (int64_t i = 0; i < n_scan; i++) {
+                    int64_t row = match_idx ? match_idx[i] : i;
+                    uint64_t h = 0;
+                    int64_t null_mask = 0;
+                    for (uint8_t k = 0; k < n_keys; k++) {
+                        int8_t t = key_types[k];
+                        uint64_t kh;
+                        bool is_null = (reprobe_nullable_s & (1u << k))
+                                       && ray_vec_is_null(key_vecs[k], row);
+                        if (is_null) {
+                            null_mask |= (int64_t)(1u << k);
+                            ek_buf[k] = 0;
+                            kh = ray_hash_i64(0);
+                        } else if (ly->wide_key_mask & (1u << k)) {
+                            uint8_t esz = ly->wide_key_esz[k];
+                            const void* src = (const char*)key_data[k] + (size_t)row * esz;
+                            ek_buf[k] = row;
+                            kh = ray_hash_bytes(src, esz);
+                        } else if (t == RAY_F64) {
+                            int64_t kv;
+                            memcpy(&kv, &((double*)key_data[k])[row], 8);
+                            ek_buf[k] = kv;
+                            kh = ray_hash_f64(((double*)key_data[k])[row]);
+                        } else {
+                            int64_t kv = read_col_i64(key_data[k], row, t, key_attrs[k]);
+                            ek_buf[k] = kv;
+                            kh = ray_hash_i64(kv);
+                        }
+                        h = (k == 0) ? kh : ray_hash_combine(h, kh);
+                    }
+                    ek_buf[n_keys] = null_mask;
+                    if (null_mask) h = ray_hash_combine(h, ray_hash_i64(null_mask));
+                    uint32_t gid = group_ht_lookup_gid(final_ht, h, ek_buf, key_types);
+                    row_gid[row] = (gid == UINT32_MAX) ? -1 : (int64_t)gid;
+                    if (gid != UINT32_MAX) grp_cnt_s[gid]++;
+                }
+                int64_t total_s = 0;
+                for (uint32_t gi = 0; gi < grp_count; gi++) {
+                    offsets_s[gi] = total_s;
+                    pos_s[gi] = total_s;
+                    total_s += grp_cnt_s[gi];
+                }
+                ray_t* ix_hdr_s = NULL;
+                int64_t* idx_buf_s = (int64_t*)scratch_alloc(&ix_hdr_s,
+                    (size_t)(total_s > 0 ? total_s : 1) * sizeof(int64_t));
+                if (idx_buf_s) {
+                    for (int64_t i = 0; i < n_scan; i++) {
+                        int64_t row = match_idx ? match_idx[i] : i;
+                        int64_t gi = row_gid[row];
+                        if (gi >= 0) idx_buf_s[pos_s[gi]++] = row;
+                    }
+                    for (uint8_t a = 0; a < n_aggs; a++) {
+                        if (!(ly->agg_is_holistic & (1u << a))) continue;
+                        if (!agg_vecs[a]) continue;
+                        ray_t* med_vec = ray_median_per_group_buf(
+                            agg_vecs[a], idx_buf_s, offsets_s, grp_cnt_s,
+                            (int64_t)grp_count);
+                        med_out[a] = med_vec;  /* NULL or RAY_IS_ERR handled below */
+                    }
+                    scratch_free(ix_hdr_s);
+                }
+            }
+            scratch_free(rg_hdr);
+            scratch_free(cnt_hdr_s);
+            scratch_free(off_hdr_s);
+            scratch_free(pos_hdr_s);
+        }
+    }
+
     /* Agg columns from inline accumulators */
     for (uint8_t a = 0; a < n_aggs; a++) {
         uint16_t agg_op = ext->agg_ops[a];
@@ -6570,6 +7158,7 @@ build_from_final_ht:
             case OP_STDDEV: case OP_STDDEV_POP:
             case OP_VAR: case OP_VAR_POP:
             case OP_PEARSON_CORR:
+            case OP_MEDIAN:
                 out_type = RAY_F64; break;
             case OP_COUNT: out_type = RAY_I64; break;
             case OP_SUM: case OP_PROD:
@@ -6577,11 +7166,24 @@ build_from_final_ht:
             default:
                 out_type = agg_col ? agg_col->type : RAY_I64; break;
         }
-        ray_t* new_col = ray_vec_new(out_type, (int64_t)grp_count);
-        if (!new_col || RAY_IS_ERR(new_col)) continue;
-        new_col->len = (int64_t)grp_count;
+        ray_t* new_col;
+        if (agg_op == OP_MEDIAN && med_out && med_out[a]
+            && !RAY_IS_ERR(med_out[a])) {
+            new_col = med_out[a];
+            med_out[a] = NULL;  /* transferred ownership */
+        } else if (agg_op == OP_MEDIAN) {
+            /* Unsupported source type or earlier failure — skip. */
+            continue;
+        } else {
+            new_col = ray_vec_new(out_type, (int64_t)grp_count);
+            if (!new_col || RAY_IS_ERR(new_col)) continue;
+            new_col->len = (int64_t)grp_count;
+        }
 
         int8_t s = ly->agg_val_slot[a]; /* unified accum slot */
+        /* Holistic agg (OP_MEDIAN) is already filled — skip row-layout
+         * reads.  Naming + add_col below still applies. */
+        if (agg_op == OP_MEDIAN) goto med_attach;
         for (uint32_t gi = 0; gi < grp_count; gi++) {
             const char* row = final_ht->rows + (size_t)gi * ly->row_stride;
             int64_t cnt = *(const int64_t*)(const void*)row;
@@ -6667,6 +7269,7 @@ build_from_final_ht:
             }
         }
 
+    med_attach:;
         /* Generate unique column name */
         ray_op_ext_t* agg_ext = find_ext(g, ext->agg_ins[a]->id);
         int64_t name_id;
@@ -6689,6 +7292,7 @@ build_from_final_ht:
                 case OP_STDDEV_POP: sfx = "_stddev_pop"; slen = 11; break;
                 case OP_VAR:        sfx = "_var";        slen = 4; break;
                 case OP_VAR_POP:    sfx = "_var_pop";    slen = 8; break;
+                case OP_MEDIAN:     sfx = "_median";     slen = 7; break;
             }
             char buf[256];
             if (base && blen + slen < sizeof(buf)) {
@@ -6722,12 +7326,18 @@ build_from_final_ht:
                 case OP_STDDEV_POP: nsfx = "_stddev_pop"; nslen = 11; break;
                 case OP_VAR:        nsfx = "_var";        nslen = 4; break;
                 case OP_VAR_POP:    nsfx = "_var_pop";    nslen = 8; break;
+                case OP_MEDIAN:     nsfx = "_median";     nslen = 7; break;
             }
             memcpy(nbuf + np, nsfx, nslen);
             name_id = ray_sym_intern(nbuf, (size_t)np + nslen);
         }
         result = ray_table_add_col(result, name_id, new_col);
         ray_release(new_col);
+    }
+    if (med_out) {
+        for (uint8_t a = 0; a < n_aggs; a++)
+            if (med_out[a] && !RAY_IS_ERR(med_out[a])) ray_release(med_out[a]);
+        scratch_free(med_hdr);
     }
     }
 

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -1323,7 +1323,15 @@ ray_t* ray_median_per_group_buf(ray_t* src,
     ray_pool_t* pool = ray_pool_get();
     bool par = pool && n_groups >= 8 && total >= 4096;
     if (par) {
-        ray_pool_dispatch_n(pool, med_per_group_fn, &ctx, (uint32_t)n_groups);
+        /* dispatch_n's task ring is capped at MAX_RING_CAP (65536); when
+         * n_groups exceeds that, fall back to elements-based dispatch
+         * (auto-grows grain so every group is covered).  Under the cap,
+         * one task per group gives the best parallelism for small K
+         * per-group work like quickselect. */
+        if (n_groups < (1 << 16))
+            ray_pool_dispatch_n(pool, med_per_group_fn, &ctx, (uint32_t)n_groups);
+        else
+            ray_pool_dispatch(pool, med_per_group_fn, &ctx, n_groups);
     } else {
         med_per_group_fn(&ctx, 0, 0, n_groups);
     }
@@ -1600,7 +1608,12 @@ ray_t* ray_topk_per_group_buf(ray_t* src,
     ray_pool_t* pool = ray_pool_get();
     bool par = pool && n_groups >= 8 && total >= 4096;
     if (par) {
-        ray_pool_dispatch_n(pool, topk_per_group_fn, &ctx, (uint32_t)n_groups);
+        /* See ray_median_per_group_buf for the rationale on the
+         * dispatch_n vs dispatch split. */
+        if (n_groups < (1 << 16))
+            ray_pool_dispatch_n(pool, topk_per_group_fn, &ctx, (uint32_t)n_groups);
+        else
+            ray_pool_dispatch(pool, topk_per_group_fn, &ctx, n_groups);
     } else {
         topk_per_group_fn(&ctx, 0, 0, n_groups);
     }

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -1448,6 +1448,13 @@ ght_layout_t ght_compute_layout(uint8_t n_keys, uint8_t n_aggs,
             if (agg_vecs[a]->type == RAY_F64)
                 ly.agg_is_f64 |= (1u << a);
             nv++;
+            /* Binary aggregator (OP_PEARSON_CORR): the y-side input
+             * occupies the very next slot so phase1 packs (x, y)
+             * consecutively.  agg_is_binary bit drives that packing. */
+            if (agg_ops && agg_ops[a] == OP_PEARSON_CORR) {
+                ly.agg_is_binary |= (uint8_t)(1u << a);
+                nv++;
+            }
         } else {
             ly.agg_val_slot[a] = -1;
         }
@@ -1482,6 +1489,15 @@ ght_layout_t ght_compute_layout(uint8_t n_keys, uint8_t n_aggs,
     if (has_first_last) {
         ly.off_first_row = off; off += block;
         ly.off_last_row  = off; off += block;
+    }
+    /* PEARSON y-side accumulators (Σy, Σy², Σxy).  Allocated when any
+     * OP_PEARSON_CORR agg is present.  x-side reuses off_sum + off_sumsq
+     * at the same slot index; the y value lives at slot+1 in agg_vals,
+     * but its derived accumulators live in their own blocks below. */
+    if (need_flags & GHT_NEED_PEARSON) {
+        ly.off_sum_y   = off; off += block;
+        ly.off_sumsq_y = off; off += block;
+        ly.off_sumxy   = off; off += block;
     }
     ly.row_stride = off;
     return ly;
@@ -5504,6 +5520,9 @@ ht_path:;
             ght_need |= GHT_NEED_SUM;
         if (aop == OP_STDDEV || aop == OP_STDDEV_POP || aop == OP_VAR || aop == OP_VAR_POP)
             { ght_need |= GHT_NEED_SUM; ght_need |= GHT_NEED_SUMSQ; }
+        if (aop == OP_PEARSON_CORR)
+            { ght_need |= GHT_NEED_SUM; ght_need |= GHT_NEED_SUMSQ;
+              ght_need |= GHT_NEED_PEARSON; }
         if (aop == OP_MIN) ght_need |= GHT_NEED_MIN;
         if (aop == OP_MAX) ght_need |= GHT_NEED_MAX;
     }

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -6349,6 +6349,7 @@ skip_top_count_filter:
                 case OP_AVG:
                 case OP_STDDEV: case OP_STDDEV_POP:
                 case OP_VAR: case OP_VAR_POP:
+                case OP_PEARSON_CORR:
                     out_type = RAY_F64; break;
                 case OP_COUNT: out_type = RAY_I64; break;
                 case OP_SUM: case OP_PROD:
@@ -6568,6 +6569,7 @@ build_from_final_ht:
             case OP_AVG:
             case OP_STDDEV: case OP_STDDEV_POP:
             case OP_VAR: case OP_VAR_POP:
+            case OP_PEARSON_CORR:
                 out_type = RAY_F64; break;
             case OP_COUNT: out_type = RAY_I64; break;
             case OP_SUM: case OP_PROD:
@@ -6626,6 +6628,22 @@ build_from_final_ht:
                         else if (agg_op == OP_VAR) v = var_pop * cnt / (cnt - 1);
                         else if (agg_op == OP_STDDEV_POP) v = sqrt(var_pop);
                         else v = sqrt(var_pop * cnt / (cnt - 1));
+                        break;
+                    }
+                    case OP_PEARSON_CORR: {
+                        if (cnt < 2) { v = 0.0; ray_vec_set_null(new_col, gi, true); break; }
+                        double sx  = is_f64 ? ROW_RD_F64(row, ly->off_sum,    s)
+                                            : (double)ROW_RD_I64(row, ly->off_sum, s);
+                        double sxx = ly->off_sumsq ? ROW_RD_F64(row, ly->off_sumsq, s) : 0.0;
+                        double sy  = ly->off_sum_y   ? ROW_RD_F64(row, ly->off_sum_y,   s) : 0.0;
+                        double syy = ly->off_sumsq_y ? ROW_RD_F64(row, ly->off_sumsq_y, s) : 0.0;
+                        double sxy = ly->off_sumxy   ? ROW_RD_F64(row, ly->off_sumxy,   s) : 0.0;
+                        double dn  = (double)cnt;
+                        double num = dn * sxy - sx * sy;
+                        double dx  = dn * sxx - sx * sx;
+                        double dy  = dn * syy - sy * sy;
+                        if (dx <= 0.0 || dy <= 0.0) { v = NAN; break; }
+                        v = num / sqrt(dx * dy);
                         break;
                     }
                     default: v = 0.0; break;

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -820,6 +820,21 @@ ray_t* ray_median_per_group_buf(ray_t* src,
                                 const int64_t* grp_cnt,
                                 int64_t n_groups);
 
+/* Parallel per-group bounded top-K / bot-K via ray_pool_dispatch_n.
+ * Reuses the same idx_buf/offsets/grp_cnt layout as
+ * ray_median_per_group_buf.  K must be >= 1; cells shorter than K when
+ * grp_cnt[gi] < K (matches the standalone topk_take_vec convention).
+ * desc=1 → top (K largest, descending), desc=0 → bot (K smallest,
+ * ascending).  Returns ray_list_new(n_groups), each cell is a vec of
+ * the same type as `src`.  NULL on unsupported source type. */
+ray_t* ray_topk_per_group_buf(ray_t* src,
+                              int64_t k,
+                              uint8_t desc,
+                              const int64_t* idx_buf,
+                              const int64_t* offsets,
+                              const int64_t* grp_cnt,
+                              int64_t n_groups);
+
 ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl, int64_t group_limit);
 
 /* ── collection.c ── */

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -926,8 +926,11 @@ void ray_group_emit_filter_set(ray_group_emit_filter_t filter);
  * space (number of passing rows), not the source column length.
  * When match_idx is NULL, `row = i` — iterating directly over source
  * column rows (no selection). */
+/* agg_vecs2 is the optional y-side input column per agg (NULL when no
+ * binary aggs).  Phase 1 packs (x, y) consecutively for binary aggs. */
 void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
                       uint8_t* key_attrs, ray_t** key_vecs, ray_t** agg_vecs,
+                      ray_t** agg_vecs2,
                       uint8_t* agg_strlen,
                       ray_t* rowsel,
                       int64_t start, int64_t end,

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -809,6 +809,17 @@ ray_t* exec_count_distinct(ray_graph_t* g, ray_op_t* op, ray_t* input);
 ray_t* ray_count_distinct_per_group(ray_t* src, const int64_t* row_gid,
                                     int64_t n_rows, int64_t n_groups);
 
+/* Parallel exact median per group via ray_pool_dispatch_n.  idx_buf is
+ * the group-contiguous row-index layout produced by the upstream
+ * group-by phase (already prefix-summed; offsets[g]..offsets[g]+
+ * grp_cnt[g] is group g's slice).  Returns F64 vec of n_groups, NULL
+ * on unsupported source type (caller falls back to serial). */
+ray_t* ray_median_per_group_buf(ray_t* src,
+                                const int64_t* idx_buf,
+                                const int64_t* offsets,
+                                const int64_t* grp_cnt,
+                                int64_t n_groups);
+
 ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl, int64_t group_limit);
 
 /* ── collection.c ── */
@@ -866,6 +877,12 @@ typedef struct {
      * pack TWO consecutive 8-byte values per row (x then y) starting at
      * agg_val_slot[a]. */
     uint8_t  agg_is_binary;
+    /* Holistic aggregators (OP_MEDIAN): no accumulator slot reserved,
+     * agg_val_slot[a] == -1, phase-1 doesn't pack a value, phase-3
+     * skips emitting from the row layout.  A separate post-radix pass
+     * runs ray_median_per_group_buf over the source column using a
+     * row_gid+grp_cnt-derived idx_buf. */
+    uint8_t  agg_is_holistic;
     /* Wide-key support: bit k set iff key k does not fit in 8 bytes
      * (e.g. RAY_GUID = 16 B).  For wide keys the 8-byte key slot
      * stores a source-row index and the actual key bytes live in the

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -820,10 +820,13 @@ ray_t* asc_vec_eager(ray_t* x);
 ray_t* desc_vec_eager(ray_t* x);
 
 /* Group HT types and helpers — shared with pivot (exec.c) */
-#define GHT_NEED_SUM   0x01
-#define GHT_NEED_MIN   0x02
-#define GHT_NEED_MAX   0x04
-#define GHT_NEED_SUMSQ 0x08
+#define GHT_NEED_SUM     0x01
+#define GHT_NEED_MIN     0x02
+#define GHT_NEED_MAX     0x04
+#define GHT_NEED_SUMSQ   0x08
+/* OP_PEARSON_CORR per-group accumulators: x-side piggybacks on SUM and
+ * SUMSQ blocks; this flag enables the y-side blocks (Σy, Σy², Σxy). */
+#define GHT_NEED_PEARSON 0x10
 
 typedef struct {
     uint16_t entry_stride;
@@ -851,6 +854,18 @@ typedef struct {
      * index of the row the entry was built from. */
     uint16_t off_first_row;
     uint16_t off_last_row;
+    /* OP_PEARSON_CORR y-side accumulators.  Allocated when
+     * GHT_NEED_PEARSON is set; for an OP_PEARSON_CORR agg at slot s the
+     * x-side accumulators live at off_sum[s] (Σx) and off_sumsq[s] (Σx²),
+     * the y-side at these three offsets at the same slot index. */
+    uint16_t off_sum_y;
+    uint16_t off_sumsq_y;
+    uint16_t off_sumxy;
+    /* Per-agg "binary input" bitset: bit a set iff agg a takes two
+     * inputs (OP_PEARSON_CORR).  Drives phase-1 packing — binary aggs
+     * pack TWO consecutive 8-byte values per row (x then y) starting at
+     * agg_val_slot[a]. */
+    uint8_t  agg_is_binary;
     /* Wide-key support: bit k set iff key k does not fit in 8 bytes
      * (e.g. RAY_GUID = 16 B).  For wide keys the 8-byte key slot
      * stores a source-row index and the actual key bytes live in the

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -836,6 +836,7 @@ ray_t* ray_topk_per_group_buf(ray_t* src,
                               int64_t n_groups);
 
 ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl, int64_t group_limit);
+ray_t* exec_group_topk_rowform(ray_graph_t* g, ray_op_t* op);
 
 /* ── collection.c ── */
 ray_t* distinct_vec_eager(ray_t* x);

--- a/src/ops/ops.h
+++ b/src/ops/ops.h
@@ -199,6 +199,13 @@ void     ray_cancel(void);
 #define OP_MEDIAN       88   /* exact median per group (bucket-scatter + quickselect) */
 #define OP_TOP_N        89   /* per-group largest K values (bounded max-heap) */
 #define OP_BOT_N        90   /* per-group smallest K values (bounded min-heap) */
+/* Dedicated single-pass per-group top-K / bot-K with row-form emission.
+ * Replaces the OP_GROUP + radix-HT + LIST<K>-cell + explode pipeline for
+ * the canonical shape `(select (top|bot col K) from t by single_key)`.
+ * Two-phase parallel: per-worker bounded heaps in phase 1; merge by hash
+ * partition in phase 2; emit a 2-column table (key, value) in row form. */
+#define OP_GROUP_TOPK_ROWFORM  91
+#define OP_GROUP_BOTK_ROWFORM 110
 
 /* Opcodes — Graph */
 #define OP_EXPAND        80   /* 1-hop CSR neighbor expansion       */
@@ -594,6 +601,14 @@ ray_op_t* ray_group3(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
                      uint16_t* agg_ops, ray_op_t** agg_ins,
                      ray_op_t** agg_ins2, const int64_t* agg_k,
                      uint8_t n_aggs);
+/* Dedicated per-group top-K / bot-K with row-form emission.  Replaces
+ * the OP_GROUP + post-radix LIST-cell + explode pipeline for the
+ * canonical shape `(select (top|bot col K) from t by single_key)`.
+ * Pass desc=1 for top-K, desc=0 for bot-K.  Result is a 2-column
+ * table: the key column (type-matched to `key`) and the value column
+ * (type-matched to `val`), both flat — one row per (group, kept-value). */
+ray_op_t* ray_group_topk_rowform(ray_graph_t* g, ray_op_t* key,
+                                  ray_op_t* val, int64_t k, uint8_t desc);
 ray_op_t* ray_distinct(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys);
 ray_op_t* ray_pivot_op(ray_graph_t* g,
                        ray_op_t** index_cols, uint8_t n_index,

--- a/src/ops/ops.h
+++ b/src/ops/ops.h
@@ -195,6 +195,7 @@ void     ray_cancel(void);
 #define OP_ILIKE        76
 #define OP_PIVOT        77   /* single-pass pivot table            */
 #define OP_ANTIJOIN     78   /* anti-semi-join (left rows with no right match) */
+#define OP_PEARSON_CORR 79   /* Pearson correlation per group (binary input) */
 
 /* Opcodes — Graph */
 #define OP_EXPAND        80   /* 1-hop CSR neighbor expansion       */
@@ -287,6 +288,11 @@ typedef struct ray_op_ext {
             uint8_t    n_aggs;
             uint16_t*  agg_ops;
             ray_op_t**  agg_ins;
+            /* Optional second input per agg — non-NULL only for binary
+             * aggregators (currently: OP_PEARSON_CORR). NULL for all
+             * unary aggs and for the whole pointer when no binary agg
+             * is present in this group. */
+            ray_op_t**  agg_ins2;
         };
         struct {               /* OP_SORT: multi-column sort */
             ray_op_t**  columns;
@@ -557,6 +563,7 @@ ray_op_t* ray_stddev(ray_graph_t* g, ray_op_t* a);
 ray_op_t* ray_stddev_pop(ray_graph_t* g, ray_op_t* a);
 ray_op_t* ray_var(ray_graph_t* g, ray_op_t* a);
 ray_op_t* ray_var_pop(ray_graph_t* g, ray_op_t* a);
+ray_op_t* ray_pearson_corr(ray_graph_t* g, ray_op_t* x, ray_op_t* y);
 
 /* Structural ops */
 ray_op_t* ray_filter(ray_graph_t* g, ray_op_t* input, ray_op_t* predicate);
@@ -565,6 +572,12 @@ ray_op_t* ray_sort_op(ray_graph_t* g, ray_op_t* table_node,
                      uint8_t n_cols);
 ray_op_t* ray_group(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
                    uint16_t* agg_ops, ray_op_t** agg_ins, uint8_t n_aggs);
+/* Variant accepting an optional second-input column per agg.  agg_ins2
+ * is parallel to agg_ins (length n_aggs); slots are NULL for unary aggs
+ * and non-NULL only for binary aggregators (currently OP_PEARSON_CORR). */
+ray_op_t* ray_group2(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
+                     uint16_t* agg_ops, ray_op_t** agg_ins,
+                     ray_op_t** agg_ins2, uint8_t n_aggs);
 ray_op_t* ray_distinct(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys);
 ray_op_t* ray_pivot_op(ray_graph_t* g,
                        ray_op_t** index_cols, uint8_t n_index,

--- a/src/ops/ops.h
+++ b/src/ops/ops.h
@@ -196,6 +196,7 @@ void     ray_cancel(void);
 #define OP_PIVOT        77   /* single-pass pivot table            */
 #define OP_ANTIJOIN     78   /* anti-semi-join (left rows with no right match) */
 #define OP_PEARSON_CORR 79   /* Pearson correlation per group (binary input) */
+#define OP_MEDIAN       88   /* exact median per group (bucket-scatter + quickselect) */
 
 /* Opcodes — Graph */
 #define OP_EXPAND        80   /* 1-hop CSR neighbor expansion       */
@@ -564,6 +565,7 @@ ray_op_t* ray_stddev_pop(ray_graph_t* g, ray_op_t* a);
 ray_op_t* ray_var(ray_graph_t* g, ray_op_t* a);
 ray_op_t* ray_var_pop(ray_graph_t* g, ray_op_t* a);
 ray_op_t* ray_pearson_corr(ray_graph_t* g, ray_op_t* x, ray_op_t* y);
+ray_op_t* ray_median(ray_graph_t* g, ray_op_t* a);
 
 /* Structural ops */
 ray_op_t* ray_filter(ray_graph_t* g, ray_op_t* input, ray_op_t* predicate);

--- a/src/ops/ops.h
+++ b/src/ops/ops.h
@@ -197,6 +197,8 @@ void     ray_cancel(void);
 #define OP_ANTIJOIN     78   /* anti-semi-join (left rows with no right match) */
 #define OP_PEARSON_CORR 79   /* Pearson correlation per group (binary input) */
 #define OP_MEDIAN       88   /* exact median per group (bucket-scatter + quickselect) */
+#define OP_TOP_N        89   /* per-group largest K values (bounded max-heap) */
+#define OP_BOT_N        90   /* per-group smallest K values (bounded min-heap) */
 
 /* Opcodes — Graph */
 #define OP_EXPAND        80   /* 1-hop CSR neighbor expansion       */
@@ -294,6 +296,11 @@ typedef struct ray_op_ext {
              * unary aggs and for the whole pointer when no binary agg
              * is present in this group. */
             ray_op_t**  agg_ins2;
+            /* Optional integer parameter per agg — used by holistic
+             * aggregators that take a scalar literal alongside the
+             * column (currently OP_TOP_N / OP_BOT_N: K).  NULL for
+             * groups whose aggs all take no scalar param. */
+            int64_t*    agg_k;
         };
         struct {               /* OP_SORT: multi-column sort */
             ray_op_t**  columns;
@@ -580,6 +587,13 @@ ray_op_t* ray_group(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
 ray_op_t* ray_group2(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
                      uint16_t* agg_ops, ray_op_t** agg_ins,
                      ray_op_t** agg_ins2, uint8_t n_aggs);
+/* Variant accepting an optional integer scalar per agg (e.g. top/bot K).
+ * agg_k is parallel to agg_ins (length n_aggs); slots are 0 for aggs
+ * that take no scalar param.  Pass NULL for agg_ins2 / agg_k if not used. */
+ray_op_t* ray_group3(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
+                     uint16_t* agg_ops, ray_op_t** agg_ins,
+                     ray_op_t** agg_ins2, const int64_t* agg_k,
+                     uint8_t n_aggs);
 ray_op_t* ray_distinct(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys);
 ray_op_t* ray_pivot_op(ray_graph_t* g,
                        ray_op_t** index_cols, uint8_t n_index,

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -328,6 +328,12 @@ static uint16_t resolve_agg_opcode(int64_t sym_id) {
      * pass over row_gid+grp_cnt (see exec_group + ray_median_per_group_buf). */
     if (len == 3 && memcmp(name, "med",    3) == 0) return OP_MEDIAN;
     if (len == 6 && memcmp(name, "median", 6) == 0) return OP_MEDIAN;
+    /* Holistic, binary-shape (col + K literal).  K compiled-time literal,
+     * not a DAG input — extracted from the dict expr at planner time and
+     * stored in agg_k[].  See ray_topk_per_group_buf for the per-group
+     * bounded-heap kernel. */
+    if (len == 3 && memcmp(name, "top",    3) == 0) return OP_TOP_N;
+    if (len == 3 && memcmp(name, "bot",    3) == 0) return OP_BOT_N;
     return 0;
 }
 
@@ -5790,12 +5796,16 @@ by_dict_done:
          * Non-agg expressions are tracked separately for post-DAG scatter.
          * agg_ins2[] is parallel to agg_ins[] — NULL for unary aggs,
          * non-NULL for binary aggs (currently OP_PEARSON_CORR).  The
-         * has_binary_agg flag selects ray_group2 below. */
+         * has_binary_agg flag selects ray_group2 below.  agg_k[] carries
+         * a scalar literal alongside the column for holistic aggs that
+         * take K (top/bot); zero in unrelated slots. */
         uint16_t agg_ops[16];
         ray_op_t* agg_ins[16];
         ray_op_t* agg_ins2[16];
+        int64_t agg_k[16];
         uint8_t n_aggs = 0;
         int has_binary_agg = 0;
+        int has_agg_k = 0;
 
         for (int64_t i = 0; i + 1 < dict_n; i += 2) {
             int64_t kid = dict_elems[i]->i64;
@@ -5810,11 +5820,23 @@ by_dict_done:
                 agg_ins[n_aggs] = compile_expr_dag(g, agg_elems[1]);
                 if (!agg_ins[n_aggs]) { ray_graph_free(g); ray_release(tbl); return ray_error("domain", NULL); }
                 agg_ins2[n_aggs] = NULL;
+                agg_k[n_aggs] = 0;
                 if (op == OP_PEARSON_CORR) {
                     if (ray_len(val_expr) < 3) { ray_graph_free(g); ray_release(tbl); return ray_error("arity", NULL); }
                     agg_ins2[n_aggs] = compile_expr_dag(g, agg_elems[2]);
                     if (!agg_ins2[n_aggs]) { ray_graph_free(g); ray_release(tbl); return ray_error("domain", NULL); }
                     has_binary_agg = 1;
+                } else if (op == OP_TOP_N || op == OP_BOT_N) {
+                    if (ray_len(val_expr) < 3) { ray_graph_free(g); ray_release(tbl); return ray_error("arity", NULL); }
+                    ray_t* k_expr = agg_elems[2];
+                    int64_t k_val;
+                    if (k_expr->type == -RAY_I64)       k_val = k_expr->i64;
+                    else if (k_expr->type == -RAY_I32)  k_val = (int64_t)(int32_t)k_expr->i64;
+                    else { ray_graph_free(g); ray_release(tbl); return ray_error("type", "top/bot K must be integer literal"); }
+                    if (k_val < 1) { ray_graph_free(g); ray_release(tbl); return ray_error("range", "top/bot K must be >= 1"); }
+                    if (k_val > 1024) { ray_graph_free(g); ray_release(tbl); return ray_error("range", "top/bot K capped at 1024"); }
+                    agg_k[n_aggs] = k_val;
+                    has_agg_k = 1;
                 }
                 n_aggs++;
             } else if (!is_group_dag_agg_expr(val_expr) && n_nonaggs < 16) {
@@ -5837,16 +5859,20 @@ by_dict_done:
                 }
                 if (can_fuse_phase1 && fused_pred_op != NULL
                     && n_nonaggs == 0 && agg_kinds_ok
-                    && !has_binary_agg)
+                    && !has_binary_agg && !has_agg_k)
                 {
                     /* exec_filtered_group dispatches: count1 (single key,
                      * single COUNT) → Phase 3 fast path; everything else →
                      * multi path with packed composite key.  Skipped when
                      * any agg is binary (filtered-group fusion only knows
-                     * about unary aggs). */
+                     * about unary aggs) or holistic with a K param. */
                     root = ray_filtered_group(g, fused_pred_op,
                                               key_ops, n_keys,
                                               agg_ops, agg_ins, n_aggs);
+                } else if (has_agg_k) {
+                    root = ray_group3(g, key_ops, n_keys, agg_ops,
+                                       agg_ins, has_binary_agg ? agg_ins2 : NULL,
+                                       agg_k, n_aggs);
                 } else if (has_binary_agg) {
                     root = ray_group2(g, key_ops, n_keys, agg_ops,
                                        agg_ins, agg_ins2, n_aggs);

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -323,6 +323,7 @@ static uint16_t resolve_agg_opcode(int64_t sym_id) {
     if (len == 7 && memcmp(name, "dev_pop",      7) == 0) return OP_STDDEV_POP;
     if (len == 7 && memcmp(name, "var_pop",      7) == 0) return OP_VAR_POP;
     if (len == 10 && memcmp(name, "stddev_pop", 10) == 0) return OP_STDDEV_POP;
+    if (len == 12 && memcmp(name, "pearson_corr", 12) == 0) return OP_PEARSON_CORR;
     return 0;
 }
 
@@ -1754,6 +1755,14 @@ static bool bounded_multikey_count_take_candidate(ray_t** dict_elems, int64_t di
     }
     return n_count_out > 0;
 }
+
+/* NOTE: binary-aggregator gates (is_aggr_binary_call /
+ * is_streaming_aggr_binary_call) are not needed at the planner-call
+ * sites for the canonical fast path — `(pearson_corr x y)` flows
+ * through is_agg_expr → is_group_dag_agg_expr → the OP_GROUP planning
+ * block that emits ray_group2.  Eval-fallback (aggr_unary_per_group_buf
+ * twin for two-input shapes, LIST keys, etc.) will need them; add
+ * alongside that path when it's wired. */
 
 /* Detect `(count (distinct <inner>))` exactly — the only shape that
  * routes through the OP_COUNT_DISTINCT fast path per group.  Returns
@@ -5628,10 +5637,15 @@ by_dict_done:
         }
 
         /* Collect aggregation expressions from output columns.
-         * Non-agg expressions are tracked separately for post-DAG scatter. */
+         * Non-agg expressions are tracked separately for post-DAG scatter.
+         * agg_ins2[] is parallel to agg_ins[] — NULL for unary aggs,
+         * non-NULL for binary aggs (currently OP_PEARSON_CORR).  The
+         * has_binary_agg flag selects ray_group2 below. */
         uint16_t agg_ops[16];
         ray_op_t* agg_ins[16];
+        ray_op_t* agg_ins2[16];
         uint8_t n_aggs = 0;
+        int has_binary_agg = 0;
 
         for (int64_t i = 0; i + 1 < dict_n; i += 2) {
             int64_t kid = dict_elems[i]->i64;
@@ -5640,10 +5654,18 @@ by_dict_done:
             ray_t* val_expr = dict_elems[i + 1];
             if (is_group_dag_agg_expr(val_expr) && n_aggs < 16) {
                 ray_t** agg_elems = (ray_t**)ray_data(val_expr);
-                agg_ops[n_aggs] = resolve_agg_opcode(agg_elems[0]->i64);
+                uint16_t op = resolve_agg_opcode(agg_elems[0]->i64);
+                agg_ops[n_aggs] = op;
                 /* Compile the aggregation input (the column reference) */
                 agg_ins[n_aggs] = compile_expr_dag(g, agg_elems[1]);
                 if (!agg_ins[n_aggs]) { ray_graph_free(g); ray_release(tbl); return ray_error("domain", NULL); }
+                agg_ins2[n_aggs] = NULL;
+                if (op == OP_PEARSON_CORR) {
+                    if (ray_len(val_expr) < 3) { ray_graph_free(g); ray_release(tbl); return ray_error("arity", NULL); }
+                    agg_ins2[n_aggs] = compile_expr_dag(g, agg_elems[2]);
+                    if (!agg_ins2[n_aggs]) { ray_graph_free(g); ray_release(tbl); return ray_error("domain", NULL); }
+                    has_binary_agg = 1;
+                }
                 n_aggs++;
             } else if (!is_group_dag_agg_expr(val_expr) && n_nonaggs < 16) {
                 if (is_single_group_key_projection(by_expr, val_expr))
@@ -5664,14 +5686,20 @@ by_dict_done:
                         agg_kinds_ok = 0;
                 }
                 if (can_fuse_phase1 && fused_pred_op != NULL
-                    && n_nonaggs == 0 && agg_kinds_ok)
+                    && n_nonaggs == 0 && agg_kinds_ok
+                    && !has_binary_agg)
                 {
                     /* exec_filtered_group dispatches: count1 (single key,
                      * single COUNT) → Phase 3 fast path; everything else →
-                     * multi path with packed composite key. */
+                     * multi path with packed composite key.  Skipped when
+                     * any agg is binary (filtered-group fusion only knows
+                     * about unary aggs). */
                     root = ray_filtered_group(g, fused_pred_op,
                                               key_ops, n_keys,
                                               agg_ops, agg_ins, n_aggs);
+                } else if (has_binary_agg) {
+                    root = ray_group2(g, key_ops, n_keys, agg_ops,
+                                       agg_ins, agg_ins2, n_aggs);
                 } else {
                     root = ray_group(g, key_ops, n_keys, agg_ops, agg_ins, n_aggs);
                 }
@@ -6311,15 +6339,19 @@ by_dict_done:
 
             uint16_t  s_agg_ops[16];
             ray_op_t* s_agg_ins[16];
+            ray_op_t* s_agg_ins2[16];
             uint8_t   s_n_aggs = 0;
+            int       s_has_binary = 0;
             for (int64_t i = 0; i + 1 < dict_n && s_n_aggs < 16; i += 2) {
                 int64_t kid = dict_elems[i]->i64;
                 if (kid == from_id || kid == where_id || kid == by_id ||
                     kid == take_id || kid == asc_id || kid == desc_id || kid == nearest_id) continue;
                 ray_t*  val_expr  = dict_elems[i + 1];
                 ray_t** agg_elems = (ray_t**)ray_data(val_expr);
-                s_agg_ops[s_n_aggs] = resolve_agg_opcode(agg_elems[0]->i64);
+                uint16_t op = resolve_agg_opcode(agg_elems[0]->i64);
+                s_agg_ops[s_n_aggs] = op;
                 s_agg_ins[s_n_aggs] = compile_expr_dag(g, agg_elems[1]);
+                s_agg_ins2[s_n_aggs] = NULL;
                 if (!s_agg_ins[s_n_aggs]) {
                     if (g->selection) {
                         ray_release(g->selection);
@@ -6328,9 +6360,27 @@ by_dict_done:
                     ray_graph_free(g); ray_release(tbl);
                     return ray_error("domain", NULL);
                 }
+                if (op == OP_PEARSON_CORR) {
+                    if (ray_len(val_expr) < 3) {
+                        if (g->selection) { ray_release(g->selection); g->selection = NULL; }
+                        ray_graph_free(g); ray_release(tbl);
+                        return ray_error("arity", NULL);
+                    }
+                    s_agg_ins2[s_n_aggs] = compile_expr_dag(g, agg_elems[2]);
+                    if (!s_agg_ins2[s_n_aggs]) {
+                        if (g->selection) { ray_release(g->selection); g->selection = NULL; }
+                        ray_graph_free(g); ray_release(tbl);
+                        return ray_error("domain", NULL);
+                    }
+                    s_has_binary = 1;
+                }
                 s_n_aggs++;
             }
-            root = ray_group(g, NULL, 0, s_agg_ops, s_agg_ins, s_n_aggs);
+            if (s_has_binary)
+                root = ray_group2(g, NULL, 0, s_agg_ops, s_agg_ins,
+                                   s_agg_ins2, s_n_aggs);
+            else
+                root = ray_group(g, NULL, 0, s_agg_ops, s_agg_ins, s_n_aggs);
         } else {
             /* Projection only (no group by) — select specific columns */
             ray_op_t* col_ops[16];

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -2229,6 +2229,110 @@ static ray_t* aggr_unary_per_group_buf(ray_t* expr, ray_t* tbl,
     return agg_vec;
 }
 
+/* Recognise `(med col)`.  Used to gate the fast median per-group path
+ * below — `med` is RAY_FN_AGGR + RAY_UNARY so it normally routes
+ * through aggr_unary_per_group_buf, which allocates one ray vector
+ * per group via ray_at_fn and then another scratch inside ray_med_fn.
+ * For 10k+ groups that's 20k+ allocs; the bucket-scatter path skips it. */
+static int is_med_call(ray_t* expr) {
+    if (!expr || expr->type != RAY_LIST) return 0;
+    if (ray_len(expr) != 2) return 0;
+    ray_t** elems = (ray_t**)ray_data(expr);
+    if (!elems[0] || elems[0]->type != -RAY_SYM) return 0;
+    ray_t* nm = ray_sym_str(elems[0]->i64);
+    if (!nm) return 0;
+    return ray_str_len(nm) == 3 && memcmp(ray_str_ptr(nm), "med", 3) == 0;
+}
+
+/* Fast median per group: read values straight out of the source column
+ * via idx_buf+offsets+grp_cnt into a reusable double scratch buffer
+ * sized at max group, then ray_median_dbl_inplace.  Returns the f64
+ * median vec of length n_groups, or NULL on type miss (caller falls
+ * back to the generic aggr_unary_per_group_buf path). */
+static ray_t* aggr_med_per_group_buf(ray_t* expr, ray_t* tbl,
+                                     const int64_t* idx_buf,
+                                     const int64_t* offsets,
+                                     const int64_t* grp_cnt,
+                                     int64_t n_groups) {
+    ray_t** elems = (ray_t**)ray_data(expr);
+    ray_t* col_expr = elems[1];
+
+    /* Resolve source column (direct ref preferred — no copy). */
+    ray_t* src = NULL;
+    int    src_owned = 0;
+    if (col_expr->type == -RAY_SYM && (col_expr->attrs & RAY_ATTR_NAME)) {
+        src = ray_table_get_col(tbl, col_expr->i64);
+        if (src) ray_retain(src);
+    }
+    if (!src) {
+        if (ray_env_push_scope() != RAY_OK) return ray_error("oom", NULL);
+        expr_bind_table_names(col_expr, tbl);
+        src = ray_eval(col_expr);
+        ray_env_pop_scope();
+        if (!src || RAY_IS_ERR(src)) return src ? src : ray_error("domain", NULL);
+        src_owned = 1;
+    }
+
+    /* Numeric only on the fast path.  Anything else → caller's fallback. */
+    int8_t t = src->type;
+    if (t != RAY_F64 && t != RAY_I64 && t != RAY_I32 &&
+        t != RAY_I16 && t != RAY_U8) {
+        ray_release(src);
+        return NULL;
+    }
+
+    int64_t max_cnt = 0;
+    for (int64_t g = 0; g < n_groups; g++)
+        if (grp_cnt[g] > max_cnt) max_cnt = grp_cnt[g];
+
+    ray_t* out = ray_vec_new(RAY_F64, n_groups);
+    if (!out || RAY_IS_ERR(out)) { ray_release(src); return out ? out : ray_error("oom", NULL); }
+    out->len = n_groups;
+    double* out_data = (double*)ray_data(out);
+
+    ray_t* scratch_hdr = NULL;
+    double* scratch = NULL;
+    if (max_cnt > 0) {
+        scratch = (double*)scratch_alloc(&scratch_hdr,
+                                          (size_t)max_cnt * sizeof(double));
+        if (!scratch) { ray_release(src); ray_release(out); return ray_error("oom", NULL); }
+    }
+
+    bool has_nulls = (src->attrs & RAY_ATTR_HAS_NULLS) != 0;
+    const uint8_t* null_bm = has_nulls ? ray_vec_nullmap_bytes(src, NULL, NULL) : NULL;
+    const void* base = ray_data(src);
+
+    for (int64_t g = 0; g < n_groups; g++) {
+        int64_t cnt = grp_cnt[g];
+        int64_t base_off = offsets[g];
+        if (cnt == 0) { out_data[g] = 0.0; ray_vec_set_null(out, g, true); continue; }
+
+        int64_t actual = 0;
+        for (int64_t i = 0; i < cnt; i++) {
+            int64_t row = idx_buf[base_off + i];
+            if (null_bm && ((null_bm[row >> 3] >> (row & 7)) & 1)) continue;
+            double v;
+            switch (t) {
+                case RAY_F64: memcpy(&v, (const char*)base + (size_t)row * 8, 8); break;
+                case RAY_I64: { int64_t iv; memcpy(&iv, (const char*)base + (size_t)row * 8, 8); v = (double)iv; break; }
+                case RAY_I32: { int32_t iv; memcpy(&iv, (const char*)base + (size_t)row * 4, 4); v = (double)iv; break; }
+                case RAY_I16: { int16_t iv; memcpy(&iv, (const char*)base + (size_t)row * 2, 2); v = (double)iv; break; }
+                case RAY_U8:  v = (double)((const uint8_t*)base)[row]; break;
+                default:      v = 0.0; break;
+            }
+            scratch[actual++] = v;
+        }
+
+        if (actual == 0) { out_data[g] = 0.0; ray_vec_set_null(out, g, true); continue; }
+        out_data[g] = ray_median_dbl_inplace(scratch, actual);
+    }
+
+    if (scratch_hdr) scratch_free(scratch_hdr);
+    (void)src_owned;
+    ray_release(src);
+    return out;
+}
+
 /* Per-group count(distinct) parallel kernel — one task per group, each
  * task does its own dedup with a scratch hash table.  Skips the
  * gather_by_idx + exec_count_distinct allocation that the serial path
@@ -7250,9 +7354,22 @@ by_dict_done:
                      * vec.  Equivalent perf-class to the streaming AGG path
                      * the eval-fallback uses for the same shapes. */
                     if (is_streaming_aggr_unary_call(nonagg_exprs[ni])) {
-                        ray_t* col = aggr_unary_per_group_buf(
-                            nonagg_exprs[ni], tbl,
-                            idx_buf, offsets, grp_cnt, n_groups);
+                        ray_t* col = NULL;
+                        /* `(med col)` fast path — bucket-scatter values
+                         * into a reused scratch and quickselect, skipping
+                         * the per-group ray_at_fn + ray_med_fn scratch
+                         * allocations.  NULL → unsupported input type
+                         * (LIST/STR/etc); fall back to the generic
+                         * aggr_unary_per_group_buf path below. */
+                        if (is_med_call(nonagg_exprs[ni])) {
+                            col = aggr_med_per_group_buf(nonagg_exprs[ni], tbl,
+                                idx_buf, offsets, grp_cnt, n_groups);
+                        }
+                        if (!col) {
+                            col = aggr_unary_per_group_buf(
+                                nonagg_exprs[ni], tbl,
+                                idx_buf, offsets, grp_cnt, n_groups);
+                        }
                         if (RAY_IS_ERR(col)) { scatter_err = col; break; }
                         result = ray_table_add_col(result, nonagg_names[ni], col);
                         ray_release(col);

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -324,6 +324,10 @@ static uint16_t resolve_agg_opcode(int64_t sym_id) {
     if (len == 7 && memcmp(name, "var_pop",      7) == 0) return OP_VAR_POP;
     if (len == 10 && memcmp(name, "stddev_pop", 10) == 0) return OP_STDDEV_POP;
     if (len == 12 && memcmp(name, "pearson_corr", 12) == 0) return OP_PEARSON_CORR;
+    /* Holistic — DAG path skips accumulator slot, fills via post-radix
+     * pass over row_gid+grp_cnt (see exec_group + ray_median_per_group_buf). */
+    if (len == 3 && memcmp(name, "med",    3) == 0) return OP_MEDIAN;
+    if (len == 6 && memcmp(name, "median", 6) == 0) return OP_MEDIAN;
     return 0;
 }
 
@@ -1238,6 +1242,7 @@ ray_op_t* compile_expr_dag(ray_graph_t* g, ray_t* expr) {
                     case OP_STDDEV_POP:  return ray_stddev_pop(g, arg);
                     case OP_VAR:         return ray_var(g, arg);
                     case OP_VAR_POP:     return ray_var_pop(g, arg);
+                    case OP_MEDIAN:      return ray_median(g, arg);
                     default: return NULL;
                 }
             }
@@ -2249,6 +2254,13 @@ static int is_med_call(ray_t* expr) {
  * sized at max group, then ray_median_dbl_inplace.  Returns the f64
  * median vec of length n_groups, or NULL on type miss (caller falls
  * back to the generic aggr_unary_per_group_buf path). */
+/* Thin wrapper around the parallel ray_median_per_group_buf kernel
+ * (src/ops/group.c).  Resolves the source column from `(med col_expr)`,
+ * then delegates to the kernel which runs one ray_pool_dispatch_n task
+ * per group — gathers values into a shared scratch buffer and runs
+ * ray_median_dbl_inplace in parallel.  See the kernel header comment
+ * for the design and why it matches DuckDB's holistic quantile
+ * approach without paying their per-group vector-grow cost. */
 static ray_t* aggr_med_per_group_buf(ray_t* expr, ray_t* tbl,
                                      const int64_t* idx_buf,
                                      const int64_t* offsets,
@@ -2257,9 +2269,7 @@ static ray_t* aggr_med_per_group_buf(ray_t* expr, ray_t* tbl,
     ray_t** elems = (ray_t**)ray_data(expr);
     ray_t* col_expr = elems[1];
 
-    /* Resolve source column (direct ref preferred — no copy). */
     ray_t* src = NULL;
-    int    src_owned = 0;
     if (col_expr->type == -RAY_SYM && (col_expr->attrs & RAY_ATTR_NAME)) {
         src = ray_table_get_col(tbl, col_expr->i64);
         if (src) ray_retain(src);
@@ -2270,67 +2280,11 @@ static ray_t* aggr_med_per_group_buf(ray_t* expr, ray_t* tbl,
         src = ray_eval(col_expr);
         ray_env_pop_scope();
         if (!src || RAY_IS_ERR(src)) return src ? src : ray_error("domain", NULL);
-        src_owned = 1;
     }
 
-    /* Numeric only on the fast path.  Anything else → caller's fallback. */
-    int8_t t = src->type;
-    if (t != RAY_F64 && t != RAY_I64 && t != RAY_I32 &&
-        t != RAY_I16 && t != RAY_U8) {
-        ray_release(src);
-        return NULL;
-    }
-
-    int64_t max_cnt = 0;
-    for (int64_t g = 0; g < n_groups; g++)
-        if (grp_cnt[g] > max_cnt) max_cnt = grp_cnt[g];
-
-    ray_t* out = ray_vec_new(RAY_F64, n_groups);
-    if (!out || RAY_IS_ERR(out)) { ray_release(src); return out ? out : ray_error("oom", NULL); }
-    out->len = n_groups;
-    double* out_data = (double*)ray_data(out);
-
-    ray_t* scratch_hdr = NULL;
-    double* scratch = NULL;
-    if (max_cnt > 0) {
-        scratch = (double*)scratch_alloc(&scratch_hdr,
-                                          (size_t)max_cnt * sizeof(double));
-        if (!scratch) { ray_release(src); ray_release(out); return ray_error("oom", NULL); }
-    }
-
-    bool has_nulls = (src->attrs & RAY_ATTR_HAS_NULLS) != 0;
-    const uint8_t* null_bm = has_nulls ? ray_vec_nullmap_bytes(src, NULL, NULL) : NULL;
-    const void* base = ray_data(src);
-
-    for (int64_t g = 0; g < n_groups; g++) {
-        int64_t cnt = grp_cnt[g];
-        int64_t base_off = offsets[g];
-        if (cnt == 0) { out_data[g] = 0.0; ray_vec_set_null(out, g, true); continue; }
-
-        int64_t actual = 0;
-        for (int64_t i = 0; i < cnt; i++) {
-            int64_t row = idx_buf[base_off + i];
-            if (null_bm && ((null_bm[row >> 3] >> (row & 7)) & 1)) continue;
-            double v;
-            switch (t) {
-                case RAY_F64: memcpy(&v, (const char*)base + (size_t)row * 8, 8); break;
-                case RAY_I64: { int64_t iv; memcpy(&iv, (const char*)base + (size_t)row * 8, 8); v = (double)iv; break; }
-                case RAY_I32: { int32_t iv; memcpy(&iv, (const char*)base + (size_t)row * 4, 4); v = (double)iv; break; }
-                case RAY_I16: { int16_t iv; memcpy(&iv, (const char*)base + (size_t)row * 2, 2); v = (double)iv; break; }
-                case RAY_U8:  v = (double)((const uint8_t*)base)[row]; break;
-                default:      v = 0.0; break;
-            }
-            scratch[actual++] = v;
-        }
-
-        if (actual == 0) { out_data[g] = 0.0; ray_vec_set_null(out, g, true); continue; }
-        out_data[g] = ray_median_dbl_inplace(scratch, actual);
-    }
-
-    if (scratch_hdr) scratch_free(scratch_hdr);
-    (void)src_owned;
+    ray_t* out = ray_median_per_group_buf(src, idx_buf, offsets, grp_cnt, n_groups);
     ray_release(src);
-    return out;
+    return out;  /* NULL → unsupported type; caller falls back */
 }
 
 /* Per-group count(distinct) parallel kernel — one task per group, each
@@ -4915,65 +4869,50 @@ by_dict_done:
                         ray_t* agg_vec = NULL;
                         ray_t** grp_items = (ray_t**)ray_data(groups);
 
-                        /* Median fast path: skip per-group ray_at_fn slice
-                         * allocation + ray_med_fn scratch allocation; read
-                         * src[idx_list[i]] straight into a reusable double
-                         * scratch buffer, then ray_median_dbl_inplace.  For
-                         * q6's 10k-group / 1k-row-per-group shape this
-                         * eliminates 20k ray-vector allocations.  Numeric
-                         * inputs only — non-numeric falls back to the
-                         * generic loop below. */
-                        bool med_fast = is_med_call(val_expr_item) &&
-                            (src_col_val->type == RAY_F64 || src_col_val->type == RAY_I64 ||
-                             src_col_val->type == RAY_I32 || src_col_val->type == RAY_I16 ||
-                             src_col_val->type == RAY_U8);
-                        if (med_fast) {
-                            int8_t  t = src_col_val->type;
-                            int64_t max_cnt = 0;
-                            for (int64_t gi = 0; gi < out_groups; gi++) {
-                                int64_t c = ray_len(grp_items[gi * 2 + 1]);
-                                if (c > max_cnt) max_cnt = c;
-                            }
-                            agg_vec = ray_vec_new(RAY_F64, out_groups);
-                            if (agg_vec && !RAY_IS_ERR(agg_vec)) {
-                                agg_vec->len = out_groups;
-                                double* out_data = (double*)ray_data(agg_vec);
-                                ray_t* sch_hdr = NULL;
-                                double* scratch = max_cnt > 0
-                                    ? (double*)scratch_alloc(&sch_hdr,
-                                          (size_t)max_cnt * sizeof(double))
-                                    : NULL;
-                                bool ok = (max_cnt == 0) || (scratch != NULL);
-                                bool has_nulls = (src_col_val->attrs & RAY_ATTR_HAS_NULLS) != 0;
-                                const uint8_t* null_bm = has_nulls
-                                    ? ray_vec_nullmap_bytes(src_col_val, NULL, NULL) : NULL;
-                                const void* base = ray_data(src_col_val);
-                                for (int64_t gi = 0; gi < out_groups && ok; gi++) {
+                        /* Median fast path: flatten `groups` LIST<(key,
+                         * idx_list)> into the (idx_buf, offsets, grp_cnt)
+                         * layout that ray_median_per_group_buf expects,
+                         * then run the parallel kernel (one task per
+                         * group via ray_pool_dispatch_n, shared flat
+                         * scratch buffer of size sum(grp_cnt), per-task
+                         * quickselect on its slice).  Numeric inputs
+                         * only — returns NULL on type miss → fall back
+                         * to the generic per-group ray_at_fn + ray_med_fn
+                         * loop below.  Uses out_groups so a preapplied
+                         * take limits the work to the kept prefix. */
+                        if (is_med_call(val_expr_item)) {
+                            ray_t* ix_hdr = NULL;
+                            ray_t* off_hdr = NULL;
+                            ray_t* cnt_hdr = NULL;
+                            int64_t total = 0;
+                            for (int64_t gi = 0; gi < out_groups; gi++)
+                                total += ray_len(grp_items[gi * 2 + 1]);
+                            int64_t* ix  = (int64_t*)scratch_alloc(&ix_hdr,
+                                (size_t)(total > 0 ? total : 1) * sizeof(int64_t));
+                            int64_t* off = (int64_t*)scratch_alloc(&off_hdr,
+                                (size_t)(out_groups > 0 ? out_groups : 1) * sizeof(int64_t));
+                            int64_t* cnt = (int64_t*)scratch_alloc(&cnt_hdr,
+                                (size_t)(out_groups > 0 ? out_groups : 1) * sizeof(int64_t));
+                            if (ix && off && cnt) {
+                                int64_t pos = 0;
+                                for (int64_t gi = 0; gi < out_groups; gi++) {
                                     ray_t* idx_list = grp_items[gi * 2 + 1];
-                                    int64_t cnt = ray_len(idx_list);
-                                    if (cnt == 0) { out_data[gi] = 0.0; ray_vec_set_null(agg_vec, gi, true); continue; }
-                                    int64_t* idx_data = (int64_t*)ray_data(idx_list);
-                                    int64_t actual = 0;
-                                    for (int64_t i = 0; i < cnt; i++) {
-                                        int64_t row = idx_data[i];
-                                        if (null_bm && ((null_bm[row >> 3] >> (row & 7)) & 1)) continue;
-                                        double v;
-                                        switch (t) {
-                                            case RAY_F64: memcpy(&v, (const char*)base + (size_t)row * 8, 8); break;
-                                            case RAY_I64: { int64_t iv; memcpy(&iv, (const char*)base + (size_t)row * 8, 8); v = (double)iv; break; }
-                                            case RAY_I32: { int32_t iv; memcpy(&iv, (const char*)base + (size_t)row * 4, 4); v = (double)iv; break; }
-                                            case RAY_I16: { int16_t iv; memcpy(&iv, (const char*)base + (size_t)row * 2, 2); v = (double)iv; break; }
-                                            case RAY_U8:  v = (double)((const uint8_t*)base)[row]; break;
-                                            default:      v = 0.0; break;
-                                        }
-                                        scratch[actual++] = v;
-                                    }
-                                    if (actual == 0) { out_data[gi] = 0.0; ray_vec_set_null(agg_vec, gi, true); continue; }
-                                    out_data[gi] = ray_median_dbl_inplace(scratch, actual);
+                                    int64_t c = ray_len(idx_list);
+                                    off[gi] = pos;
+                                    cnt[gi] = c;
+                                    if (c > 0)
+                                        memcpy(ix + pos, ray_data(idx_list),
+                                               (size_t)c * sizeof(int64_t));
+                                    pos += c;
                                 }
-                                if (sch_hdr) scratch_free(sch_hdr);
+                                agg_vec = ray_median_per_group_buf(
+                                    src_col_val, ix, off, cnt, out_groups);
                             }
-                        } else {
+                            if (ix_hdr) scratch_free(ix_hdr);
+                            if (off_hdr) scratch_free(off_hdr);
+                            if (cnt_hdr) scratch_free(cnt_hdr);
+                        }
+                        if (!agg_vec) {
                             for (int64_t gi = 0; gi < out_groups; gi++) {
                                 ray_t* idx_list = grp_items[gi * 2 + 1];
                                 ray_t* subset = ray_at_fn(src_col_val, idx_list);
@@ -5363,64 +5302,49 @@ by_dict_done:
                     ray_t* agg_vec = NULL;
                     ray_t** grp_items = (ray_t**)ray_data(groups);
 
-                    /* Median fast path — see the twin site above for
-                     * rationale (skips per-group ray_at_fn + ray_med_fn
-                     * scratch allocations). */
-                    bool med_fast = is_med_call(val_expr_item) &&
-                        (src_col_val->type == RAY_F64 || src_col_val->type == RAY_I64 ||
-                         src_col_val->type == RAY_I32 || src_col_val->type == RAY_I16 ||
-                         src_col_val->type == RAY_U8);
-                    if (med_fast) {
-                        int8_t  t = src_col_val->type;
-                        int64_t max_cnt = 0;
-                        for (int64_t gi = 0; gi < n_groups; gi++) {
-                            int64_t c = ray_len(grp_items[gi * 2 + 1]);
-                            if (c > max_cnt) max_cnt = c;
-                        }
-                        agg_vec = ray_vec_new(RAY_F64, n_groups);
-                        if (agg_vec && !RAY_IS_ERR(agg_vec)) {
-                            agg_vec->len = n_groups;
-                            double* out_data = (double*)ray_data(agg_vec);
-                            ray_t* sch_hdr = NULL;
-                            double* scratch = max_cnt > 0
-                                ? (double*)scratch_alloc(&sch_hdr,
-                                      (size_t)max_cnt * sizeof(double))
-                                : NULL;
-                            bool ok = (max_cnt == 0) || (scratch != NULL);
-                            bool has_nulls = (src_col_val->attrs & RAY_ATTR_HAS_NULLS) != 0;
-                            const uint8_t* null_bm = has_nulls
-                                ? ray_vec_nullmap_bytes(src_col_val, NULL, NULL) : NULL;
-                            const void* base = ray_data(src_col_val);
-                            for (int64_t gi = 0; gi < n_groups && ok; gi++) {
+                    /* Median fast path — flatten `groups` into
+                     * (idx_buf, offsets, grp_cnt) then call the parallel
+                     * ray_median_per_group_buf kernel.  See twin site
+                     * above for the design rationale. */
+                    if (is_med_call(val_expr_item)) {
+                        ray_t* ix_hdr = NULL;
+                        ray_t* off_hdr = NULL;
+                        ray_t* cnt_hdr = NULL;
+                        int64_t total = 0;
+                        for (int64_t gi = 0; gi < n_groups; gi++)
+                            total += ray_len(grp_items[gi * 2 + 1]);
+                        int64_t* ix  = (int64_t*)scratch_alloc(&ix_hdr,
+                            (size_t)(total > 0 ? total : 1) * sizeof(int64_t));
+                        int64_t* off = (int64_t*)scratch_alloc(&off_hdr,
+                            (size_t)n_groups * sizeof(int64_t));
+                        int64_t* cnt = (int64_t*)scratch_alloc(&cnt_hdr,
+                            (size_t)n_groups * sizeof(int64_t));
+                        if (ix && off && cnt) {
+                            int64_t pos = 0;
+                            for (int64_t gi = 0; gi < n_groups; gi++) {
                                 ray_t* idx_list = grp_items[gi * 2 + 1];
-                                int64_t cnt = ray_len(idx_list);
-                                if (cnt == 0) { out_data[gi] = 0.0; ray_vec_set_null(agg_vec, gi, true); continue; }
-                                int64_t* idx_data = (int64_t*)ray_data(idx_list);
-                                int64_t actual = 0;
-                                for (int64_t i = 0; i < cnt; i++) {
-                                    int64_t row = idx_data[i];
-                                    if (null_bm && ((null_bm[row >> 3] >> (row & 7)) & 1)) continue;
-                                    double v;
-                                    switch (t) {
-                                        case RAY_F64: memcpy(&v, (const char*)base + (size_t)row * 8, 8); break;
-                                        case RAY_I64: { int64_t iv; memcpy(&iv, (const char*)base + (size_t)row * 8, 8); v = (double)iv; break; }
-                                        case RAY_I32: { int32_t iv; memcpy(&iv, (const char*)base + (size_t)row * 4, 4); v = (double)iv; break; }
-                                        case RAY_I16: { int16_t iv; memcpy(&iv, (const char*)base + (size_t)row * 2, 2); v = (double)iv; break; }
-                                        case RAY_U8:  v = (double)((const uint8_t*)base)[row]; break;
-                                        default:      v = 0.0; break;
-                                    }
-                                    scratch[actual++] = v;
-                                }
-                                if (actual == 0) { out_data[gi] = 0.0; ray_vec_set_null(agg_vec, gi, true); continue; }
-                                out_data[gi] = ray_median_dbl_inplace(scratch, actual);
+                                int64_t c = ray_len(idx_list);
+                                off[gi] = pos;
+                                cnt[gi] = c;
+                                if (c > 0)
+                                    memcpy(ix + pos, ray_data(idx_list),
+                                           (size_t)c * sizeof(int64_t));
+                                pos += c;
                             }
-                            if (sch_hdr) scratch_free(sch_hdr);
+                            agg_vec = ray_median_per_group_buf(
+                                src_col_val, ix, off, cnt, n_groups);
                         }
-                        ray_release(src_col_val);
-                        agg_names[n_agg_out] = kid;
-                        agg_results[n_agg_out] = agg_vec;
-                        n_agg_out++;
-                        continue;
+                        if (ix_hdr) scratch_free(ix_hdr);
+                        if (off_hdr) scratch_free(off_hdr);
+                        if (cnt_hdr) scratch_free(cnt_hdr);
+                        if (agg_vec && !RAY_IS_ERR(agg_vec)) {
+                            ray_release(src_col_val);
+                            agg_names[n_agg_out] = kid;
+                            agg_results[n_agg_out] = agg_vec;
+                            n_agg_out++;
+                            continue;
+                        }
+                        agg_vec = NULL;  /* type miss → fall through */
                     }
 
                     for (int64_t gi = 0; gi < n_groups; gi++) {
@@ -10055,7 +9979,8 @@ ray_t* ray_window_join_fn(ray_t** args, int64_t n) {
             case OP_COUNT: rt = RAY_I64; break;
             case OP_AVG:
             case OP_VAR: case OP_VAR_POP:
-            case OP_STDDEV: case OP_STDDEV_POP: rt = RAY_F64; break;
+            case OP_STDDEV: case OP_STDDEV_POP:
+            case OP_MEDIAN: rt = RAY_F64; break;
             case OP_SUM: case OP_PROD:
                 rt = agg_is_float[a] ? RAY_F64 : RAY_I64; break;
             default: /* MIN/MAX/FIRST/LAST */ rt = t; break;

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -4914,26 +4914,87 @@ by_dict_done:
 
                         ray_t* agg_vec = NULL;
                         ray_t** grp_items = (ray_t**)ray_data(groups);
-                        for (int64_t gi = 0; gi < out_groups; gi++) {
-                            ray_t* idx_list = grp_items[gi * 2 + 1];
-                            ray_t* subset = ray_at_fn(src_col_val, idx_list);
-                            if (!subset || RAY_IS_ERR(subset)) continue;
-                            ray_t* agg_val = NULL;
-                            ray_t* fn_obj = ray_env_get(agg_fn_name->i64);
-                            if (fn_obj && fn_obj->type == RAY_UNARY) {
-                                ray_unary_fn uf = (ray_unary_fn)(uintptr_t)fn_obj->i64;
-                                agg_val = uf(subset);
+
+                        /* Median fast path: skip per-group ray_at_fn slice
+                         * allocation + ray_med_fn scratch allocation; read
+                         * src[idx_list[i]] straight into a reusable double
+                         * scratch buffer, then ray_median_dbl_inplace.  For
+                         * q6's 10k-group / 1k-row-per-group shape this
+                         * eliminates 20k ray-vector allocations.  Numeric
+                         * inputs only — non-numeric falls back to the
+                         * generic loop below. */
+                        bool med_fast = is_med_call(val_expr_item) &&
+                            (src_col_val->type == RAY_F64 || src_col_val->type == RAY_I64 ||
+                             src_col_val->type == RAY_I32 || src_col_val->type == RAY_I16 ||
+                             src_col_val->type == RAY_U8);
+                        if (med_fast) {
+                            int8_t  t = src_col_val->type;
+                            int64_t max_cnt = 0;
+                            for (int64_t gi = 0; gi < out_groups; gi++) {
+                                int64_t c = ray_len(grp_items[gi * 2 + 1]);
+                                if (c > max_cnt) max_cnt = c;
                             }
-                            ray_release(subset);
-                            if (!agg_val || RAY_IS_ERR(agg_val)) continue;
-                            if (!agg_vec) {
-                                int8_t vt = -(agg_val->type);
-                                agg_vec = ray_vec_new(vt, out_groups);
-                                if (!agg_vec || RAY_IS_ERR(agg_vec)) { ray_release(agg_val); break; }
+                            agg_vec = ray_vec_new(RAY_F64, out_groups);
+                            if (agg_vec && !RAY_IS_ERR(agg_vec)) {
                                 agg_vec->len = out_groups;
+                                double* out_data = (double*)ray_data(agg_vec);
+                                ray_t* sch_hdr = NULL;
+                                double* scratch = max_cnt > 0
+                                    ? (double*)scratch_alloc(&sch_hdr,
+                                          (size_t)max_cnt * sizeof(double))
+                                    : NULL;
+                                bool ok = (max_cnt == 0) || (scratch != NULL);
+                                bool has_nulls = (src_col_val->attrs & RAY_ATTR_HAS_NULLS) != 0;
+                                const uint8_t* null_bm = has_nulls
+                                    ? ray_vec_nullmap_bytes(src_col_val, NULL, NULL) : NULL;
+                                const void* base = ray_data(src_col_val);
+                                for (int64_t gi = 0; gi < out_groups && ok; gi++) {
+                                    ray_t* idx_list = grp_items[gi * 2 + 1];
+                                    int64_t cnt = ray_len(idx_list);
+                                    if (cnt == 0) { out_data[gi] = 0.0; ray_vec_set_null(agg_vec, gi, true); continue; }
+                                    int64_t* idx_data = (int64_t*)ray_data(idx_list);
+                                    int64_t actual = 0;
+                                    for (int64_t i = 0; i < cnt; i++) {
+                                        int64_t row = idx_data[i];
+                                        if (null_bm && ((null_bm[row >> 3] >> (row & 7)) & 1)) continue;
+                                        double v;
+                                        switch (t) {
+                                            case RAY_F64: memcpy(&v, (const char*)base + (size_t)row * 8, 8); break;
+                                            case RAY_I64: { int64_t iv; memcpy(&iv, (const char*)base + (size_t)row * 8, 8); v = (double)iv; break; }
+                                            case RAY_I32: { int32_t iv; memcpy(&iv, (const char*)base + (size_t)row * 4, 4); v = (double)iv; break; }
+                                            case RAY_I16: { int16_t iv; memcpy(&iv, (const char*)base + (size_t)row * 2, 2); v = (double)iv; break; }
+                                            case RAY_U8:  v = (double)((const uint8_t*)base)[row]; break;
+                                            default:      v = 0.0; break;
+                                        }
+                                        scratch[actual++] = v;
+                                    }
+                                    if (actual == 0) { out_data[gi] = 0.0; ray_vec_set_null(agg_vec, gi, true); continue; }
+                                    out_data[gi] = ray_median_dbl_inplace(scratch, actual);
+                                }
+                                if (sch_hdr) scratch_free(sch_hdr);
                             }
-                            store_typed_elem(agg_vec, gi, agg_val);
-                            ray_release(agg_val);
+                        } else {
+                            for (int64_t gi = 0; gi < out_groups; gi++) {
+                                ray_t* idx_list = grp_items[gi * 2 + 1];
+                                ray_t* subset = ray_at_fn(src_col_val, idx_list);
+                                if (!subset || RAY_IS_ERR(subset)) continue;
+                                ray_t* agg_val = NULL;
+                                ray_t* fn_obj = ray_env_get(agg_fn_name->i64);
+                                if (fn_obj && fn_obj->type == RAY_UNARY) {
+                                    ray_unary_fn uf = (ray_unary_fn)(uintptr_t)fn_obj->i64;
+                                    agg_val = uf(subset);
+                                }
+                                ray_release(subset);
+                                if (!agg_val || RAY_IS_ERR(agg_val)) continue;
+                                if (!agg_vec) {
+                                    int8_t vt = -(agg_val->type);
+                                    agg_vec = ray_vec_new(vt, out_groups);
+                                    if (!agg_vec || RAY_IS_ERR(agg_vec)) { ray_release(agg_val); break; }
+                                    agg_vec->len = out_groups;
+                                }
+                                store_typed_elem(agg_vec, gi, agg_val);
+                                ray_release(agg_val);
+                            }
                         }
                         ray_release(src_col_val);
                         agg_names[n_agg_out] = kid;
@@ -5301,6 +5362,67 @@ by_dict_done:
                     /* For each group, compute aggregation */
                     ray_t* agg_vec = NULL;
                     ray_t** grp_items = (ray_t**)ray_data(groups);
+
+                    /* Median fast path — see the twin site above for
+                     * rationale (skips per-group ray_at_fn + ray_med_fn
+                     * scratch allocations). */
+                    bool med_fast = is_med_call(val_expr_item) &&
+                        (src_col_val->type == RAY_F64 || src_col_val->type == RAY_I64 ||
+                         src_col_val->type == RAY_I32 || src_col_val->type == RAY_I16 ||
+                         src_col_val->type == RAY_U8);
+                    if (med_fast) {
+                        int8_t  t = src_col_val->type;
+                        int64_t max_cnt = 0;
+                        for (int64_t gi = 0; gi < n_groups; gi++) {
+                            int64_t c = ray_len(grp_items[gi * 2 + 1]);
+                            if (c > max_cnt) max_cnt = c;
+                        }
+                        agg_vec = ray_vec_new(RAY_F64, n_groups);
+                        if (agg_vec && !RAY_IS_ERR(agg_vec)) {
+                            agg_vec->len = n_groups;
+                            double* out_data = (double*)ray_data(agg_vec);
+                            ray_t* sch_hdr = NULL;
+                            double* scratch = max_cnt > 0
+                                ? (double*)scratch_alloc(&sch_hdr,
+                                      (size_t)max_cnt * sizeof(double))
+                                : NULL;
+                            bool ok = (max_cnt == 0) || (scratch != NULL);
+                            bool has_nulls = (src_col_val->attrs & RAY_ATTR_HAS_NULLS) != 0;
+                            const uint8_t* null_bm = has_nulls
+                                ? ray_vec_nullmap_bytes(src_col_val, NULL, NULL) : NULL;
+                            const void* base = ray_data(src_col_val);
+                            for (int64_t gi = 0; gi < n_groups && ok; gi++) {
+                                ray_t* idx_list = grp_items[gi * 2 + 1];
+                                int64_t cnt = ray_len(idx_list);
+                                if (cnt == 0) { out_data[gi] = 0.0; ray_vec_set_null(agg_vec, gi, true); continue; }
+                                int64_t* idx_data = (int64_t*)ray_data(idx_list);
+                                int64_t actual = 0;
+                                for (int64_t i = 0; i < cnt; i++) {
+                                    int64_t row = idx_data[i];
+                                    if (null_bm && ((null_bm[row >> 3] >> (row & 7)) & 1)) continue;
+                                    double v;
+                                    switch (t) {
+                                        case RAY_F64: memcpy(&v, (const char*)base + (size_t)row * 8, 8); break;
+                                        case RAY_I64: { int64_t iv; memcpy(&iv, (const char*)base + (size_t)row * 8, 8); v = (double)iv; break; }
+                                        case RAY_I32: { int32_t iv; memcpy(&iv, (const char*)base + (size_t)row * 4, 4); v = (double)iv; break; }
+                                        case RAY_I16: { int16_t iv; memcpy(&iv, (const char*)base + (size_t)row * 2, 2); v = (double)iv; break; }
+                                        case RAY_U8:  v = (double)((const uint8_t*)base)[row]; break;
+                                        default:      v = 0.0; break;
+                                    }
+                                    scratch[actual++] = v;
+                                }
+                                if (actual == 0) { out_data[gi] = 0.0; ray_vec_set_null(agg_vec, gi, true); continue; }
+                                out_data[gi] = ray_median_dbl_inplace(scratch, actual);
+                            }
+                            if (sch_hdr) scratch_free(sch_hdr);
+                        }
+                        ray_release(src_col_val);
+                        agg_names[n_agg_out] = kid;
+                        agg_results[n_agg_out] = agg_vec;
+                        n_agg_out++;
+                        continue;
+                    }
+
                     for (int64_t gi = 0; gi < n_groups; gi++) {
                         ray_t* idx_list = grp_items[gi * 2 + 1];
                         ray_t* subset = ray_at_fn(src_col_val, idx_list);

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -5870,9 +5870,58 @@ by_dict_done:
                                               key_ops, n_keys,
                                               agg_ops, agg_ins, n_aggs);
                 } else if (has_agg_k) {
-                    root = ray_group3(g, key_ops, n_keys, agg_ops,
-                                       agg_ins, has_binary_agg ? agg_ins2 : NULL,
-                                       agg_k, n_aggs);
+                    /* Fast path: dedicated row-form emit for the exact
+                     * shape `(select (top|bot col K) from T by single_key)`.
+                     * Avoids the OP_GROUP + radix-HT + LIST<K> + adapter-
+                     * side explode pipeline; two-phase parallel hashed
+                     * top-K with direct (key, val) row emission.  Falls
+                     * through to ray_group3 for any unsupported shape.
+                     *
+                     * Restricted to non-SYM key/val column types — SYM
+                     * columns and LIST/STR/GUID stay on the OP_TOP_N path
+                     * so prior callers depending on LIST-cell output
+                     * (existing rfl tests) keep their semantics.  q8
+                     * canonical (I64 id6 + F64 v3) hits this path. */
+                    int rowform_ok = 0;
+                    if (n_aggs == 1 && n_keys == 1 && n_nonaggs == 0
+                        && !where_expr
+                        && (agg_ops[0] == OP_TOP_N || agg_ops[0] == OP_BOT_N)
+                        && agg_k[0] >= 1 && agg_k[0] <= 255
+                        && key_ops[0] && key_ops[0]->opcode == OP_SCAN
+                        && agg_ins[0] && agg_ins[0]->opcode == OP_SCAN)
+                    {
+                        /* Resolve key/val column types from the bound
+                         * table — only route numeric/temporal types
+                         * the executor handles. */
+                        ray_op_ext_t* kext = find_ext(g, key_ops[0]->id);
+                        ray_op_ext_t* vext = find_ext(g, agg_ins[0]->id);
+                        ray_t* kc = (kext && tbl) ? ray_table_get_col(tbl, kext->sym) : NULL;
+                        ray_t* vc = (vext && tbl) ? ray_table_get_col(tbl, vext->sym) : NULL;
+                        if (kc && vc) {
+                            int8_t kt = kc->type, vt = vc->type;
+                            int kt_ok = (kt == RAY_I64 || kt == RAY_I32 ||
+                                         kt == RAY_I16 || kt == RAY_U8 ||
+                                         kt == RAY_BOOL || kt == RAY_DATE ||
+                                         kt == RAY_TIME || kt == RAY_TIMESTAMP ||
+                                         kt == RAY_F64);
+                            int vt_ok = (vt == RAY_I64 || vt == RAY_I32 ||
+                                         vt == RAY_I16 || vt == RAY_U8 ||
+                                         vt == RAY_BOOL || vt == RAY_DATE ||
+                                         vt == RAY_TIME || vt == RAY_TIMESTAMP ||
+                                         vt == RAY_F64);
+                            if (kt_ok && vt_ok) rowform_ok = 1;
+                        }
+                    }
+                    if (rowform_ok) {
+                        uint8_t desc = (agg_ops[0] == OP_TOP_N) ? 1 : 0;
+                        root = ray_group_topk_rowform(g, key_ops[0],
+                                                      agg_ins[0],
+                                                      agg_k[0], desc);
+                    } else {
+                        root = ray_group3(g, key_ops, n_keys, agg_ops,
+                                           agg_ins, has_binary_agg ? agg_ins2 : NULL,
+                                           agg_k, n_aggs);
+                    }
                 } else if (has_binary_agg) {
                     root = ray_group2(g, key_ops, n_keys, agg_ops,
                                        agg_ins, agg_ins2, n_aggs);

--- a/test/rfl/integration/canonical_h2o.rfl
+++ b/test/rfl/integration/canonical_h2o.rfl
@@ -96,6 +96,27 @@
 ;; (A,X) max = 3, (A,Y) max = 2, (B,X) max = 4, (B,Y) max = 6
 (count (select {top: (take (desc v) 1) by: [g h] from: Tq8b})) -- 4
 
+;; ─── q8 native: (top col K) / (bot col K) aggregators ──────────────
+;;
+;; The OP_TOP_N / OP_BOT_N DAG-route — same canonical Tq8 as above
+;; but using the native bounded-heap aggregator instead of the
+;; (take (desc v) K) composition.  Result is a LIST<vec> per group.
+;;   A → [5 3] (top-2 of {3,1,5}), B → [7 2], C → [9 8]
+(count (select {top2: (top v3 2) by: id6 from: Tq8})) -- 3
+;; sum of (count of each list) == total kept across groups
+;;   A: min(3,2)=2, B: min(2,2)=2, C: min(4,2)=2 → 6
+(sum (map count (at (select {top2: (top v3 2) by: id6 from: Tq8}) 'top2))) -- 6
+;; Symmetric for bot: A→[1 3], B→[2 7], C→[4 6]
+(count (select {bot2: (bot v3 2) by: id6 from: Tq8})) -- 3
+;; F64 source preserves cell type: each cell is a vec of doubles
+(set Tq8f (table [id v] (list [A A A B B C C C C] [3.0 1.0 5.0 2.0 7.0 4.0 9.0 6.0 8.0])))
+(type (at (at (select {t: (top v 2) by: id from: Tq8f}) 't) 0)) -- 'F64
+;; K > grp_cnt → cell shorter than K (matches standalone topk_take_vec)
+;; Tq8 group B has 2 rows {2,7}; K=3 → cell length 2
+(count (at (at (select {t: (top v3 3) by: id6 from: Tq8}) 't) 1)) -- 2
+;; K=1 → 1-element cell, equivalent to (max v3) wrapped in a vec
+(at (at (select {t: (top v3 1) by: id6 from: Tq8}) 't) 0) -- [5]
+
 ;; ─── Composite-key correctness regression for the atom_eq fix ─────
 ;;
 ;; The exact shape that exposed the atom_eq RAY_LIST bug — confirms

--- a/test/test_dump.c
+++ b/test/test_dump.c
@@ -123,6 +123,7 @@ static test_result_t test_dump_opcode_name_all(void) {
         { OP_STDDEV,"STDDEV"}, { OP_STDDEV_POP,"STDDEV_POP"},
         { OP_VAR,"VAR"}, { OP_VAR_POP,"VAR_POP"},
         { OP_PEARSON_CORR,"PEARSON_CORR"},
+        { OP_MEDIAN,"MEDIAN"},
         { OP_FILTER,"FILTER"}, { OP_SORT,"SORT"}, { OP_GROUP,"GROUP"},
         { OP_PIVOT,"PIVOT"}, { OP_ANTIJOIN,"ANTIJOIN"}, { OP_JOIN,"JOIN"},
         { OP_WINDOW_JOIN,"WINDOW_JOIN"}, { OP_SELECT,"SELECT"},

--- a/test/test_dump.c
+++ b/test/test_dump.c
@@ -122,6 +122,7 @@ static test_result_t test_dump_opcode_name_all(void) {
         { OP_COUNT_DISTINCT,"COUNT_DISTINCT"},
         { OP_STDDEV,"STDDEV"}, { OP_STDDEV_POP,"STDDEV_POP"},
         { OP_VAR,"VAR"}, { OP_VAR_POP,"VAR_POP"},
+        { OP_PEARSON_CORR,"PEARSON_CORR"},
         { OP_FILTER,"FILTER"}, { OP_SORT,"SORT"}, { OP_GROUP,"GROUP"},
         { OP_PIVOT,"PIVOT"}, { OP_ANTIJOIN,"ANTIJOIN"}, { OP_JOIN,"JOIN"},
         { OP_WINDOW_JOIN,"WINDOW_JOIN"}, { OP_SELECT,"SELECT"},


### PR DESCRIPTION
## Summary

17 commits closing the perf gap to DuckDB on canonical H2O queries q6 (median+stddev), q8 (top-2 per group), q9 (pearson²). New DAG opcodes + dedicated post-radix passes + supporting infra fixes.

Stacks on top of #202.

### New opcodes (DAG-routed aggregates)

| query | opcode | algorithm |
|---|---|---|
| q9 (pearson_corr) | \`OP_PEARSON_CORR\` | vectorized single-pass hash-agg (n·Σxy − Σx·Σy) / sqrt(...) inline in radix HT |
| q6 (median) | \`OP_MEDIAN\` | post-radix bucket-scatter (idx_buf from row_gid+grp_cnt) + per-group parallel quickselect |
| q8 (top-N) | \`OP_TOP_N\` / \`OP_BOT_N\` | post-radix bounded-heap per group → LIST<F64>[K] cells |
| q8 (alternate fast path) | \`OP_GROUP_TOPK_ROWFORM\` | dedicated morsel-driven scatter + L2-hot per-partition HTs with inline K-slot heap → direct row-form emit (skips radix HT, idx_buf, LIST intermediate) |

### Supporting fixes
- \`perf(raze): O(N) fast path for same-typed numeric vectors\` (bed7f7a2) — was O(N²) pairwise concat
- \`fix(group): per-group dispatch survives n_groups > 65536\` (f2b5f159) — \`ray_pool_dispatch_n\` silently clamps tasks at MAX_RING_CAP=65536
- \`perf(group): cap histscat tasks at worker count\` (9771a017) — hist matrix sized [n_tasks × n_groups] was 1GB+ for 100k groups; cap to ~n_workers

### Perf numbers (10M rows, k=100 cardinality)

| query | rayforce before | rayforce after | duckdb | ratio |
|---|---:|---:|---:|---:|
| q6 | ~5550 ms (eval-fallback) | **120 ms** | 178 ms | **1.5× faster** |
| q8 | ~400 ms (eval-fallback) → 215 ms (DAG + explode) | **40 ms** | 157 ms | **4× faster** |
| q9 | ~7000 ms (eval-fallback) → 49 ms | **49 ms** | 78 ms | **1.6× faster** |

q8 win comes from the dedicated \`OP_GROUP_TOPK_ROWFORM\` operator: per-worker scatter into (worker, partition) buffers in phase 1; phase 2 builds L2-hot per-partition HTs (~400 entries each, fits L1) with inline K-slot bounded-heap and emits row-form directly. Skips the radix HT, idx_buf materialization, LIST<F64>[K] intermediate, and explode step. Pattern follows Siddiqui et al. VLDB 2024 ("Cache-Efficient Top-k Aggregation over High Cardinality Large Datasets").

### Related

- RayforceDB/rayforce-py#12 — Python wrappers
- RayforceDB/rayforce-bench PR (forthcoming) — bench adapter consuming these

## Test plan
- [x] \`make test\` passes (2406/2407, 1 skipped, 0 failed)
- [x] Cross-adapter correctness via \`make check LOCAL=1\` → \`pass — 665/665 comparisons matched polars, 0 NYI\`
- [x] Bench numbers above reproduced with rayforce-bench harness at 10M k=100 (3 warmup + 7 iters)


## Known limitations
- **Parted columns + `OP_GROUP_TOPK_ROWFORM`**: the new row-form top/bot operator reads source columns via `ray_data(col)` assuming contiguous data. If `col` is parted (segments via `.csv.parted` / `.csv.splayed` loaders introduced in #5944632e), `ray_data` returns the segment-array pointer, not contiguous values. Planner gate currently does NOT check `RAY_IS_PARTED(col->type)` before routing to this opcode. Current bench (`Table.from_csv` regular path) is not affected. Follow-up needed before parted-column production use: either add a parted-aware fallback to `OP_GROUP` in the planner gate, or extend the kernel to iterate per-segment.
