### PR TITLE
Coverage push + 5 bug fixes — group/query/cmp/agg

### DIFF
--- a/src/ops/cmp.c
+++ b/src/ops/cmp.c
@@ -273,9 +273,13 @@ static ray_t* eval_and_short(ray_t* arg) {
 }
 
 ray_t* ray_and_vary_fn(ray_t** args, int64_t n) {
-    if (n < 2) return ray_error("arity", "expected at least 2 args, got %lld", (long long)n);
+    if (n < 1) return ray_error("arity", "expected at least 1 arg, got %lld", (long long)n);
     ray_t* acc = eval_and_short(args[0]);
     if (!acc || RAY_IS_ERR(acc)) return acc;
+    /* Single arg = identity: (and X) == X, (or X) == X — monoid identity
+     * rule (Scheme/Haskell).  Enables programmatic AST construction like
+     * `(cons 'and preds)` where preds may have length 1. */
+    if (n == 1) return acc;
     /* Short-circuit only when the running result is a *scalar* falsy.
      * If acc is a vector, subsequent args still need element-wise
      * combination (so `(and vec false)` broadcasts to all-false vector
@@ -295,9 +299,11 @@ ray_t* ray_and_vary_fn(ray_t** args, int64_t n) {
 }
 
 ray_t* ray_or_vary_fn(ray_t** args, int64_t n) {
-    if (n < 2) return ray_error("arity", "expected at least 2 args, got %lld", (long long)n);
+    if (n < 1) return ray_error("arity", "expected at least 1 arg, got %lld", (long long)n);
     ray_t* acc = eval_and_short(args[0]);
     if (!acc || RAY_IS_ERR(acc)) return acc;
+    /* Single arg = identity — see ray_and_vary_fn for rationale. */
+    if (n == 1) return acc;
     /* Short-circuit only on scalar truthy accumulator (see AND comment). */
     if (ray_is_atom(acc) && is_truthy(acc)) return acc;
     for (int64_t i = 1; i < n; i++) {

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -1675,6 +1675,7 @@ static ray_t* reduction_i64_result(int64_t val, int8_t out_type) {
         case RAY_I32:       return ray_i32((int32_t)val);
         case RAY_I16:       return ray_i16((int16_t)val);
         case RAY_U8:        return ray_u8((uint8_t)val);
+        case RAY_SYM:       return ray_sym(val);
         default:            return ray_i64(val);
     }
 }

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -1171,6 +1171,17 @@ ray_op_t* compile_expr_dag(ray_graph_t* g, ray_t* expr) {
          * Balanced tree (rather than left-fold) keeps the canonical
          * shape symmetric and minimises dependency-chain depth, which
          * future OoO / parallel-instruction executors can exploit. */
+        /* (and X) / (or X) — single conjunct = identity.  Matches the
+         * eval-level monoid identity rule in ray_and_vary_fn /
+         * ray_or_vary_fn; without it, `where: (and X)` would fall
+         * through to compile_expr_dag returning NULL → domain error. */
+        if (n == 2) {
+            bool is_and1 = (fname_len == 3 && memcmp(fname, "and", 3) == 0);
+            bool is_or1  = (fname_len == 2 && memcmp(fname, "or",  2) == 0);
+            if (is_and1 || is_or1) {
+                return compile_expr_dag(g, elems[1]);
+            }
+        }
         if (n >= 4) {
             bool is_and = (fname_len == 3 && memcmp(fname, "and", 3) == 0);
             bool is_or  = (fname_len == 2 && memcmp(fname, "or",  2) == 0);

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -2003,6 +2003,21 @@ static ray_t* nonagg_eval_per_group_core(ray_t* expr, ray_t* tbl,
             if (result) ray_release(result);
             return cell ? cell : ray_error("domain", NULL);
         }
+        /* Materialise lazy cells before storing.  Per-group projection
+         * eval can return a RAY_LAZY (e.g. (reverse v) returns a fresh
+         * lazy chain).  Lazy values stored as-is in a LIST get their
+         * graph stolen by the first ray_lazy_materialize via fmt_obj,
+         * leaving subsequent reads with a half-dead lazy whose execute
+         * fails with "nyi".  Eager materialisation here keeps each cell
+         * concrete and re-readable. */
+        if (ray_is_lazy(cell)) {
+            cell = ray_lazy_materialize(cell);
+            if (!cell || RAY_IS_ERR(cell)) {
+                ray_env_pop_scope();
+                if (result) ray_release(result);
+                return cell ? cell : ray_error("domain", NULL);
+            }
+        }
 
         if (gi == 0) {
             int8_t t = cell->type;

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -1782,6 +1782,77 @@ static bool bounded_multikey_count_take_candidate(ray_t** dict_elems, int64_t di
  * expr is full-table-evaluable.  Anything where the outer call is
  * not a plain `(count …)` or the inner is not a plain `(distinct …)`
  * is rejected so the eval fallback handles it. */
+/* AST-level idiom rewrites for per-group aggregator slot.
+ *
+ * Mirrors the DAG-level rewrites in src/ops/idiom.c, but at the AST
+ * stage — idiom.c's DAG pass walks `inputs[]` only, so it never reaches
+ * agg subtrees that live in OP_GROUP's ext->agg_ins[].  Without this,
+ * `(select {m: (first (asc v)) by: k from: T})` errors `domain` while
+ * the equivalent `(min v)` works.
+ *
+ * Patterns recognised (parallel to idiom.c's ray_idioms table):
+ *   (first (asc col))    -> (min col)    if col is null-free
+ *   (last  (asc col))    -> (max col)    if col is null-free
+ *   (count (asc col))    -> (count col)
+ *   (count (desc col))   -> (count col)
+ *   (count (reverse col))-> (count col)
+ *
+ * The null-free precondition for first/last matches idiom.c's
+ * pre_no_nulls_on_asc_input — first(asc null-bearing) returns the null
+ * (xasc puts nulls first) while min(...) skips nulls.
+ *
+ * On match: *op_out and *arg_out point to the simpler op + col expr;
+ * caller builds agg_ins[i] from *arg_out.  Returns true if rewritten. */
+static bool simplify_agg_idiom(ray_t* val_expr, ray_t* tbl,
+                                uint16_t* op_out, ray_t** arg_out) {
+    if (!val_expr || val_expr->type != RAY_LIST || ray_len(val_expr) < 2) return false;
+    ray_t** outer = (ray_t**)ray_data(val_expr);
+    if (!outer[0] || outer[0]->type != -RAY_SYM) return false;
+    ray_t* outer_nm = ray_sym_str(outer[0]->i64);
+    if (!outer_nm) return false;
+    const char* op_s = ray_str_ptr(outer_nm);
+    size_t op_n = ray_str_len(outer_nm);
+
+    ray_t* inner = outer[1];
+    if (!inner || inner->type != RAY_LIST || ray_len(inner) < 2) return false;
+    ray_t** inner_e = (ray_t**)ray_data(inner);
+    if (!inner_e[0] || inner_e[0]->type != -RAY_SYM) return false;
+    ray_t* inner_nm = ray_sym_str(inner_e[0]->i64);
+    if (!inner_nm) return false;
+    const char* wrap_s = ray_str_ptr(inner_nm);
+    size_t wrap_n = ray_str_len(inner_nm);
+    ray_t* col_expr = inner_e[1];
+
+    bool wrap_is_asc     = (wrap_n == 3 && memcmp(wrap_s, "asc", 3) == 0);
+    bool wrap_is_desc    = (wrap_n == 4 && memcmp(wrap_s, "desc", 4) == 0);
+    bool wrap_is_reverse = (wrap_n == 7 && memcmp(wrap_s, "reverse", 7) == 0);
+    if (!wrap_is_asc && !wrap_is_desc && !wrap_is_reverse) return false;
+
+    /* (count (asc|desc|reverse col)) -> (count col) — cardinality preserved */
+    if (op_n == 5 && memcmp(op_s, "count", 5) == 0) {
+        *op_out = OP_COUNT;
+        *arg_out = col_expr;
+        return true;
+    }
+
+    /* (first|last (asc col)) -> (min|max col) — only when col is null-free */
+    if (!wrap_is_asc) return false;
+    bool is_first = (op_n == 5 && memcmp(op_s, "first", 5) == 0);
+    bool is_last  = (op_n == 4 && memcmp(op_s, "last",  4) == 0);
+    if (!is_first && !is_last) return false;
+
+    /* Null-free precondition: col_expr must be a column ref naming a
+     * null-free col of tbl.  Mirrors idiom.c:pre_no_nulls_on_asc_input. */
+    if (!col_expr || col_expr->type != -RAY_SYM || !(col_expr->attrs & RAY_ATTR_NAME))
+        return false;
+    ray_t* col = ray_table_get_col(tbl, col_expr->i64);
+    if (!col || (col->attrs & RAY_ATTR_HAS_NULLS)) return false;
+
+    *op_out = is_first ? OP_MIN : OP_MAX;
+    *arg_out = col_expr;
+    return true;
+}
+
 static ray_t* match_count_distinct(ray_t* expr) {
     if (!expr || expr->type != RAY_LIST) return NULL;
     int64_t n = ray_len(expr);
@@ -5807,9 +5878,21 @@ by_dict_done:
             if (is_group_dag_agg_expr(val_expr) && n_aggs < 16) {
                 ray_t** agg_elems = (ray_t**)ray_data(val_expr);
                 uint16_t op = resolve_agg_opcode(agg_elems[0]->i64);
+                ray_t* agg_arg = agg_elems[1];
+                /* AST-level idiom rewrite — see simplify_agg_idiom comment.
+                 * Resolves (first (asc col)) / (last (asc col)) and
+                 * (count (asc|desc|reverse col)) before agg_ins is built. */
+                {
+                    uint16_t new_op;
+                    ray_t* new_arg;
+                    if (simplify_agg_idiom(val_expr, tbl, &new_op, &new_arg)) {
+                        op = new_op;
+                        agg_arg = new_arg;
+                    }
+                }
                 agg_ops[n_aggs] = op;
                 /* Compile the aggregation input (the column reference) */
-                agg_ins[n_aggs] = compile_expr_dag(g, agg_elems[1]);
+                agg_ins[n_aggs] = compile_expr_dag(g, agg_arg);
                 if (!agg_ins[n_aggs]) { ray_graph_free(g); ray_release(tbl); return ray_error("domain", NULL); }
                 agg_ins2[n_aggs] = NULL;
                 agg_k[n_aggs] = 0;

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -313,7 +313,7 @@ static uint16_t resolve_agg_opcode(int64_t sym_id) {
     if (len == 3 && memcmp(name, "avg",   3) == 0) return OP_AVG;
     if (len == 3 && memcmp(name, "min",   3) == 0) return OP_MIN;
     if (len == 3 && memcmp(name, "max",   3) == 0) return OP_MAX;
-    if (len == 3 && memcmp(name, "dev",   3) == 0) return OP_STDDEV;
+    if (len == 3 && memcmp(name, "dev",   3) == 0) return OP_STDDEV_POP;
     if (len == 3 && memcmp(name, "var",   3) == 0) return OP_VAR;
     if (len == 4 && memcmp(name, "prod",  4) == 0) return OP_PROD;
     if (len == 4 && memcmp(name, "last",  4) == 0) return OP_LAST;

--- a/test/rfl/agg/min_max_sym.rfl
+++ b/test/rfl/agg/min_max_sym.rfl
@@ -1,0 +1,32 @@
+;; Bug 1: (min SYM_vec) / (max SYM_vec) must return a SYM atom.
+;;
+;; Before fix: returned int64 (the internal sym id) — type lost.
+;; After fix: returns SYM atom; type preserved.
+;;
+;; Root cause: src/ops/group.c:reduction_i64_result switch had no
+;; case for RAY_SYM, so SYM out_type fell through to ray_i64(val).
+
+;; ─── Singleton: trivially min == max == only element ──────────────
+(min ['x]) -- 'x
+(max ['x]) -- 'x
+(type (min ['x])) -- 'sym
+(type (max ['x])) -- 'sym
+
+;; ─── Two elements ────────────────────────────────────────────────
+;; min/max over SYM uses internal id order (insertion order in this
+;; case). Whatever the first-interned wins for min, last-interned for
+;; max — but type must be SYM in both cases.
+(type (min ['alpha 'beta])) -- 'sym
+(type (max ['alpha 'beta])) -- 'sym
+
+;; ─── Identity round-trip: min of repeated single sym is that sym ──
+(min ['foo 'foo 'foo 'foo]) -- 'foo
+(max ['foo 'foo 'foo 'foo]) -- 'foo
+(type (min ['foo 'foo 'foo 'foo])) -- 'sym
+(type (max ['foo 'foo 'foo 'foo])) -- 'sym
+
+;; ─── Comparison round-trip ────────────────────────────────────────
+;; (== (min v) <some-sym>) must work — verifies SYM atom equality
+;; survives the reduction
+(== (min ['z 'z 'z]) 'z) -- true
+(== (max ['z 'z 'z]) 'z) -- true

--- a/test/rfl/agg/per_group_holistic.rfl
+++ b/test/rfl/agg/per_group_holistic.rfl
@@ -1,0 +1,316 @@
+;; ════════════════════════════════════════════════════════════════════
+;; Per-group holistic aggregators in src/ops/group.c.
+;;
+;; Holistic aggregators (med/median, top/bot K, var/var_pop/stddev/
+;; stddev_pop) cannot be merged from a partial-row layout the way
+;; sum/count/min/max can — each group's full payload must be visible
+;; before the answer materialises.  The kernels under test:
+;;
+;;   - ray_median_per_group_buf : bucket-scatter + quickselect per group
+;;   - ray_topk_per_group_buf   : bounded heap per group (K parameter)
+;;   - OP_VAR / OP_STDDEV (and _pop) per-group : single-pass sum + sumsq
+;;     accumulator, finalised post-radix from off_sumsq slot
+;;
+;; Existing tests already cover the row-form (top/bot K with a single
+;; OP_SCAN key + agg, no where) and the count_distinct / pearson_corr
+;; paths.  This file targets the *generic per-group* code path —
+;; specifically the eval-level scatter that runs when:
+;;
+;;   - the agg is med/var/stddev/stddev_pop/var_pop (any per-group),
+;;   - multiple aggregators in one select share the same group key,
+;;   - top/bot K against a SYM key (falls through to OP_TOP_N path).
+;;
+;; All assertions are happy-path; any genuine wrong-output or domain
+;; error is left visible (per CRITICAL RULE) — none observed in this
+;; round.
+;; ════════════════════════════════════════════════════════════════════
+
+
+;; ─── median per group: I64 value, I64 key ───────────────────────────
+;;   g=0 → [10 30 20 50 40] → median 30.0
+;;   g=1 → [5 15]           → median 10.0  (avg of 5, 15)
+;;   g=2 → [100]            → median 100.0  (1-element group)
+(set Tmed (table [g v] (list (as 'I64 [0 0 0 0 0 1 1 2]) (as 'I64 [10 30 20 50 40 5 15 100]))))
+(count (select {m: (med v) by: g from: Tmed})) -- 3
+(sum (at (select {m: (med v) by: g from: Tmed}) 'm)) -- 140.0
+(type (at (select {m: (med v) by: g from: Tmed}) 'm)) -- 'F64
+
+
+;; ─── median per group: F64 value ────────────────────────────────────
+;;   g=0 → [1.5 2.5 3.5 4.5]  → 3.0
+;;   g=1 → [10.0 20.0 30.0]   → 20.0
+;;   g=2 → [7.5 7.5 7.5 7.5]  → 7.5
+(set Tmedf (table [g v] (list (as 'I64 [0 0 0 0 1 1 1 2 2 2 2]) (as 'F64 [1.5 2.5 3.5 4.5 10.0 20.0 30.0 7.5 7.5 7.5 7.5]))))
+(count (select {m: (med v) by: g from: Tmedf})) -- 3
+(sum (at (select {m: (med v) by: g from: Tmedf}) 'm)) -- 30.5
+(type (at (select {m: (med v) by: g from: Tmedf}) 'm)) -- 'F64
+
+
+;; ─── median per group: narrow integer (I32) ─────────────────────────
+;;   g=0 → [1 2 3 4 5]   → 3.0
+;;   g=1 → [10 20 30]    → 20.0
+(set Tmedi32 (table [g v] (list (as 'I64 [0 0 0 0 0 1 1 1]) (as 'I32 [1 2 3 4 5 10 20 30]))))
+(count (select {m: (med v) by: g from: Tmedi32})) -- 2
+(sum (at (select {m: (med v) by: g from: Tmedi32}) 'm)) -- 23.0
+
+
+;; ─── median per group: multi-key SYM ────────────────────────────────
+;;
+;; Multi-key by-clause forces the eval-level group path (DAG fast
+;; scatter is single-key).  Mirrors canonical_h2o q6:
+;;   (A,X) → [10]      → 10
+;;   (A,Y) → [20, 60]  → 40
+;;   (B,X) → [30, 50]  → 40
+;;   (B,Y) → [40]      → 40
+;;   sum 130.0
+(set Tmm (table [id1 id2 v] (list [A A B B B A] [X Y X Y X Y] (as 'F64 [10.0 20.0 30.0 40.0 50.0 60.0]))))
+(count (select {m: (med v) by: [id1 id2] from: Tmm})) -- 4
+(sum (at (select {m: (med v) by: [id1 id2] from: Tmm}) 'm)) -- 130.0
+
+
+;; ─── top-K / bot-K per group via SYM key (LIST-cell path) ───────────
+;;
+;; SYM keys fall through the row-form gate (rowform_topk owns the
+;; non-SYM path); this exercises the OP_TOP_N per-group cell path
+;; backed by ray_topk_per_group_buf.  Result is a LIST<vec> column.
+;;
+;;   A → v={3,1,5}      top-2 = [5,3], bot-2 = [1,3]
+;;   B → v={2,7}        top-2 = [7,2], bot-2 = [2,7]
+;;   C → v={4,9,6,8}    top-2 = [9,8], bot-2 = [4,6]
+(set Ttop (table [k v] (list [A A A B B C C C C] (as 'I64 [3 1 5 2 7 4 9 6 8]))))
+(count (select {t: (top v 2) by: k from: Ttop})) -- 3
+(count (select {b: (bot v 2) by: k from: Ttop})) -- 3
+;; cell-wise counts: top-2 cell sizes = min(3,2)+min(2,2)+min(4,2) = 6
+(sum (map count (at (select {t: (top v 2) by: k from: Ttop}) 't))) -- 6
+;; total of all top-2 elements across cells (flatten via raze, then sum):
+;; (5+3)+(7+2)+(9+8) = 34
+(sum (raze (at (select {t: (top v 2) by: k from: Ttop}) 't))) -- 34
+;; bot-2 sum across all cells = (1+3)+(2+7)+(4+6) = 23
+(sum (raze (at (select {b: (bot v 2) by: k from: Ttop}) 'b))) -- 23
+
+
+;; ─── top-K=1 per group (degenerates to per-group max via LIST-cell) ──
+;; sum across cells == sum of per-group max = 5 + 7 + 9 = 21; bot = 1 + 2 + 4 = 7.
+(sum (raze (at (select {t: (top v 1) by: k from: Ttop}) 't))) -- 21
+(sum (raze (at (select {b: (bot v 1) by: k from: Ttop}) 'b))) -- 7
+
+
+;; ─── top-K=N (K >= group size): cells cap at group size, no padding ──
+;; K=4: group A 3 elts, group B 2 elts, group C 4 elts; total 9; sum 45.
+(sum (map count (at (select {t: (top v 4) by: k from: Ttop}) 't))) -- 9
+(sum (raze (at (select {t: (top v 4) by: k from: Ttop}) 't))) -- 45
+
+
+;; ─── top-K per group with F64 value (cell preserves type) ───────────
+(set Ttopf (table [k v] (list [A A A B B C C C C] (as 'F64 [3.5 1.5 5.5 2.5 7.5 4.5 9.5 6.5 8.5]))))
+(count (select {t: (top v 2) by: k from: Ttopf})) -- 3
+(type (at (at (select {t: (top v 2) by: k from: Ttopf}) 't) 0)) -- 'F64
+;; top-2 sum = (5.5+3.5) + (7.5+2.5) + (9.5+8.5) = 9 + 10 + 18 = 37.0
+(sum (raze (at (select {t: (top v 2) by: k from: Ttopf}) 't))) -- 37.0
+
+
+;; ─── variance / stddev per group: canonical Wikipedia fixture ───────
+;; Two copies of [2 4 4 4 5 5 7 9] under two group keys.  Per-group:
+;;   pop_var      = 4.0   → sum_g 8.0
+;;   pop_stddev   = 2.0   → sum_g 4.0
+;;   sample_var   = 32/7  → sum_g 64/7 ≈ 9.142857
+;;   sample_stddev= √(32/7) → sum_g 2 * √(32/7) ≈ 4.276179
+(set Tvar (table [g v] (list (as 'I64 [0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1]) (as 'I64 [2 4 4 4 5 5 7 9 2 4 4 4 5 5 7 9]))))
+(count (select {v: (var_pop v) by: g from: Tvar})) -- 2
+(count (select {v: (stddev_pop v) by: g from: Tvar})) -- 2
+(count (select {v: (var v) by: g from: Tvar})) -- 2
+(count (select {v: (stddev v) by: g from: Tvar})) -- 2
+
+;; Population variance / stddev — exact integer answers.
+(sum (at (select {v: (var_pop v) by: g from: Tvar}) 'v))    -- 8.0
+(sum (at (select {v: (stddev_pop v) by: g from: Tvar}) 'v)) -- 4.0
+;; Asymmetry: scalar `dev` aliases stddev_pop (ray_stddev_pop_fn at
+;; agg.c:625-628), but in a select-by, query.c:316 maps `dev` →
+;; OP_STDDEV (sample), NOT OP_STDDEV_POP.  Per-group `dev` therefore
+;; equals per-group sample stddev — sum across 2 groups = 2 * √(32/7).
+;; (Locking this in: changing the planner mapping would surface as a
+;; failing assertion here.)
+(< (abs (- (sum (at (select {v: (dev v) by: g from: Tvar}) 'v)) (* 2.0 2.138089935299395))) 0.000001) -- true
+;; Sanity: stddev_pop (explicit) sums to 4.0 (= 2 * 2.0).
+(sum (at (select {v: (stddev_pop v) by: g from: Tvar}) 'v)) -- 4.0
+;; Per-group dev != per-group stddev_pop (because of the asymmetry):
+(< (abs (- (sum (at (select {v: (dev v) by: g from: Tvar}) 'v)) (sum (at (select {v: (stddev_pop v) by: g from: Tvar}) 'v)))) 0.001) -- false
+
+;; Sample variance / stddev — fp tolerance.
+(< (abs (- (sum (at (select {v: (var v) by: g from: Tvar}) 'v)) (* 2.0 4.571428571428571))) 0.000001) -- true
+(< (abs (- (sum (at (select {v: (stddev v) by: g from: Tvar}) 'v)) (* 2.0 2.138089935299395))) 0.000001) -- true
+
+;; Result column type is F64 for every variant.
+(type (at (select {v: (var v) by: g from: Tvar}) 'v))        -- 'F64
+(type (at (select {v: (var_pop v) by: g from: Tvar}) 'v))    -- 'F64
+(type (at (select {v: (stddev v) by: g from: Tvar}) 'v))     -- 'F64
+(type (at (select {v: (stddev_pop v) by: g from: Tvar}) 'v)) -- 'F64
+
+
+;; ─── variance / stddev per group: F64 source ────────────────────────
+(set TvarF (table [g v] (list (as 'I64 [0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1]) (as 'F64 [2.0 4.0 4.0 4.0 5.0 5.0 7.0 9.0 2.0 4.0 4.0 4.0 5.0 5.0 7.0 9.0]))))
+(sum (at (select {v: (var_pop v) by: g from: TvarF}) 'v))    -- 8.0
+(sum (at (select {v: (stddev_pop v) by: g from: TvarF}) 'v)) -- 4.0
+
+
+;; ─── variance per group: constant group → 0.0 ───────────────────────
+(set Tconst (table [g v] (list (as 'I64 [0 0 0 0 1 1 1 1]) (as 'I64 [7 7 7 7 13 13 13 13]))))
+(sum (at (select {v: (var_pop v) by: g from: Tconst}) 'v))    -- 0.0
+(sum (at (select {v: (var v) by: g from: Tconst}) 'v))        -- 0.0
+(sum (at (select {v: (stddev_pop v) by: g from: Tconst}) 'v)) -- 0.0
+(sum (at (select {v: (stddev v) by: g from: Tconst}) 'v))     -- 0.0
+
+
+;; ─── variance per group: 1-element groups (pop_* = 0, sample_* = null) ──
+;;
+;; The finaliser branches on cnt <= 1 for OP_VAR/OP_STDDEV (sample)
+;; and cnt <= 0 for the _pop variants.  A single-element group thus
+;; produces 0.0 for pop_* and NULL_F64 for sample.  sum-with-nulls
+;; folds nulls to identity (0.0).
+(set T1 (table [g v] (list (as 'I64 [0 1 2]) (as 'I64 [10 20 30]))))
+(count (select {v: (var_pop v) by: g from: T1})) -- 3
+(sum (at (select {v: (var_pop v) by: g from: T1}) 'v))    -- 0.0
+(sum (at (select {v: (stddev_pop v) by: g from: T1}) 'v)) -- 0.0
+(sum (at (select {v: (var v) by: g from: T1}) 'v))    -- 0.0
+(sum (at (select {v: (stddev v) by: g from: T1}) 'v)) -- 0.0
+
+
+;; ─── multi-agg in one query: med + var_pop + count ──────────────────
+;;
+;; per group (same Tvar fixture):
+;;   med([2,4,4,4,5,5,7,9]) = 4.5 (avg of 4,5)
+;;   var_pop = 4.0
+;;   count = 8
+(set Tmany (select {m: (med v) v: (var_pop v) c: (count v) by: g from: Tvar}))
+(count Tmany) -- 2
+(sum (at Tmany 'm)) -- 9.0
+(sum (at Tmany 'v)) -- 8.0
+(sum (at Tmany 'c)) -- 16
+
+
+;; ─── multi-agg: med + stddev (single key, generic eval path) ────────
+(set Tms (select {m: (med v) s: (stddev v) by: g from: Tvar}))
+(count Tms) -- 2
+(sum (at Tms 'm)) -- 9.0
+(< (abs (- (sum (at Tms 's)) (* 2.0 2.138089935299395))) 0.000001) -- true
+
+
+;; ─── multi-agg: med + stddev with 2-key SYM by-clause (fast path) ───
+;;
+;; Hits the query.c:6032 (med, stddev) 2-key gate.  Each cell holds 4
+;; values offset by group:
+;;   (A,X) → 10 20 30 40   median = 25  pop_var = 125 pop_stddev = √125
+;;   (A,Y) → 11 21 31 41   median = 26  pop_var = 125 pop_stddev = √125
+;;   (B,X) → 12 22 32 42   median = 27  pop_var = 125 pop_stddev = √125
+;;   (B,Y) → 13 23 33 43   median = 28  pop_var = 125 pop_stddev = √125
+;; sum of medians = 25+26+27+28 = 106.0
+;; sample stddev per cell = sqrt(2000/12) ≈ 12.909944; sum = 4 * that.
+(set Tms2 (table [id1 id2 v] (list [A A A A A A A A B B B B B B B B] [X X X X Y Y Y Y X X X X Y Y Y Y] (as 'F64 [10.0 20.0 30.0 40.0 11.0 21.0 31.0 41.0 12.0 22.0 32.0 42.0 13.0 23.0 33.0 43.0]))))
+(set Tms2r (select {m: (med v) s: (stddev v) by: [id1 id2] from: Tms2}))
+(count Tms2r) -- 4
+(sum (at Tms2r 'm)) -- 106.0
+(< (abs (- (sum (at Tms2r 's)) (* 4.0 12.909944487358056))) 0.000001) -- true
+
+
+;; ─── multi-agg 3-way: med + stddev + count (ms_with_count path) ─────
+(set Tms3 (select {m: (med v) s: (stddev v) c: (count v) by: [id1 id2] from: Tms2}))
+(count Tms3) -- 4
+(sum (at Tms3 'm)) -- 106.0
+(sum (at Tms3 'c)) -- 16
+
+
+;; ─── narrow-int median per group preserves accuracy ─────────────────
+;; I16 path:
+;;   g=0 → [100 200 300 400 500] → 300
+;;   g=1 → [10 20]               → 15
+;;   sum 315.0
+(set Tmedi16 (table [g v] (list (as 'I64 [0 0 0 0 0 1 1]) (as 'I16 [100 200 300 400 500 10 20]))))
+(sum (at (select {m: (med v) by: g from: Tmedi16}) 'm)) -- 315.0
+
+;; U8 path:
+;;   g=0 → [10 20 30] → 20; g=1 → [40 50 60] → 50; sum 70.
+(set Tmedu8 (table [g v] (list (as 'I64 [0 0 0 1 1 1]) (as 'U8 [10 20 30 40 50 60]))))
+(sum (at (select {m: (med v) by: g from: Tmedu8}) 'm)) -- 70.0
+
+
+;; ─── parallel threshold: ray_median_per_group_buf ───────────────────
+;;
+;; Threshold (group.c:1377): par=true iff n_groups>=8 AND total>=4096.
+;; N=8192 rows with 16 groups (each 512 elements).  For group g in
+;; [0..15] values are { g, g+16, g+32, …, g+511*16 } — arithmetic
+;; progression.  Median per cell = (first+last)/2 = g + 511*8 = g + 4088.
+;; sum over 16 groups: 16*4088 + (0+1+…+15) = 65408 + 120 = 65528.
+(set Nbig 8192)
+(set Tbig (table [g v] (list (% (til Nbig) 16) (til Nbig))))
+(count (select {m: (med v) by: g from: Tbig})) -- 16
+(sum (at (select {m: (med v) by: g from: Tbig}) 'm)) -- 65528.0
+
+
+;; ─── parallel threshold: var_pop / stddev_pop ───────────────────────
+;;
+;; Same Tbig.  Group g is AP { g, g+16, …, g+511*16 }, n=512, d=16.
+;; var_pop = d² (n² - 1) / 12 = 256 * 262143 / 12 = 5,592,384.
+;; Sum over 16 groups = 16 * 5592384 = 89,478,144.
+(< (abs (- (sum (at (select {v: (var_pop v) by: g from: Tbig}) 'v)) 89478144.0)) 1.0) -- true
+;; Pop stddev = sqrt(5592384); * 16.
+(< (abs (- (sum (at (select {v: (stddev_pop v) by: g from: Tbig}) 'v)) (* 16.0 (sqrt 5592384.0)))) 0.001) -- true
+
+
+;; ─── empty-input edge case: degenerate group (after WHERE) ──────────
+;;
+;; WHERE clause filters out ALL rows of group 1; group 0 keeps
+;; [10 20 30 40 50] → med=30, var_pop=200.
+(set Twh (table [g v] (list (as 'I64 [0 0 0 0 0 1 1 1]) (as 'I64 [10 20 30 40 50 999 999 999]))))
+(count (select {m: (med v) by: g from: Twh where: (< v 100)})) -- 1
+(sum (at (select {m: (med v) by: g from: Twh where: (< v 100)}) 'm))    -- 30.0
+(sum (at (select {v: (var_pop v) by: g from: Twh where: (< v 100)}) 'v)) -- 200.0
+
+
+;; ─── multi-key holistic, non-SYM I64 keys (generic eval path) ───────
+;;
+;; Forces the eval-level multi-key group path with numeric (non-SYM)
+;; keys and multi-agg holistic shapes.
+;;   (0,0) → [5 5]          → med 5,   pop_var 0
+;;   (0,1) → [10]           → med 10,  pop_var 0
+;;   (1,0) → [20 40]        → med 30,  pop_var 100   (Σ(x-30)²/2)
+;;   (1,1) → [60 80 100 60] → med 70   (avg of 60,80 after sort 60,60,80,100)
+;;                            mean = 75, pop_var = (225+25+625+225)/4 = 275
+;;   sum med = 5 + 10 + 30 + 70 = 115; sum pop_var = 0+0+100+275 = 375
+(set Tmmi (table [g h v] (list (as 'I64 [0 0 0 1 1 1 1 1 1]) (as 'I64 [0 0 1 0 0 1 1 1 1]) (as 'I64 [5 5 10 20 40 60 80 100 60]))))
+(count (select {m: (med v) by: [g h] from: Tmmi})) -- 4
+(sum (at (select {m: (med v) by: [g h] from: Tmmi}) 'm)) -- 115.0
+(sum (at (select {v: (var_pop v) by: [g h] from: Tmmi}) 'v)) -- 375.0
+
+
+;; ─── ties: median of duplicate-only group equals that value ─────────
+(set Ttie (table [g v] (list (as 'I64 [0 0 0 0 1 1 1 1]) (as 'I64 [7 7 7 7 13 13 13 13]))))
+(sum (at (select {m: (med v) by: g from: Ttie}) 'm)) -- 20.0
+
+
+;; ─── median of mixed-sign values ────────────────────────────────────
+;; g=0 → [-5 -1 0 1 5] → 0; g=1 → [-10 -5 0 5 10] → 0; sum 0.
+(set Tneg (table [g v] (list (as 'I64 [0 0 0 0 0 1 1 1 1 1]) (as 'I64 [-5 -1 0 1 5 -10 -5 0 5 10]))))
+(sum (at (select {m: (med v) by: g from: Tneg}) 'm)) -- 0.0
+
+
+;; ─── top-K per group: K=1 with many small SYM groups (LIST-cell) ────
+;; 5 groups; each 2 elements.  Max per group = idx*10 + 1.
+;; Sum of maxes = 1+11+21+31+41 = 105; sum of mins = 0+10+20+30+40 = 100.
+(set Tk1 (table [k v] (list [A A B B C C D D E E] (as 'I64 [0 1 10 11 20 21 30 31 40 41]))))
+(count (select {t: (top v 1) by: k from: Tk1})) -- 5
+(sum (raze (at (select {t: (top v 1) by: k from: Tk1}) 't))) -- 105
+(sum (raze (at (select {b: (bot v 1) by: k from: Tk1}) 'b))) -- 100
+
+
+;; ─── algebraic invariants: positivity + var >= var_pop ──────────────
+(set Trn (table [g v] (list (% (til 800) 8) (til 800))))
+(set Vp   (sum (at (select {v: (var v) by: g from: Trn}) 'v)))
+(set Sp   (sum (at (select {s: (stddev v) by: g from: Trn}) 's)))
+(set Vpop (sum (at (select {v: (var_pop v) by: g from: Trn}) 'v)))
+(set Spop (sum (at (select {s: (stddev_pop v) by: g from: Trn}) 's)))
+(> Vp 0.0) -- true
+(> Sp 0.0) -- true
+(>= Vpop 0.0) -- true
+(>= Spop 0.0) -- true
+;; sample variance >= pop variance per group (for n>=2) → sums obey too.
+(>= Vp Vpop) -- true

--- a/test/rfl/agg/per_group_holistic.rfl
+++ b/test/rfl/agg/per_group_holistic.rfl
@@ -124,17 +124,17 @@
 ;; Population variance / stddev — exact integer answers.
 (sum (at (select {v: (var_pop v) by: g from: Tvar}) 'v))    -- 8.0
 (sum (at (select {v: (stddev_pop v) by: g from: Tvar}) 'v)) -- 4.0
-;; Asymmetry: scalar `dev` aliases stddev_pop (ray_stddev_pop_fn at
-;; agg.c:625-628), but in a select-by, query.c:316 maps `dev` →
-;; OP_STDDEV (sample), NOT OP_STDDEV_POP.  Per-group `dev` therefore
-;; equals per-group sample stddev — sum across 2 groups = 2 * √(32/7).
-;; (Locking this in: changing the planner mapping would surface as a
-;; failing assertion here.)
-(< (abs (- (sum (at (select {v: (dev v) by: g from: Tvar}) 'v)) (* 2.0 2.138089935299395))) 0.000001) -- true
+;; Bug 5 (now fixed): `dev` in select-by used to map to OP_STDDEV
+;; (sample) while scalar `dev` is OP_STDDEV_POP (population).  The
+;; one-line fix at src/ops/query.c:316 aligns the planner mapping so
+;; per-group `dev` is also population — `dev` is now an alias of
+;; `stddev_pop` (and `dev_pop`) in every context, matching Q/K
+;; convention (`dev` = pop, `sdev` would be sample).
+(sum (at (select {v: (dev v) by: g from: Tvar}) 'v))        -- 4.0
 ;; Sanity: stddev_pop (explicit) sums to 4.0 (= 2 * 2.0).
 (sum (at (select {v: (stddev_pop v) by: g from: Tvar}) 'v)) -- 4.0
-;; Per-group dev != per-group stddev_pop (because of the asymmetry):
-(< (abs (- (sum (at (select {v: (dev v) by: g from: Tvar}) 'v)) (sum (at (select {v: (stddev_pop v) by: g from: Tvar}) 'v)))) 0.001) -- false
+;; Per-group dev == per-group stddev_pop after the fix:
+(< (abs (- (sum (at (select {v: (dev v) by: g from: Tvar}) 'v)) (sum (at (select {v: (stddev_pop v) by: g from: Tvar}) 'v)))) 0.001) -- true
 
 ;; Sample variance / stddev — fp tolerance.
 (< (abs (- (sum (at (select {v: (var v) by: g from: Tvar}) 'v)) (* 2.0 4.571428571428571))) 0.000001) -- true

--- a/test/rfl/cmp/and.rfl
+++ b/test/rfl/cmp/and.rfl
@@ -33,8 +33,14 @@
 (and true true true true false) -- false
 
 ;; ── arity boundaries ──
+;; 0 args still rejected (no vacuous-truth element exposed); 1 arg is
+;; identity per monoid rule (Scheme/Haskell): (and X) == X.  Enables
+;; programmatic AST construction like `(cons 'and preds)` where preds
+;; may have length 1.  See test/rfl/cmp/and_or_identity.rfl for the
+;; happy-path identity matrix.
 (and)        !- arity
-(and true)   !- arity
+(and true)   -- true
+(and false)  -- false
 
 ;; ── short-circuit semantics (matches v1 FN_SPECIAL_FORM) ──
 ;; PR #8 dropped FN_SPECIAL_FORM, breaking v1's contract.  Restored:

--- a/test/rfl/cmp/and_or_identity.rfl
+++ b/test/rfl/cmp/and_or_identity.rfl
@@ -1,0 +1,37 @@
+;; Bug 4 (Option C): single-arg `and`/`or` is identity — `(and X) == X`,
+;; `(or X) == X`.  Mirrors monoid identity from Scheme/Haskell.
+;;
+;; Before fix: `(and X)` and `(or X)` returned `error: arity`. The
+;; companion `and.rfl` / `or.rfl` tests pinning that behavior were
+;; the contract.  Now relaxed: 0 args still arity-rejected, 1 arg
+;; flows through as the value itself.
+;;
+;; Why we changed it: WHERE clauses built programmatically via
+;;   (set query (cons 'and preds))
+;; previously broke when `preds` happened to have length 1 — the
+;; planner returned `error: domain` for `where: (and (> v 100))`.
+
+;; ─── Atom bool ───────────────────────────────────────────────────
+(and true)  -- true
+(and false) -- false
+(or  true)  -- true
+(or  false) -- false
+
+;; ─── Vector bool — identity, no broadcast change ────────────────
+(and [true false true])  -- [true false true]
+(or  [true false true])  -- [true false true]
+
+;; ─── Truthy non-bool atom — identity passes the value through ───
+(and 42)   -- 42
+(and 'x)   -- 'x
+(or  42)   -- 42
+(or  'x)   -- 'x
+
+;; ─── WHERE-clause programmatic use (was Bug 4) ──────────────────
+(set T (table [v] (list [50 150 200])))
+(count (select {from: T where: (and (> v 100))})) -- 2
+(count (select {from: T where: (or  (> v 100))})) -- 2
+
+;; ─── Nested: (and (and X)) flattens to X ────────────────────────
+(and (and 42))     -- 42
+(and (or  'sym))   -- 'sym

--- a/test/rfl/cmp/or.rfl
+++ b/test/rfl/cmp/or.rfl
@@ -38,8 +38,13 @@
 (or false false false false true)  -- true
 
 ;; ── arity boundaries ──
+;; 0 args still rejected (no vacuous-falsity element exposed); 1 arg is
+;; identity per monoid rule: (or X) == X.  See and.rfl for the same
+;; rationale on AND, and test/rfl/cmp/and_or_identity.rfl for the
+;; happy-path identity matrix.
 (or)         !- arity
-(or false)   !- arity
+(or true)    -- true
+(or false)   -- false
 
 ;; ── short-circuit semantics (matches v1 FN_SPECIAL_FORM) ──
 ;; Subsequent args are NOT evaluated once a scalar truthy is seen.

--- a/test/rfl/datalog/graph_algos_advanced.rfl
+++ b/test/rfl/datalog/graph_algos_advanced.rfl
@@ -1,0 +1,214 @@
+;; graph_algos_advanced.rfl — happy-path regression for advanced graph algos
+;; in src/ops/traverse.c.  Complements traverse_coverage.rfl (which targets
+;; error / domain branches) and traverse_weighted.rfl with deeper correctness
+;; invariants for the *successful* execution paths.
+;;
+;; Algorithms covered:
+;;   PageRank   (exec_pagerank)          — hub-graph ranking
+;;   Louvain    (exec_louvain)           — community detection on a 2-cluster
+;;                                          graph
+;;   var-expand realloc                  — frontier (cap=256) + output buffer
+;;                                          (cap=1024) growth paths
+;;
+;; Algorithms NOT covered, and why:
+;;   A* (exec_a_star / exec_astar) — implementation lives in traverse.c but
+;;     is NOT exposed via any .graph.* builtin in src/ops/graph_builtin.c,
+;;     and no register_vary(".graph.astar", ...) call exists in
+;;     src/lang/eval.c.  See graph_advanced.rfl line ~241 for the existing
+;;     SKIPPED note.  Per "CRITICAL RULE — DO NOT ROUTE AROUND BUGS" the
+;;     correct response when the surface is unreachable is to document and
+;;     skip, not to invent a binding.
+;;   SCC (strongly-connected components) — no implementation exists.  No
+;;     exec_scc / ray_graph_scc / "tarjan" / "kosaraju" symbol in src/ or
+;;     include/.  The feature is unimplemented at the C level.
+
+;; ======================================================================
+;; Fixture HUB5: 5-node in-hub graph.  Nodes 1..4 each have a single
+;; out-edge → 0.  Node 0 is a dangling sink.  An extra edge 1→2 gives
+;; node 1 an additional out-degree (out-deg 2) so the rank distribution
+;; isn't uniform across the spokes.
+;;
+;;     1 ─→ 0 ←─ 2
+;;     │    ↑    ↑
+;;     ↓    │    │
+;;     2    3    4
+;;
+;; Expected: rank[0] is the largest; sum of ranks is ≈ 1.
+;; ======================================================================
+(set HUB5Edges (table [src dst] (list [1 2 3 4 1] [0 0 0 0 2])))
+(set HUB5 (.graph.build HUB5Edges 'src 'dst))
+
+(set PrHub (.graph.pagerank HUB5 50 0.85))
+(count PrHub) -- 5
+;; ranks sum to ≈ 1.0
+(>= (sum (at PrHub '_rank)) 0.99) -- true
+(<= (sum (at PrHub '_rank)) 1.01) -- true
+;; all ranks positive
+(> (min (at PrHub '_rank)) 0.0) -- true
+
+;; the hub (node 0) holds the largest rank
+(set PrHub_node (at PrHub '_node))
+(set PrHub_rank (at PrHub '_rank))
+(set PrHub_max  (max PrHub_rank))
+;; rank of node 0 == max rank
+(set PrHub_r0 (at PrHub_rank (at (where (== PrHub_node 0)) 0)))
+(== PrHub_r0 PrHub_max) -- true
+;; node 0 strictly dominates each spoke (1,2,3,4)
+(> PrHub_r0 (at PrHub_rank (at (where (== PrHub_node 1)) 0))) -- true
+(> PrHub_r0 (at PrHub_rank (at (where (== PrHub_node 2)) 0))) -- true
+(> PrHub_r0 (at PrHub_rank (at (where (== PrHub_node 3)) 0))) -- true
+(> PrHub_r0 (at PrHub_rank (at (where (== PrHub_node 4)) 0))) -- true
+
+;; default damping (0.85) path: same hub-dominance invariant must hold
+;; with the default-arg branch of ray_graph_pagerank_fn (n==2, no damping).
+(set PrHub2 (.graph.pagerank HUB5 25))
+(count PrHub2) -- 5
+(set PrHub2_node (at PrHub2 '_node))
+(set PrHub2_rank (at PrHub2 '_rank))
+(> (at PrHub2_rank (at (where (== PrHub2_node 0)) 0)) (at PrHub2_rank (at (where (== PrHub2_node 1)) 0))) -- true
+
+;; default iters + damping (n==1 path)
+(set PrHub3 (.graph.pagerank HUB5))
+(count PrHub3) -- 5
+(>= (sum (at PrHub3 '_rank)) 0.99) -- true
+(<= (sum (at PrHub3 '_rank)) 1.01) -- true
+
+;; ======================================================================
+;; Fixture LOUV2: 8-node graph with two clearly separated clusters.
+;; Cluster A: nodes 0..3, full quadrilateral with diagonals (every pair
+;; connected, bidirectional) — i.e. K4 modelled as directed edges.
+;; Cluster B: nodes 4..7, same structure.
+;; Bridge: a single edge 0 → 4 connecting the two halves.
+;;
+;; Louvain treats the graph as undirected; with 6 directed edges per K4
+;; (= 6 undirected edges, since each undirected edge appears as both
+;; (u,v) and (v,u) in the CSR via the rev-CSR), the bridge is dwarfed
+;; by intra-cluster connectivity, so Louvain phase-1 separates A from B.
+;;
+;; Cluster A directed edges (u<v then v<u, 6 undirected → 12 directed):
+;;   0-1, 0-2, 0-3, 1-2, 1-3, 2-3  → 12 directed rows
+;; Same for cluster B with nodes 4..7.
+;; Bridge: 0→4.
+;; ======================================================================
+(set LOUV2Edges (table [src dst] (list [0 1 0 2 0 3 1 2 1 3 2 3 4 5 4 6 4 7 5 6 5 7 6 7 0] [1 0 2 0 3 0 2 1 3 1 3 2 5 4 6 4 7 4 6 5 7 5 7 6 4])))
+(set LOUV2 (.graph.build LOUV2Edges 'src 'dst))
+
+(set Lou (.graph.louvain LOUV2 200))
+(count Lou) -- 8
+;; community IDs are normalised to [0..k-1]
+(min (at Lou '_community)) -- 0
+;; observation: this Louvain phase-1 implementation produces 4 communities
+;; on a K4+K4+bridge graph rather than the 2 a multi-pass Louvain would
+;; find.  This is consistent with the comment in src/ops/traverse.c:1166
+;; ("Pass 1 only (no graph contraction)") — Louvain's second pass is
+;; what consolidates greedy phase-1 sub-clusters into the natural global
+;; partition.  Keeping the assertion as-observed so a future second-pass
+;; addition will trip it and force a re-evaluation.
+(count (distinct (at Lou '_community))) -- 4
+;; every node assigned (no gaps)
+(count (distinct (at Lou '_node))) -- 8
+(min (at Lou '_node)) -- 0
+(max (at Lou '_node)) -- 7
+
+;; Partition observation (phase-1 only): on the K4+K4+bridge fixture the
+;; algorithm fragments each K4 into a pair of 2-node sub-communities,
+;; producing 4 communities total of size 2 each.  The boundary between
+;; the two halves (nodes 0..3 vs 4..7) is still respected — node 0 and
+;; node 4 are never in the same community — but the further intra-half
+;; fragmentation is suboptimal vs canonical multi-pass Louvain.
+(set Lou_node (at Lou '_node))
+(set Lou_comm (at Lou '_community))
+(set CommOf0 (at Lou_comm (at (where (== Lou_node 0)) 0)))
+(set CommOf4 (at Lou_comm (at (where (== Lou_node 4)) 0)))
+;; Cross-cluster invariant must hold even with phase-1 fragmentation:
+;; a node in cluster A and a node in cluster B never share a community
+;; (the bridge 0→4 is too weak to merge them).
+(!= CommOf0 CommOf4) -- true
+(!= (at Lou_comm (at (where (== Lou_node 1)) 0)) CommOf4) -- true
+(!= (at Lou_comm (at (where (== Lou_node 2)) 0)) CommOf4) -- true
+(!= (at Lou_comm (at (where (== Lou_node 3)) 0)) CommOf4) -- true
+;; Each community contains exactly 2 nodes (the phase-1 fragmentation
+;; produces uniform pairs — direct observation of this implementation's
+;; greedy convergence on K4-cliques).
+(== (count (where (== Lou_comm 0))) 2) -- true
+(== (count (where (== Lou_comm 1))) 2) -- true
+(== (count (where (== Lou_comm 2))) 2) -- true
+(== (count (where (== Lou_comm 3))) 2) -- true
+
+;; default max-iter (n==1 path: iters defaults to 100) — same partition.
+(set Lou2 (.graph.louvain LOUV2))
+(count Lou2) -- 8
+(== (count (distinct (at Lou2 '_community))) 4) -- true
+
+;; ======================================================================
+;; Fixture REALLOC: large star graph to force exec_var_expand realloc.
+;;
+;; Buffers in exec_var_expand grow as power-of-two from initial capacities:
+;;   - frontier (per-source): front_cap = 256 → 512, 1024, …
+;;   - output table:          out_cap   = 1024 → 2048, 4096, …
+;;
+;; A star with hub=0 and 1500 leaves (1..1500) produces:
+;;   - 1500 depth-1 neighbours from a single source → next_len passes 256,
+;;     exercising the frontier scratch_realloc path.
+;;   - 1500 emitted (start, end, depth=1) rows → out_count passes 1024,
+;;     exercising the atomic 3-buffer grow path (the "alloc 3 new copies,
+;;     commit only if all succeed" branch).
+;;
+;; Total nodes = 1501; edges = 1500.
+;; ======================================================================
+(set N 1500)
+;; src column: hub=0 repeated 1500 times.  dst column: 1..N.
+;; (% (til N) 1) is always 0; we want a constant 0 vector of length N.
+;; Build via (& (til N) 0) ? simpler: (* 0 (til N)).
+(set REALLOCEdges (table [src dst] (list (* 0 (til N)) (+ 1 (til N)))))
+(set REALLOC (.graph.build REALLOCEdges 'src 'dst))
+;; sanity: 1501 nodes total, 1500 edges
+(at (.graph.info REALLOC) 'n_nodes) -- 1501
+(at (.graph.info REALLOC) 'n_edges) -- 1500
+
+;; var-expand from hub=0 with min=1 max=1 (one hop, forward) — emits
+;; 1500 rows, blasting through both the 256-frontier and the 1024-out
+;; realloc thresholds.
+(set ReBlast (.graph.var-expand REALLOC 0 1 1 0))
+(count ReBlast) -- 1500
+;; every emitted row starts at the hub
+(count (distinct (at ReBlast '_start))) -- 1
+(first (at ReBlast '_start)) -- 0
+;; every emitted depth is 1 (single hop)
+(count (distinct (at ReBlast '_depth))) -- 1
+(first (at ReBlast '_depth)) -- 1
+;; the destination nodes are exactly leaves 1..1500
+(count (distinct (at ReBlast '_end))) -- 1500
+(min (at ReBlast '_end)) -- 1
+(max (at ReBlast '_end)) -- 1500
+
+;; max=2 still gives 1500 rows (leaves have no further out-edges, so
+;; depth 2 frontier is empty).  This re-exercises the same realloc
+;; paths plus the "depth>max with non-empty frontier exit" branch.
+(set ReBlast2 (.graph.var-expand REALLOC 0 1 2 0))
+(count ReBlast2) -- 1500
+(== (count (distinct (at ReBlast2 '_depth))) 1) -- true
+(first (at ReBlast2 '_depth)) -- 1
+
+;; direction=2 (both fwd+rev) from the hub: same 1500 fwd-leaves, no
+;; rev neighbours, so still 1500 rows — exercises the realloc paths
+;; via the direction==2 dual-CSR walk.
+(set ReBlastBoth (.graph.var-expand REALLOC 0 1 1 2))
+(count ReBlastBoth) -- 1500
+(min (at ReBlastBoth '_end)) -- 1
+(max (at ReBlastBoth '_end)) -- 1500
+
+;; reverse direction from a leaf: depth-1 fwd-neighbours of a leaf via
+;; the reverse CSR is exactly the hub (1 row).  This isn't itself a
+;; realloc trigger, but it verifies the dir=1 branch still works on the
+;; large fixture (the rev CSR n_nodes equals fwd's, 1501).
+(set ReRevLeaf (.graph.var-expand REALLOC 1500 1 1 1))
+(count ReRevLeaf) -- 1
+(first (at ReRevLeaf '_end)) -- 0
+
+;; ======================================================================
+;; Cleanup
+;; ======================================================================
+(.graph.free HUB5)
+(.graph.free LOUV2)
+(.graph.free REALLOC)

--- a/test/rfl/datalog/traverse_weighted.rfl
+++ b/test/rfl/datalog/traverse_weighted.rfl
@@ -1,0 +1,338 @@
+;; traverse_weighted.rfl — happy-path coverage for weighted graph algorithms
+;; in src/ops/traverse.c.
+;;
+;; This file deliberately complements test/rfl/datalog/traverse_coverage.rfl
+;; (which targets error/edge branches) by exercising the *forward* (happy)
+;; paths of:
+;;   - exec_dijkstra      : weighted shortest path (single-source + point-to-point)
+;;   - exec_mst           : Kruskal MST + mst_edge_cmp comparator
+;;   - exec_random_walk   : walk on acyclic (dead-end) graphs
+;;   - exec_var_expand    : multi-hop expansion with min_depth/max_depth
+;;   - exec_shortest_path : BFS hop-count on weighted acyclic graphs
+;;   - exec_k_shortest    : Yen's k-shortest paths on a DAG (1 < K ≤ k_max)
+;;   - exec_connected_comp: components on a disconnected *weighted* graph
+;;
+;; Graphs are small enough to hand-compute references.  Cycles were covered
+;; in an earlier round; this file focuses on acyclic / forest shapes.
+
+;; ======================================================================
+;; Fixture DAG1: 5-node weighted DAG.
+;;   edges (src dst w):
+;;     0->1 (2.0)  0->2 (5.0)  1->2 (1.0)  1->3 (6.0)
+;;     2->3 (2.0)  2->4 (9.0)  3->4 (3.0)
+;;
+;; Hand-computed Dijkstra distances from source 0:
+;;   dist[0]=0   dist[1]=2   dist[2]=3 (0->1->2: 2+1)
+;;   dist[3]=5  (0->1->2->3: 2+1+2)
+;;   dist[4]=8  (0->1->2->3->4: 2+1+2+3, beats 2->4: 3+9=12 and 3->4 via 1->3: 2+6+3=11)
+;; Depth of node 4 along that path is 4 hops.
+;; ======================================================================
+(set DAG1Edges (table [src dst w] (list [0 0 1 1 2 2 3] [1 2 2 3 3 4 4] [2.0 5.0 1.0 6.0 2.0 9.0 3.0])))
+(set DAG1 (.graph.build DAG1Edges 'src 'dst 'w))
+
+;; ======================================================================
+;; Fixture K4: 4-node fully-connected weighted graph (directed edges,
+;; but Kruskal MST treats it as undirected).
+;;   0->1 (1.0)  0->2 (4.0)  0->3 (3.0)
+;;   1->2 (2.0)  1->3 (5.0)  2->3 (6.0)
+;;
+;; MST edges (sorted by weight): (0,1,1) (1,2,2) (0,3,3)
+;;   total weight = 1 + 2 + 3 = 6.0
+;;   spanning tree has n-1 = 3 edges.
+;; ======================================================================
+(set K4Edges (table [src dst w] (list [0 0 0 1 1 2] [1 2 3 2 3 3] [1.0 4.0 3.0 2.0 5.0 6.0])))
+(set K4 (.graph.build K4Edges 'src 'dst 'w))
+
+;; ======================================================================
+;; Fixture CHAIN: linear 4-node chain (DAG) 0->1->2->3, unit weights.
+;;   For multi-hop var-expand and deterministic dead-end random walks.
+;; ======================================================================
+(set CHAINEdges (table [src dst w] (list [0 1 2] [1 2 3] [1.0 1.0 1.0])))
+(set CHAIN (.graph.build CHAINEdges 'src 'dst 'w))
+
+;; ======================================================================
+;; Fixture DISC2: two disconnected weighted triangles (non-unit weights).
+;;   Component A (nodes 0,1,2):
+;;     0->1 (2.0)  1->2 (3.0)  0->2 (4.0)
+;;   Component B (nodes 3,4,5):
+;;     3->4 (1.5)  3->5 (2.5)  4->5 (4.0)
+;;
+;; MST is a *forest*:
+;;   A picks (0,1,2.0) (1,2,3.0) — 2 edges, weight 5.0
+;;   B picks (3,4,1.5) (3,5,2.5) — 2 edges, weight 4.0
+;;   Total: 4 edges, summed weight 9.0
+;; ======================================================================
+(set DISC2Edges (table [src dst w] (list [0 0 1 3 3 4] [1 2 2 4 5 5] [2.0 4.0 3.0 1.5 2.5 4.0])))
+(set DISC2 (.graph.build DISC2Edges 'src 'dst 'w))
+
+;; ======================================================================
+;; 1. exec_dijkstra — single-source on DAG1
+;; ======================================================================
+(set Dj1 (.graph.dijkstra DAG1 0))
+(count Dj1) -- 5
+(set Dj1_node (at Dj1 '_node))
+(set Dj1_dist (at Dj1 '_dist))
+(set Dj1_depth (at Dj1 '_depth))
+
+;; Hand-computed distances.
+(at Dj1_dist (at (where (== Dj1_node 0)) 0)) -- 0.0
+(at Dj1_dist (at (where (== Dj1_node 1)) 0)) -- 2.0
+(at Dj1_dist (at (where (== Dj1_node 2)) 0)) -- 3.0
+(at Dj1_dist (at (where (== Dj1_node 3)) 0)) -- 5.0
+(at Dj1_dist (at (where (== Dj1_node 4)) 0)) -- 8.0
+
+;; Depth (hop count along the relaxed shortest-path tree).
+(at Dj1_depth (at (where (== Dj1_node 0)) 0)) -- 0
+(at Dj1_depth (at (where (== Dj1_node 1)) 0)) -- 1
+(at Dj1_depth (at (where (== Dj1_node 2)) 0)) -- 2
+(at Dj1_depth (at (where (== Dj1_node 3)) 0)) -- 3
+(at Dj1_depth (at (where (== Dj1_node 4)) 0)) -- 4
+
+;; ======================================================================
+;; 2. exec_dijkstra — point-to-point (src,dst) mode triggers early-exit
+;;    `if (u == dst_id) break;` branch in the main relaxation loop.
+;; ======================================================================
+(set DjPt (.graph.dijkstra DAG1 0 4))
+;; Point-to-point still returns the table of all nodes whose dist < inf
+;; at the moment of early exit; DAG1 has no unreachable nodes from 0.
+(count DjPt) -- 5
+(set DjPt_node (at DjPt '_node))
+(set DjPt_dist (at DjPt '_dist))
+;; The destination distance must match the hand-computed shortest path.
+(at DjPt_dist (at (where (== DjPt_node 4)) 0)) -- 8.0
+
+;; ======================================================================
+;; 3. exec_dijkstra — explicit max-depth knob (4th arg).
+;;    Passing a non-default max_depth exercises the parameter wiring in
+;;    ray_graph_dijkstra_fn but the algorithm body is identical.
+;; ======================================================================
+(set DjMax (.graph.dijkstra DAG1 0 -1 10))
+(count DjMax) -- 5
+
+;; ======================================================================
+;; 4. exec_mst — Kruskal on a fully-connected 4-node graph (K4).
+;;    Exercises mst_edge_cmp (qsort comparator on doubles) and the
+;;    union-by-rank with path compression.
+;; ======================================================================
+(set MstK4 (.graph.mst K4))
+;; Spanning tree on n=4 nodes -> n-1 = 3 edges.
+(count MstK4) -- 3
+;; Total weight = 1+2+3 = 6.0 (hand-Kruskal).
+(sum (at MstK4 '_weight)) -- 6.0
+;; MST edges must span all 4 nodes — the min src and min dst cover node 0.
+(min (at MstK4 '_src)) -- 0
+;; The maximum dst is node 3 (terminal of the spanning tree).
+(max (at MstK4 '_dst)) -- 3
+;; Weights are sorted in pick order (mst_edge_cmp is ascending).
+(set MstK4_w (at MstK4 '_weight))
+(at MstK4_w 0) -- 1.0
+(at MstK4_w 1) -- 2.0
+(at MstK4_w 2) -- 3.0
+
+;; ======================================================================
+;; 5. exec_mst — Kruskal on a *disconnected* weighted graph (DISC2).
+;;    Output is a spanning *forest*: n - (#components) edges total.
+;;    Also re-verifies mst_edge_cmp with float weights that include
+;;    sub-integer values (1.5, 2.5).
+;; ======================================================================
+(set MstDisc2 (.graph.mst DISC2))
+;; n=6 nodes, 2 components → 6-2 = 4 forest edges.
+(count MstDisc2) -- 4
+;; Total weight = (2.0 + 3.0) + (1.5 + 2.5) = 9.0
+(sum (at MstDisc2 '_weight)) -- 9.0
+;; The two smallest-weight edges chosen are 1.5 and 2.0 (one per component).
+(set MstDisc2_w (at MstDisc2 '_weight))
+(at MstDisc2_w 0) -- 1.5
+(at MstDisc2_w 1) -- 2.0
+
+;; ======================================================================
+;; 6. exec_mst — on DAG1 (5 nodes, 7 edges).
+;;    Sorted weights: 1.0 2.0 2.0 3.0 5.0 6.0 9.0
+;;    Pick (1,2,1.0), (0,1,2.0), (2,3,2.0), (3,4,3.0) — 4 edges, weight 8.0.
+;; ======================================================================
+(set MstDag1 (.graph.mst DAG1))
+(count MstDag1) -- 4
+(sum (at MstDag1 '_weight)) -- 8.0
+;; Smallest-weight edge chosen first (mst_edge_cmp ascending).
+(at (at MstDag1 '_weight) 0) -- 1.0
+
+;; ======================================================================
+;; 7. exec_random_walk — deterministic dead-end on CHAIN (each node has at
+;;    most one out-edge, so xorshift pick is irrelevant after step 0).
+;;    Walk from node 0 with walk_len=10:
+;;      step 0 → 0, step 1 → 1, step 2 → 2, step 3 → 3 (dead end, break).
+;;    Expected output: 4 rows, nodes = [0,1,2,3], steps = [0,1,2,3].
+;; ======================================================================
+(set RwChain (.graph.random-walk CHAIN 0 10))
+(count RwChain) -- 4
+(at (at RwChain '_node) 0) -- 0
+(at (at RwChain '_node) 1) -- 1
+(at (at RwChain '_node) 2) -- 2
+(at (at RwChain '_node) 3) -- 3
+(at (at RwChain '_step) 0) -- 0
+(at (at RwChain '_step) 3) -- 3
+
+;; Random walk from middle of CHAIN — also dead-end deterministic.
+(set RwChain2 (.graph.random-walk CHAIN 2 10))
+(count RwChain2) -- 2
+(at (at RwChain2 '_node) 0) -- 2
+(at (at RwChain2 '_node) 1) -- 3
+
+;; Random walk from terminal node of CHAIN — immediate dead end.
+(set RwChain3 (.graph.random-walk CHAIN 3 5))
+(count RwChain3) -- 1
+(at (at RwChain3 '_node) 0) -- 3
+
+;; ======================================================================
+;; 8. exec_random_walk — invariants on a branching DAG (DAG1).
+;;    The xorshift64 seed is derived from start_node, so for a given
+;;    (graph, start_node, walk_len) the output is deterministic but its
+;;    exact path depends on RNG bits — assert structural invariants only.
+;; ======================================================================
+(set RwDag1 (.graph.random-walk DAG1 0 5))
+;; total = walk_len + 1 = 6 maximum (may be shorter if a dead-end is hit).
+(<= (count RwDag1) 6) -- true
+(>= (count RwDag1) 1) -- true
+;; First row is always the source.
+(at (at RwDag1 '_node) 0) -- 0
+;; First step index is 0; step values are dense [0..count-1].
+(at (at RwDag1 '_step) 0) -- 0
+;; All visited nodes must be in [0..4] (DAG1 has n_nodes=5).
+(>= (min (at RwDag1 '_node)) 0) -- true
+(<= (max (at RwDag1 '_node)) 4) -- true
+
+;; ======================================================================
+;; 9. exec_var_expand — multi-hop expansion with min/max depth on CHAIN.
+;;    From node 0, forward, depth range [1..3]:
+;;      depth 1 → {1};  depth 2 → {2};  depth 3 → {3};  total 3 rows.
+;; ======================================================================
+(set Ve1 (.graph.var-expand CHAIN 0 1 3))
+(count Ve1) -- 3
+(min (at Ve1 '_depth)) -- 1
+(max (at Ve1 '_depth)) -- 3
+(min (at Ve1 '_end)) -- 1
+(max (at Ve1 '_end)) -- 3
+
+;; Same chain, [2..3]: skip depth-1 ({1}) — only depths 2 and 3 emit.
+(set Ve2 (.graph.var-expand CHAIN 0 2 3))
+(count Ve2) -- 2
+(min (at Ve2 '_depth)) -- 2
+(max (at Ve2 '_depth)) -- 3
+
+;; Exact depth=3 (min==max) on CHAIN: only {3} at depth 3.
+(set Ve3 (.graph.var-expand CHAIN 0 3 3))
+(count Ve3) -- 1
+(at (at Ve3 '_end) 0) -- 3
+(at (at Ve3 '_depth) 0) -- 3
+
+;; min_depth=0 lets the start node itself escape — but var-expand emits
+;; only frontier *transitions*; depth=0 self-emission is suppressed by the
+;; `depth >= 1` loop init, so min=0 max=3 behaves like min=1 max=3.
+(set Ve0 (.graph.var-expand CHAIN 0 0 3))
+(count Ve0) -- 3
+
+;; var-expand on DAG1 from node 0 with depth [1..4]: BFS visits all 4
+;; non-source nodes, each emitted exactly once at the BFS depth-of-first-
+;; visit.  The first-visit BFS depths are:
+;;   1 → depth 1   (0->1)
+;;   2 → depth 1   (0->2)
+;;   3 → depth 2   (via 1->3 or 2->3, BFS sees one of them first)
+;;   4 → depth 2   (via 2->4)
+;; Total emitted rows = 4.
+(set VeDag1 (.graph.var-expand DAG1 0 1 4))
+(count VeDag1) -- 4
+(min (at VeDag1 '_end)) -- 1
+(max (at VeDag1 '_end)) -- 4
+;; Source is the only _start value emitted.
+(count (distinct (at VeDag1 '_start))) -- 1
+(at (at VeDag1 '_start) 0) -- 0
+
+;; ======================================================================
+;; 10. exec_shortest_path — BFS hop-count on weighted DAGs.
+;;     This re-uses the unweighted BFS path inside traverse.c — the
+;;     weight column is ignored; only hop-count matters.  Happy path:
+;;     reachable src/dst on the DAG.
+;; ======================================================================
+;; CHAIN: hops 0->3 = 3 edges → 4-row path table.
+(set SpChain (.graph.shortest-path CHAIN 0 3))
+(count SpChain) -- 4
+;; First node is the source.
+(first (at SpChain '_node)) -- 0
+;; Last node is the destination.
+(at (at SpChain '_node) 3) -- 3
+
+;; DAG1 from 0 to 4: BFS picks min-hop path 0->2->4 (2 hops) over
+;; 0->1->2->3->4 (4 hops).
+(set SpDag1 (.graph.shortest-path DAG1 0 4))
+(count SpDag1) -- 3
+(first (at SpDag1 '_node)) -- 0
+(at (at SpDag1 '_node) 2) -- 4
+
+;; ======================================================================
+;; 11. exec_k_shortest — Yen's algorithm on DAG1 from 0 to 4.
+;;     K=2: P0 = 0->1->2->3->4 (cost 8.0)
+;;          P1 = next-cheapest spur deviation (cost = 10.0 via 0->2->3->4).
+;; ======================================================================
+(set Ksp (.graph.k-shortest DAG1 0 4 2))
+;; Two distinct path_ids (0 and 1).
+(count (distinct (at Ksp '_path_id))) -- 2
+;; Path 0 starts at source and ends at destination.
+(set Ksp_pid (at Ksp '_path_id))
+(set Ksp_node (at Ksp '_node))
+(set Ksp_dist (at Ksp '_dist))
+;; Cost of path 0 (terminal node distance) = 8.0 (hand-Dijkstra).
+(set p0_idx (where (== Ksp_pid 0)))
+(set p0_last (- (count p0_idx) 1))
+(at Ksp_dist (at p0_idx p0_last)) -- 8.0
+;; Cost of path 1 should be ≥ cost of path 0 (Yen's enumerates ascending).
+(set p1_idx (where (== Ksp_pid 1)))
+(set p1_last (- (count p1_idx) 1))
+(>= (at Ksp_dist (at p1_idx p1_last)) 8.0) -- true
+
+;; K=1 (just the shortest) on K4 from 0 to 3 — Dijkstra-only path.
+;; 0->3 direct edge has weight 3.0 (and is the cheapest), so K=1 returns
+;; cost 3.0.  Cheaper alternative 0->1->2->3 = 1+2+6 = 9, so direct wins.
+(set Ksp4 (.graph.k-shortest K4 0 3 1))
+(count (distinct (at Ksp4 '_path_id))) -- 1
+(set Ksp4_pid (at Ksp4 '_path_id))
+(set Ksp4_dist (at Ksp4 '_dist))
+(set Ksp4_idx (where (== Ksp4_pid 0)))
+(set Ksp4_last (- (count Ksp4_idx) 1))
+(at Ksp4_dist (at Ksp4_idx Ksp4_last)) -- 3.0
+
+;; ======================================================================
+;; 12. exec_connected_comp — components on a disconnected weighted graph.
+;;     DISC2 has 2 isolated triangles → component count = 2.
+;; ======================================================================
+(set CcDisc2 (.graph.connected DISC2))
+(count CcDisc2) -- 6
+(count (distinct (at CcDisc2 '_component))) -- 2
+;; Nodes 0,1,2 share a component; nodes 3,4,5 share another.
+(set CcDisc2_node (at CcDisc2 '_component))
+;; Component label is monotone (smallest representative). The components
+;; for nodes {0,1,2} are all equal; same for nodes {3,4,5}.  We assert
+;; that the multiset of component labels has exactly 3 of one value and
+;; 3 of another — i.e. group sizes are balanced.
+(min (at CcDisc2 '_component)) -- 0
+;; DAG1 and CHAIN are fully connected (one weakly-connected component).
+(count (distinct (at (.graph.connected DAG1) '_component))) -- 1
+(count (distinct (at (.graph.connected CHAIN) '_component))) -- 1
+
+;; ======================================================================
+;; 13. exec_expand — single-hop (already covered in graph_basic but
+;;     repeat on the new CHAIN/DAG1 fixtures for region coverage).
+;; ======================================================================
+;; CHAIN: node 0 has one fwd neighbor {1}.
+(count (.graph.expand CHAIN 0)) -- 1
+;; DAG1 node 0 has two fwd neighbors {1,2}.
+(count (.graph.expand DAG1 0)) -- 2
+;; DAG1 node 2 has two fwd neighbors {3,4}.
+(count (.graph.expand DAG1 2)) -- 2
+
+;; ======================================================================
+;; Cleanup
+;; ======================================================================
+(.graph.free DAG1)
+(.graph.free K4)
+(.graph.free CHAIN)
+(.graph.free DISC2)

--- a/test/rfl/group/count_distinct_paths.rfl
+++ b/test/rfl/group/count_distinct_paths.rfl
@@ -1,0 +1,268 @@
+;; Per-group count(distinct) coverage for src/ops/group.c — focused on
+;; the kernels added by the recent ClickBench perf commits:
+;;
+;;   ray_count_distinct_per_group   (single global hash, serial)
+;;   count_distinct_per_group_parallel (cdpg_hist_fn / cdpg_scat_fn /
+;;                                      cdpg_dedup_fn, partitioned)
+;;   count_distinct_per_group_buf   (per-group slice, low-cardinality)
+;;
+;; Dispatch site (src/ops/query.c:7622-7659):
+;;   - n_groups > 50000 + direct-column inner  → ray_count_distinct_per_group
+;;       └─ n_rows >= 200000 + worker pool      → count_distinct_per_group_parallel
+;;       └─ otherwise                          → serial global-hash CD_INSERT
+;;   - n_groups <= 50000                       → count_distinct_per_group_buf
+;;       └─ n_groups >= 4 + pool >= 2 + flat   → parallel cdpg_buf_par_fn
+;;       └─ else / type miss                   → exec_count_distinct per group
+;;
+;; All inputs are happy-path: correct types/shapes, no null payloads.
+;;
+;; Companion file test/rfl/agg/count_distinct.rfl covers ungrouped
+;; count(distinct) and one parallel CDPG smoke at 200000×51000.  This
+;; file fills in the per-group kernel matrix (val types × key shape ×
+;; cardinality buckets) so every per-group path lights up.
+;;
+;; Cross-check methodology: every assertion is verifiable by hand from
+;; the table generator.  We assert (count R), (sum (at R 'c)), and the
+;; per-group `c` value via `(at (at R 'c) i)` — three orthogonal probes
+;; that catch off-by-one and per-group-undercount regressions.
+
+;; ════════════════════════════════════════════════════════════════════
+;; 1. SMALL TABLE — serial global-hash path (sequential)
+;;    n_rows < 200000  AND  n_groups > 50000? No → routes via
+;;    count_distinct_per_group_buf (n_groups <= 50000 branch) which
+;;    itself dispatches to parallel cdpg_buf_par_fn when n_groups >= 4.
+;;    With n_groups = 3 we fall through to the serial exec_count_distinct
+;;    per-group loop (query.c:2613-2639) — sequential reference path.
+;; ════════════════════════════════════════════════════════════════════
+
+;; 12 rows, 3 groups, I64 vals.  Sequential per-group loop (n_groups < 4
+;; bypasses cdpg_buf_par_fn entirely).
+(set Ts1 (table [k v] (list [1 1 1 1 2 2 2 2 3 3 3 3] [10 10 20 20 30 31 32 33 40 40 41 41])))
+(set Rs1 (select {c: (count (distinct v)) from: Ts1 by: k}))
+(count Rs1) -- 3
+;; k=1 → {10,20} = 2 distinct; k=2 → {30,31,32,33} = 4; k=3 → {40,41} = 2.
+(at (at Rs1 'c) 0) -- 2
+(at (at Rs1 'c) 1) -- 4
+(at (at Rs1 'c) 2) -- 2
+(sum (at Rs1 'c)) -- 8
+
+;; ════════════════════════════════════════════════════════════════════
+;; 2. SMALL/MEDIUM TABLE — cdpg_buf_par_fn (per-group-slice parallel)
+;;    n_groups >= 4 + pool >= 2 trips the parallel buf kernel in
+;;    query.c:2589-2603.  Each task dedupes one group with the
+;;    single-array open-addressing HT (CDPG_BUF_INSERT macro).
+;; ════════════════════════════════════════════════════════════════════
+
+;; 6 groups (>= 4 → parallel buf path) with predictable distinct counts.
+;; v[r] = r mod 13 → 13 distinct values cycle.  k[r] = r mod 6 → 6 groups.
+;; With N=600 rows, each group sees 100 rows, and v mod 13 covers all 13
+;; values in each group (since 100 > 13).  Cross-checked by enumeration.
+(set Nb 600)
+(set Tb1 (table [k v] (list (% (til Nb) 6) (% (til Nb) 13))))
+(set Rb1 (select {c: (count (distinct v)) from: Tb1 by: k}))
+(count Rb1) -- 6
+;; Each group has 100 rows; v cycles 0..12 → 13 distinct per group.
+(at (at Rb1 'c) 0) -- 13
+(at (at Rb1 'c) 3) -- 13
+(at (at Rb1 'c) 5) -- 13
+;; 6 * 13 = 78
+(sum (at Rb1 'c)) -- 78
+
+;; ════════════════════════════════════════════════════════════════════
+;; 3. cdpg_buf_par_fn — F64 vals (is_f64 branch)
+;;    Trips the F64 NaN/0.0 normalisation arm (query.c CDPG_BUF_INSERT
+;;    F64 path) and the F64 typed read.
+;; ════════════════════════════════════════════════════════════════════
+
+(set Nf 1000)
+;; 10 groups, each row's v = (r % 7) cast to F64.
+;; Each group has 7 distinct F64 values.
+(set Tf1 (table [k v] (list (% (til Nf) 10) (as 'F64 (% (til Nf) 7)))))
+;; Each k in 0..9 receives 100 rows; v cycles 0..6 → 7 distinct per group.
+(set Rf1 (select {c: (count (distinct v)) from: Tf1 by: k}))
+(count Rf1) -- 10
+;; All 10 groups have 7 distinct F64 values.
+(at (at Rf1 'c) 0) -- 7
+(at (at Rf1 'c) 9) -- 7
+(sum (at Rf1 'c)) -- 70
+
+;; ════════════════════════════════════════════════════════════════════
+;; 4. cdpg_buf_par_fn — esz=4 (I32) and esz=2 (I16) and esz=1 (U8/BOOL)
+;;    Trips the typed-pointer specialisations in cdpg_buf_par_fn.
+;; ════════════════════════════════════════════════════════════════════
+
+;; I32 — esz=4 branch.
+(set Ti32 (table [k v] (list (% (til Nf) 8) (as 'I32 (% (til Nf) 5)))))
+(set Ri32 (select {c: (count (distinct v)) from: Ti32 by: k}))
+(count Ri32) -- 8
+(at (at Ri32 'c) 0) -- 5
+(sum (at Ri32 'c)) -- 40
+
+;; I16 — esz=2 branch.  K=6 and D=5 are coprime → 5 distinct per group.
+(set Ti16 (table [k v] (list (% (til Nf) 6) (as 'I16 (% (til Nf) 5)))))
+(set Ri16 (select {c: (count (distinct v)) from: Ti16 by: k}))
+(count Ri16) -- 6
+(at (at Ri16 'c) 0) -- 5
+(sum (at Ri16 'c)) -- 30
+
+;; U8 — esz=1 branch.
+(set Tu8 (table [k v] (list (% (til Nf) 5) (as 'U8 (% (til Nf) 3)))))
+(set Ru8 (select {c: (count (distinct v)) from: Tu8 by: k}))
+(count Ru8) -- 5
+(at (at Ru8 'c) 0) -- 3
+(sum (at Ru8 'c)) -- 15
+
+;; ════════════════════════════════════════════════════════════════════
+;; 5. cdpg_buf_par_fn — SYM vals (RAY_IS_SYM branch)
+;;    SYM payload goes through the SYM-attrs preserving gather and the
+;;    SYM esz/8 specialisation in cdpg_buf_par_fn.
+;; ════════════════════════════════════════════════════════════════════
+
+(set Ts (table [k v] (list [1 1 1 2 2 2 3 3 3 4 4 4] ['a 'b 'a 'c 'c 'd 'e 'e 'e 'f 'g 'h])))
+(set Rs (select {c: (count (distinct v)) from: Ts by: k}))
+(count Rs) -- 4
+;; k=1 → {'a 'b} = 2; k=2 → {'c 'd} = 2; k=3 → {'e} = 1; k=4 → {'f 'g 'h} = 3.
+(at (at Rs 'c) 0) -- 2
+(at (at Rs 'c) 1) -- 2
+(at (at Rs 'c) 2) -- 1
+(at (at Rs 'c) 3) -- 3
+(sum (at Rs 'c)) -- 8
+
+;; ════════════════════════════════════════════════════════════════════
+;; 6. ray_count_distinct_per_group — single-array HT (DuckDB-style),
+;;    n_groups > 50000 sub-200000 rows triggers serial global-hash.
+;;    Path: query.c:7650 → ray_count_distinct_per_group → CD_INSERT
+;;    loop (group.c:1162-1227, esz=8 I64 specialisation).
+;; ════════════════════════════════════════════════════════════════════
+
+;; 100000 rows × 60000 groups, I64 vals.  n_rows < 200000 → SKIP
+;; the parallel kernel (group.c:1092 threshold), n_groups > 50000 → ENTER
+;; ray_count_distinct_per_group serial CD_INSERT loop.
+(set Nh 100000)
+(set Th1 (table [k v] (list (% (til Nh) 60000) (% (til Nh) 3))))
+(set Rh1 (select {c: (count (distinct v)) from: Th1 by: k}))
+;; 60000 distinct gids in the key column.
+(count Rh1) -- 60000
+
+;; ════════════════════════════════════════════════════════════════════
+;; 7. count_distinct_per_group_parallel — partitioned kernel
+;;    n_rows >= 200000 + n_groups > 50000 + worker pool present.
+;;    Path: group.c:1093 → cdpg_hist_fn / cdpg_scat_fn / cdpg_dedup_fn.
+;;    The agg/count_distinct.rfl already covers I64 here; we add F64 +
+;;    SYM coverage that wasn't there.
+;; ════════════════════════════════════════════════════════════════════
+
+;; 200000 rows × 51000 groups, F64 vals.  Trips the F64 arms in
+;; cdpg_hist_fn / cdpg_scat_fn / cdpg_dedup_fn including the NaN
+;; normalisation (group.c:1169-1172).
+(set Np 200000)
+(set Tp1 (table [k v] (list (% (til Np) 51000) (as 'F64 (% (til Np) 5)))))
+(set Rp1 (select {c: (count (distinct v)) from: Tp1 by: k}))
+(count Rp1) -- 51000
+
+;; Same shape, SYM vals — exercises the SYM esz dispatch in the
+;; partitioned kernel.  3 distinct syms cycling so per-group count
+;; saturates at 3 (or 4 when row count per group rounds favourably).
+(set Tp2 (table [k v] (list (% (til Np) 51000) (take ['x 'y 'z] Np))))
+(set Rp2 (select {c: (count (distinct v)) from: Tp2 by: k}))
+(count Rp2) -- 51000
+
+;; ════════════════════════════════════════════════════════════════════
+;; 8. Multi-key composite group — by [k1 k2]
+;;    Composite gid takes the gid-pack path in the DAG group prep.
+;;    Lights up the same cdpg_buf_par_fn / ray_count_distinct_per_group
+;;    branches via the composite-gid wrapper rather than the single-col
+;;    fast path.
+;; ════════════════════════════════════════════════════════════════════
+
+;; 6 distinct (k1,k2) pairs over 24 rows.
+(set Tmk (table [k1 k2 v] (list [1 1 1 1 2 2 2 2 3 3 3 3 1 1 1 1 2 2 2 2 3 3 3 3] [1 1 2 2 1 1 2 2 1 1 2 2 1 1 2 2 1 1 2 2 1 1 2 2] [100 100 200 201 300 301 400 401 500 500 600 601 100 110 200 210 300 310 400 410 500 510 600 610])))
+(set Rmk (select {c: (count (distinct v)) from: Tmk by: [k1 k2]}))
+(count Rmk) -- 6
+;; (1,1): {100,110}=2; (1,2): {200,201,210}=3; (2,1): {300,301,310}=3;
+;; (2,2): {400,401,410}=3; (3,1): {500,510}=2; (3,2): {600,601,610}=3.
+;; Sum = 2+3+3+3+2+3 = 16.
+(sum (at Rmk 'c)) -- 16
+
+;; ════════════════════════════════════════════════════════════════════
+;; 9. Multi-key composite at the parallel threshold — exercises the
+;;    composite-gid wrapper at n_rows >= 200000 (drives gid through
+;;    count_distinct_per_group_parallel via the composite pack).
+;; ════════════════════════════════════════════════════════════════════
+
+;; Large multi-key: k1 in 0..199, k2 in 0..254 → 200*255 = 51000 pairs.
+;; Pack drives n_groups around 51000 — exactly the > 50000 threshold to
+;; route through ray_count_distinct_per_group.
+(set Nmk 200000)
+(set Tmkp (table [k1 k2 v] (list (% (til Nmk) 200) (% (til Nmk) 255) (% (til Nmk) 4))))
+(set Rmkp (select {c: (count (distinct v)) from: Tmkp by: [k1 k2]}))
+;; Asserting only that the result has >= 50000 rows (composite cardinality
+;; is data-dependent on the LCM; the planner should produce one row per
+;; observed (k1,k2) pair).  Use a precise count from the table generator:
+;; pairs (i % 200, i % 255) cycle with period lcm(200,255) = 10200 → 10200
+;; distinct pairs.
+(count Rmkp) -- 10200
+
+;; ════════════════════════════════════════════════════════════════════
+;; 10. SYM key with I64 vals — count_distinct_per_group_buf path
+;;     SYM keys force the eval-level group fallback at low cardinality
+;;     (the DAG group-boundary path can't pack SYM keys in some configs);
+;;     verifies the buf kernel still produces the right answer when the
+;;     planner routes through count_distinct_per_group_groups (the LIST-
+;;     keyed variant) or count_distinct_per_group_buf as appropriate.
+;; ════════════════════════════════════════════════════════════════════
+
+(set Tsk (table [s v] (list ['A 'A 'A 'B 'B 'B 'C 'C 'C 'D 'D 'D] [10 20 30 40 40 50 60 70 70 80 90 90])))
+(set Rsk (select {c: (count (distinct v)) from: Tsk by: s}))
+(count Rsk) -- 4
+;; A → {10,20,30}=3; B → {40,50}=2; C → {60,70}=2; D → {80,90}=2.
+(sum (at Rsk 'c)) -- 9
+
+;; ════════════════════════════════════════════════════════════════════
+;; 11. I64 vals + I64 keys at medium scale — buf kernel with the
+;;     n_groups >= 4 parallel dispatch active, ~10 groups × ~1k rows.
+;;     Exact match of the brief's "medium" bucket.
+;; ════════════════════════════════════════════════════════════════════
+
+(set Nm 1000)
+;; K=10, D=11 — coprime so every group sees all 11 distinct values.
+(set Tm1 (table [k v] (list (% (til Nm) 10) (% (til Nm) 11))))
+(set Rm1 (select {c: (count (distinct v)) from: Tm1 by: k}))
+(count Rm1) -- 10
+(at (at Rm1 'c) 0) -- 11
+(at (at Rm1 'c) 5) -- 11
+(at (at Rm1 'c) 9) -- 11
+(sum (at Rm1 'c)) -- 110
+
+;; ════════════════════════════════════════════════════════════════════
+;; 12. Large-N + few-groups (~100 groups × 50k rows) — buf parallel
+;;     path with substantial per-group work.  Mirrors the brief's
+;;     "large" bucket but stays under the 200000-row partitioned
+;;     threshold so this exercises the per-group-slice parallel kernel,
+;;     not the partitioned one.
+;; ════════════════════════════════════════════════════════════════════
+
+(set Nlb 50000)
+(set Tlb (table [k v] (list (% (til Nlb) 100) (% (til Nlb) 13))))
+(set Rlb (select {c: (count (distinct v)) from: Tlb by: k}))
+(count Rlb) -- 100
+;; Each k receives 500 rows; v cycles 0..12 → 13 distinct per group
+;; (500 >> 13 so every cycle position lands in every group).
+(at (at Rlb 'c) 0) -- 13
+(at (at Rlb 'c) 50) -- 13
+(at (at Rlb 'c) 99) -- 13
+(sum (at Rlb 'c)) -- 1300
+
+;; ════════════════════════════════════════════════════════════════════
+;; 13. Cross-check against ungrouped (count (distinct ...)) reference.
+;;     For each per-group result above we can confirm the total distinct
+;;     pairs equals (sum c).  Here we round-trip a small example through
+;;     both formulations.
+;; ════════════════════════════════════════════════════════════════════
+
+(set Txc (table [k v] (list [1 1 2 2 3 3 1 2 3] [10 20 30 40 50 60 10 30 50])))
+;; Per-group: k=1 → {10,20}=2; k=2 → {30,40}=2; k=3 → {50,60}=2; sum=6.
+(set Rxc (select {c: (count (distinct v)) from: Txc by: k}))
+(sum (at Rxc 'c)) -- 6
+;; Ungrouped reference: distinct(v) over the whole column = {10,20,30,40,50,60} = 6.
+(count (distinct (at Txc 'v))) -- 6

--- a/test/rfl/group/reprobe_stress.rfl
+++ b/test/rfl/group/reprobe_stress.rfl
@@ -1,0 +1,174 @@
+;; ════════════════════════════════════════════════════════════════════
+;; Reprobe / per-group dispatch stress for n_groups > 65536
+;; (src/ops/group.c).
+;;
+;; Targets four 0%-coverage functions activated only above the
+;; ray_pool_dispatch_n task-ring cap (MAX_RING_CAP = 1<<16 = 65536):
+;;
+;;   - ray_median_per_group_buf / ray_topk_per_group_buf
+;;       fix 91531da8 added an `n_groups < (1 << 16)` branch that
+;;       falls back to ray_pool_dispatch (elements-based) above the
+;;       cap.  Below 65536 stays on dispatch_n.  Both branches must
+;;       cover all groups — a multi-key holistic agg over 65536+
+;;       distinct groups previously dropped the tail (returned 65536
+;;       cells instead of n_groups).
+;;
+;;   - reprobe_rows_fn  (group.c:4329)
+;;       Post-radix re-probe: holistic aggs need a per-group row slice
+;;       so the executor re-hashes each source row against the
+;;       partitioned HTs to recover global gids.  Always runs when
+;;       `ght_layout.agg_is_holistic` is set; queries below force a
+;;       multi-key holistic dispatch over a high-cardinality table so
+;;       both the reprobe scan and the subsequent dispatch_n /
+;;       dispatch fallback are exercised.
+;;
+;;   - group_ht_insert_empty_group  (group.c:2337)
+;;   - group_rows_range_existing    (group.c:2529)
+;;   - group_probe_existing_entry   (group.c:2364)
+;;       Top-count emit-filter path: planner converts
+;;         (select {c:(count k) by:[k1 k2] desc:c take:N})
+;;       into a runtime emit filter; group.c at 6700 / 6900 / 7160
+;;       pre-populates a result HT with the heavy keys via
+;;       group_ht_insert_empty_group, then re-scans every source row
+;;       via group_rows_range_existing → group_probe_existing_entry
+;;       to fold matching rows into the kept groups.  Only multi-key
+;;       (n_keys >= 2 && n_keys <= 5) routes here; single key uses a
+;;       different fused path.  HT-grow path is reached when the
+;;       initial ht_cap (256, grown to fit heavy_count*2 worst case)
+;;       fills past load factor 0.5 across the re-scan.
+;;
+;; Trigger conditions in this file:
+;;   - 70_000 unique I64 keys → n_groups > 1<<16 (65536) cap
+;;   - holistic agg via (med v) or (top v K) under by: [k1 k2]
+;;   - top-count filter via desc:c take:N over multi-key by:
+;;
+;; Sub-threshold baseline (50_000 groups) verifies the dispatch_n
+;; branch still works — i.e. the gate's "<" boundary stays correct.
+;;
+;; Sizing: 70_000 rows / groups is just above
+;;   - RAY_PARALLEL_THRESHOLD (64*1024 = 65536, ops.h:92) → radix path
+;;   - the new 1<<16 dispatch_n cap in the per-group buf kernels.
+;; ════════════════════════════════════════════════════════════════════
+
+;; ── 1. Multi-key median over 70k distinct (k1, k2) groups ───────────
+;; 70k rows, k1 ∈ [0..69999], k2 = 0 — uniqueness of (k1, k2) is
+;; driven by k1.  Holistic agg + multi-key forces the post-radix
+;; reprobe_rows_fn + ray_median_per_group_buf with n_groups = 70000
+;; > 65536, hitting the new ray_pool_dispatch elements-based branch.
+;; v is row index so per-group median is the value at the single row.
+(set N 70000)
+(set Tmed (table [k1 k2 v] (list (as 'I64 (til N)) (as 'I64 (% (til N) 1)) (as 'I64 (til N)))))
+(set Rmed (select {m: (med v) by: [k1 k2] from: Tmed}))
+(count Rmed) -- 70000
+;; Each group has exactly one row, so med == v == k1.
+;; Sum of medians = sum of (til 70000) = 70000*69999/2 = 2449965000.
+(sum (at Rmed 'm)) -- 2449965000.0
+;; med returns F64.
+(type (at Rmed 'm)) -- 'F64
+
+;; ── 2. Multi-key median with multi-row groups (n_groups > 65536) ────
+;; 140k rows, 70k distinct (k1, k2) pairs — every group sees exactly
+;; 2 rows (row i and row i+N).  Per-group median = (v_i + v_{i+N}) / 2
+;; = (i + (i+N)) / 2 = i + N/2 = i + 35000.  Sum of medians = sum
+;; over i of (i + 35000) = 2449965000 + 70000*35000 = 4899965000.0
+(set N2 140000)
+(set Tmed2 (table [k1 k2 v] (list (as 'I64 (% (til N2) N)) (as 'I64 (% (til N2) 1)) (as 'I64 (til N2)))))
+(set Rmed2 (select {m: (med v) by: [k1 k2] from: Tmed2}))
+(count Rmed2) -- 70000
+(sum (at Rmed2 'm)) -- 4899965000.0
+;; min median is for k1=0: (0 + 70000) / 2 = 35000.0
+(min (at Rmed2 'm)) -- 35000.0
+;; max median is for k1=69999: (69999 + 139999) / 2 = 104999.0
+(max (at Rmed2 'm)) -- 104999.0
+
+;; ── 3. Multi-key top-K with n_groups > 65536 ────────────────────────
+;; Same Tmed2 (140k rows, 70k groups, 2 rows per group).
+;; (top v 1) per group = max of the two rows = i + N = i + 70000.
+;; Result cells are LIST<I64>, one elem each.
+(set Rtop1 (select {t: (top v 1) by: [k1 k2] from: Tmed2}))
+(count Rtop1) -- 70000
+;; Each cell holds 1 element → total kept = 70000.
+(fold + 0 (map count (at Rtop1 't))) -- 70000
+;; Sum of all (single-element) cells = sum over i of (i + N)
+;;   = (N*(N-1)/2) + N*N = 2449965000 + 70000*70000 = 7349965000.
+(fold + 0 (map sum (at Rtop1 't))) -- 7349965000
+;; Symmetric: (bot v 1) keeps the lower of the two = i; sum = 2449965000.
+(fold + 0 (map sum (at (select {t: (bot v 1) by: [k1 k2] from: Tmed2}) 't))) -- 2449965000
+
+;; (top v 2) per group: both elements kept; group sum = 2i + N.
+;; Each cell has length 2.  Total kept = 140000.  Sum across all cells
+;; = sum over groups of (i + (i + N)) = 2 * 2449965000 + 70000*70000
+;; = 4899930000 + 4900000000 = 9799930000.
+(set Rtop2 (select {t: (top v 2) by: [k1 k2] from: Tmed2}))
+(fold + 0 (map count (at Rtop2 't))) -- 140000
+(fold + 0 (map sum   (at Rtop2 't))) -- 9799930000
+
+;; ── 4. Top-count filter: desc:c take:N over 70k multi-key groups ────
+;; (count v) with by:[k1 k2] + desc:c + take:K triggers the emit
+;; filter `top_count_take` path; n_keys=2 routes through the
+;; group_ht_insert_empty_group / group_rows_range_existing /
+;; group_probe_existing_entry block at group.c:6700-7060.
+;;
+;; Tcc has 70k rows, 35000 distinct (k1, k2) pairs, each with count
+;; 2.  Top-K is deterministic over count, ties broken by partition
+;; order.  We assert exact row count and the heavy-count sum.
+(set Ncc 70000)
+(set Tcc (table [k1 k2 v] (list (as 'I64 (% (til Ncc) 35000)) (as 'I64 (% (til Ncc) 1)) (as 'I64 (til Ncc)))))
+(set Rcc (select {c: (count v) from: Tcc by: [k1 k2] desc: c take: 100}))
+(count Rcc) -- 100
+;; Each surviving group has count 2.
+(sum (at Rcc 'c)) -- 200
+(max (at Rcc 'c)) -- 2
+(min (at Rcc 'c)) -- 2
+
+;; ── 5. Top-count filter at the 70k-group level (heavy-key promote) ──
+;; Imbalanced counts so the heap selects identifiable winners.  Tcc2
+;; has 70_010 rows: 70_000 unique k1 values with one row each, then
+;; 10 extra rows duplicating k1=0..9.  k1=0..9 have count 2; the
+;; rest have count 1.  Top-5 by count must keep 5 of those 10 ties,
+;; all with c == 2.
+(set Nbase 70000)
+(set Tcc2 (table [k1 k2 v] (list (as 'I64 (concat (til Nbase) (til 10))) (as 'I64 (% (til (+ Nbase 10)) 1)) (as 'I64 (til (+ Nbase 10))))))
+(set Rcc2 (select {c: (count v) from: Tcc2 by: [k1 k2] desc: c take: 5}))
+(count Rcc2) -- 5
+(sum (at Rcc2 'c)) -- 10
+(min (at Rcc2 'c)) -- 2
+(max (at Rcc2 'c)) -- 2
+
+;; ── 6. Three-key top-count filter, 70k groups ───────────────────────
+;; n_keys=3 still routes through the multi-key emit-filter block
+;; (range 2..5 inclusive).  Re-uses N2 (140k rows, 70k unique
+;; (k1, k2, k3=k2) triples).  desc:c take:50 keeps 50 groups, each
+;; with count 2.
+(set Tcc3 (table [k1 k2 k3 v] (list (as 'I64 (% (til N2) N)) (as 'I64 (% (til N2) 1)) (as 'I64 (% (til N2) 1)) (as 'I64 (til N2)))))
+(set Rcc3 (select {c: (count v) from: Tcc3 by: [k1 k2 k3] desc: c take: 50}))
+(count Rcc3) -- 50
+(sum (at Rcc3 'c)) -- 100
+(min (at Rcc3 'c)) -- 2
+
+;; ── 7. Sub-threshold baseline: 50_000 groups (stays on dispatch_n) ──
+;; n_groups < 1<<16 → ray_pool_dispatch_n branch (original path).
+;; Verifies the gate boundary did not regress.  50k rows, 50k unique
+;; (k1, k2) groups, multi-key holistic median.
+(set Nbase2 50000)
+(set Tlow (table [k1 k2 v] (list (as 'I64 (til Nbase2)) (as 'I64 (% (til Nbase2) 1)) (as 'I64 (til Nbase2)))))
+(set Rlow (select {m: (med v) by: [k1 k2] from: Tlow}))
+(count Rlow) -- 50000
+;; Each group is a single row, sum(med) = sum(v) = 50000*49999/2 = 1249975000.0.
+(sum (at Rlow 'm)) -- 1249975000.0
+
+;; ── 8. F64 value column with n_groups > 65536 holistic median ───────
+;; Reaches the F64 arm of med_read_as_f64 + the >65536 dispatch.
+(set Tfmed (table [k1 k2 v] (list (as 'I64 (% (til N2) N)) (as 'I64 (% (til N2) 1)) (as 'F64 (til N2)))))
+(set Rfmed (select {m: (med v) by: [k1 k2] from: Tfmed}))
+(count Rfmed) -- 70000
+(sum (at Rfmed 'm)) -- 4899965000.0
+
+;; ── 9. SYM keys with n_groups > 65536 holistic median ───────────────
+;; Wide-key (SYM) path through reprobe_rows_fn.  70k distinct
+;; symbol keys → 70k groups.  (as 'SYMBOL (til N)) interns N
+;; distinct symbols.
+(set Tsmed (table [k1 k2 v] (list (as 'SYMBOL (til N)) (as 'SYMBOL (% (til N) 1)) (as 'I64 (til N)))))
+(set Rsmed (select {m: (med v) by: [k1 k2] from: Tsmed}))
+(count Rsmed) -- 70000
+(sum (at Rsmed 'm)) -- 2449965000.0

--- a/test/rfl/ops/expr_mixed_types.rfl
+++ b/test/rfl/ops/expr_mixed_types.rfl
@@ -1,0 +1,444 @@
+;; Mixed-type binary expressions in src/ops/expr.c — combinations NOT
+;; covered by expr_typed_fast.rfl.  Drives the generic LV_READ / RV_READ
+;; arms of binary_range (expr.c:1632-1782) and binary_range_str
+;; (expr.c:1420-1478), focusing on:
+;;
+;;   - Cross-width / cross-family integer arithmetic where the fast
+;;     paths BR_AR_FAST / BR_FAST are skipped (lhs->type != out_type,
+;;     or out_type is RAY_F64 / RAY_U8 / RAY_BOOL).
+;;   - F64 arms: out_type=F64 with at least one integer-family operand
+;;     (LV_READ / RV_READ does the int→double cast).
+;;   - Vec-vec dispatch (both !l_scalar && !r_scalar).
+;;   - Temporal arithmetic: DATE+I64, TIME+I64, TIMESTAMP+I64.
+;;   - SYM-vec × SYM-vec compare, STR-vec × STR-vec compare, BOOL ops
+;;     on vec-vec inputs (out_type=BOOL float-family branch).
+;;
+;; All sizes here are deliberately small (≤ 2048) — the fast paths
+;; and the parallel pool dispatch are already covered by
+;; expr_typed_fast.rfl.  These tests target the sequential, generic
+;; element-wise arms.
+;;
+;; Happy path: no nulls, no div-by-zero, no overflow / type errors.
+
+;; ════════════════════════════════════════════════════════════════════
+;; 1. INT-VEC × F64-SCALAR  (out_type=F64; BR_AR_FAST skipped because
+;;    lhs->type != out_type → generic F64 arm at expr.c:1688-1700)
+;; ════════════════════════════════════════════════════════════════════
+
+(set VI16 (as 'I16 [1h 2h 3h 4h 5h]))
+(set VI32 [1i 2i 3i 4i 5i])
+(set VI64 [1 2 3 4 5])
+
+;; I64-vec + F64-scalar → F64 vec
+(+ VI64 0.5)            -- [1.5 2.5 3.5 4.5 5.5]
+(- VI64 0.25)           -- [0.75 1.75 2.75 3.75 4.75]
+(* VI64 2.0)            -- [2.0 4.0 6.0 8.0 10.0]
+(/ VI64 2.0)            -- [0.5 1.0 1.5 2.0 2.5]
+(type (+ VI64 0.5))     -- 'F64
+
+;; I32-vec + F64-scalar → F64 vec (lhs is read via lp_i32 → cast to double)
+(+ VI32 0.5)            -- [1.5 2.5 3.5 4.5 5.5]
+(* VI32 0.5)            -- [0.5 1.0 1.5 2.0 2.5]
+(type (+ VI32 0.5))     -- 'F64
+
+;; I16-vec + F64-scalar → F64 vec (lhs read via lp_i16)
+(+ VI16 0.5)            -- [1.5 2.5 3.5 4.5 5.5]
+(* VI16 2.5)            -- [2.5 5.0 7.5 10.0 12.5]
+(type (+ VI16 0.5))     -- 'F64
+
+;; ════════════════════════════════════════════════════════════════════
+;; 2. F64-VEC × INT-SCALAR  (out_type=F64; r_scalar=true, lp_f64 set,
+;;    integer scalar read via r_i64 cast to double in RV_READ)
+;; ════════════════════════════════════════════════════════════════════
+
+(set VF64 [1.0 2.0 3.0 4.0 5.0])
+
+(+ VF64 1)              -- [2.0 3.0 4.0 5.0 6.0]
+(- VF64 1)              -- [0.0 1.0 2.0 3.0 4.0]
+(* VF64 2)              -- [2.0 4.0 6.0 8.0 10.0]
+(/ VF64 2)              -- [0.5 1.0 1.5 2.0 2.5]
+(+ VF64 1h)             -- [2.0 3.0 4.0 5.0 6.0]
+(+ VF64 1i)             -- [2.0 3.0 4.0 5.0 6.0]
+(type (+ VF64 1))       -- 'F64
+
+;; ════════════════════════════════════════════════════════════════════
+;; 3. INT-VEC × INT-SCALAR with type promotion to wider type
+;;    (lhs->type != out_type → BR_AR_FAST skipped; generic out_type arm)
+;; ════════════════════════════════════════════════════════════════════
+
+;; I32-vec + I64-scalar → I64 vec
+(+ VI32 100)            -- [101 102 103 104 105]
+(- VI32 1)              -- [0 1 2 3 4]
+(* VI32 10)             -- [10 20 30 40 50]
+(type (+ VI32 100))     -- 'I64
+
+;; I16-vec + I64-scalar → I64 vec
+(+ VI16 1000)           -- [1001 1002 1003 1004 1005]
+(* VI16 100)            -- [100 200 300 400 500]
+(type (+ VI16 1000))    -- 'I64
+
+;; I16-vec + I32-scalar → I32 vec (BR_AR_FAST l_esz=2 path — lhs->type
+;; differs from out_type=I32 → skipped → generic I32 arm at expr.c:1714)
+(+ VI16 100i)           -- [101i 102i 103i 104i 105i]
+(- VI16 1i)             -- [0i 1i 2i 3i 4i]
+(* VI16 10i)            -- [10i 20i 30i 40i 50i]
+(type (+ VI16 100i))    -- 'I32
+
+;; ════════════════════════════════════════════════════════════════════
+;; 4. VEC-VEC ARITHMETIC  (both !l_scalar && !r_scalar; covers the
+;;    branches where BOTH lhs and rhs are typed pointer reads)
+;; ════════════════════════════════════════════════════════════════════
+
+;; I64-vec + I64-vec → I64
+(+ VI64 [10 20 30 40 50])      -- [11 22 33 44 55]
+(- VI64 [1 1 1 1 1])           -- [0 1 2 3 4]
+(* VI64 [2 2 2 2 2])           -- [2 4 6 8 10]
+(% [10 20 30 40 50] [3 3 3 3 3]) -- [1 2 0 1 2]
+
+;; I32-vec + I32-vec → I32
+(+ VI32 [10i 20i 30i 40i 50i]) -- [11i 22i 33i 44i 55i]
+(type (+ VI32 VI32))           -- 'I32
+
+;; I16-vec + I16-vec → I16
+(+ VI16 (as 'I16 [10h 20h 30h 40h 50h]))   -- [11h 22h 33h 44h 55h]
+(type (+ VI16 VI16))           -- 'I16
+
+;; F64-vec + F64-vec → F64
+(+ VF64 [10.0 20.0 30.0 40.0 50.0])  -- [11.0 22.0 33.0 44.0 55.0]
+(* VF64 [2.0 2.0 2.0 2.0 2.0])       -- [2.0 4.0 6.0 8.0 10.0]
+(/ VF64 [2.0 4.0 6.0 8.0 10.0])      -- [0.5 0.5 0.5 0.5 0.5]
+
+;; I32-vec + I64-vec → I64 (mixed-width vec-vec)
+(+ VI32 VI64)            -- [2 4 6 8 10]
+(type (+ VI32 VI64))     -- 'I64
+
+;; I16-vec + I64-vec → I64
+(+ VI16 VI64)            -- [2 4 6 8 10]
+(type (+ VI16 VI64))     -- 'I64
+
+;; I16-vec + I32-vec → I32
+(+ VI16 VI32)            -- [2i 4i 6i 8i 10i]
+(type (+ VI16 VI32))     -- 'I32
+
+;; I64-vec + F64-vec → F64 (int read via lp_i64, float read via rp_f64)
+(+ VI64 VF64)            -- [2.0 4.0 6.0 8.0 10.0]
+(type (+ VI64 VF64))     -- 'F64
+
+;; I32-vec + F64-vec → F64
+(+ VI32 VF64)            -- [2.0 4.0 6.0 8.0 10.0]
+
+;; ════════════════════════════════════════════════════════════════════
+;; 5. VEC-VEC COMPARISONS  (out_type=BOOL, src_is_i64_all branch at
+;;    expr.c:1755-1767 OR float-family branch at 1768-1781)
+;; ════════════════════════════════════════════════════════════════════
+
+;; I64 × I64 vec-vec → BOOL
+(== VI64 [1 2 99 4 5])    -- [true true false true true]
+(!= VI64 [1 2 99 4 5])    -- [false false true false false]
+(<  VI64 [2 2 4 4 6])     -- [true false true false true]
+(>= VI64 [1 3 3 5 5])     -- [true false true false true]
+
+;; Mixed-width int vec-vec → BOOL (both operands integer-family)
+(== VI32 [1 2 3 4 5])              -- [true true true true true]
+(== VI16 VI32)                     -- [true true true true true]
+(<  VI16 VI64)                     -- [false false false false false]
+
+;; F64 × F64 vec-vec → BOOL (float-family arm; NaN handling not exercised
+;; on happy path, all-finite inputs → ln/rn both 0).
+(== VF64 [1.0 2.0 99.0 4.0 5.0])   -- [true true false true true]
+(<  VF64 [2.0 2.0 4.0 4.0 6.0])    -- [true false true false true]
+(>  [5.0 5.0 5.0 5.0 5.0] VF64)    -- [true true true true false]
+
+;; F64 × I64 vec-vec → BOOL (mixed-family; takes the float-family arm
+;; because at least one side is F64).
+(== VF64 VI64)                      -- [true true true true true]
+(<  VF64 [10 10 10 10 10])          -- [true true true true true]
+
+;; ════════════════════════════════════════════════════════════════════
+;; 6. BOOL OPS — vec-vec AND / OR  (out_type=BOOL, op=OP_AND/OP_OR;
+;;    src_is_i64_all branch when both inputs integer-family).
+;; ════════════════════════════════════════════════════════════════════
+
+(set VB1 [true false true false true])
+(set VB2 [true true false false true])
+
+(and VB1 VB2)   -- [true false false false true]
+(or  VB1 VB2)   -- [true true true false true]
+
+;; AND/OR over derived BOOL vectors (predicate combinator pattern).
+(set GT  (> VI64 2))             ;; [false false true true true]
+(set LT  (< VI64 5))             ;; [true true true true false]
+(and GT LT)                      -- [false false true true false]
+(or  GT LT)                      -- [true true true true true]
+
+;; AND/OR with scalar BOOL on the right.
+(and VB1 true)   -- [true false true false true]
+(and VB1 false)  -- [false false false false false]
+(or  VB1 false)  -- [true false true false true]
+(or  VB1 true)   -- [true true true true true]
+
+;; ════════════════════════════════════════════════════════════════════
+;; 7. TEMPORAL ARITHMETIC — DATE/TIME/TIMESTAMP + INT-SCALAR
+;;    Same-type arith → BR_AR_FAST l_esz=4 (DATE/TIME) or l_esz=8
+;;    (TIMESTAMP) when scalar matches the column's underlying int type.
+;; ════════════════════════════════════════════════════════════════════
+
+;; DATE + I32-scalar → DATE  (BR_AR_FAST l_esz=4, lhs->type==RAY_DATE)
+;; DATE epoch = 2000.01.01 (Rayforce convention; see src/store/part.c:78).
+;; 2024.01.01 = 8766 days since 2000.01.01.
+(set VD (as 'DATE [2024.01.01 2024.01.02 2024.01.03 2024.01.04 2024.01.05]))
+
+;; Spot-check the underlying I32 element value (epoch days).
+(at (as 'I32 VD) 0)             -- 8766i
+(at (as 'I32 VD) 4)             -- 8770i
+(at (as 'I32 (+ VD 10i)) 0)     -- 8776i
+(at (as 'I32 (+ VD 10i)) 4)     -- 8780i
+(at (as 'I32 (- VD 5i)) 0)      -- 8761i
+
+;; (+ DATE DATE) and (- DATE DATE) are explicit type errors at the
+;; lang level — date arithmetic only accepts a date and an integer
+;; offset.  Vec-vec arith is therefore not reachable for DATE.
+
+;; TIME + I32-scalar → TIME (BR_AR_FAST l_esz=4)
+(set VT (as 'TIME [00:00:00.000 00:00:01.000 00:00:02.000]))
+(at (as 'I32 VT) 0)             -- 0i
+(at (as 'I32 VT) 1)             -- 1000i
+(at (as 'I32 (+ VT 500i)) 0)    -- 500i
+(at (as 'I32 (+ VT 500i)) 1)    -- 1500i
+(at (as 'I32 (- VT 100i)) 1)    -- 900i
+
+;; TIMESTAMP + I64-scalar → TIMESTAMP (BR_AR_FAST l_esz=8)
+(set VTS (as 'TIMESTAMP [1000 2000 3000 4000 5000]))
+(at (as 'I64 (+ VTS 500)) 0)    -- 1500
+(at (as 'I64 (+ VTS 500)) 4)    -- 5500
+(at (as 'I64 (- VTS 100)) 0)    -- 900
+
+;; TIMESTAMP comparison (BR_FAST l_esz=8, RAY_TIMESTAMP arm at expr.c:1550)
+;; Comparison against a TIMESTAMP atom (must be same type — lang rejects
+;; bare-int compare against TIMESTAMP-vec with a `type` error).
+(== VTS (as 'TIMESTAMP 3000))   -- [false false true false false]
+(<  VTS (as 'TIMESTAMP 3000))   -- [true true false false false]
+(>= VTS (as 'TIMESTAMP 2000))   -- [false true true true true]
+
+;; DATE comparison: BR_FAST l_esz=4, lhs->type=RAY_DATE arm at 1572.
+(== VD 2024.01.03)              -- [false false true false false]
+(<  VD 2024.01.03)              -- [true true false false false]
+(>= VD 2024.01.04)              -- [false false false true true]
+
+;; TIME comparison: BR_FAST l_esz=4 arm
+(== VT 00:00:01.000)            -- [false true false]
+(<  VT 00:00:02.000)            -- [true true false]
+
+;; ════════════════════════════════════════════════════════════════════
+;; 8. SYM-vec × SYM-vec COMPARE  (out_type=BOOL; lp_u32/lp_i64 set on
+;;    both sides → falls to the generic BOOL arm at expr.c:1755 with
+;;    src_is_i64_all=1 because both classify as integer-family).
+;;    The W8 fast-eq path (lhs SYM, rhs scalar) is NOT taken for vec-vec.
+;; ════════════════════════════════════════════════════════════════════
+
+(set VS1 ['a 'b 'c 'd 'e])
+(set VS2 ['a 'b 'X 'd 'Y])
+
+;; Element-wise SYM compare
+(== VS1 VS2)   -- [true true false true false]
+(!= VS1 VS2)   -- [false false true false true]
+
+;; SYM-vec == SYM-vec (same).
+(== VS1 VS1)   -- [true true true true true]
+(sum (as 'I64 (== VS1 VS1)))  -- 5
+
+;; SYM-vec compare with SYM-atom — uses the SIMD fast-eq for atom case
+;; (already covered by expr_typed_fast.rfl; here we add a non-scalar mix
+;; via length-1 atom literal).
+(== VS1 'a)    -- [true false false false false]
+
+;; SYM-vec compared to RAY_STR scalar — the str_resolved branch in
+;; exec_elementwise_binary (expr.c:1906-1918) only fires when control
+;; reaches expr.c via the DAG executor.  The slow-path frontend
+;; (eval.c) excludes SYM from IS_NUM_TYPE, so `(== sym-vec "a")` at the
+;; REPL falls through to a per-element loop and currently emits a
+;; `type` error.  That path IS used inside select() / where clauses
+;; where columns are typed RAY_SYM and literals are RAY_STR, so the
+;; expr.c branch is reachable through the table fixture below.
+(set TSym (table [k v] (list ['a 'b 'c 'a 'b] [10 20 30 40 50])))
+(sum (at (select {from: TSym where: (== k "a")}) 'v))   -- 50
+(sum (at (select {from: TSym where: (!= k "a")}) 'v))   -- 100
+(sum (at (select {from: TSym where: (== k "b")}) 'v))   -- 70
+
+;; SYM × SYM ordering: comparison by intern ID — relies on insertion
+;; order.  Test with == and != only (ordering of intern IDs isn't
+;; semantic).  Skip < / > between distinct syms here.
+
+;; ════════════════════════════════════════════════════════════════════
+;; 9. STR-vec × STR-vec COMPARE  (binary_range_str at expr.c:1420)
+;;    Drives the !l_scalar && !r_scalar branch — both sides are STR
+;;    vectors so step_l=step_r=1 advances through both ray_str_t arrays.
+;; ════════════════════════════════════════════════════════════════════
+
+(set VSTR1 (list "apple" "banana" "cherry" "date" "elderberry"))
+(set VSTR2 (list "apple" "BANANA" "cherry" "date" "fig"))
+
+;; STR vec-vec EQ → BOOL (uses ray_str_t_eq via STR_CMP_LOOP)
+(== VSTR1 VSTR2)   -- [true false true true false]
+(!= VSTR1 VSTR2)   -- [false true false false true]
+
+;; Lexicographic ordering: "BANANA" < "banana" (uppercase < lowercase).
+;; "cherry" == "cherry" (both equal → < is false, <= is true).
+(<  VSTR1 VSTR2)   -- [false false false false true]
+(<= VSTR1 VSTR2)   -- [true false true true true]
+(>  VSTR1 VSTR2)   -- [false true false false false]
+(>= VSTR1 VSTR2)   -- [true true true true false]
+
+;; STR-vec × STR-scalar (already covered by expr_typed_fast.rfl, but
+;; mirror at the small-sequential size to confirm the generic
+;; binary_range_str arm at expr.c:1895 with r_scalar=true).
+;; "apple" "banana" "cherry" "date" "elderberry" vs "cherry":
+;;   a<c, b<c, c==c, d>c, e>c
+(== VSTR1 "cherry")  -- [false false true false false]
+(<  VSTR1 "cherry")  -- [true true false false false]
+(>  VSTR1 "cherry")  -- [false false false true true]
+
+;; STR-scalar × STR-vec (l_scalar=true) — atom_to_str_t path at
+;; expr.c:1438-1441 with step_l=0.
+(== "cherry" VSTR1)  -- [false false true false false]
+(<  "cherry" VSTR1)  -- [false false false true true]
+(>  "cherry" VSTR1)  -- [true true false false false]
+
+;; ════════════════════════════════════════════════════════════════════
+;; 10. IN — membership tests at multiple type widths.
+;;     exec_in lives in exec.c, but the BOOL-output mixed-type paths
+;;     it routes through call exec_elementwise_binary helpers and
+;;     overlap with the expr.c reachability set.
+;; ════════════════════════════════════════════════════════════════════
+
+;; I64-vec IN I64-vec literal
+(in VI64 [2 4 6])           -- [false true false true false]
+(in VI64 [1 3 5])           -- [true false true false true]
+
+;; SYM-vec IN SYM-vec literal
+(in VS1 ['a 'c 'e])         -- [true false true false true]
+(in VS1 ['x 'y])            -- [false false false false false]
+
+;; F64 vec IN F64 vec literal (use_double path in exec_in)
+(in VF64 [2.0 4.0])         -- [false true false true false]
+
+;; Scalar IN vec
+(in 3 VI64)                 -- true
+(in 99 VI64)                -- false
+
+;; not-in: same combinations, inverted
+(in [1 2 3] [2 3 4])        -- [false true true]   ;; sanity
+(in VI64 [99 100])          -- [false false false false false]
+
+;; NOTE: mixed-family IN at the standalone-`in` primitive (eval.c
+;; ray_in_fn) does NOT promote int → double — e.g.
+;;   (in [1 2 3 4 5] [2.0 4.0]) → [false false false false false]
+;; even though exec_in's float-promoted path (exec.c:737) would match.
+;; The path through exec_in is only taken when OP_IN is constructed
+;; from a query; that's exercised below via select() / where:.
+(set TInMix (table [v] (list [1 2 3 4 5])))
+(count (select {from: TInMix where: (in v [2.0 4.0])}))  -- 2
+(count (select {from: TInMix where: (in v [1 3 5])}))    -- 3
+
+;; ════════════════════════════════════════════════════════════════════
+;; 11. DIV / IDIV / MOD with mixed-type vec-vec (out_type arms).
+;;     `(/ I64 I64)` → F64; `(div I64 I64)` → I64; `(% I64 I64)` → I64.
+;; ════════════════════════════════════════════════════════════════════
+
+(/ [10 20 30 40 50] [2 4 6 8 10])   -- [5.0 5.0 5.0 5.0 5.0]
+(/ [10 20 30 40 50] [1 2 3 4 5])    -- [10.0 10.0 10.0 10.0 10.0]
+(% [10 20 30 40 50] [3 3 3 3 3])    -- [1 2 0 1 2]
+(div [10 20 30 40 50] [3 3 3 3 3])  -- [3 6 10 13 16]
+
+;; F64-vec / F64-vec → F64
+(/ VF64 VF64)               -- [1.0 1.0 1.0 1.0 1.0]
+(/ [10.0 20.0 30.0] [4.0 4.0 4.0]) -- [2.5 5.0 7.5]
+
+;; F64-vec % F64-vec → F64 (uses fmod with sign-fix; happy path: positive
+;; dividend & divisor → matches fmod directly).
+(% [10.0 20.0 30.0] [3.0 3.0 3.0])  -- [1.0 2.0 0.0]
+
+;; ════════════════════════════════════════════════════════════════════
+;; 12. MIN2 / MAX2 — element-wise min/max are OP_MIN2 / OP_MAX2 inside
+;;     expr.c (BR_AR_FAST handles them) but are not registered as
+;;     RFL primitives.  Reachable only via the DAG executor inside
+;;     compiled queries; not driven from this happy-path file.
+;;
+;; ════════════════════════════════════════════════════════════════════
+;; 13. U8-vec arithmetic / comparison (out_type=RAY_U8 arm at
+;;     expr.c:1740-1751; out_type=RAY_BOOL with U8 inputs at the
+;;     src_is_i64_all branch).
+;; ════════════════════════════════════════════════════════════════════
+
+(set VU8 (as 'U8 [0x01 0x02 0x03 0x04 0x05]))
+
+;; U8 + U8-scalar → U8 (BR_AR_FAST doesn't fire for l_esz=1)
+(+ VU8 0x02)        -- [0x03 0x04 0x05 0x06 0x07]
+(type (+ VU8 0x02)) -- 'U8
+
+;; U8 vec-vec
+(+ VU8 VU8)         -- [0x02 0x04 0x06 0x08 0x0a]
+
+;; U8 compare → BOOL
+(== VU8 0x03)       -- [false false true false false]
+(<  VU8 0x03)       -- [true true false false false]
+(== VU8 VU8)        -- [true true true true true]
+
+;; ════════════════════════════════════════════════════════════════════
+;; 14. BOOL × U8 / BOOL × I64 — promote() rules:
+;;     bool < u8 < i16 < i32 < i64 — mixed produces wider type.
+;; ════════════════════════════════════════════════════════════════════
+
+(set VBOOL [true false true false true])
+
+;; BOOL + I64-scalar → I64 (out_type from promote(BOOL, I64) = I64)
+(+ VBOOL 10)        -- [11 10 11 10 11]
+(type (+ VBOOL 10)) -- 'I64
+
+;; BOOL + U8-vec — the eval.c slow path widens to I64 (boolean coerce
+;; to int, then I64 arithmetic) rather than the DAG promote(BOOL,U8)=U8.
+;; Pin the observed behavior; the underlying values are correct.
+(+ VBOOL VU8)       -- [2 2 4 4 6]
+(type (+ VBOOL VU8)) -- 'I64
+
+;; BOOL compare BOOL → BOOL
+(== VBOOL [true true false false true])  -- [true false false true true]
+(!= VBOOL [true true false false true])  -- [false true true false false]
+
+;; ════════════════════════════════════════════════════════════════════
+;; 15. SCALAR-ON-LEFT mixed-type — covers !l_scalar=false / r_scalar=
+;;     false branch for non-fast-path types.
+;; ════════════════════════════════════════════════════════════════════
+
+;; F64-scalar - I64-vec  → F64 vec (lp_f64 NULL but l_scalar=true with
+;; l_f64 set; rp_i64 set → RV_READ casts int to double).
+(- 10.0 VI64)              -- [9.0 8.0 7.0 6.0 5.0]
+(- 100 VI32)               -- [99 98 97 96 95]
+(- 100i VI16)              -- [99i 98i 97i 96i 95i]
+
+;; SYM-atom compare SYM-vec
+(== 'a VS1)                 -- [true false false false false]
+(!= 'a VS1)                 -- [false true true true true]
+
+;; STR-scalar compare STR-vec mirror (already in section 9 but here under
+;; ordering for the BR_FAST coverage table).
+
+;; ════════════════════════════════════════════════════════════════════
+;; 16. LENGTH MISMATCH — eval.c routes lists of different lengths
+;;     through a per-element loop that truncates to the shorter side
+;;     (q/k atomic semantics).  The expr.c-level length guard at
+;;     expr.c:1848 is only reached when both sides are typed numeric
+;;     vectors of equal type that take the DAG path.  Pin the
+;;     observed truncation here.
+(+ [1 2 3] [1 2 3 4])      -- [2 4 6]
+(+ [1 2 3 4] [1 2 3])      -- [2 4 6]
+
+;; Reachability notes:
+;;   - F32 cannot be constructed from RFL source (idxop_coverage.rfl
+;;     comment) — F32 lp_f32 arm not exercised.
+;;   - SYM W64: only ≥4 G interned syms — not RFL-reachable.
+;;   - Selection-aware par_binary_fn: covered by section 5 of
+;;     expr_typed_fast.rfl (TBig fixture ≥ RAY_PARALLEL_THRESHOLD).
+;;   - LIKE: handled by ops/string.c, not src/ops/expr.c — out of scope.
+;;   - Null sentinels in mixed-type binary: covered by null/arith.rfl.
+;;   - Div-by-zero: not happy-path; covered by null/arith.rfl error tests.

--- a/test/rfl/ops/expr_typed_fast.rfl
+++ b/test/rfl/ops/expr_typed_fast.rfl
@@ -1,0 +1,374 @@
+;; Typed fast paths in src/ops/expr.c — binary_range, binary_range_str,
+;; par_binary_fn, par_binary_str_fn.
+;;
+;; Targets recent perf commits:
+;;   325db211 binary_range: typed fast path for int-vec vs int scalar arith
+;;   c866c781 binary_range: typed fast path for int-vec vs int scalar BOOL cmp
+;;   573516d7 binary_range: thread g->selection through par_binary_fn
+;;   7396a516 SIMD-friendly (== SYM-vec SYM-atom) fast path
+;;
+;; Constants:
+;;   RAY_MORSEL_ELEMS      = 1024
+;;   RAY_PARALLEL_THRESHOLD= 64 * 1024 = 65536
+;;
+;; We build large typed vectors (>= 70000 rows) so dispatch crosses the
+;; pool threshold and runs par_binary_fn / par_binary_str_fn.  Smaller
+;; (e.g. 1024-row) vectors hit the sequential path.  Both are exercised
+;; per opcode so the typed-fast-path body executes under both callers.
+;;
+;; Hand-computed references:
+;;   `(til N)` = [0,1,...,N-1]; sum = N*(N-1)/2; sum_sq = N*(N-1)*(2N-1)/6.
+;;   For (- v c) over til N: sum = sum(til N) - N*c = N*(N-1)/2 - N*c.
+;;   For (+ v c) over til N: sum = N*(N-1)/2 + N*c.
+;;   For (* v c) over til N: sum = c * N*(N-1)/2.
+;;
+;; All assertions are happy-path: well-typed inputs, finite scalars,
+;; no null sentinels.  No probes; standard mainline pipeline.
+
+;; ────────────────────────────────────────────────────────────────────
+;; Sizes
+;; ────────────────────────────────────────────────────────────────────
+(set NB 70000)  ;; > RAY_PARALLEL_THRESHOLD — drives par_binary_fn
+(set NS 2048)   ;; < threshold; sequential binary_range
+
+;; ════════════════════════════════════════════════════════════════════
+;; 1. ARITHMETIC FAST PATH — int-vec × int-scalar, type matches out_type
+;;    Drives BR_AR_FAST (expr.c:1613-1629) for l_esz=8/4/2 arms.
+;; ════════════════════════════════════════════════════════════════════
+
+;; ──── I64-vec × I64-scalar (BR_AR_FAST(int64_t), l_esz=8) ────
+(set VI64B (til NB))
+(set VI64S (til NS))
+
+;; OP_ADD: sum(v+5) = sum(v) + 5*N.  sum(til 70000) = 2449965000.
+(sum (+ VI64B 5)) -- 2450315000
+(sum (+ VI64S 5)) -- 2106368
+
+;; OP_SUB: sum(v-3) = sum(v) - 3*N
+(sum (- VI64B 3)) -- 2449755000
+(sum (- VI64S 3)) -- 2089984
+
+;; OP_MUL: sum(v*2) = 2*sum(v)
+(sum (* VI64B 2)) -- 4899930000
+(sum (* VI64S 2)) -- 4192256
+
+;; Endpoint spot-checks confirm the fast-path inner loop writes the
+;; correct element, not a typed-promotion artefact.
+(at (+ VI64B 100) 0)     -- 100
+(at (+ VI64B 100) 69999) -- 70099
+(at (- VI64B 1)   0)     -- -1
+(at (- VI64B 1)   69999) -- 69998
+(at (* VI64B 3)   1)     -- 3
+(at (* VI64B 3)   69998) -- 209994
+
+;; ──── I32-vec × scalar (BR_AR_FAST(int32_t), l_esz=4) ────
+;; Result type must match input type — `(- col scalar)` over I32 col
+;; preserves I32 (no narrowing required, fast path is engaged).
+(set VI32B (as 'I32 (til NB)))
+(set VI32S (as 'I32 (til NS)))
+
+(sum (+ VI32B 7i)) -- 2450455000
+(sum (+ VI32S 7i)) -- 2110464
+(sum (- VI32B 4i)) -- 2449685000
+(sum (- VI32S 4i)) -- 2087936
+
+;; Confirm output stays I32: small multiplier keeps within INT32_MAX.
+(at (+ VI32B 1i) 5)  -- 6i
+(at (- VI32B 2i) 10) -- 8i
+(at (* VI32B 2i) 7)  -- 14i
+
+;; ──── I16-vec × scalar (BR_AR_FAST(int16_t), l_esz=2) ────
+;; Keep values inside [-32768, 32767] so neither op wraps modulo 2^16.
+;; (% (til NB) 256) is a benign 0..255 column and a 70k-row I16 vec.
+(set VI16B (as 'I16 (% (til NB) 256)))
+(set VI16S (as 'I16 (% (til NS) 256)))
+
+;; sum((til NB) mod 256) computed: 273 full cycles of 0..255 (sum 32640
+;; each) + tail [0..(70000 mod 256)-1] = 273*32640 + sum(0..111)
+;; = 8910720 + 6216 = 8916936.
+(sum (+ VI16B 0h)) -- 8916936
+
+;; OP_ADD/SUB stays within range when adding small constants.
+(at (+ VI16B 1h) 0)  -- 1h
+(at (+ VI16B 1h) 5)  -- 6h
+(at (- VI16B 1h) 10) -- 9h
+(at (* VI16B 0h) 1)  -- 0h
+
+;; ──── TIMESTAMP-vec × scalar (l_esz=8, type==RAY_TIMESTAMP) ────
+;; Cast a small I64 til-range to TIMESTAMP nanoseconds.  Arithmetic
+;; preserves TIMESTAMP — the lhs->type == out_type guard fires.
+(set VTSS (as 'TIMESTAMP (til NS)))
+;; (+ ts c) preserves TIMESTAMP element type & is the BR_AR_FAST(int64_t) arm.
+;; sum(til NS) + 1000*NS = 2096128 + 2048000 = 4144128.
+(sum (as 'I64 (+ VTSS 1000))) -- 4144128
+
+;; ──── DATE-vec × scalar (l_esz=4, type==RAY_DATE) ────
+(set VDS (as 'DATE (til NS)))
+(at (as 'I32 (+ VDS 1000i)) 0)    -- 1000i
+(at (as 'I32 (+ VDS 1000i)) 100)  -- 1100i
+(at (as 'I32 (- VDS 5i)) 10)      -- 5i
+
+;; ──── F64-vec × F64-scalar (no fast-path arith — generic out_type==RAY_F64) ────
+;; Drives the F64 arm of binary_range (expr.c:1688-1700) over both
+;; sequential & parallel sizes.
+(set VF64B (as 'F64 (til NB)))
+(set VF64S (as 'F64 (til NS)))
+
+;; (+ vF c) returns F64.  sum = sum(til N) + c*N.
+;; 2449965000 + 0.5*70000 = 2450000000.0
+(sum (+ VF64B 0.5))  -- 2450000000.0
+;; 2096128 + 0.25*2048 = 2096640.0
+(sum (+ VF64S 0.25)) -- 2096640.0
+
+;; OP_SUB, OP_MUL, OP_DIV
+(at (+ VF64B 2.5) 100)  -- 102.5
+(at (- VF64B 1.5) 200)  -- 198.5
+(at (* VF64B 0.5) 6)    -- 3.0
+(at (/ VF64B 2.0) 8)    -- 4.0
+
+;; OP_DIV: scalar 2.0 produces F64 with exact half values.
+;; sum(til 2048)/2 = 2096128/2 = 1048064.0
+(sum (/ VF64S 2.0)) -- 1048064.0
+
+;; ════════════════════════════════════════════════════════════════════
+;; 2. BOOL COMPARISON FAST PATH — out_type=RAY_BOOL, !l_scalar, r_scalar
+;;    Drives BR_FAST (expr.c:1533-1586) for each width arm.
+;; ════════════════════════════════════════════════════════════════════
+
+;; ──── I64-vec cmp I64-scalar (BR_FAST int64_t, l_esz=8) ────
+(sum (as 'I64 (== VI64B 12345))) -- 1
+(sum (as 'I64 (!= VI64B 0)))     -- 69999
+;; (< v c): count of v in [0..c-1] = c (for c<=N).
+(sum (as 'I64 (< VI64B 1000)))   -- 1000
+(sum (as 'I64 (<= VI64B 1000)))  -- 1001
+;; (> v c): count of v in [c+1..N-1] = N-1-c.
+(sum (as 'I64 (> VI64B 50000)))  -- 19999
+(sum (as 'I64 (>= VI64B 50000))) -- 20000
+
+;; Endpoint masks confirm the boolean writeback.
+(at (== VI64B 0)     0)     -- true
+(at (== VI64B 69999) 69999) -- true
+(at (!= VI64B 5)     5)     -- false
+(at (< VI64B 10)     9)     -- true
+(at (< VI64B 10)     10)    -- false
+
+;; Sequential-size mirror to drive BR_FAST under direct binary_range
+;; (no pool dispatch).
+(sum (as 'I64 (== VI64S 7)))    -- 1
+(sum (as 'I64 (< VI64S 100)))   -- 100
+(sum (as 'I64 (>= VI64S 2000))) -- 48
+
+;; ──── I32-vec cmp I64-scalar (BR_FAST int32_t, l_esz=4) ────
+;; The fast path reads i32 lhs and compares signed-promoted to r_i64.
+(sum (as 'I64 (== VI32B 100i))) -- 1
+(sum (as 'I64 (< VI32B 500i)))  -- 500
+(sum (as 'I64 (>= VI32B 69998i))) -- 2
+(at (== VI32B 0i)     0)     -- true
+(at (>  VI32B 69997i) 69998) -- true
+(at (>  VI32B 69997i) 69997) -- false
+
+;; Sequential.
+(sum (as 'I64 (!= VI32S 0i))) -- 2047
+
+;; ──── I16-vec cmp scalar (BR_FAST int16_t, l_esz=2) ────
+;; VI16B = (til NB) % 256.  Count of (== col 0) = ceil(NB/256) = 274.
+(sum (as 'I64 (== VI16B 0h))) -- 274
+;; Count of (< col 10) = 10 * ceil(NB/256) = 2735+? — compute directly:
+;;   full 256-cycles in 70000: 273*10 = 2730 from [0..9]
+;;   tail [0..NB%256-1] = [0..143]; 144 covers all of [0..9] -> +10.
+;; Total = 2740.
+(sum (as 'I64 (< VI16B 10h))) -- 2740
+
+;; ──── BOOL-vec cmp BOOL-scalar (BR_FAST uint8_t, l_esz=1) ────
+;; `(> col c)` where col is BOOL, c is BOOL scalar → reaches the
+;; l_esz==1 fast-path arm.
+(set VBB (> (til NB) 34999))
+(sum (as 'I64 VBB))             -- 35000
+;; (== boolvec true) = boolvec; sum = 35000.
+(sum (as 'I64 (== VBB true)))   -- 35000
+;; (!= boolvec false) = boolvec.
+(sum (as 'I64 (!= VBB false)))  -- 35000
+;; (< boolvec true) = !boolvec → 35000 false (NB - 35000).
+(sum (as 'I64 (< VBB true)))    -- 35000
+
+;; ──── SYM-vec cmp SYM atom — exercises SYM W8/W16/W32 width arms ────
+;; SYM column built from `(as 'SYMBOL ...)` over a many-distinct-value
+;; pattern goes to W16 (256 ≤ count) or W32 (≥65k); a small-cardinality
+;; column stays W8 (≤255).
+;;
+;; Small-card SYM column (W8): take 3 distinct sym atoms × 70000.
+(set VSYM3 (take ['a 'b 'c] NB))
+;; (== sym-vec 'a) — drives SIMD-friendly EQ for SYM (commit 7396a516).
+;; Pattern is round-robin, so 'a appears at positions 0,3,6,... — total
+;; = ceil(NB/3) = 23334 (NB=70000, 23333*3 + 1).
+(sum (as 'I64 (== VSYM3 'a))) -- 23334
+(sum (as 'I64 (== VSYM3 'b))) -- 23333
+(sum (as 'I64 (== VSYM3 'c))) -- 23333
+(sum (as 'I64 (!= VSYM3 'a))) -- 46666
+(at (== VSYM3 'a) 0) -- true
+(at (== VSYM3 'a) 1) -- false
+(at (== VSYM3 'a) 3) -- true
+
+;; Sequential (NS=2048) SYM EQ mirror.
+(set VSYM3S (take ['x 'y 'z] NS))
+(sum (as 'I64 (== VSYM3S 'x))) -- 683
+(sum (as 'I64 (!= VSYM3S 'x))) -- 1365
+
+;; ════════════════════════════════════════════════════════════════════
+;; 3. ATOM-VEC MIRROR — l_scalar=true, !r_scalar.
+;;    The integer-vec-vs-integer-scalar fast paths only fire when the
+;;    VECTOR is on the LEFT.  Scalar-on-left routes through the
+;;    generic LV_READ / RV_READ kernel.  Drive that branch explicitly
+;;    (expr.c:1691 / 1709 referenced in the test_exec_expr_i32_scalar_left
+;;    C-level fixture) so par_binary_fn covers the !fast-path arm too.
+;; ════════════════════════════════════════════════════════════════════
+
+;; ──── I64 scalar on left, I64 vec on right ────
+;; sum(5 - v) = 5*N - sum(v) = 5*70000 - 2449965000 = -2449615000
+(sum (- 5 VI64B)) -- -2449615000
+;; 5*2048 - 2096128 = 10240 - 2096128 = -2085888
+(sum (- 5 VI64S)) -- -2085888
+(at (- 10 VI64B) 0)     -- 10
+(at (- 10 VI64B) 5)     -- 5
+(at (* 3 VI64B) 7)      -- 21
+;; 2096128 + 1*2048 = 2098176
+(sum (+ 1 VI64S))       -- 2098176
+
+;; ──── I32 scalar on left, I32 vec on right ────
+(at (- 100i VI32B) 0)  -- 100i
+(at (- 100i VI32B) 50) -- 50i
+
+;; ──── F64 scalar on left, F64 vec on right ────
+(at (- 5.0 VF64B) 0)   -- 5.0
+(at (- 5.0 VF64B) 5)   -- 0.0
+(at (+ 0.5 VF64B) 100) -- 100.5
+
+;; ──── Scalar-left BOOL comparison: doesn't hit the (lhs typed) BOOL
+;; fast path either (its `!l_scalar && r_scalar` guard is reversed),
+;; so this also covers the generic BOOL arm at expr.c:1753.
+;; (< 10 v) = count of v in [11..NB-1] = NB - 11 = 69989
+(sum (as 'I64 (< 10 VI64B))) -- 69989
+(sum (as 'I64 (== 7 VI64B))) -- 1
+
+;; ════════════════════════════════════════════════════════════════════
+;; 4. PARALLEL STR EQ — par_binary_str_fn over RAY_STR vec ≥ threshold.
+;;    binary_range_str at expr.c:1420; par dispatch at expr.c:1886.
+;; ════════════════════════════════════════════════════════════════════
+
+;; Build a 70000-row STR vec with 3 distinct values.  RAY_STR (uppercase
+;; literal "..." inside list) is the per-row string type that drives
+;; par_binary_str_fn, distinct from interned SYM.
+(set VSTR (take (list "alpha" "beta" "gamma") NB))
+
+(sum (as 'I64 (== VSTR "alpha"))) -- 23334
+(sum (as 'I64 (== VSTR "beta")))  -- 23333
+(sum (as 'I64 (== VSTR "gamma"))) -- 23333
+(sum (as 'I64 (!= VSTR "alpha"))) -- 46666
+(at (== VSTR "alpha") 0) -- true
+(at (== VSTR "alpha") 1) -- false
+(at (== VSTR "alpha") 3) -- true
+
+;; STR ordering: lexicographic — alpha < beta < gamma.
+;; (< vec "beta") = positions where elem == "alpha".
+(sum (as 'I64 (< VSTR "beta")))  -- 23334
+(sum (as 'I64 (<= VSTR "beta"))) -- 46667
+;; (> "alpha") = positions where elem in {"beta","gamma"} = 46666.
+(sum (as 'I64 (> VSTR "alpha"))) -- 46666
+(sum (as 'I64 (>= VSTR "alpha"))) -- 70000
+
+;; Sequential STR (NS < threshold): drives the direct binary_range_str
+;; call at expr.c:1895, not via the pool.
+(set VSTRS (take (list "a" "b" "c") NS))
+(sum (as 'I64 (== VSTRS "a"))) -- 683
+(sum (as 'I64 (!= VSTRS "a"))) -- 1365
+(sum (as 'I64 (< VSTRS "b")))  -- 683
+
+;; ════════════════════════════════════════════════════════════════════
+;; 5. SELECTION-AWARE par_binary_fn — exec.c sets g->selection inside
+;;    a nested (select v from T where pred-with-binop). The first
+;;    predicate writes a row-selection bitmap; the second binary op
+;;    runs with sel_flg / sel_offs / sel_idx populated, hitting
+;;    par_binary_fn's selection branch at expr.c:1819-1836.
+;;
+;;    For the selection threading to be visible at the par level the
+;;    table must be ≥ RAY_PARALLEL_THRESHOLD rows (else exec_binary
+;;    drops to the sequential path).
+;; ════════════════════════════════════════════════════════════════════
+
+(set TBig (table [a b c] (list (til NB) (- NB (til NB)) (as 'I32 (% (til NB) 1000)))))
+
+;; Two-conjunct WHERE: first conjunct produces selection; second is a
+;; binary op evaluated with g->selection set.  Both conjuncts route
+;; through binary_range / par_binary_fn.
+(count (select {from: TBig where: (and (> a 1000) (< a 2000))})) -- 999
+;; sum(1001..1999) = sum(0..1999) - sum(0..1000) = 1999000 - 500500 = 1498500
+(sum (at (select {from: TBig where: (and (> a 1000) (< a 2000))}) 'a)) -- 1498500
+
+;; Chained nested select: outer predicate runs over the post-filter
+;; selection — outer par_binary_fn sees a non-NULL g->selection.
+(count (select {from: (select {from: TBig where: (> a 100)}) where: (< a 200)})) -- 99
+(sum (at (select {from: (select {from: TBig where: (> a 100)}) where: (< a 200)}) 'a)) -- 14850
+
+;; Derived-column with binary op runs through par_binary_fn whose
+;; segments may be RAY_SEL_NONE for far-out rows; the selection-aware
+;; loop skips them.  Verify the projection result equals the manual
+;; computation:
+;;   (- a 5) on the 999 rows where a in (1001..1999) → sum = 1499500 - 999*5 = 1494505.
+;; sum((1001..1999) - 5) = sum(1001..1999) - 5*999 = 1498500 - 4995 = 1493505.
+(sum (at (select {x: (- a 5) from: TBig where: (and (> a 1000) (< a 2000))}) 'x)) -- 1493505
+
+;; ════════════════════════════════════════════════════════════════════
+;; 6. DIV / IDIV / MOD on I64-vec × I64-scalar.
+;;    These ops don't take the BR_AR_FAST path (it only handles
+;;    ADD/SUB/MUL/MIN2/MAX2); they fall through to the generic
+;;    I64-arm switch at expr.c:1707-1709 — which is part of the same
+;;    par_binary_fn region we're growing coverage on.
+;; ════════════════════════════════════════════════════════════════════
+
+(at (% VI64B 7)  0)   -- 0
+(at (% VI64B 7)  10)  -- 3
+;; `/` is float division → F64 result; element 10 = 10/2 = 5.0.
+(at (/ VI64B 2)  10)  -- 5.0
+(at (/ VI64B 2)  11)  -- 5.5
+;; `div` is integer floor-division (OP_IDIV) — non-negative input = truncation.
+(at (div VI64B 3) 7)  -- 2
+(at (div VI64B 3) 8)  -- 2
+(at (div VI64B 3) 9)  -- 3
+
+;; Sequential mirror.
+(at (% VI64S 5)  0)  -- 0
+(at (% VI64S 5)  4)  -- 4
+(at (/ VI64S 4)  16) -- 4.0
+
+;; ════════════════════════════════════════════════════════════════════
+;; 7. CHAR / U8 narrow path coverage.
+;;    BR_AR_FAST doesn't cover l_esz==1 (only 8/4/2), so U8 arith is
+;;    NOT in the fast path.  We still drive it through the generic
+;;    U8 arm at expr.c:1740-1751 for completeness on the parallel
+;;    boundary — output type RAY_U8 with U8 vec input.
+;;
+;; Note: building a U8 column ≥70000 is straightforward via `as 'U8`.
+;; Arithmetic on it stays U8 when scalar is small enough not to wrap.
+;; ════════════════════════════════════════════════════════════════════
+
+(set VU8S (as 'U8 (% (til NS) 64)))
+;; Sum of (til NS) % 64 over 2048 rows = 32*64*63/2 = 32*2016 = 64512.
+;; Check sum after `(+ col 0x00)` matches (0x00 is a U8 atom literal).
+(sum (as 'I64 (+ VU8S 0x00))) -- 64512
+
+;; ────────────────────────────────────────────────────────────────────
+;; Reachability notes (intentionally NOT exercised):
+;;   - SYM W64 storage: only produced when interned sym ID count exceeds
+;;     ~4 billion. Not RFL-reachable.
+;;   - F64 BOOL fast path: BOOL comparison fast path at 1515 gates on
+;;     integer-family LHS only; F64 cmp goes through the generic float
+;;     BOOL arm at 1768-1781, already covered above via (cmp F64-vec
+;;     F64-scalar) chains in arith/cmp tests.
+;;   - I32-vec × I64-scalar arith with auto-promotion to I64: when the
+;;     scalar literal forces out_type=I64 the lhs->type != out_type
+;;     guard fails, so BR_AR_FAST is skipped. The fast path requires
+;;     same-type input/output (the by-design narrow case for autovec).
+;;   - lhs is a vector but len==1: l_scalar=true branch — same kernel,
+;;     redundant.
+;;   - Null inputs / wrong types / div-by-zero ERR branches: per spec,
+;;     happy path only.

--- a/test/rfl/ops/idiom_in_query.rfl
+++ b/test/rfl/ops/idiom_in_query.rfl
@@ -1,0 +1,301 @@
+;; Integration tests for src/ops/idiom.c — the unit-style tests in
+;; test/rfl/ops/idiom.rfl already cover the bare-expression form;
+;; this file extends to *real query contexts* (select / by / set / let /
+;; DAG VM bindings / nested chains), where the idiom rewrite dispatch
+;; in src/ops/opt.c:ray_idiom_pass walks a more interesting graph and
+;; the rewrite paths in src/ops/idiom.c run alongside SIP, factorize,
+;; predicate pushdown, projection pushdown, etc.
+;;
+;; Idioms exercised (rewrite functions in src/ops/idiom.c):
+;;   - rw_count_distinct       : (count (distinct v)) → OP_COUNT_DISTINCT
+;;   - rw_count_passthrough    : (count (asc|desc|reverse v)) → OP_COUNT
+;;   - rw_first_asc_to_min     : (first (asc v)) → OP_MIN  [null-free precond]
+;;   - rw_last_asc_to_max      : (last  (asc v)) → OP_MAX  [null-free precond]
+;;
+;; Happy-path only — every assertion has a hand-computed reference value.
+;; Reachability notes appear at the end of each section.
+
+;; ──────────────────────────────────────────────────────────────────────
+;; Section 1 — (count (distinct v)) inside select-by aggregator slot
+;; ──────────────────────────────────────────────────────────────────────
+;; Hits: rw_count_distinct under the eval-level group fallback
+;; (query.c:2529 per-group count-distinct kernel).  Group keys SYM and
+;; I64 take separate code paths inside the per-group eval branch.
+
+;; SYM key → 3 groups, value column I64
+(set TS (table [k v] (list ['a 'a 'b 'b 'c] [1 2 2 3 3])))
+(set RS (select {cd: (count (distinct v)) from: TS by: k}))
+(count RS) -- 3
+(sum (at RS 'cd)) -- 5
+;; Per-group:  a:{1,2}=2, b:{2,3}=2, c:{3}=1
+(at (at RS 'cd) 0) -- 2
+(at (at RS 'cd) 1) -- 2
+(at (at RS 'cd) 2) -- 1
+
+;; I64 key → numeric-key DAG group-boundary + per-group eval path
+(set TI (table [k v] (list [1 1 2 2 3 3 3] [10 20 20 30 30 30 40])))
+(set RI (select {cd: (count (distinct v)) from: TI by: k}))
+(count RI) -- 3
+;; Per-group:  1:{10,20}=2, 2:{20,30}=2, 3:{30,30,40}=2
+(sum (at RI 'cd)) -- 6
+(at (at RI 'cd) 0) -- 2
+(at (at RI 'cd) 1) -- 2
+(at (at RI 'cd) 2) -- 2
+
+;; F64 values → F64 distinct dispatch
+(set TF (table [k v] (list ['a 'a 'b 'b 'c] (as 'F64 [1.5 2.5 2.5 3.0 3.0]))))
+(set RF (select {cd: (count (distinct v)) from: TF by: k}))
+(sum (at RF 'cd)) -- 5
+(at (at RF 'cd) 0) -- 2
+(at (at RF 'cd) 1) -- 2
+(at (at RF 'cd) 2) -- 1
+
+;; SYM values (intern table) → SYM distinct dispatch
+(set TSy (table [k v] (list [1 1 2 2 3] ['x 'y 'y 'z 'z])))
+(set RSy (select {cd: (count (distinct v)) from: TSy by: k}))
+(sum (at RSy 'cd)) -- 5
+
+;; Multi-key by + count(distinct) — composite key path
+(set TMK (table [k1 k2 v] (list ['a 'a 'b 'b 'c 'c] [1 2 1 2 1 2] [10 10 20 30 30 40])))
+(set RMK (select {cd: (count (distinct v)) from: TMK by: [k1 k2]}))
+(count RMK) -- 6
+;; Each (k1,k2) cell has exactly 1 row → all count-distincts = 1
+(sum (at RMK 'cd)) -- 6
+
+;; Reachability: count(distinct) under SYM, I64, F64 group keys and
+;; over I64, F64, SYM value columns; single- and multi-key by.
+
+;; ──────────────────────────────────────────────────────────────────────
+;; Section 2 — multiple idioms in a single select-by
+;; ──────────────────────────────────────────────────────────────────────
+;; Combines count(distinct) per-group with regular aggs (sum, count).
+;; The OP_COUNT_DISTINCT replacement node sits next to other agg nodes
+;; in the same graph; aggr_unary_per_group_buf streaming branch handles
+;; the mix.
+
+(set TM (table [k v] (list ['a 'a 'b 'b 'c] [1 2 2 3 3])))
+(set RM (select {cd: (count (distinct v)) s: (sum v) c: (count v) from: TM by: k}))
+(count RM) -- 3
+(sum (at RM 'cd)) -- 5
+(sum (at RM 's))  -- 11
+(sum (at RM 'c))  -- 5
+
+;; Reachability: ensures multiple idiom replacements survive subsequent
+;; optimization passes (SIP, factorize, projection pushdown) without
+;; aliasing each other in graph_alloc_node_opt.
+
+;; ──────────────────────────────────────────────────────────────────────
+;; Section 3 — cardinality-preserving rewrites in projection slot
+;; ──────────────────────────────────────────────────────────────────────
+;; (reverse v) / (asc v) / (desc v) in a non-aggregator projection of
+;; a select-by produces LIST columns where each cell holds the
+;; cardinality-preserving rearrangement of that group's slice.  Outside
+;; of by-groups, these collapse via row-aligned projection.
+
+(set TR (table [k v] (list ['a 'a 'b 'b 'c] [1 2 3 4 5])))
+
+;; reverse per group — produces 3 groups (LIST column).  Verification
+;; is structure-level (count of groups, count of cells per group, and
+;; the sum-of-all-elements invariant: reverse preserves the multiset).
+(set Rr (select {rv: (reverse v) from: TR by: k}))
+(count Rr) -- 3
+(count (at Rr 'rv)) -- 3
+
+;; asc per group — same invariants.
+(set Ra (select {av: (asc v) from: TR by: k}))
+(count Ra) -- 3
+(count (at Ra 'av)) -- 3
+
+;; desc per group — same invariants.
+(set Rd (select {dv: (desc v) from: TR by: k}))
+(count Rd) -- 3
+(count (at Rd 'dv)) -- 3
+
+;; Reachability: exercises rw_count_passthrough's siblings asc/desc/
+;; reverse as projections (not consumed by count), confirming the idiom
+;; pass does NOT mis-fire — the rewrite is only triggered when the
+;; *parent* op matches the row's root_op (OP_COUNT).
+
+;; ──────────────────────────────────────────────────────────────────────
+;; Section 4 — DAG-VM bindings via (set X …) and nested compositions
+;; ──────────────────────────────────────────────────────────────────────
+;; Each `(set X …)` calls into eval which builds a fresh DAG, runs
+;; ray_optimize (including ray_idiom_pass), and stores the result.
+;; Composing idioms tests that the post-order walk in idiom.c rewrites
+;; children before parents and updates root correctly when the root
+;; itself was rewritten.
+
+(set V [3 1 4 1 5 9 2 6 5 3 5])
+
+;; count(distinct) under set — root rewrite path
+(set CD (count (distinct V)))
+CD -- 7
+
+;; count(asc) — passthrough rewrite drops the sort node (dead-code)
+(set CA (count (asc V)))
+CA -- 11
+
+(set CDsc (count (desc V)))
+CDsc -- 11
+
+(set CR (count (reverse V)))
+CR -- 11
+
+;; first(asc) and last(asc) — null-free I64, precondition fires true
+;; ⇒ rw_first_asc_to_min / rw_last_asc_to_max replace the root.
+(set MN (first (asc V)))
+MN -- 1
+(set MX (last (asc V)))
+MX -- 9
+
+;; Composition: count(distinct(asc v)) — two idioms in one chain.
+;; Post-order: rewrite count(asc) first → count(v); BUT here the
+;; parent of asc is distinct, not count, so the count(asc) rule does
+;; NOT fire — only the outer (count (distinct …)) rewrites.
+(set CDAsc (count (distinct (asc V))))
+CDAsc -- 7
+
+;; Composition: count(distinct(reverse v)) — same shape.
+(set CDRev (count (distinct (reverse V))))
+CDRev -- 7
+
+;; Composition where inner rule does fire: count(reverse(distinct v))
+;; → count(distinct v) → OP_COUNT_DISTINCT
+(set CRDD (count (reverse (distinct V))))
+CRDD -- 7
+
+;; Chained sorts: first(asc(asc v)) — inner asc(asc v) is fed by an
+;; OP_ASC, which is NOT OP_CONST/OP_SCAN, so the null-free
+;; precondition bails (returns false).  Slow path runs and produces
+;; the correct minimum.
+(set MNN (first (asc (asc V))))
+MNN -- 1
+(set MXX (last (asc (asc V))))
+MXX -- 9
+
+;; Reachability: covers idiom.c try_rewrite first-match-wins logic
+;; under nested patterns + the root_id == repl tracking in the
+;; bottom-up loop of ray_idiom_pass.
+
+;; ──────────────────────────────────────────────────────────────────────
+;; Section 5 — idioms over table-column scans (OP_SCAN inputs)
+;; ──────────────────────────────────────────────────────────────────────
+;; pre_no_nulls_on_asc_input has an OP_SCAN branch
+;; (idiom.c:122-127): when the asc input is a column scan, it calls
+;; scan_source_col + RAY_ATTR_HAS_NULLS to decide.  Without going
+;; through a select, the table-scan ext still gets attached when the
+;; column is referenced via (at T 'col).
+
+(set TC (table [v] (list [7 3 5 1 9 2 8 4 6])))
+
+;; bare (first (asc (at TC 'v))) — sniffs the SCAN attrs path
+(first (asc (at TC 'v))) -- 1
+(last  (asc (at TC 'v))) -- 9
+(count (distinct (at TC 'v))) -- 9
+(count (asc (at TC 'v))) -- 9
+(count (reverse (at TC 'v))) -- 9
+
+;; same with F64 column
+(set TCf (table [v] (list (as 'F64 [3.0 1.0 4.0 1.0 5.0 9.0 2.0 6.0]))))
+(first (asc (at TCf 'v))) -- 1.0
+(last  (asc (at TCf 'v))) -- 9.0
+(count (distinct (at TCf 'v))) -- 7
+
+;; arithmetic-derived expression — input to asc is no longer OP_SCAN/
+;; OP_CONST, so the null-free precondition bails to false.  Slow path
+;; runs; result still correct.
+(first (asc (* (at TC 'v) 2))) -- 2
+(last  (asc (* (at TC 'v) 2))) -- 18
+(count (distinct (* (at TC 'v) 2))) -- 9
+
+;; Reachability: OP_SCAN branch of pre_no_nulls_on_asc_input vs the
+;; "computed input" fallthrough (returns false).
+
+;; ──────────────────────────────────────────────────────────────────────
+;; Section 6 — count(distinct) inside scalar / aggregator nesting
+;; ──────────────────────────────────────────────────────────────────────
+;; OP_COUNT_DISTINCT used as an operand of arithmetic or comparison —
+;; ensures the replacement node has the correct out_type (RAY_I64).
+
+(set V2 [1 1 2 3 3 3 4 5 5])
+
+;; sum + count(distinct)
+(+ (sum V2) (count (distinct V2))) -- 32
+
+;; comparison: count(distinct) > k
+(> (count (distinct V2)) 3) -- true
+(<= (count (distinct V2)) 5) -- true
+
+;; count(asc) + count(reverse) — both rewrites fire, both → OP_COUNT
+(+ (count (asc V2)) (count (reverse V2))) -- 18
+
+;; first(asc) + last(asc) — both rewrites fire, → OP_MIN / OP_MAX
+(+ (first (asc V2)) (last (asc V2))) -- 6
+(- (last (asc V2)) (first (asc V2))) -- 4
+
+;; Reachability: the replacement node's out_type RAY_I64 is consumed
+;; by arithmetic/comparison ops downstream; covers consumer-redirect in
+;; idiom.c via redirect_consumers.
+
+;; ──────────────────────────────────────────────────────────────────────
+;; Section 7 — null-bearing inputs (precondition fires false → slow path)
+;; ──────────────────────────────────────────────────────────────────────
+;; pre_no_nulls_on_asc_input returns false when literal has
+;; RAY_ATTR_HAS_NULLS; rw_first_asc_to_min / rw_last_asc_to_max do NOT
+;; replace.  Slow path runs (true asc + first/last) and produces the
+;; right answer per existing semantics (first(asc null-bearing) = the
+;; smallest non-null since xasc places nulls first; last(asc) = max
+;; element).  Verified upstream in test/rfl/ops/idiom.rfl lines 33-37;
+;; we replay the same idiom inside the DAG-VM `set` context here so
+;; the slow-path graph is built under ray_optimize.
+
+(set Vn [1 0Nl 2 0Nl 3])
+(set MnN (first (asc Vn)))
+MnN -- 1
+(set MxN (last (asc Vn)))
+MxN -- 3
+
+;; null-bearing count(distinct) — distinct preserves nulls as a single
+;; bucket; idiom rewrite still fires (no null precondition on this rule).
+(set CDn (count (distinct Vn)))
+CDn -- 4
+
+;; null-bearing count(asc) — count-passthrough rewrite is unconditional.
+(set CAn (count (asc Vn)))
+CAn -- 5
+
+;; null-bearing inside select-by — slow path under per-group eval
+(set TN (table [k v] (list ['a 'a 'a 'b 'b] [1 0Nl 1 2 0Nl])))
+(set RN (select {cd: (count (distinct v)) from: TN by: k}))
+;; a:{1, null} = 2 distinct;  b:{2, null} = 2 distinct
+(sum (at RN 'cd)) -- 4
+
+;; Reachability: confirms slow-path correctness for first/last(asc) on
+;; null-bearing OP_CONST literals, and that count(distinct) with nulls
+;; per-group routes through the eval-level fallback (query.c:2547+).
+
+;; ──────────────────────────────────────────────────────────────────────
+;; Section 8 — ordering of optimization passes
+;; ──────────────────────────────────────────────────────────────────────
+;; In src/ops/opt.c:ray_optimize, idiom pass runs *before* SIP and
+;; projection pushdown.  When the rewritten node feeds into a select,
+;; subsequent passes must still see a consistent graph.  These tests
+;; ensure correctness end-to-end through the full pipeline.
+
+(set TQ (table [k v1 v2] (list ['x 'x 'y 'y 'z 'z] [1 2 2 3 3 4] [10 10 20 20 30 30])))
+
+;; (count (distinct v1)) per group, with where: clause
+(set RQ (select {cd: (count (distinct v1)) from: TQ by: k where: (> v2 0)}))
+(sum (at RQ 'cd)) -- 6
+;; x:{1,2}=2, y:{2,3}=2, z:{3,4}=2
+
+;; where filters out all rows of one group → still works
+(set RQ2 (select {cd: (count (distinct v1)) from: TQ by: k where: (< v2 25)}))
+;; only x and y survive (v2 in 10,10,20,20)
+(count RQ2) -- 2
+;; x:{1,2}=2, y:{2,3}=2
+(sum (at RQ2 'cd)) -- 4
+
+;; Reachability: count(distinct) survives predicate pushdown
+;; (opt.c:2043) + projection pushdown (opt.c:2051) without losing its
+;; OP_COUNT_DISTINCT identity.

--- a/test/rfl/ops/idiom_in_select_by.rfl
+++ b/test/rfl/ops/idiom_in_select_by.rfl
@@ -1,0 +1,50 @@
+;; Bug 2: idiom rewrites inside select-by aggregator slot.
+;;
+;; (first (asc v)) → OP_MIN(v) idiom (and last/asc → max) must work
+;; when the expression is the aggregator inside select{by:}, not just
+;; at the bare-expression top level.
+;;
+;; Before fix: returned `error: domain` because redirect_consumers in
+;;   src/ops/opt.c did not update OP_GROUP's ext->agg_ins[] when the
+;;   rewrite replaced the OP_FIRST node with OP_MIN — the group node
+;;   kept pointing to the dead OP_FIRST node.
+;;
+;; After fix: returns the per-group min/max value just like
+;;   (select {from: T m: (min v) by: k}) does.
+
+(set T (table [v k] (list [3 1 4 1 5 9 2 6] [1 1 1 1 2 2 2 2])))
+
+;; Per-group reference: bare (min v) / (max v) — already works.
+(set Rmin (select {from: T m: (min v) by: k}))
+(set Rmax (select {from: T m: (max v) by: k}))
+
+;; Idiom form: (first (asc v)) / (last (asc v)) — must produce the
+;; same per-group min/max values.
+(set Rfa (select {from: T m: (first (asc v)) by: k}))
+(set Rla (select {from: T m: (last (asc v)) by: k}))
+
+;; Parity: cell-level checks (no table-to-table ==).
+;; Per-group min/max of [3 1 4 1 5 9 2 6] grouped by [1 1 1 1 2 2 2 2]:
+;;   group1 = {3,1,4,1} -> min=1, max=4
+;;   group2 = {5,9,2,6} -> min=2, max=9
+(at (at Rfa 'm) 0) -- 1
+(at (at Rfa 'm) 1) -- 2
+(at (at Rla 'm) 0) -- 4
+(at (at Rla 'm) 1) -- 9
+;; Spot-parity with the (min v) / (max v) references built above.
+(== (at (at Rfa 'm) 0) (at (at Rmin 'm) 0)) -- true
+(== (at (at Rfa 'm) 1) (at (at Rmin 'm) 1)) -- true
+(== (at (at Rla 'm) 0) (at (at Rmax 'm) 0)) -- true
+(== (at (at Rla 'm) 1) (at (at Rmax 'm) 1)) -- true
+
+;; F64 column — same idiom shape.
+(set Tf (table [v k] (list [3.5 1.5 4.5 1.5 5.5 9.5 2.5 6.5] [1 1 1 1 2 2 2 2])))
+(set RfaF (select {from: Tf m: (first (asc v)) by: k}))
+(at (at RfaF 'm) 0) -- 1.5
+(at (at RfaF 'm) 1) -- 2.5
+
+;; Multi-key by — exercises the same redirect path through multi-key
+;; group construction.
+(set Tm (table [v k1 k2] (list [3 1 4 1] [1 1 2 2] ['a 'a 'b 'b])))
+(set RfaM (select {from: Tm m: (first (asc v)) by: [k1 k2]}))
+(count RfaM) -- 2

--- a/test/rfl/query/list_col_at_extraction.rfl
+++ b/test/rfl/query/list_col_at_extraction.rfl
@@ -1,0 +1,55 @@
+;; Bug 3: extracting a LIST column from a select-by-result table via
+;; `(at Rr 'col)` returned `[error: nyi × N]` even though the same
+;; column displayed correctly when the whole table was printed.
+;;
+;; Root cause: nonagg_eval_per_group_core stored per-group cells as
+;; RAY_LAZY values directly. The first fmt_obj of the table called
+;; ray_lazy_materialize, which frees the lazy's graph — leaving the
+;; LIST cell pointing at a half-dead lazy. Subsequent reads (e.g.
+;; (at table 'col)) returned the dead cell, and any access on it
+;; failed with "nyi" inside execute.
+;;
+;; Fix: materialise lazy cells eagerly in nonagg_eval_per_group_core
+;; before storing them in the result LIST.  Each cell is now a
+;; concrete typed-vec / atom — safe to re-read any number of times.
+
+;; ─── Reverse per group ─────────────────────────────────────────
+(set TR (table [k v] (list ['a 'a 'b 'b 'c] [1 2 3 4 5])))
+(set Rr (select {rv: (reverse v) from: TR by: k}))
+
+;; (a) Full-table display materialises cells — the original happy
+;; path that was already working.
+(count Rr) -- 3
+(count (at Rr 'rv)) -- 3
+
+;; (b) Column extraction must give concrete per-group vecs, not
+;; half-dead lazies.  This was the failing read.
+(set Crv (at Rr 'rv))
+(at Crv 0) -- [2 1]
+(at Crv 1) -- [4 3]
+(at Crv 2) -- [5]
+
+;; (c) Repeated reads of the same cell — must stay valid (lazy
+;; cells would fail the second time after fmt_obj stole the graph).
+(at (at Rr 'rv) 0) -- [2 1]
+(at (at Rr 'rv) 1) -- [4 3]
+(at (at Rr 'rv) 0) -- [2 1]
+(at (at Rr 'rv) 0) -- [2 1]
+
+;; ─── asc per group ────────────────────────────────────────────
+(set TA (table [k v] (list ['a 'a 'a 'b 'b] [3 1 2 5 4])))
+(set Ra (select {av: (asc v) from: TA by: k}))
+(at (at Ra 'av) 0) -- [1 2 3]
+(at (at Ra 'av) 1) -- [4 5]
+(at (at Ra 'av) 1) -- [4 5]
+
+;; ─── desc per group ───────────────────────────────────────────
+(set Rd (select {dv: (desc v) from: TA by: k}))
+(at (at Rd 'dv) 0) -- [3 2 1]
+(at (at Rd 'dv) 1) -- [5 4]
+
+;; ─── F64 ──────────────────────────────────────────────────────
+(set TF (table [k v] (list ['a 'a 'b 'b] [1.5 2.5 3.5 4.5])))
+(set Rf (select {rv: (reverse v) from: TF by: k}))
+(at (at Rf 'rv) 0) -- [2.5 1.5]
+(at (at Rf 'rv) 1) -- [4.5 3.5]

--- a/test/rfl/query/where_and_chain.rfl
+++ b/test/rfl/query/where_and_chain.rfl
@@ -279,12 +279,13 @@
 ;; (and X) shape returns NULL → the WHERE-not-supported "domain"
 ;; error at L4189-4195.
 ;;
-;; XFAIL: single-conjunct (and X) is rejected at compile time instead
-;; of being folded to X.  The cheap fix is to detect ray_len == 2 in
-;; the WHERE compiler and unwrap before compile_expr_dag.
+;; Bug 4 (now fixed): single-conjunct (and X) collapses to X per the
+;; monoid identity rule.  compile_expr_dag handles n==2 case explicitly
+;; (src/ops/query.c) and the eval-level ray_and_vary_fn / ray_or_vary_fn
+;; accept n==1 as identity (src/ops/cmp.c).  See and_or_identity.rfl.
 ;; ====================================================================
-(count (select {from: T0 where: (and (> v 100))})) !- domain
-(sum (at (select {from: T0 where: (and (> v 100))}) 'v)) !- domain
+(count (select {from: T0 where: (and (> v 100))}))       -- 49899
+(sum (at (select {from: T0 where: (and (> v 100))}) 'v)) -- 1249969950
 ;; Sanity: the un-wrapped form works as expected.  Rows {101..49999},
 ;; n=49899, sum = (101+49999)*49899/2 = 50100*49899/2 = 1,249,969,950.
 (count (select {from: T0 where: (> v 100)})) -- 49899

--- a/test/rfl/query/where_and_chain.rfl
+++ b/test/rfl/query/where_and_chain.rfl
@@ -1,0 +1,299 @@
+;; Coverage for the WHERE-AND chained-filter compile path + planner
+;; branches that hang off it in `src/ops/query.c`:
+;;
+;;   - `query.c:4058..4202` — `and_chained` path that splits a variadic
+;;     `(and a b c ...)` WHERE into K independent OP_FILTER chains so
+;;     each surviving conjunct is evaluated under a progressively
+;;     refined rowsel (selection-aware exec_like / IN / range cmp).
+;;   - Conjunct cost estimator + cost-based reorder (selection sort
+;;     by `cost[]`) — verifies result correctness when the selective
+;;     predicate is written last (planner reorders cheap-first
+;;     silently; user sees identical data).
+;;   - `reorder_safe = 0` guard — when a conjunct uses an op the
+;;     planner can't prove safe to reorder (the `default:` arm sets
+;;     `reorder_safe = 0`), the chain preserves user order so a
+;;     short-circuit guard like `(!= y 0)` keeps protecting a later
+;;     division.  Happy-path: verify the result is still correct.
+;;   - Fallback path (`and_chained=0`): variadic OR, mixed AND/OR, and
+;;     the `> 64 conjuncts` bail — fall through to the OP_AND tree
+;;     compiled by `compile_expr_dag` directly.
+;;   - WHERE + by-group: chained filter feeds the group-by executor.
+;;     Per-group sum/count must match the manual filter-then-group
+;;     formulation (the predicate-pushdown oracle).
+;;   - Mixed agg + non-agg projection with a WHERE — confirms the
+;;     filtered rowsel reaches both projection paths consistently.
+;;   - `(in col …)` semijoin-style filter inside an AND chain — IN
+;;     has cost 20, the column compare has cost 5, so the reorder
+;;     puts the IN second.
+;;   - Predicate pushdown past projection — `(select … where: pred
+;;     from: (select … from: T))` must equal the filter-first form
+;;     (the optimizer's `pass_predicate_pushdown` swaps FILTER below
+;;     OP_SELECT/OP_ALIAS when the child is single-consumer).
+;;
+;; Fixture sizing: 50_000 rows ensures we cross the >= 200_000 *parallel*
+;; probe threshold from `parallel_probe.rfl`'s scope without overlap; the
+;; chained-filter compile path triggers regardless of row count, while
+;; reduction-style aggs at 50k still measure something non-trivial.
+
+;; ====================================================================
+;; Fixture T0 — 50_000-row table, round-robin SYM key over {A,B,C}.
+;; v = (til Nrow), so row index = v.  k cycles A,B,C,A,B,C,…
+;; Hand-computed reference values (see comments inline).
+;; ====================================================================
+(set Nrow 50000)
+(set T0 (table [k v] (list (take ['A 'B 'C] Nrow) (til Nrow))))
+
+;; Sanity pin on the fixture itself — these numbers anchor the
+;; oracles below.
+(count T0) -- 50000
+;; k='A': r%3==0 → rows {0,3,…,49998}, count = 16667.
+(count (select {from: T0 where: (== k 'A)})) -- 16667
+;; k='B': r%3==1 → rows {1,4,…,49999}, count = 16667.
+(count (select {from: T0 where: (== k 'B)})) -- 16667
+;; k='C': r%3==2 → rows {2,5,…,49997}, count = 16666.
+(count (select {from: T0 where: (== k 'C)})) -- 16666
+
+;; ====================================================================
+;; 3-conjunct AND — exercises the `and_chained` compile path.
+;; Predicate: (and (> v 100) (< v 500) (!= k 'C))
+;;   v in {101..499}  → 399 rows.  Excluding r%3==2:
+;;     r%3==0 in [101,499]: {102,105,…,498}, n=133, sum=133*300=39900
+;;     r%3==1 in [101,499]: {103,106,…,499}, n=133, sum=133*301=40033
+;;   Total: 266 rows, sum=79933.
+;; ====================================================================
+(count (select {from: T0 where: (and (> v 100) (< v 500) (!= k 'C))})) -- 266
+(sum (at (select {from: T0 where: (and (> v 100) (< v 500) (!= k 'C))}) 'v)) -- 79933
+
+;; Same predicate, conjuncts in different user orders — chained filter
+;; semantics are commutative under refinement (each predicate must
+;; just be VALID on surviving rows, which a fully-evaluated bool
+;; column is).  All four orderings must agree on the same row set.
+(count (select {from: T0 where: (and (!= k 'C) (< v 500) (> v 100))})) -- 266
+(count (select {from: T0 where: (and (< v 500) (!= k 'C) (> v 100))})) -- 266
+(sum (at (select {from: T0 where: (and (< v 500) (> v 100) (!= k 'C))}) 'v)) -- 79933
+
+;; ====================================================================
+;; 4-conjunct AND — beyond pairwise nesting; still well under the
+;; k <= 64 cap.  Adds an extra non-trivial range to confirm the
+;; selection-sort over `cost[]` doesn't lose conjuncts.
+;; Predicate: (and (> v 100) (< v 500) (!= k 'C) (>= v 200))
+;;   v in {200..499} excluding r%3==2:
+;;     r%3==0 in [200,499]: {201,204,…,498}, n=100, sum=100*(201+498)/2=34950
+;;     r%3==1 in [200,499]: {202,205,…,499}, n=100, sum=100*(202+499)/2=35050
+;;   Total: 200 rows, sum=70000.
+;; ====================================================================
+(count (select {from: T0 where: (and (> v 100) (< v 500) (!= k 'C) (>= v 200))})) -- 200
+(sum (at (select {from: T0 where: (and (> v 100) (< v 500) (!= k 'C) (>= v 200))}) 'v)) -- 70000
+
+;; ====================================================================
+;; Cost-based reorder — selective predicate written LAST.
+;; The optimizer's selection-sort runs over compile_expr_dag's coarse
+;; cost map (EQ/NE/LT/.. = 5, IN = 20, LIKE = 50).  All three
+;; conjuncts here are cmp-cost-5, so the sort is stable wrt user
+;; order; semantics are unchanged because rowsel refinement is
+;; commutative on side-effect-free bool predicates.
+;; Predicate: (and (> v 0) (< v 50000) (== v 12345))
+;;   The first two pass nearly every row; the last keeps exactly one.
+;;   r=12345 has k='?' for 12345%3=0 → 'A'.  Sum = 12345.
+;; ====================================================================
+(count (select {from: T0 where: (and (> v 0) (< v 50000) (== v 12345))})) -- 1
+(sum (at (select {from: T0 where: (and (> v 0) (< v 50000) (== v 12345))}) 'v)) -- 12345
+;; Reverse user order — same answer.
+(count (select {from: T0 where: (and (== v 12345) (< v 50000) (> v 0))})) -- 1
+(sum (at (select {from: T0 where: (and (== v 12345) (< v 50000) (> v 0))}) 'v)) -- 12345
+
+;; ====================================================================
+;; IN inside AND — exercises the OP_IN cost-20 arm of the estimator
+;; (compile_expr_dag → planner.cost_estimate switch L4124-4126).
+;; Predicate: (and (> v 100) (in v [200 300 400 500]) (!= k 'C))
+;;   v ∈ {200,300,400,500} surviving >100: all four.
+;;   r%3 for 200=2(C), 300=0(A), 400=1(B), 500=2(C).
+;;   Drop C: keep {300, 400} → 2 rows, sum = 700.
+;; ====================================================================
+(count (select {from: T0 where: (and (> v 100) (in v [200 300 400 500]) (!= k 'C))})) -- 2
+(sum (at (select {from: T0 where: (and (> v 100) (in v [200 300 400 500]) (!= k 'C))}) 'v)) -- 700
+
+;; ====================================================================
+;; LIKE inside AND — exercises the OP_LIKE cost-50 arm.  LIKE is
+;; expensive enough that the planner forces it LAST after every cheap
+;; cmp regardless of user order.  Use a STR column to feed exec_like.
+;; Fixture T1: 1200 rows with a STR column whose values cycle three
+;; literals "alpha", "beta", "gamma".
+;; ====================================================================
+(set Nl 1200)
+(set T1 (table [s v] (list (take ["alpha" "beta" "gamma"] Nl) (til Nl))))
+;; Sanity:
+(count T1) -- 1200
+;; Predicate: (and (> v 100) (< v 500) (like s "a*"))
+;;   v in {101..499}, 399 rows.  s[r] = ["alpha","beta","gamma"][r%3].
+;;   "a*" matches only "alpha", i.e. r%3==0.
+;;   r%3==0 in [101,499]: {102,…,498}, 133 rows.  sum = 39900.
+(count (select {from: T1 where: (and (> v 100) (< v 500) (like s "a*"))})) -- 133
+(sum (at (select {from: T1 where: (and (> v 100) (< v 500) (like s "a*"))}) 'v)) -- 39900
+;; LIKE written first — planner sorts it to last.  Same answer.
+(count (select {from: T1 where: (and (like s "a*") (> v 100) (< v 500))})) -- 133
+
+;; ====================================================================
+;; `reorder_safe = 0` guard — a conjunct containing an op the cost
+;; estimator's switch doesn't have an explicit arm for (here:
+;; multiplication) lands in the `default:` case at L4136-4148, which
+;; pessimistically sets `reorder_safe = 0`.  The chain is still
+;; emitted, but the user's order is preserved — so a guard like
+;; `(!= v 0)` that precedes a division of `(/ 100 v)` keeps
+;; short-circuiting.  Happy path: the result is correct.
+;;
+;; We construct a predicate where the guard is necessary (v=0 would
+;; trip divide-by-zero behaviour) and verify the row count.  T0 has
+;; row 0 with v=0; the guard's job is to keep that row from reaching
+;; the division.
+;; Predicate: (and (!= v 0) (> (/ 1000 v) 5))
+;;   v != 0 keeps 49999 rows.
+;;   1000/v > 5  ⇔  v < 200  (and v > 0).
+;;   So result is v ∈ {1..199}: 199 rows.  sum = 199*200/2 = 19900.
+;; ====================================================================
+(count (select {from: T0 where: (and (!= v 0) (> (/ 1000 v) 5))})) -- 199
+(sum (at (select {from: T0 where: (and (!= v 0) (> (/ 1000 v) 5))}) 'v)) -- 19900
+
+;; ====================================================================
+;; Fallback: OR doesn't get chained — must hit the OP_AND-tree
+;; compile path (the `and_chained = 0` arm at L4186-4202).  Happy
+;; path: variadic OR works just as well via compile_expr_dag.
+;; Predicate: (or (== v 50) (== v 100) (== v 150))
+;;   3 rows.  Sum = 300.
+;; ====================================================================
+(count (select {from: T0 where: (or (== v 50) (== v 100) (== v 150))})) -- 3
+(sum (at (select {from: T0 where: (or (== v 50) (== v 100) (== v 150))}) 'v)) -- 300
+
+;; Nested AND-of-ORs — chained-filter still applies to the outer AND;
+;; each conjunct is an OR (single OP_OR vec), which compiles to one
+;; OP_FILTER per outer conjunct.
+;; Predicate: (and (or (== v 100) (== v 200)) (or (== k 'A) (== k 'B)))
+;;   v ∈ {100,200}, both rows: r=100 (k='B', 100%3=1), r=200 (k='C', 200%3=2).
+;;   Keep r=100 only (k!='C').  1 row, sum=100.
+(count (select {from: T0 where: (and (or (== v 100) (== v 200)) (or (== k 'A) (== k 'B)))})) -- 1
+(sum (at (select {from: T0 where: (and (or (== v 100) (== v 200)) (or (== k 'A) (== k 'B)))}) 'v)) -- 100
+
+;; ====================================================================
+;; WHERE + by-group — chained predicates feed the group-by executor.
+;; Per-group sum must match the manual filter-then-group oracle.
+;; Predicate: (and (> v 100) (< v 500))
+;;   v in {101..499} = 399 rows.  Group by k:
+;;     k='A' (r%3==0): {102,…,498}, 133 rows, sum = 133*300 = 39900.
+;;     k='B' (r%3==1): {103,…,499}, 133 rows, sum = 133*301 = 40033.
+;;     k='C' (r%3==2): {101,104,…,497}, 133 rows, sum = 133*299 = 39767.
+;;   Total: 119700.
+;; ====================================================================
+(set Rw0 (select {s: (sum v) c: (count v) by: k from: T0 where: (and (> v 100) (< v 500))}))
+(count Rw0) -- 3
+(sum (at Rw0 's)) -- 119700
+(sum (at Rw0 'c)) -- 399
+;; Order of SYM group keys is implementation-dependent (hash bucket
+;; order, not first-occurrence — first-occurrence reorder fires only
+;; for BOOL keys, see query.c:6971).  Pin per-group totals by
+;; re-filtering the result table by key, so the assertion is order-
+;; agnostic.
+;;   k='A' (r%3==0) ∩ {101..499}: 133 rows, sum=39900
+;;   k='B' (r%3==1) ∩ {101..499}: 133 rows, sum=40033
+;;   k='C' (r%3==2) ∩ {101..499}: 133 rows, sum=39767
+(at (at (select {from: Rw0 where: (== k 'A)}) 's) 0) -- 39900
+(at (at (select {from: Rw0 where: (== k 'B)}) 's) 0) -- 40033
+(at (at (select {from: Rw0 where: (== k 'C)}) 's) 0) -- 39767
+(at (at (select {from: Rw0 where: (== k 'A)}) 'c) 0) -- 133
+(at (at (select {from: Rw0 where: (== k 'B)}) 'c) 0) -- 133
+(at (at (select {from: Rw0 where: (== k 'C)}) 'c) 0) -- 133
+
+;; Predicate-pushdown oracle: filter-then-group must equal
+;; group-with-WHERE.  This pins the chained-filter rowsel onto the
+;; group-by executor (the `where:` clause's selection survives into
+;; the group's scatter via g->selection).
+(set Manual (select {s: (sum v) c: (count v) by: k from: (select {from: T0 where: (and (> v 100) (< v 500))})}))
+(count Manual) -- 3
+(sum (at Manual 's)) -- 119700
+(sum (at Manual 'c)) -- 399
+
+;; ====================================================================
+;; Mixed agg + non-agg projection — exercises both the streaming
+;; aggregator dispatch AND the row-aligned column projection under
+;; the same WHERE rowsel.
+;; (select {tot: (sum v) avg_v: (avg v) from: T0 where: ...})
+;;   For v in {101..499}: 399 rows, sum=119700, avg=119700/399=300.0.
+;; ====================================================================
+(set Rmix (select {tot: (sum v) avg_v: (avg v) from: T0 where: (and (> v 100) (< v 500))}))
+(count Rmix) -- 1
+(at (at Rmix 'tot) 0) -- 119700
+(at (at Rmix 'avg_v) 0) -- 300.0
+
+;; Non-agg-with-inner-agg + WHERE + by — fires `nonagg_eval_per_group`
+;; over the post-filter rowsel.  Per-group (max v - min v) across the
+;; surviving rows.
+;;   k='A': rows {102,…,498}, max=498, min=102 → 396.
+;;   k='B': rows {103,…,499}, max=499, min=103 → 396.
+;;   k='C': rows {101,…,497}, max=497, min=101 → 396.
+(set Rng (select {r: (- (max v) (min v)) by: k from: T0 where: (and (> v 100) (< v 500))}))
+(count Rng) -- 3
+(sum (at Rng 'r)) -- 1188
+
+;; ====================================================================
+;; Predicate pushdown past projection — the optimizer's
+;; `pass_predicate_pushdown` swaps FILTER below OP_SELECT/OP_ALIAS
+;; when the child is single-consumer.  Verify the answer doesn't
+;; depend on whether the user wrote it nested or flat.
+;; ====================================================================
+;; v ∈ {49001..49499}, n=499, sum = 499 * (49001+49499)/2 = 499 * 49250
+;; = 24,575,750.
+(set Pre  (select {from: T0 where: (and (> v 49000) (< v 49500))}))
+(set Post (select {from: (select {v: v k: k from: T0}) where: (and (> v 49000) (< v 49500))}))
+(count Pre)  -- 499
+(count Post) -- 499
+(sum (at Pre 'v))  -- 24575750
+(sum (at Post 'v)) -- 24575750
+(sum (at Post 'v)) -- (sum (at Pre 'v))
+
+;; ====================================================================
+;; `(in col …)` semijoin-style filter — `col in (other-table-col)`.
+;; Build a small "lookup" set, then a WHERE that exercises the
+;; membership test.  Combined with an AND so the chained-filter path
+;; fires (single-conjunct WHEREs bypass the and_chained branch).
+;; ====================================================================
+(set Lookup [100 200 300 400 500])
+;; (and (in v Lookup) (!= k 'C)):
+;;   r ∈ {100,200,300,400,500} surviving the !=C filter.
+;;   k for these: 100→B, 200→C, 300→A, 400→B, 500→C.
+;;   Keep {100,300,400}: 3 rows, sum=800.
+(count (select {from: T0 where: (and (in v Lookup) (!= k 'C))})) -- 3
+(sum (at (select {from: T0 where: (and (in v Lookup) (!= k 'C))}) 'v)) -- 800
+
+;; "In a derived column": Lookup pulled from another table's column.
+;; Predicate-pushdown still applies because both compile to the same
+;; OP_IN over a materialized literal-vec input.
+(set Tlk (table [x] (list [100 200 300 400 500])))
+(set LookupCol (at Tlk 'x))
+(count (select {from: T0 where: (and (in v LookupCol) (!= k 'C))})) -- 3
+(sum (at (select {from: T0 where: (and (in v LookupCol) (!= k 'C))}) 'v)) -- 800
+
+;; ====================================================================
+;; Edge: single-conjunct AND — `(and (> v 100))` is rejected by the
+;; chained-filter branch (`ray_len(where_expr) >= 3` requires AT
+;; LEAST 2 conjuncts plus the head sym at query.c:4060).  It falls
+;; through to `compile_expr_dag(where_expr)` at L4187, which on a
+;; (and X) shape returns NULL → the WHERE-not-supported "domain"
+;; error at L4189-4195.
+;;
+;; XFAIL: single-conjunct (and X) is rejected at compile time instead
+;; of being folded to X.  The cheap fix is to detect ray_len == 2 in
+;; the WHERE compiler and unwrap before compile_expr_dag.
+;; ====================================================================
+(count (select {from: T0 where: (and (> v 100))})) !- domain
+(sum (at (select {from: T0 where: (and (> v 100))}) 'v)) !- domain
+;; Sanity: the un-wrapped form works as expected.  Rows {101..49999},
+;; n=49899, sum = (101+49999)*49899/2 = 50100*49899/2 = 1,249,969,950.
+(count (select {from: T0 where: (> v 100)})) -- 49899
+(sum (at (select {from: T0 where: (> v 100)}) 'v)) -- 1249969950
+
+;; ====================================================================
+;; Edge: 2-conjunct AND — the smallest k for which the chained path
+;; actually fires (ray_len(where_expr) = 3: 'and head + 2 conjuncts).
+;; Predicate: (and (> v 100) (< v 500)) — 399 rows, sum 119700.
+;; ====================================================================
+(count (select {from: T0 where: (and (> v 100) (< v 500))})) -- 399
+(sum (at (select {from: T0 where: (and (> v 100) (< v 500))}) 'v)) -- 119700

--- a/test/rfl/store/serde_roundtrip.rfl
+++ b/test/rfl/store/serde_roundtrip.rfl
@@ -1,0 +1,540 @@
+;; Coverage for src/store/serde.c — happy-path roundtrip via (ser X)/(de X).
+;;
+;; Why this file exists:
+;;   serde.c sits at 87 % region / 72 % branch coverage on master.  The
+;;   under-tested branches are the type-dispatch arms in ray_serde_size,
+;;   ray_ser_raw, and ray_de_raw — each of {BOOL, U8, I16, I32, F32, F64,
+;;   I64, DATE, TIME, TIMESTAMP, GUID, SYM, STR} × {atom, vec, vec+null}
+;;   has its own case label.  The existing rfl/system/serde.rfl covers I64
+;;   + F64 + SYM + STR atoms and i64 vectors only; this file fills in the
+;;   remaining {DATE, TIME, TIMESTAMP, GUID, BOOL, U8, I16, I32} atom and
+;;   vector arms, the slice/lazy materialise paths, the LIST/DICT/TABLE
+;;   compound recursive arms, sentinel-null vectors, and the file-backed
+;;   .db.splayed.set / .db.splayed.get path that re-enters serde for
+;;   on-disk persistence.
+;;
+;; Reachability map (RFL surface vs. the C dispatch):
+;;
+;;   serde.c ser_raw / de_raw arm           how this file reaches it
+;;   ───────────────────────────────────    ─────────────────────────
+;;   atom -RAY_BOOL                         (de (ser true))
+;;   atom -RAY_U8                           (de (ser (as 'U8 200)))
+;;   atom -RAY_I16                          (de (ser 1234h))
+;;   atom -RAY_I32                          (de (ser 987654i))
+;;   atom -RAY_I64                          (de (ser 42)) (already covered)
+;;   atom -RAY_F64                          (de (ser 3.14)) (already covered)
+;;   atom -RAY_DATE                         (de (ser 2024.06.15))
+;;   atom -RAY_TIME                         (de (ser 12:30:45.000))
+;;   atom -RAY_TIMESTAMP                    (de (ser 2024.06.15D...))
+;;   atom -RAY_GUID                         (set G (first (guid 1))) ; (de (ser G))
+;;   atom -RAY_SYM                          (de (ser 'hello)) (already covered)
+;;   atom -RAY_STR                          (de (ser "world")) (already covered)
+;;   typed null atoms                       (de (ser 0Nh)) / 0Ni / etc.
+;;
+;;   vec RAY_BOOL                           (as 'BOOL [1 0 1])
+;;   vec RAY_U8                             (as 'U8 [1 2 3])
+;;   vec RAY_I16                            (as 'I16 [1 2 3])
+;;   vec RAY_I32                            (as 'I32 [1 2 3])
+;;   vec RAY_I64                            [1 2 3] (already covered)
+;;   vec RAY_F64                            [1.5 2.5] (already covered)
+;;   vec RAY_DATE                           (as 'DATE [7305 7306])
+;;   vec RAY_TIME                           (as 'TIME [3723000])
+;;   vec RAY_TIMESTAMP                      (as 'TIMESTAMP [123456789])
+;;   vec RAY_GUID                           (guid N)
+;;   vec RAY_SYM                            ['a 'b 'c]
+;;   vec RAY_STR                            ["a" "b"]
+;;   vec with HAS_NULLS                     [1 0N 3] / (as 'F64 [1.0 0N 2.0])
+;;
+;;   compound RAY_LIST                      (list ...) recursive ser/de
+;;   compound RAY_DICT                      (dict K V) — slot pair recurses
+;;   compound RAY_TABLE                     (table ...) — schema (SYM via I64)
+;;                                          + cols (RAY_LIST) recurse
+;;
+;;   lazy materialise in ray_ser            (set X (asc V)) ; (ser X)
+;;                                          (commit f1c143b0 — fix(serde):
+;;                                          materialise lazy objects before
+;;                                          persisting)
+;;
+;;   file path (ray_obj_save indirectly)    .db.splayed.set / .db.splayed.get
+;;                                          uses ray_col_save/_load which
+;;                                          bypass serde.c — note at end.
+;;
+;; Skipped (per task brief — happy path only):
+;;   - malformed wire bytes / wire version mismatch / size overflow:
+;;     covered in test/test_store.c::test_serde_wire_version_mismatch
+;;     and test_serde_de_error_paths (C-level).
+;;   - F32 atom/vec arm: ray_cast_fn has no 'F32 target (see
+;;     src/ops/builtins.c::ray_cast_fn), so an F32 vector can't be
+;;     produced from rfl source.  C-level test_serde_f32_atom_and_edge_cases
+;;     covers ser_raw F32 atom (memcpy of (float)obj->f64 narrow).
+;;
+;; Cleanup: rf_test_serde_* matches the Makefile clean rule and is removed
+;; at file end.
+
+;; ════════════════════════════════════════════════════════════════
+;; 1. Atom roundtrip — every supported atom type.
+;;
+;; Hits the atom arms in ray_serde_size (lines 127-149), ray_ser_raw
+;; (lines 257-322), and ray_de_raw (lines 491-565).  Format-compare
+;; the deserialized value against the source literal — proves the
+;; flags byte (typed-null bit) is 0 on these and the value-bytes
+;; survive bit-exact.
+;; ════════════════════════════════════════════════════════════════
+
+;; BOOL atom
+(de (ser true))  -- true
+(de (ser false)) -- false
+(type (de (ser true))) -- 'b8
+
+;; U8 atom — value preserved, type tag preserved
+(type (de (ser (as 'U8 200)))) -- 'u8
+(de (ser (as 'U8 200))) -- 0xc8
+(de (ser (as 'U8 0))) -- 0x00
+
+;; I16 atom
+(de (ser 1234h)) -- 1234h
+(de (ser -1234h)) -- -1234h
+(de (ser 0h)) -- 0h
+(type (de (ser 1234h))) -- 'i16
+
+;; I32 atom
+(de (ser 987654i)) -- 987654i
+(de (ser -987654i)) -- -987654i
+(de (ser 0i)) -- 0i
+(type (de (ser 987654i))) -- 'i32
+
+;; I64 atom — large value (sign bit set), zero, negative
+(de (ser 9223372036854775806)) -- 9223372036854775806
+(de (ser -9223372036854775807)) -- -9223372036854775807
+(de (ser 0)) -- 0
+
+;; F64 atom — negative + zero
+(de (ser -3.14)) -- -3.14
+(de (ser 0.0)) -- 0.0
+
+;; DATE atom
+(de (ser 2024.06.15)) -- 2024.06.15
+(de (ser 2000.01.01)) -- 2000.01.01
+(type (de (ser 2024.06.15))) -- 'date
+
+;; TIME atom
+(de (ser 12:30:45.000)) -- 12:30:45.000
+(de (ser 00:00:00.000)) -- 00:00:00.000
+(type (de (ser 12:30:45.000))) -- 'time
+
+;; TIMESTAMP atom
+(de (ser 2024.06.15D12:30:45.123456789)) -- 2024.06.15D12:30:45.123456789
+(de (ser 2000.01.01D00:00:00.000000000)) -- 2000.01.01D00:00:00.000000000
+(type (de (ser 2024.06.15D12:30:45.123456789))) -- 'timestamp
+
+;; GUID atom — non-deterministic byte pattern, so capture and compare
+;; format-equality.  Exercises ray_ser_raw GUID arm (line 294-300) +
+;; ray_de_raw GUID arm (line 540-542): both need an obj->obj pointer
+;; to a 16-byte buffer to round-trip the underlying bytes.
+(set G (first (guid 1))) (de (ser G)) -- G
+(type G) -- 'guid
+
+;; SYM atom — already covered in serde.rfl, add a long-ish one for the
+;; safe_strlen path in ray_de_raw line 544.
+(de (ser 'supercalifragilisticexpialidocious))   -- 'supercalifragilisticexpialidocious
+
+;; STR atom — empty + multibyte-content (covers slen=0 + slen>0 in
+;; ray_ser_raw STR arm line 312-319 and ray_de_raw line 554-561).
+(de (ser "")) -- ""
+(de (ser "hello world with spaces and punctuation!")) -- "hello world with spaces and punctuation!"
+
+;; ════════════════════════════════════════════════════════════════
+;; 2. Typed-null atoms — flags byte bit 0 carries the typed-null
+;; marker.  Regression for the v3 wire format (commit
+;; S3'.1: serde ser_null_bitmap derives bits from sentinel reads).
+;;
+;; Hits ray_typed_null branches in ray_de_raw (line 501-542).  The
+;; ser side packs nullmap[0]&1 into the flags byte (line 258); the de
+;; side reads flags, returns ray_typed_null(type) when bit 0 is set.
+;; ════════════════════════════════════════════════════════════════
+
+(de (ser 0Nh)) -- 0Nh
+(de (ser 0Ni)) -- 0Ni
+(de (ser 0Nl)) -- 0Nl
+(de (ser 0Nf)) -- 0Nf
+
+;; Type tag survives the null round-trip — proves we don't fall back
+;; to ray_i64(0) like the v2 wire format did.
+(type (de (ser 0Nh))) -- 'i16
+(type (de (ser 0Ni))) -- 'i32
+(type (de (ser 0Nl))) -- 'i64
+(type (de (ser 0Nf))) -- 'f64
+
+;; ════════════════════════════════════════════════════════════════
+;; 3. Vector roundtrip — every supported element-type arm.
+;;
+;; Hits the vector switch in ray_serde_size (line 160-220), ray_ser_raw
+;; (line 331-410), and ray_de_raw (line 571-663).
+;;
+;; The wire format for fixed-width vec types is identical (just elem
+;; size differs), but each type has its own case label so we touch
+;; every region.  For each arm: type preserved, length preserved,
+;; values preserved.
+;; ════════════════════════════════════════════════════════════════
+
+;; BOOL vec (RAY_BOOL → type tag 'B8 on output)
+(type (de (ser (as 'BOOL [1 0 1 1 0])))) -- 'B8
+(count (de (ser (as 'BOOL [1 0 1 1 0])))) -- 5
+(at (de (ser (as 'BOOL [1 0 1 1 0]))) 0) -- true
+(at (de (ser (as 'BOOL [1 0 1 1 0]))) 1) -- false
+(at (de (ser (as 'BOOL [1 0 1 1 0]))) 2) -- true
+
+;; U8 vec — exercise the same 1-byte/elem branch as BOOL but distinct
+;; type tag dispatch.
+(type (de (ser (as 'U8 [1 2 3 255 0])))) -- 'U8
+(count (de (ser (as 'U8 [1 2 3 255 0])))) -- 5
+(sum (de (ser (as 'U8 [1 2 3 255 0])))) -- 261
+
+;; I16 vec — 2-byte/elem branch
+(type (de (ser (as 'I16 [1 -2 3 -4 5])))) -- 'I16
+(sum (de (ser (as 'I16 [1 -2 3 -4 5])))) -- 3
+(count (de (ser (as 'I16 [1 -2 3 -4 5])))) -- 5
+
+;; I32 vec — 4-byte/elem branch
+(type (de (ser (as 'I32 [10 20 30])))) -- 'I32
+(sum (de (ser (as 'I32 [10 20 30])))) -- 60
+
+;; I64 vec — already covered (in serde.rfl), add a wider one for the
+;; null-bit pack/unpack path (>8 elems crosses a byte boundary).
+(count (de (ser [1 2 3 4 5 6 7 8 9 10]))) -- 10
+(sum (de (ser [1 2 3 4 5 6 7 8 9 10]))) -- 55
+
+;; F64 vec — already covered (in serde.rfl), add a negative + zero
+;; mix for the float bit-pattern preservation.
+(sum (de (ser [-1.5 0.0 2.5]))) -- 1.0
+(at (de (ser [-1.5 0.0 2.5])) 0) -- -1.5
+
+;; DATE vec — 4-byte/elem branch shared with I32 + TIME + F32
+(type (de (ser (as 'DATE [7305 7306 7307])))) -- 'DATE
+(count (de (ser (as 'DATE [7305 7306 7307])))) -- 3
+;; DATE epoch is 2000.01.01 (= day 0); 7305 days ≈ 2020-01-02.  We
+;; assert via type+count above and use the round-trip equality below
+;; — proves bit-exact day index preservation.
+(at (de (ser (as 'DATE [7305 7306 7307]))) 0) -- (at (as 'DATE [7305 7306 7307]) 0)
+
+;; TIME vec
+(type (de (ser (as 'TIME [3723000 7200000])))) -- 'TIME
+(count (de (ser (as 'TIME [3723000 7200000])))) -- 2
+
+;; TIMESTAMP vec — 8-byte/elem branch shared with I64 + F64
+(type (de (ser (as 'TIMESTAMP [123456789 987654321])))) -- 'TIMESTAMP
+(count (de (ser (as 'TIMESTAMP [123456789 987654321])))) -- 2
+
+;; GUID vec — 16-byte/elem branch, unique to GUID
+;; (guid N) generates N random GUIDs; capture in a variable so the LHS
+;; deserialized form has a stable reference for comparison.
+(set Gv (guid 3))
+(type (de (ser Gv))) -- 'GUID
+(count (de (ser Gv))) -- 3
+(de (ser Gv)) -- Gv
+
+;; SYM vec — variable-length-per-elem branch (line 377-393 / 605-633).
+;; Includes a long sym to exercise safe_strlen across multiple
+;; iterations (line 620-628).
+(set Sv ['alpha 'beta 'gamma 'supercalifragilisticexpialidocious])
+(count (de (ser Sv))) -- 4
+(at (de (ser Sv)) 0) -- 'alpha
+(at (de (ser Sv)) 3) -- 'supercalifragilisticexpialidocious
+(type (de (ser Sv))) -- 'SYM
+
+;; STR vec — variable-length-per-elem branch (line 395-410 / 635-663).
+;; Mixed lengths drive the per-elem len-prefix + raw-bytes path.
+(set Stv ["x" "yy" "" "longer string here" "z"])
+(count (de (ser Stv))) -- 5
+(at (de (ser Stv)) 0) -- "x"
+(at (de (ser Stv)) 2) -- ""
+(at (de (ser Stv)) 3) -- "longer string here"
+(type (de (ser Stv))) -- 'STR
+
+;; ════════════════════════════════════════════════════════════════
+;; 4. Vectors with embedded nulls — sentinel-encoded after the recent
+;; null-bitmap-to-sentinel migration.
+;;
+;; The wire format keeps a HAS_NULLS attrs bit (line 329 / 601) but
+;; the actual null bits are derived from sentinel reads of the value
+;; payload.  Roundtripping a null-containing vec must preserve:
+;;   (a) the value bits for non-null positions
+;;   (b) the null marker (so (nil? (at v i)) reports the same result)
+;; ════════════════════════════════════════════════════════════════
+
+;; I64 nulls — uses INT64_MIN sentinel
+(count (de (ser [1 0N 3 0N 5]))) -- 5
+(sum (de (ser [1 0N 3 0N 5]))) -- 9
+(nil? (at (de (ser [1 0N 3])) 1)) -- true
+
+;; F64 nulls — uses NaN sentinel
+(count (de (ser (as 'F64 [1.0 0N 2.0 0N 3.0])))) -- 5
+(sum (de (ser (as 'F64 [1.0 0N 2.0 0N 3.0])))) -- 6.0
+(nil? (at (de (ser (as 'F64 [1.0 0N 2.0]))) 1)) -- true
+
+;; I32 nulls — uses INT32_MIN sentinel
+(count (de (ser (as 'I32 [1 0N 3])))) -- 3
+(type (de (ser (as 'I32 [1 0N 3])))) -- 'I32
+(nil? (at (de (ser (as 'I32 [1 0N 3]))) 1)) -- true
+
+;; I16 nulls — uses INT16_MIN sentinel
+(count (de (ser (as 'I16 [1 0N 3])))) -- 3
+(type (de (ser (as 'I16 [1 0N 3])))) -- 'I16
+(nil? (at (de (ser (as 'I16 [1 0N 3]))) 1)) -- true
+
+;; DATE/TIME/TIMESTAMP nulls share the I32/I64 sentinels.
+(count (de (ser (as 'DATE [7305 0N 7307])))) -- 3
+(nil? (at (de (ser (as 'DATE [7305 0N 7307]))) 1)) -- true
+(count (de (ser (as 'TIMESTAMP [123 0N 789])))) -- 3
+(nil? (at (de (ser (as 'TIMESTAMP [123 0N 789]))) 1)) -- true
+
+;; Long null-mask span: 10 elems alternating value/null forces the
+;; HAS_NULLS attrs bit to propagate across a multi-byte payload.
+(count (de (ser [1 0N 3 0N 5 0N 7 0N 9 0N]))) -- 10
+(sum (de (ser [1 0N 3 0N 5 0N 7 0N 9 0N]))) -- 25
+
+;; ════════════════════════════════════════════════════════════════
+;; 5. Slice vectors — slice of a larger backing vec.  In RAM these
+;; carry RAY_ATTR_SLICE (with an offset + len < backing->len), but the
+;; wire format never includes the slice attr (cleared at line 329 in
+;; ser_raw).  Round-tripping a slice should produce a self-owned vec
+;; with the same values.
+;; ════════════════════════════════════════════════════════════════
+
+;; take N from front
+(count (de (ser (take [1 2 3 4 5 6 7 8] 3)))) -- 3
+(sum (de (ser (take [1 2 3 4 5 6 7 8] 3)))) -- 6
+
+;; take -N from back
+(de (ser (take [10 20 30 40 50] -3))) -- [30 40 50]
+
+;; slice of a typed-narrow vec — proves the elem-size dispatch on the
+;; backing vec's type (not its parent's).
+(type (de (ser (take (as 'I16 [1 2 3 4 5 6]) 4)))) -- 'I16
+(count (de (ser (take (as 'I16 [1 2 3 4 5 6]) 4)))) -- 4
+
+;; slice of a DATE vec — exercises the 4-byte/elem arm
+(type (de (ser (take (as 'DATE [7305 7306 7307 7308]) 2)))) -- 'DATE
+
+;; slice of SYM vec (variable-length-per-elem)
+(count (de (ser (take ['a 'b 'c 'd 'e] 3)))) -- 3
+(at (de (ser (take ['a 'b 'c 'd 'e] 3))) 0) -- 'a
+
+;; ════════════════════════════════════════════════════════════════
+;; 6. Compound types — recursive serialize / deserialize.
+;;
+;; Each compound (LIST/DICT/TABLE) wraps recursive calls into
+;; ray_ser_raw / ray_de_raw for the inner objects.  Hits lines
+;; 412-470 (ser) + 665-824 (de).
+;; ════════════════════════════════════════════════════════════════
+
+;; LIST — heterogeneous, exercises element-by-element recursion
+(count (de (ser (list 1 "two" 'three 4.5)))) -- 4
+(at (de (ser (list 1 "two" 'three 4.5))) 0) -- 1
+(at (de (ser (list 1 "two" 'three 4.5))) 1) -- "two"
+(at (de (ser (list 1 "two" 'three 4.5))) 2) -- 'three
+(at (de (ser (list 1 "two" 'three 4.5))) 3) -- 4.5
+
+;; LIST of vectors — each inner vec recurses through its own arm
+(at (at (de (ser (list [1 2 3] [4 5 6]))) 0) 1) -- 2
+(at (at (de (ser (list [1 2 3] [4 5 6]))) 1) 2) -- 6
+
+;; LIST of SYM vecs (variable-length-per-elem inside variable-length-
+;; recursive)
+(at (at (de (ser (list ['a 'b] ['c 'd 'e]))) 0) 0) -- 'a
+(at (at (de (ser (list ['a 'b] ['c 'd 'e]))) 1) 2) -- 'e
+
+;; Nested LIST of LIST
+(at (at (de (ser (list (list 1 2) (list 3 4)))) 0) 1) -- 2
+(at (at (de (ser (list (list 1 2) (list 3 4)))) 1) 0) -- 3
+
+;; DICT — slot-pair recursion (keys vec + values vec).  Hits the
+;; RAY_DICT arm in serde_size (line 200-204), ser_raw (line 434-441),
+;; de_raw (line 763-792).
+(set D (dict [a b c] [10 20 30]))
+(de (ser D)) -- D
+(key (de (ser D))) -- [a b c]
+(value (de (ser D))) -- [10 20 30]
+(count (de (ser D))) -- 3
+(at (de (ser D)) 'b) -- 20
+
+;; Empty DICT — zero-length keys + values arms exercise the len=0 fast
+;; paths in vec deserialize.
+(count (de (ser (dict [] [])))) -- 0
+
+;; DICT with string values
+(set Ds (dict [k1 k2] ["v1" "v2"]))
+(at (de (ser Ds)) 'k1) -- "v1"
+(at (de (ser Ds)) 'k2) -- "v2"
+
+;; TABLE — schema (RAY_I64 of sym IDs) + columns (RAY_LIST).  Hits the
+;; RAY_TABLE arm in serde_size (line 195-199), ser_raw (line 424-432),
+;; de_raw (line 708-761) + the schema_names helpers (line 82-110, 93-110)
+;; that write/read the per-column sym names.
+(set T (table [a b c] (list [1 2 3] [4 5 6] [7 8 9])))
+(de (ser T)) -- T
+(count (de (ser T))) -- 3
+(key (de (ser T))) -- [a b c]
+(at (de (ser T)) 'a) -- [1 2 3]
+(at (de (ser T)) 'b) -- [4 5 6]
+(at (de (ser T)) 'c) -- [7 8 9]
+
+;; TABLE with mixed-type columns — each column recurses through its
+;; own type arm.
+(set Tm (table [i s f] (list [1 2 3] ["a" "b" "c"] [1.5 2.5 3.5])))
+(at (de (ser Tm)) 's) -- ["a" "b" "c"]
+(at (de (ser Tm)) 'f) -- [1.5 2.5 3.5]
+
+;; TABLE with a SYM column (narrows the schema sym IDs path further)
+(set Tsym (table [tag v] (list ['AAPL 'GOOG 'MSFT] [100 200 300])))
+(at (de (ser Tsym)) 'tag) -- ['AAPL 'GOOG 'MSFT]
+(at (de (ser Tsym)) 'v) -- [100 200 300]
+
+;; TABLE with null-containing columns — combines the HAS_NULLS attr
+;; flow with the recursive deserialize.
+(set Tn (table [a b] (list [1 0N 3] (as 'F64 [1.0 0N 3.0]))))
+(count (de (ser Tn))) -- 3
+(sum (at (de (ser Tn)) 'a)) -- 4
+(sum (at (de (ser Tn)) 'b)) -- 4.0
+
+;; ════════════════════════════════════════════════════════════════
+;; 7. Lazy materialise — ray_ser/ray_obj_save call ray_lazy_materialize
+;; before serialize (commit f1c143b0).  An (asc V) / (desc V) /
+;; (reverse V) / (distinct V) result is lazy; serializing it must
+;; materialise to a concrete vec first.
+;;
+;; Hits ray_ser line 858-864 (lazy detect + materialise) and the
+;; flushed value's normal vec arm.
+;; ════════════════════════════════════════════════════════════════
+
+;; asc — produces lazy
+(de (ser (asc [3 1 4 1 5]))) -- [1 1 3 4 5]
+
+;; bound lazy then ser
+(set La (asc [9 8 7 6 5])) (de (ser La)) -- [5 6 7 8 9]
+
+;; desc
+(de (ser (desc [1 2 3 4 5]))) -- [5 4 3 2 1]
+
+;; reverse
+(de (ser (reverse [1 2 3 4 5]))) -- [5 4 3 2 1]
+
+;; distinct
+(count (de (ser (distinct [1 1 2 2 3 3 4])))) -- 4
+
+;; Lazy scalar (sum) already covered in serde.rfl; add an avg too.
+(de (ser (avg [1 2 3 4 5]))) -- 3.0
+(de (ser (min [3 1 4 1 5 9 2 6]))) -- 1
+
+;; Nested lazy: asc inside list
+(at (de (ser (list (asc [3 1 2]) (asc [6 5 4])))) 0) -- [1 2 3]
+(at (de (ser (list (asc [3 1 2]) (asc [6 5 4])))) 1) -- [4 5 6]
+
+;; ════════════════════════════════════════════════════════════════
+;; 8. Empty + minimal — edge cases of length=0 and length=1 across
+;; the dispatch arms.  Each empty-vec hits the len==0 fast-paths in
+;; ray_ser_raw / ray_de_raw which would otherwise be skipped.
+;; ════════════════════════════════════════════════════════════════
+
+;; Empty I64 vec — note: empty [] roundtrips as 'I64 of length 0
+;; (the parser types [] as I64 by default).
+(type (de (ser []))) -- 'I64
+(count (de (ser []))) -- 0
+
+;; Empty I16 vec via cast
+(count (de (ser (as 'I16 [])))) -- 0
+(type (de (ser (as 'I16 [])))) -- 'I16
+
+;; Single-element vecs across narrow widths
+(count (de (ser [42]))) -- 1
+(at (de (ser [42])) 0) -- 42
+(count (de (ser (as 'U8 [200])))) -- 1
+(count (de (ser (as 'I16 [1234])))) -- 1
+(at (de (ser ['only])) 0) -- 'only
+
+;; ════════════════════════════════════════════════════════════════
+;; 9. Header invariants — (ser X) emits a U8 vec with the 16-byte
+;; ray_ipc_header_t prefix + payload.  Validates ray_ser packing the
+;; header (line 880-886) and ray_de validating it (line 914-925).
+;;
+;; The exact size for an atom is header (16) + 1 (type) + 1 (flags)
+;; + value-bytes; for an I64 atom that's 16+1+1+8 = 26.
+;; ════════════════════════════════════════════════════════════════
+
+(type (ser 42)) -- 'U8
+(count (ser 42)) -- 26
+(count (ser true)) -- 19
+(count (ser 1234h)) -- 20
+(count (ser 987654i)) -- 22
+;; Header must round-trip cleanly: de(ser X) = X
+(de (ser 999)) -- 999
+
+;; ════════════════════════════════════════════════════════════════
+;; 10. File-backed roundtrip via .db.splayed.set / .db.splayed.get.
+;;
+;; Note: .db.splayed.{set,get} go through src/store/splay.c + col.c,
+;; NOT through serde.c — column files use a different on-disk format
+;; per (type, attrs).  Including this path here keeps the regression
+;; safety net wide enough to catch cross-cutting changes to "save and
+;; reload my table" expectations users would attribute to serde.  The
+;; serde.c persistence call is ray_obj_save, used internally by
+;; src/store/journal.c — not exposed as a top-level rfl builtin in
+;; this tree.  See reachability notes below.
+;; ════════════════════════════════════════════════════════════════
+
+(.sys.exec "rm -rf rf_test_serde_splay") -- 0
+
+(set Tsp (table [id v s] (list [1 2 3 4 5] (as 'F64 [1.5 2.5 3.5 4.5 5.5]) ['a 'b 'c 'd 'e])))
+(.db.splayed.set "rf_test_serde_splay" Tsp) -- Tsp
+
+(set Rsp (.db.splayed.get "rf_test_serde_splay"))
+(count Rsp) -- 5
+(at Rsp 'id) -- [1 2 3 4 5]
+(at Rsp 'v) -- (as 'F64 [1.5 2.5 3.5 4.5 5.5])
+(at Rsp 's) -- ['a 'b 'c 'd 'e]
+(key Rsp) -- [id v s]
+
+(.sys.exec "rm -rf rf_test_serde_splay") -- 0
+
+;; ════════════════════════════════════════════════════════════════
+;; reachability notes
+;; ════════════════════════════════════════════════════════════════
+;;
+;; Reached above but worth calling out: the GUID atom arm
+;; (ser_raw line 294-300, de_raw line 540-542) was previously only
+;; exercised by C-level tests because (guid N) returns a *vec* — the
+;; (first ...) extraction here unwraps to a scalar that flows through
+;; the atom dispatch.
+;;
+;; NOT reached from rfl source (covered at the C level in
+;; test/test_store.c):
+;;
+;; F32 atom + F32 vec arms (ser_raw line 277-286, 351-358; de_raw
+;;   line 522-526, 571-603 for the RAY_F32 case):
+;;   ray_cast_fn (src/ops/builtins.c) has no 'F32 / 'f32 target, so
+;;   we can't construct an F32 value from the rfl surface.  Covered
+;;   by test_serde_f32_atom_and_edge_cases + test_serde_atom_types.
+;;
+;; ERROR (RAY_ERROR) arm (ser_raw line 233-238 / 463-466, de_raw line
+;;   841-846):  errors aren't first-class values in rfl source — an
+;;   error always aborts the eval before reaching (ser ...).  Covered
+;;   by test_serde_error_roundtrip in C.
+;;
+;; LAMBDA / UNARY / BINARY / VARY arms (ser_raw line 443-461, de_raw
+;;   line 794-839):  user-defined fns + builtin handles aren't
+;;   serializable directly via the (ser X)/(de X) path used here.
+;;   Covered by test_serde_function_types in C.
+;;
+;; ray_obj_save / ray_obj_load file path (line 932-1013): not exposed
+;;   as an rfl builtin in this tree; only used by the journal snapshot
+;;   code via .log.snapshot.  test_serde_obj_save_load + the
+;;   log_journal_advanced.rfl regression exercise it through the
+;;   journal surface.
+;;
+;; SERDE_NULL marker bare (when (ser obj) sees obj == NULL pointer):
+;;   the eval layer normalises null literals to RAY_NULL_OBJ before
+;;   they reach (ser ...), so the !obj branch at line 229 is only
+;;   reachable from C callers passing a raw NULL.  Covered by
+;;   test_serde_list_with_null_elem indirectly (the inline NULL
+;;   produced inside a LIST round-trips via the substitution at
+;;   line 695-696).

--- a/test/rfl/strop/like_patterns.rfl
+++ b/test/rfl/strop/like_patterns.rfl
@@ -1,0 +1,230 @@
+;; like_patterns.rfl — happy-path RFL coverage for the compiled-shape
+;; branches in src/ops/string.c exec_like / exec_ilike.
+;;
+;; Prior round Q covered the parallel SYM/STR backbone at large N.
+;; This round walks every compiled glob shape (EXACT / PREFIX / SUFFIX /
+;; CONTAINS / ANY / GLOB) over small ~10-row vectors of both STR and
+;; SYM input, exercising the in-memory (non-parted) vec branches of
+;; exec_like (src/ops/string.c:566-704) and exec_ilike (string.c:712-784).
+;;
+;; Pattern shape is classified once by ray_glob_compile (src/ops/glob.c);
+;; the comment after each query lists the shape that branch should hit.
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; STR-vector inputs — exec_like RAY_STR branch (string.c:566-588)
+;; ════════════════════════════════════════════════════════════════════════════
+
+;; 10-row STR vector with a mix of plausible literals + boundary content
+;; (empty string, short and long entries) so every compiled shape has a
+;; mix of hits & misses to count.
+(set TS (table [s] (list (list "abc" "abcdef" "xyzabc" "axc" "" "ABC" "abcabc" "abx" "zabc" "abc?"))))
+
+;; SHAPE_EXACT — pure literal, no meta.  "abc" matches itself (1).
+(count (select {from: TS where: (like s "abc")})) -- 1
+;; SHAPE_EXACT miss — pattern with no rows that match.
+(count (select {from: TS where: (like s "nope")})) -- 0
+
+;; SHAPE_PREFIX — "<lit>*".  Rows starting with "abc": "abc","abcdef",
+;; "abcabc","abc?" → 4.
+(count (select {from: TS where: (like s "abc*")})) -- 4
+;; SHAPE_PREFIX miss
+(count (select {from: TS where: (like s "qq*")})) -- 0
+
+;; SHAPE_SUFFIX — "*<lit>".  Rows ending in "abc": "abc","xyzabc",
+;; "ABC"-not (case-sensitive), "abcabc","zabc" → 4.
+(count (select {from: TS where: (like s "*abc")})) -- 4
+
+;; SHAPE_CONTAINS — "*<lit>*" memmem path.  "abc" substring appears in:
+;; "abc","abcdef","xyzabc","abcabc","zabc","abc?" → 6.
+(count (select {from: TS where: (like s "*abc*")})) -- 6
+
+;; SHAPE_ANY — single "*" — must match every row including "".
+(count (select {from: TS where: (like s "*")})) -- 10
+
+;; SHAPE_NONE general matcher — `?` single-char wildcard.  "abc","ABC",
+;; "abx" match "a?c"? "abc" yes, "ABC" no (case-sens.), "abx" no.
+;; Wait — "a?c" is 3 chars; "axc","abc","ABC" each 3 chars.  Hits:
+;; "axc" (a-x-c yes), "abc" (a-b-c yes), "ABC" (A != a — no) → 2.
+(count (select {from: TS where: (like s "a?c")})) -- 2
+
+;; SHAPE_NONE — character class.  "[aA]bc" matches first char a/A then
+;; literal "bc"; "ABC" has "BC" so fails — only "abc" → 1.
+(count (select {from: TS where: (like s "[aA]bc")})) -- 1
+
+;; SHAPE_NONE — multiple stars / mixed meta.  "a*c*" matches strings
+;; starting with 'a' that contain a 'c' afterwards: "abc","abcdef",
+;; "axc","abcabc","abc?" → 5.
+(count (select {from: TS where: (like s "a*c*")})) -- 5
+
+;; Empty pattern "" — SHAPE_EXACT vs empty literal: only matches the
+;; empty input row.
+(count (select {from: TS where: (like s "")})) -- 1
+
+;; Mixed shape: "a?c*" — '?' forces SHAPE_NONE; needs len>=3, first 'a',
+;; third 'c'.  Hits: "abc","abcdef","axc","abcabc","abc?" → 5.
+(count (select {from: TS where: (like s "a?c*")})) -- 5
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; SYM-vector inputs — exec_like RAY_IS_SYM dict-cache branch (string.c:589-701)
+;; ════════════════════════════════════════════════════════════════════════════
+
+;; Hand-built SYM column.  Same shape mix as TS, with repeated sym_ids
+;; to exercise the seen[]/lut[] dictionary cache (string.c:618-682).
+(set TY (table [s] (list ['abc 'abcdef 'xyzabc 'axc 'ABC 'abcabc 'abx 'zabc 'abc 'abcdef])))
+
+;; SHAPE_EXACT — 'abc appears twice; case-sensitive so 'ABC is excluded.
+(count (select {from: TY where: (like s "abc")})) -- 2
+
+;; SHAPE_PREFIX — sym_ids starting with "abc": 'abc(×2), 'abcdef(×2),
+;; 'abcabc → 5.
+(count (select {from: TY where: (like s "abc*")})) -- 5
+
+;; SHAPE_SUFFIX — ends with "abc": 'abc(×2), 'xyzabc, 'abcabc, 'zabc → 5.
+(count (select {from: TY where: (like s "*abc")})) -- 5
+
+;; SHAPE_CONTAINS — contains "abc": 'abc(×2), 'abcdef(×2), 'xyzabc,
+;; 'abcabc, 'zabc → 7.
+(count (select {from: TY where: (like s "*abc*")})) -- 7
+
+;; SHAPE_ANY — every row.
+(count (select {from: TY where: (like s "*")})) -- 10
+
+;; SHAPE_NONE — `?` wildcard.  3-char syms matching a?c: 'abc(×2),
+;; 'axc → 3.  'ABC fails (case-sens).
+(count (select {from: TY where: (like s "a?c")})) -- 3
+
+;; SHAPE_NONE — char class [aA]bc, literal "bc" after — only 'abc(×2);
+;; 'ABC needs "BC" which is not literal "bc" → 2.
+(count (select {from: TY where: (like s "[aA]bc")})) -- 2
+
+;; SHAPE_NONE — multi-star: 'a*c*' → starts with 'a', has 'c' later.
+;; 'abc(×2), 'abcdef(×2), 'axc, 'abcabc → 6.
+(count (select {from: TY where: (like s "a*c*")})) -- 6
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; ILIKE on STR — exec_ilike RAY_STR branch (string.c:731-738)
+;; ════════════════════════════════════════════════════════════════════════════
+
+;; Same TS rows; ilike folds ASCII case.
+
+;; SHAPE_EXACT ci: matches "abc","ABC" → 2.
+(count (select {from: TS where: (ilike s "abc")})) -- 2
+;; SHAPE_EXACT ci: pattern upper-case folds to lower-case lit.
+(count (select {from: TS where: (ilike s "ABC")})) -- 2
+
+;; SHAPE_PREFIX ci: "abc*" hits "abc","abcdef","ABC","abcabc","abc?" → 5.
+(count (select {from: TS where: (ilike s "abc*")})) -- 5
+(count (select {from: TS where: (ilike s "ABC*")})) -- 5
+
+;; SHAPE_SUFFIX ci: "*abc" hits "abc","xyzabc","ABC","abcabc","zabc" → 5.
+(count (select {from: TS where: (ilike s "*abc")})) -- 5
+(count (select {from: TS where: (ilike s "*ABC")})) -- 5
+
+;; SHAPE_CONTAINS ci: "*abc*" — all rows containing abc/ABC → 7.
+(count (select {from: TS where: (ilike s "*abc*")})) -- 7
+(count (select {from: TS where: (ilike s "*ABC*")})) -- 7
+
+;; SHAPE_ANY ci: always 10.
+(count (select {from: TS where: (ilike s "*")})) -- 10
+
+;; SHAPE_NONE ci '?': "a?c" matches "abc","ABC","axc" → 3.
+(count (select {from: TS where: (ilike s "a?c")})) -- 3
+
+;; SHAPE_NONE ci char class: "[a]bc" same as "abc" ci → 2.
+(count (select {from: TS where: (ilike s "[a]bc")})) -- 2
+
+;; SHAPE_NONE ci multi-star: "a*c*" ci → "abc","abcdef","axc","ABC",
+;; "abcabc","abc?" → 6.
+(count (select {from: TS where: (ilike s "a*c*")})) -- 6
+
+;; Empty pattern ilike — same as like, only "" row.
+(count (select {from: TS where: (ilike s "")})) -- 1
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; ILIKE on SYM — exec_ilike RAY_IS_SYM dict-cache branch (string.c:739-777)
+;; ════════════════════════════════════════════════════════════════════════════
+
+(set TYi (table [s] (list ['Apple 'apple 'APPLE 'banana 'BANANA 'cherry 'Berry 'BERRY 'apricot 'APRICOT])))
+
+;; SHAPE_EXACT ci: "apple" matches 'Apple,'apple,'APPLE → 3.
+(count (select {from: TYi where: (ilike s "apple")})) -- 3
+
+;; SHAPE_PREFIX ci: "ap*" hits 'Apple,'apple,'APPLE,'apricot,'APRICOT → 5.
+(count (select {from: TYi where: (ilike s "ap*")})) -- 5
+(count (select {from: TYi where: (ilike s "AP*")})) -- 5
+
+;; SHAPE_SUFFIX ci: "*RY" hits 'cherry,'Berry,'BERRY → 3.
+(count (select {from: TYi where: (ilike s "*RY")})) -- 3
+(count (select {from: TYi where: (ilike s "*ry")})) -- 3
+
+;; SHAPE_CONTAINS ci: "*an*" hits 'banana,'BANANA → 2.
+(count (select {from: TYi where: (ilike s "*an*")})) -- 2
+(count (select {from: TYi where: (ilike s "*AN*")})) -- 2
+
+;; SHAPE_ANY ci: all 10.
+(count (select {from: TYi where: (ilike s "*")})) -- 10
+
+;; SHAPE_NONE ci '?': "?pple" matches 5-char syms ending in "pple":
+;; 'Apple,'apple,'APPLE → 3.
+(count (select {from: TYi where: (ilike s "?pple")})) -- 3
+
+;; SHAPE_NONE ci char class: "[Aa]pple" — ci folds, hits 'Apple,'apple,
+;; 'APPLE → 3.
+(count (select {from: TYi where: (ilike s "[Aa]pple")})) -- 3
+
+;; SHAPE_NONE ci range: "[a-z]*" — ci, every row starts with a letter → 10.
+(count (select {from: TYi where: (ilike s "[a-z]*")})) -- 10
+(count (select {from: TYi where: (ilike s "[A-Z]*")})) -- 10
+
+;; SHAPE_NONE ci multi-meta: "a*e" — ci, starts with a/A, ends with e/E.
+;; 'Apple,'apple,'APPLE → 3.
+(count (select {from: TYi where: (ilike s "a*e")})) -- 3
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; Edge: pattern longer than every input — every row fails SHAPE_EXACT/
+;; PREFIX/SUFFIX/CONTAINS literal-length check (string.c shape branches
+;; short-circuit when lit_len > sn).
+;; ════════════════════════════════════════════════════════════════════════════
+
+(set TShort (table [s] (list (list "a" "bb" "ccc"))))
+(count (select {from: TShort where: (like s "longliteral")})) -- 0      ;; EXACT
+(count (select {from: TShort where: (like s "longliteral*")})) -- 0     ;; PREFIX
+(count (select {from: TShort where: (like s "*longliteral")})) -- 0     ;; SUFFIX
+(count (select {from: TShort where: (like s "*longliteral*")})) -- 0    ;; CONTAINS
+(count (select {from: TShort where: (like s "*")})) -- 3                ;; ANY
+;; '?' requires exactly N chars — "??" matches 2-char rows only.
+(count (select {from: TShort where: (like s "??")})) -- 1               ;; GLOB '?'
+
+;; Same edge over SYM.
+(set TYShort (table [s] (list ['a 'bb 'ccc])))
+(count (select {from: TYShort where: (like s "longliteral")})) -- 0
+(count (select {from: TYShort where: (like s "longliteral*")})) -- 0
+(count (select {from: TYShort where: (like s "*longliteral")})) -- 0
+(count (select {from: TYShort where: (like s "*longliteral*")})) -- 0
+(count (select {from: TYShort where: (like s "*")})) -- 3
+(count (select {from: TYShort where: (like s "??")})) -- 1
+
+;; ════════════════════════════════════════════════════════════════════════════
+;; Scalar sanity (atom × atom) — re-asserts the compiled-shape paths
+;; via the eval-on-atom form so the same shape dispatch is exercised
+;; once with sn=0 input (empty operand) for each shape.
+;; ════════════════════════════════════════════════════════════════════════════
+
+;; Empty input row against every shape — explicit shape-empty matrix.
+(like "" "")        -- true   ;; SHAPE_EXACT, lit_len==0
+(like "" "abc")     -- false  ;; SHAPE_EXACT, sn=0 < lit_len
+(like "" "abc*")    -- false  ;; SHAPE_PREFIX, lit_len>0
+(like "" "*abc")    -- false  ;; SHAPE_SUFFIX, lit_len>0
+(like "" "*abc*")   -- false  ;; SHAPE_CONTAINS, lit_len>0
+(like "" "*")       -- true   ;; SHAPE_ANY
+(like "" "?")       -- false  ;; GLOB ? needs one char
+
+;; ILIKE is registered only as a DAG/query op (see like.rfl chunk 9),
+;; so the empty-input ci matrix is surfaced via single-row select.
+(set TEmpty (table [s] (list (list ""))))
+(count (select {from: TEmpty where: (ilike s "")}))       -- 1   ;; SHAPE_EXACT ci
+(count (select {from: TEmpty where: (ilike s "abc")}))    -- 0
+(count (select {from: TEmpty where: (ilike s "abc*")}))   -- 0
+(count (select {from: TEmpty where: (ilike s "*abc")}))   -- 0
+(count (select {from: TEmpty where: (ilike s "*abc*")}))  -- 0
+(count (select {from: TEmpty where: (ilike s "*")}))      -- 1   ;; SHAPE_ANY ci

--- a/test/rfl/strop/string_manipulation.rfl
+++ b/test/rfl/strop/string_manipulation.rfl
@@ -1,0 +1,481 @@
+;; string_manipulation.rfl — happy-path coverage for the per-element
+;; transform paths in src/ops/string.c:
+;;
+;;   exec_string_unary (OP_UPPER / OP_LOWER / OP_TRIM)  (string.c:795-874)
+;;   exec_strlen                                         (string.c:877-912)
+;;   exec_substr                                         (string.c:914-1019)
+;;   exec_replace                                        (string.c:1022-1124)
+;;   exec_concat (variadic 2..6 args)                    (string.c:1127-1267)
+;;
+;; Prior rounds (test/rfl/strop/strlen.rfl, like_patterns.rfl,
+;; string_par.rfl) already covered:
+;;   * the parallel LIKE / ILIKE shapes,
+;;   * the parallel binary STR/SYM comparison kernel,
+;;   * the 100k+ row dispatch through the worker pool,
+;;   * the basic 3-row functional shape for upper/lower/trim/substr/replace.
+;;
+;; This round goes wider on small (~10-row) deterministic vectors and
+;; walks the body of each op against the dimensions called out in the
+;; planning brief:
+;;
+;;   * concat   — 2/3/4/5/6 args, SYM-only / STR-only / mixed-SYM-STR
+;;                + STR atom interleaved into a SYM column
+;;   * substr   — scalar I64 / scalar F64 / single-elem vec / per-row vec
+;;                offsets that cross the RAY_STR_INLINE_MAX = 12-byte SSO
+;;                boundary in src/vec/str.h (lines 39-45)
+;;   * replace  — exact-match (same length), shrinking, expanding,
+;;                no-match, whole-string match, multi-occurrence;
+;;                SYM + STR; pooled-output rows
+;;   * upper/lower/trim — ASCII; SYM + STR; trim covers leading/trailing/
+;;                both/interior/all-whitespace/empty/no-pad
+;;   * strlen   — empty, single, 7, 12 (old/new SSO), 13, 20, 40, 44 bytes;
+;;                SYM + STR
+;;
+;; Verification idiom: build a small deterministic source column, run
+;; the op via (select {col: (op ...) from: T}) — that's the only
+;; surface that calls exec_concat/substr/replace/upper/lower/trim on
+;; a vec (see src/ops/query.c:282-1050).  Compare the result column
+;; element-wise via (at result i) or vector equality (== R E) reduced
+;; via (sum (== R E)) == nrows.
+;;
+;; Test runner is strictly line-based (test/main.c:191-209), so each
+;; expression and its `-- expected` is kept on a single line.
+
+;; ════════════════════════════════════════════════════════════════════
+;; 1. exec_concat — 2-arg, SYM × SYM column → SYM output
+;; ════════════════════════════════════════════════════════════════════
+(set Tcc (table [a b] (list ['ax 'bx 'cx 'dx 'ex 'fx 'gx 'hx 'ix 'jx] ['Ay 'By 'Cy 'Dy 'Ey 'Fy 'Gy 'Hy 'Iy 'Jy])))
+(count Tcc) -- 10
+(set R1 (at (select {r: (concat a b) from: Tcc}) 'r))
+(count R1) -- 10
+(at R1 0) -- 'axAy
+(at R1 4) -- 'exEy
+(at R1 9) -- 'jxJy
+(sum (== R1 ['axAy 'bxBy 'cxCy 'dxDy 'exEy 'fxFy 'gxGy 'hxHy 'ixIy 'jxJy])) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 2. exec_concat — 2-arg, STR × STR column → STR output
+;; ════════════════════════════════════════════════════════════════════
+;; STR side flips out_str = true (line 1166); result is RAY_STR.
+(set Tcs (table [a b] (list ["alpha" "bravo" "charlie" "delta" "echo" "foxtrot" "golf" "hotel" "india" "juliet"] ["-1" "-2" "-3" "-4" "-5" "-6" "-7" "-8" "-9" "-10"])))
+(set R2 (at (select {r: (concat a b) from: Tcs}) 'r))
+(count R2) -- 10
+(at R2 0) -- "alpha-1"
+(at R2 5) -- "foxtrot-6"
+(at R2 9) -- "juliet-10"
+(sum (== R2 ["alpha-1" "bravo-2" "charlie-3" "delta-4" "echo-5" "foxtrot-6" "golf-7" "hotel-8" "india-9" "juliet-10"])) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 3. exec_concat — mixed: SYM column + STR atom → SYM output
+;; ════════════════════════════════════════════════════════════════════
+;; -RAY_STR scalar alone does NOT flip out_str (line 1166 only flips on
+;; vec or +RAY_STR atom).  Output is SYM.
+(set R3 (at (select {r: (concat a "_z") from: Tcc}) 'r))
+(at R3 0) -- 'ax_z
+(at R3 9) -- 'jx_z
+(sum (== R3 ['ax_z 'bx_z 'cx_z 'dx_z 'ex_z 'fx_z 'gx_z 'hx_z 'ix_z 'jx_z])) -- 10
+
+(set R4 (at (select {r: (concat "p_" a) from: Tcc}) 'r))
+(at R4 0) -- 'p_ax
+(at R4 9) -- 'p_jx
+(sum (== R4 ['p_ax 'p_bx 'p_cx 'p_dx 'p_ex 'p_fx 'p_gx 'p_hx 'p_ix 'p_jx])) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 4. exec_concat — 3 args (trail[] expansion, string.c:1145-1148)
+;; ════════════════════════════════════════════════════════════════════
+(set R5 (at (select {r: (concat a "+" b) from: Tcs}) 'r))
+(at R5 0) -- "alpha+-1"
+(at R5 9) -- "juliet+-10"
+(sum (== R5 ["alpha+-1" "bravo+-2" "charlie+-3" "delta+-4" "echo+-5" "foxtrot+-6" "golf+-7" "hotel+-8" "india+-9" "juliet+-10"])) -- 10
+
+(set R6 (at (select {r: (concat a b "!") from: Tcc}) 'r))
+(at R6 0) -- 'axAy!
+(at R6 9) -- 'jxJy!
+
+;; ════════════════════════════════════════════════════════════════════
+;; 5. exec_concat — 4 args
+;; ════════════════════════════════════════════════════════════════════
+(set R7 (at (select {r: (concat "[" a "|" b) from: Tcs}) 'r))
+(at R7 0) -- "[alpha|-1"
+(at R7 9) -- "[juliet|-10"
+
+;; ════════════════════════════════════════════════════════════════════
+;; 6. exec_concat — 5 args
+;; ════════════════════════════════════════════════════════════════════
+(set R8 (at (select {r: (concat "<" a "|" b ">") from: Tcs}) 'r))
+(at R8 0) -- "<alpha|-1>"
+(at R8 4) -- "<echo|-5>"
+(at R8 9) -- "<juliet|-10>"
+
+;; ════════════════════════════════════════════════════════════════════
+;; 7. exec_concat — 6 args (full width)
+;; ════════════════════════════════════════════════════════════════════
+(set R9 (at (select {r: (concat "(" a "," b "," "end" ")") from: Tcs}) 'r))
+(at R9 0) -- "(alpha,-1,end)"
+(at R9 5) -- "(foxtrot,-6,end)"
+(at R9 9) -- "(juliet,-10,end)"
+
+;; ════════════════════════════════════════════════════════════════════
+;; 8. exec_string_unary — UPPER over a 10-row STR column
+;; ════════════════════════════════════════════════════════════════════
+;; Mix of all-lower / mixed-case / all-upper / digits+punct / empty /
+;; whitespace-bearing — exercises the toupper loop (line 851) across a
+;; representative ASCII set, including the empty-row branch (line 819).
+(set TStrU (table [s] (list ["alpha" "Bravo" "CHARLIE" "delta42" "Echo!" "" "Foxtrot" "golfING" "HoTeL" "  india  "])))
+(set RUpStr (at (select {r: (upper s) from: TStrU}) 'r))
+(count RUpStr) -- 10
+(at RUpStr 0) -- "ALPHA"
+(at RUpStr 1) -- "BRAVO"
+(at RUpStr 2) -- "CHARLIE"
+(at RUpStr 3) -- "DELTA42"
+(at RUpStr 4) -- "ECHO!"
+(at RUpStr 5) -- ""
+(at RUpStr 6) -- "FOXTROT"
+(at RUpStr 7) -- "GOLFING"
+(at RUpStr 8) -- "HOTEL"
+(at RUpStr 9) -- "  INDIA  "
+(sum (== RUpStr ["ALPHA" "BRAVO" "CHARLIE" "DELTA42" "ECHO!" "" "FOXTROT" "GOLFING" "HOTEL" "  INDIA  "])) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 9. exec_string_unary — UPPER over a 10-row SYM column
+;; ════════════════════════════════════════════════════════════════════
+;; SYM path takes the sym_dst branch (line 868) and re-interns via
+;; ray_sym_intern.  SYM literals cannot carry whitespace at the parser
+;; level, so the row-5 fixture uses 'x to keep row count at 10.
+(set TSymU (table [s] (list ['alpha 'Bravo 'CHARLIE 'delta42 'Echo 'x 'Foxtrot 'golfING 'HoTeL 'india])))
+(set RUpSym (at (select {r: (upper s) from: TSymU}) 'r))
+(count RUpSym) -- 10
+(at RUpSym 0) -- 'ALPHA
+(at RUpSym 1) -- 'BRAVO
+(at RUpSym 2) -- 'CHARLIE
+(at RUpSym 3) -- 'DELTA42
+(at RUpSym 4) -- 'ECHO
+(at RUpSym 5) -- 'X
+(at RUpSym 7) -- 'GOLFING
+(at RUpSym 9) -- 'INDIA
+(sum (== RUpSym ['ALPHA 'BRAVO 'CHARLIE 'DELTA42 'ECHO 'X 'FOXTROT 'GOLFING 'HOTEL 'INDIA])) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 10. exec_string_unary — LOWER over STR and SYM columns
+;; ════════════════════════════════════════════════════════════════════
+(set RLoStr (at (select {r: (lower s) from: TStrU}) 'r))
+(at RLoStr 0) -- "alpha"
+(at RLoStr 2) -- "charlie"
+(at RLoStr 3) -- "delta42"
+(at RLoStr 8) -- "hotel"
+(at RLoStr 9) -- "  india  "
+(sum (== RLoStr ["alpha" "bravo" "charlie" "delta42" "echo!" "" "foxtrot" "golfing" "hotel" "  india  "])) -- 10
+
+(set RLoSym (at (select {r: (lower s) from: TSymU}) 'r))
+(at RLoSym 1) -- 'bravo
+(at RLoSym 2) -- 'charlie
+(at RLoSym 7) -- 'golfing
+(sum (== RLoSym ['alpha 'bravo 'charlie 'delta42 'echo 'x 'foxtrot 'golfing 'hotel 'india])) -- 10
+
+;; Round-trip: upper-then-lower of an already-lower SYM column.
+(set TRT (table [s] (list ['alpha 'bravo 'charlie])))
+(set RRT (at (select {r: (lower (upper s)) from: TRT}) 'r))
+(sum (== RRT ['alpha 'bravo 'charlie])) -- 3
+
+;; ════════════════════════════════════════════════════════════════════
+;; 11. exec_string_unary — TRIM over STR column
+;; ════════════════════════════════════════════════════════════════════
+;; TRIM walks both ends with isspace (lines 856-857), preserves middle.
+;; Rows exercise: leading-only, trailing-only, both ends, interior
+;; whitespace preserved, tab/newline as whitespace, all-whitespace,
+;; empty, no-whitespace, single char.
+(set TTrim (table [s] (list ["  leading" "trailing  " "  both  " "in side" "no_pad" "" "   " "\ttabbed\t" "\nnl\n" "x"])))
+(set RTrim (at (select {r: (trim s) from: TTrim}) 'r))
+(count RTrim) -- 10
+(at RTrim 0) -- "leading"
+(at RTrim 1) -- "trailing"
+(at RTrim 2) -- "both"
+(at RTrim 3) -- "in side"
+(at RTrim 4) -- "no_pad"
+(at RTrim 5) -- ""
+(at RTrim 6) -- ""
+(at RTrim 7) -- "tabbed"
+(at RTrim 8) -- "nl"
+(at RTrim 9) -- "x"
+
+;; trim is idempotent.
+(set RTrim2 (at (select {r: (trim (trim s)) from: TTrim}) 'r))
+(sum (== RTrim RTrim2)) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 12. exec_strlen — STR column with lengths straddling the SSO boundary
+;; ════════════════════════════════════════════════════════════════════
+;; RAY_STR_INLINE_MAX = 12 (src/vec/str.h:45).  Lengths chosen:
+;;   0, 1, 7, 12 (inline)
+;;   13, 20, 40, 44 (pooled)
+;;   2, 4 (inline)
+(set TLen (table [s] (list ["" "a" "abcdefg" "abcdefghijkl" "abcdefghijklm" "abcdefghijklmnopqrst" "aaaaabbbbbcccccdddddeeeeefffffggggghhhhh" "aaaaabbbbbcccccdddddeeeeefffffggggghhhhhiiii" "xy" "wxyz"])))
+(set RLen (at (select {r: (strlen s) from: TLen}) 'r))
+(count RLen) -- 10
+(at RLen 0) -- 0
+(at RLen 1) -- 1
+(at RLen 2) -- 7
+(at RLen 3) -- 12
+(at RLen 4) -- 13
+(at RLen 5) -- 20
+(at RLen 6) -- 40
+(at RLen 7) -- 44
+(at RLen 8) -- 2
+(at RLen 9) -- 4
+(sum (== RLen [0 1 7 12 13 20 40 44 2 4])) -- 10
+(sum RLen) -- 143
+
+;; ════════════════════════════════════════════════════════════════════
+;; 13. exec_strlen — SYM column with varied lengths
+;; ════════════════════════════════════════════════════════════════════
+;; RFL doesn't allow an empty sym literal, so row 0 uses 'x (len 1).
+(set TSL (table [s] (list ['x 'ab 'abcdefg 'abcdefghijkl 'abcdefghijklm 'abcdefghijklmnopqrst 'aaaaabbbbbcccccdddddeeeeefffffggggghhhhh 'aaaaabbbbbcccccdddddeeeeefffffggggghhhhhiiii 'a 'wxyz])))
+(set RSL (at (select {r: (strlen s) from: TSL}) 'r))
+(count RSL) -- 10
+(sum (== RSL [1 2 7 12 13 20 40 44 1 4])) -- 10
+(sum RSL) -- 144
+
+;; ════════════════════════════════════════════════════════════════════
+;; 14. exec_substr — scalar I64 start/length over STR (inline output)
+;; ════════════════════════════════════════════════════════════════════
+;; Output strings <= 12 bytes ⇒ result stays inline.  Source rows span
+;; inline (<=12) and pooled (>12) so the substr loop (string.c:976-1016)
+;; reads from both layouts.
+(set TSubS (table [s] (list ["alphabet" "bravocharlie" "this_is_long_enough" "ABCDEFGHIJKLMNOP" "x" "" "alphabetagamma" "delta" "echofoxtrot" "0123456789abcdef"])))
+
+;; start=1 (1-based ⇒ 0-based 0), len=3.
+(set RSub1 (at (select {r: (substr s 1 3) from: TSubS}) 'r))
+(at RSub1 0) -- "alp"
+(at RSub1 1) -- "bra"
+(at RSub1 2) -- "thi"
+(at RSub1 3) -- "ABC"
+(at RSub1 4) -- "x"
+(at RSub1 5) -- ""
+(at RSub1 6) -- "alp"
+(at RSub1 7) -- "del"
+(at RSub1 8) -- "ech"
+(at RSub1 9) -- "012"
+(sum (== RSub1 ["alp" "bra" "thi" "ABC" "x" "" "alp" "del" "ech" "012"])) -- 10
+
+;; start=5, len=4 — middle window; "x" past end ⇒ "" (string.c:1001).
+(set RSub2 (at (select {r: (substr s 5 4) from: TSubS}) 'r))
+;; start=5 (1-based) ⇒ 0-based 4, len=4.
+(at RSub2 0) -- "abet"      ;; "alphabet"[4..7]
+(at RSub2 1) -- "ocha"      ;; "bravocharlie"[4..7]
+(at RSub2 2) -- "_is_"      ;; "this_is_long_enough"[4..7]
+(at RSub2 3) -- "EFGH"
+(at RSub2 4) -- ""
+(at RSub2 5) -- ""
+(at RSub2 6) -- "abet"
+(at RSub2 9) -- "4567"
+
+;; start=1, len=-1 — full-string take (line 1009).  Pooled rows yield
+;; pooled output.
+(set RSub3 (at (select {r: (substr s 1 -1) from: TSubS}) 'r))
+(at RSub3 0) -- "alphabet"
+(at RSub3 1) -- "bravocharlie"
+(at RSub3 2) -- "this_is_long_enough"
+(at RSub3 3) -- "ABCDEFGHIJKLMNOP"
+(at RSub3 4) -- "x"
+(at RSub3 5) -- ""
+(at RSub3 9) -- "0123456789abcdef"
+
+;; start=1, len=999 — len > remaining ⇒ capped to remaining (line 1009).
+(set RSub4 (at (select {r: (substr s 1 999) from: TSubS}) 'r))
+(sum (== RSub4 RSub3)) -- 10
+
+;; start=0 (1-based; clamped to 0 ⇒ st=-1 ⇒ st=0, line 1000), len=3.
+(set RSub5 (at (select {r: (substr s 0 3) from: TSubS}) 'r))
+(sum (== RSub5 RSub1)) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 15. exec_substr — scalar F64 path (start_v->type == -RAY_F64,
+;; line 952; same for len_v at line 964)
+;; ════════════════════════════════════════════════════════════════════
+(set RSubF (at (select {r: (substr s 1.0 3.0) from: TSubS}) 'r))
+(sum (== RSubF RSub1)) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 16. exec_substr — single-element vec path (start_v->len == 1,
+;; lines 953-960)
+;; ════════════════════════════════════════════════════════════════════
+(set RSubV (at (select {r: (substr s [1] [3]) from: TSubS}) 'r))
+(sum (== RSubV RSub1)) -- 10
+(set RSubVS (at (select {r: (substr s [1] 3) from: TSubS}) 'r))
+(sum (== RSubVS RSub1)) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 17. exec_substr — per-row I64 vector start+len (s_data, l_data
+;; populated at lines 962 / 974)
+;; ════════════════════════════════════════════════════════════════════
+(set TSubR (table [s start lenc] (list ["alphabet" "bravocharlie" "this_is_long_enough" "ABCDEFGHIJKLMNOP" "echo" "x" "ww" "delta" "alphabetagamma" "0123456789abcdef"] [1 2 3 4 1 1 1 2 3 5] [3 4 5 6 4 1 2 3 4 7])))
+(set RSubR (at (select {r: (substr s start lenc) from: TSubR}) 'r))
+(count RSubR) -- 10
+;; Per-row start/lenc (1-based start ⇒ 0-based start-1):
+;; row 0  "alphabet"           [0..2]  = "alp"
+;; row 1  "bravocharlie"        [1..4]  = "ravo"
+;; row 2  "this_is_long_enough" [2..6]  = "is_is"
+;; row 3  "ABCDEFGHIJKLMNOP"    [3..8]  = "DEFGHI"
+;; row 4  "echo"                [0..3]  = "echo"
+;; row 5  "x"                   [0..0]  = "x"
+;; row 6  "ww"                  [0..1]  = "ww"
+;; row 7  "delta"               [1..3]  = "elt"
+;; row 8  "alphabetagamma"      [2..5]  = "phab"
+;; row 9  "0123456789abcdef"    [4..10] = "456789a"
+(at RSubR 0) -- "alp"
+(at RSubR 1) -- "ravo"
+(at RSubR 2) -- "is_is"
+(at RSubR 3) -- "DEFGHI"
+(at RSubR 4) -- "echo"
+(at RSubR 5) -- "x"
+(at RSubR 6) -- "ww"
+(at RSubR 7) -- "elt"
+(at RSubR 8) -- "phab"
+(at RSubR 9) -- "456789a"
+(sum (== RSubR ["alp" "ravo" "is_is" "DEFGHI" "echo" "x" "ww" "elt" "phab" "456789a"])) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 18. exec_substr — SYM column variant (sym_dst branch, line 1014)
+;; ════════════════════════════════════════════════════════════════════
+(set TSubY (table [s] (list ['alphabet 'bravocharlie 'thisislongenough 'ABCDEFGHIJKLMNOP 'x 'q 'alphabetagamma 'delta 'echofoxtrot 'gamma])))
+(set RSubY (at (select {r: (substr s 1 3) from: TSubY}) 'r))
+(at RSubY 0) -- 'alp
+(at RSubY 1) -- 'bra
+(at RSubY 2) -- 'thi
+(at RSubY 3) -- 'ABC
+(at RSubY 4) -- 'x
+(at RSubY 5) -- 'q
+(at RSubY 9) -- 'gam
+(sum (== RSubY ['alp 'bra 'thi 'ABC 'x 'q 'alp 'del 'ech 'gam])) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 19. exec_replace — STR column, single-char from→to (same length)
+;; ════════════════════════════════════════════════════════════════════
+;; Multi-occurrence rows exercise the resume-after-match j += from_len
+;; (line 1106).  Same-length keeps worst = sl+1 (line 1088).
+(set TRep (table [s] (list ["apple" "banana" "cherry" "delta" "echo" "foxtrot" "golf" "hotel" "india" "juliet"])))
+(set RRep1 (at (select {r: (replace s "a" "A") from: TRep}) 'r))
+(at RRep1 0) -- "Apple"
+(at RRep1 1) -- "bAnAnA"
+(at RRep1 3) -- "deltA"
+(at RRep1 8) -- "indiA"
+(sum (== RRep1 ["Apple" "bAnAnA" "cherry" "deltA" "echo" "foxtrot" "golf" "hotel" "indiA" "juliet"])) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 20. exec_replace — shrinking (to_len < from_len)
+;; ════════════════════════════════════════════════════════════════════
+;; Row 5 "no_lone" — no "ll" substring ⇒ unchanged passthrough branch.
+;; Row 6 "lll" (3 l's) — first "ll" at j=0 matches ⇒ "L", trailing 'l'
+;;       at j=2 falls into the pass-through branch (line 1108) ⇒ "Ll".
+;; Row 8 "alllllo" (5 l's): "ll" at j=1, "ll" at j=3, lone 'l' at j=5,
+;;       'o' at j=6 ⇒ "a" + "L" + "L" + "l" + "o" = "aLLlo".
+(set TRepShrink (table [s] (list ["hello" "yellow" "callable" "balloon" "stallion" "no_lone" "lll" "" "alllllo" "a"])))
+(set RRepSh (at (select {r: (replace s "ll" "L") from: TRepShrink}) 'r))
+(at RRepSh 0) -- "heLo"
+(at RRepSh 1) -- "yeLow"
+(at RRepSh 2) -- "caLable"
+(at RRepSh 3) -- "baLoon"
+(at RRepSh 4) -- "staLion"
+(at RRepSh 5) -- "no_lone"
+(at RRepSh 6) -- "Ll"
+(at RRepSh 7) -- ""
+;; Row 8 ("alllllo", 5 l's): match "ll" at j=1, then j=3, then lone 'l'
+;; at j=5 (not "ll"), then 'o' ⇒ "a" + "L" + "L" + "l" + "o" = "aLLlo".
+(at RRepSh 8) -- "aLLlo"
+(at RRepSh 9) -- "a"
+
+;; ════════════════════════════════════════════════════════════════════
+;; 21. exec_replace — expanding (to_len > from_len)
+;; ════════════════════════════════════════════════════════════════════
+;; worst = n_matches * to_len + (sl % from_len) + 1 (line 1085).  Some
+;; rows cross the 12-byte SSO boundary ⇒ pooled output.
+(set TRepExp (table [s] (list ["alpha" "abracadabra" "banana" "" "noamatch" "aaa" "aA" "happy" "a" "AaAaA"])))
+(set RRepEx (at (select {r: (replace s "a" "XYZ") from: TRepExp}) 'r))
+(at RRepEx 0) -- "XYZlphXYZ"
+(at RRepEx 1) -- "XYZbrXYZcXYZdXYZbrXYZ"
+(at RRepEx 2) -- "bXYZnXYZnXYZ"
+(at RRepEx 3) -- ""
+(at RRepEx 4) -- "noXYZmXYZtch"
+(at RRepEx 5) -- "XYZXYZXYZ"
+(at RRepEx 6) -- "XYZA"
+(at RRepEx 7) -- "hXYZppy"
+(at RRepEx 8) -- "XYZ"
+;; Row 9 "AaAaA" (case-sensitive): 'a' at pos 1, 3 ⇒ "AXYZAXYZA".
+(at RRepEx 9) -- "AXYZAXYZA"
+;; total strlen = 9+21+12+0+12+9+4+7+3+9 = 86
+(sum (strlen RRepEx)) -- 86
+
+;; ════════════════════════════════════════════════════════════════════
+;; 22. exec_replace — no-match (from absent from every row)
+;; ════════════════════════════════════════════════════════════════════
+(set RRepNo (at (select {r: (replace s "ZZZ" "XYZ") from: TRep}) 'r))
+(sum (== RRepNo ["apple" "banana" "cherry" "delta" "echo" "foxtrot" "golf" "hotel" "india" "juliet"])) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 23. exec_replace — whole-string match
+;; ════════════════════════════════════════════════════════════════════
+(set RRepWh (at (select {r: (replace s "apple" "FRUIT") from: TRep}) 'r))
+(at RRepWh 0) -- "FRUIT"
+(at RRepWh 1) -- "banana"
+(at RRepWh 9) -- "juliet"
+
+;; ════════════════════════════════════════════════════════════════════
+;; 24. exec_replace — pooled-output path (>12-byte result)
+;; ════════════════════════════════════════════════════════════════════
+(set TRepP (table [s] (list (list "abcabcabc"))))
+(set RRepP (at (select {r: (replace s "a" "XX") from: TRepP}) 'r))
+(at RRepP 0) -- "XXbcXXbcXXbc"
+(strlen (at RRepP 0)) -- 12
+(set TRepP2 (table [s] (list (list "abcabcabc"))))
+(set RRepP2 (at (select {r: (replace s "a" "XYZ") from: TRepP2}) 'r))
+(at RRepP2 0) -- "XYZbcXYZbcXYZbc"
+(strlen (at RRepP2 0)) -- 15
+
+;; ════════════════════════════════════════════════════════════════════
+;; 25. exec_replace — SYM column variant (line 1117)
+;; ════════════════════════════════════════════════════════════════════
+(set TRepY (table [s] (list ['hello 'yellow 'callable 'balloon 'stallion 'noLL 'lll 'q 'alllllo 'a])))
+(set RRepY (at (select {r: (replace s "ll" "L") from: TRepY}) 'r))
+(at RRepY 0) -- 'heLo
+(at RRepY 1) -- 'yeLow
+(at RRepY 2) -- 'caLable
+(at RRepY 3) -- 'baLoon
+(at RRepY 4) -- 'staLion
+(at RRepY 5) -- 'noLL
+(at RRepY 6) -- 'Ll
+(at RRepY 7) -- 'q
+(at RRepY 8) -- 'aLLlo
+(at RRepY 9) -- 'a
+
+(set RRepYE (at (select {r: (replace s "a" "XYZ") from: TRepY}) 'r))
+(at RRepYE 0) -- 'hello
+(at RRepYE 1) -- 'yellow
+(at RRepYE 2) -- 'cXYZllXYZble
+(at RRepYE 9) -- 'XYZ
+
+;; ════════════════════════════════════════════════════════════════════
+;; 26. Pipeline — concat + substr + upper in one projection
+;; ════════════════════════════════════════════════════════════════════
+;; Stresses re-entry into the same exec_string_* helpers as inner
+;; result columns get rebuilt across op nodes.
+(set Tpipe (table [s] (list ["alpha" "bravo" "charlie" "delta" "echo" "foxtrot" "golf" "hotel" "india" "juliet"])))
+(set Rpipe (at (select {r: (concat (substr (upper s) 1 3) "_END") from: Tpipe}) 'r))
+(at Rpipe 0) -- "ALP_END"
+(at Rpipe 5) -- "FOX_END"
+(at Rpipe 9) -- "JUL_END"
+(sum (== Rpipe ["ALP_END" "BRA_END" "CHA_END" "DEL_END" "ECH_END" "FOX_END" "GOL_END" "HOT_END" "IND_END" "JUL_END"])) -- 10
+
+;; ════════════════════════════════════════════════════════════════════
+;; 27. Atom-only forms (eval-fallback / RFL builtin path)
+;; ════════════════════════════════════════════════════════════════════
+;; The eval-level builtin `concat` (lang/eval.c:2620, ray_concat_fn) is
+;; a different code path from exec_concat — it's binary-only at the
+;; bare-call site (register_binary).  Use nesting to chain.  Strlen on
+;; atoms exercises byte-counts on inline + pooled atom strings.
+(concat "hello" "world") -- "helloworld"
+(concat (concat "hello" " ") "world") -- "hello world"
+(strlen "abcdefghijkl") -- 12
+(strlen "abcdefghijklm") -- 13
+(strlen "") -- 0
+(strlen 'abcdefghijkl) -- 12
+(strlen 'abcdefghijklm) -- 13

--- a/test/rfl/strop/strlen_partitioned.rfl
+++ b/test/rfl/strop/strlen_partitioned.rfl
@@ -1,0 +1,198 @@
+;; src/ops/strop.c — happy-path coverage for strlen on partitioned columns.
+;;
+;; ray_strlen_fn dispatches on x->type after the atom + vec checks:
+;;   • x->type == RAY_MAPCOMMON          → strlen_mapcommon  (61 regions)
+;;   • RAY_IS_PARTED(x->type)            → strlen_parted     (50 regions)
+;;
+;; A MAPCOMMON column is the partition-key column produced by
+;; .db.parted.get when the partition directory names are NOT all
+;; date-shaped and NOT all integer-shaped — collect_part_dirs accepts
+;; any digit/dot sequence, so dirs like "1.2.3" pass the filter,
+;; fail is_date_dir (length != 10) and is_integer_str (contains dots),
+;; and infer_mc_type falls through to RAY_MC_SYM.  ray_sym_intern
+;; stores the literal directory name as the sym; (strlen sym) is then
+;; the literal name length.
+;;
+;; A PARTED column is the data column shape (RAY_PARTED_BASE + RAY_SYM
+;; or + RAY_STR): one segment per partition, each segment a flat SYM /
+;; STR vector.  strlen_parted iterates segments and per-row reads each
+;; segment via strlen_vec_value.
+;;
+;; Fixture dirs use the rf_test_* prefix so the Makefile's
+;; `rm -f rf_test_*.csv` rule is consistent with the convention; the
+;; partition directories themselves are cleaned explicitly below.
+
+;; ────────────── pre-flight cleanup ──────────────
+(.sys.exec "rm -rf rf_test_strlen_mc_sym rf_test_strlen_mc_long rf_test_strlen_parted_sym rf_test_strlen_parted_date rf_test_strlen_parted_int")
+
+;; ════════════════════════════════════════════════════════════════
+;; 1. strlen on RAY_MAPCOMMON (RAY_MC_SYM partition key).
+;;
+;; Two partition dirs "1.2.3" (len 5) and "4.5.67" (len 6).  Each has
+;; a splayed table with 3 + 2 rows.  The partition-key column is named
+;; 'part and has type RAY_MAPCOMMON / attrs=RAY_MC_SYM.  strlen_mapcommon
+;; walks keys/counts and emits an I64 vector of length total_rows
+;; where each row in partition p has value strlen(part_dirs[p]).
+;; Expected: 3×5 + 2×6 = 27.
+;; ════════════════════════════════════════════════════════════════
+(set MC-A (table [v] (list ['alpha 'beta 'gamma])))
+(set MC-B (table [v] (list ['x 'yz])))
+(.db.splayed.set "rf_test_strlen_mc_sym/1.2.3/t/" MC-A)
+(.db.splayed.set "rf_test_strlen_mc_sym/4.5.67/t/" MC-B)
+
+(set Pmc (.db.parted.get "rf_test_strlen_mc_sym/" 't))
+(count Pmc) -- 5
+(first (key Pmc)) -- 'part
+
+;; strlen on the MAPCOMMON column itself — exercises strlen_mapcommon.
+;; Result has one entry per row: 3 rows in "1.2.3" (len 5) +
+;; 2 rows in "4.5.67" (len 6) → [5 5 5 6 6].
+(count (strlen (at Pmc 'part))) -- 5
+(sum (strlen (at Pmc 'part))) -- 27
+(at (strlen (at Pmc 'part)) 0) -- 5
+(at (strlen (at Pmc 'part)) 2) -- 5
+(at (strlen (at Pmc 'part)) 3) -- 6
+(at (strlen (at Pmc 'part)) 4) -- 6
+
+;; ════════════════════════════════════════════════════════════════
+;; 2. strlen on RAY_MAPCOMMON with mixed-length dir names.
+;;
+;; Three partitions whose names sort lexically (bubble sort in
+;; collect_part_dirs is the same one exercised in part.rfl) into
+;; "1.2.3" (5), "12.3" (4), "9.87" (4).  Row counts 1 + 2 + 3.
+;; Expected strlen sum: 1*5 + 2*4 + 3*4 = 5 + 8 + 12 = 25.
+;;
+;; This case proves strlen_mapcommon's inner expansion loop runs the
+;; counts[p] iterations correctly across more than two partitions
+;; and that each partition's per-row value is the right sym's length.
+;; ════════════════════════════════════════════════════════════════
+(set ML-A (table [v] (list ['a])))
+(set ML-B (table [v] (list ['p 'q])))
+(set ML-C (table [v] (list ['x 'y 'z])))
+(.db.splayed.set "rf_test_strlen_mc_long/1.2.3/t/" ML-A)
+(.db.splayed.set "rf_test_strlen_mc_long/12.3/t/"  ML-B)
+(.db.splayed.set "rf_test_strlen_mc_long/9.87/t/"  ML-C)
+
+(set Pml (.db.parted.get "rf_test_strlen_mc_long/" 't))
+(count Pml) -- 6
+(first (key Pml)) -- 'part
+
+(count (strlen (at Pml 'part))) -- 6
+(sum (strlen (at Pml 'part))) -- 25
+;; Sorted dir order is ["1.2.3", "12.3", "9.87"].
+(at (strlen (at Pml 'part)) 0) -- 5
+(at (strlen (at Pml 'part)) 1) -- 4
+(at (strlen (at Pml 'part)) 2) -- 4
+(at (strlen (at Pml 'part)) 3) -- 4
+(at (strlen (at Pml 'part)) 4) -- 4
+(at (strlen (at Pml 'part)) 5) -- 4
+
+;; ════════════════════════════════════════════════════════════════
+;; 3. strlen on RAY_PARTED + RAY_SYM (the SYM data column shape).
+;;
+;; Two partitions, each with a SYM column 'tag.  After load the 'tag
+;; column has type RAY_PARTED_BASE + RAY_SYM and len = part_count.
+;; strlen_parted walks each segment and produces a flat I64 vec of
+;; length total_rows.
+;;
+;; Symbols and their lengths:
+;;   part 0 (2024.01.01): ['alpha 'beta]        → [5 4]
+;;   part 1 (2024.01.02): ['gamma 'delta 'eps]  → [5 5 3]
+;; Sum: 5+4+5+5+3 = 22.
+;; ════════════════════════════════════════════════════════════════
+(set PS-A (table [tag v] (list ['alpha 'beta] [10 20])))
+(set PS-B (table [tag v] (list ['gamma 'delta 'eps] [30 40 50])))
+(.db.splayed.set "rf_test_strlen_parted_sym/2024.01.01/t/" PS-A)
+(.db.splayed.set "rf_test_strlen_parted_sym/2024.01.02/t/" PS-B)
+
+(set Pps (.db.parted.get "rf_test_strlen_parted_sym/" 't))
+(count Pps) -- 5
+(key Pps) -- ['date 'tag 'v]
+
+;; strlen on the parted SYM column — exercises strlen_parted.
+(count (strlen (at Pps 'tag))) -- 5
+(sum (strlen (at Pps 'tag))) -- 22
+(at (strlen (at Pps 'tag)) 0) -- 5
+(at (strlen (at Pps 'tag)) 1) -- 4
+(at (strlen (at Pps 'tag)) 2) -- 5
+(at (strlen (at Pps 'tag)) 3) -- 5
+(at (strlen (at Pps 'tag)) 4) -- 3
+
+;; ════════════════════════════════════════════════════════════════
+;; 4. strlen on RAY_PARTED + RAY_SYM, single-symbol-name partition.
+;;
+;; Edge case for the per-segment inner loop in strlen_parted: a
+;; partition with exactly one row exercises seg->len == 1.  Also
+;; uses a date-shaped partition key for variety (so the MAPCOMMON
+;; sub-type is RAY_MC_DATE; we don't strlen the date column here —
+;; strlen on int/date MAPCOMMON keys would be a separate code path
+;; gated by the keys->type != RAY_STR && != RAY_SYM check at
+;; strlen_mapcommon's top).
+;; ════════════════════════════════════════════════════════════════
+(set PD-A (table [tag] (list ['onesym])))
+(set PD-B (table [tag] (list ['ab 'cdefgh])))
+(.db.splayed.set "rf_test_strlen_parted_date/2024.05.01/t/" PD-A)
+(.db.splayed.set "rf_test_strlen_parted_date/2024.05.02/t/" PD-B)
+
+(set Ppd (.db.parted.get "rf_test_strlen_parted_date/" 't))
+(count Ppd) -- 3
+;; 'tag is the parted SYM column.
+(count (strlen (at Ppd 'tag))) -- 3
+(sum (strlen (at Ppd 'tag))) -- 14
+(at (strlen (at Ppd 'tag)) 0) -- 6
+(at (strlen (at Ppd 'tag)) 1) -- 2
+(at (strlen (at Ppd 'tag)) 2) -- 6
+
+;; ════════════════════════════════════════════════════════════════
+;; 5. strlen on RAY_PARTED + RAY_SYM with int-partitioned root.
+;;
+;; Pure-integer partition names yield RAY_MC_I64 for the key column
+;; (we don't strlen the key here — see note above) but the parted
+;; data column is unchanged: still RAY_PARTED_BASE + RAY_SYM.  This
+;; cross-checks that strlen_parted is independent of the MAPCOMMON
+;; sub-type carried alongside it in the same table.
+;; ════════════════════════════════════════════════════════════════
+(set PI-A (table [tag] (list ['hi 'bye])))
+(set PI-B (table [tag] (list ['hello])))
+(set PI-C (table [tag] (list ['x 'yy 'zzz])))
+(.db.splayed.set "rf_test_strlen_parted_int/10/t/"  PI-A)
+(.db.splayed.set "rf_test_strlen_parted_int/200/t/" PI-B)
+(.db.splayed.set "rf_test_strlen_parted_int/300/t/" PI-C)
+
+(set Ppi (.db.parted.get "rf_test_strlen_parted_int/" 't))
+(count Ppi) -- 6
+(first (key Ppi)) -- 'part
+
+(count (strlen (at Ppi 'tag))) -- 6
+;; Lexical sort: "10", "200", "300" → ['hi 'bye 'hello 'x 'yy 'zzz]
+;; Lengths: [2 3 5 1 2 3], sum = 16.
+(sum (strlen (at Ppi 'tag))) -- 16
+(at (strlen (at Ppi 'tag)) 0) -- 2
+(at (strlen (at Ppi 'tag)) 1) -- 3
+(at (strlen (at Ppi 'tag)) 2) -- 5
+(at (strlen (at Ppi 'tag)) 3) -- 1
+(at (strlen (at Ppi 'tag)) 4) -- 2
+(at (strlen (at Ppi 'tag)) 5) -- 3
+
+;; ────────────── teardown ──────────────
+(.sys.exec "rm -rf rf_test_strlen_mc_sym rf_test_strlen_mc_long rf_test_strlen_parted_sym rf_test_strlen_parted_date rf_test_strlen_parted_int")
+
+;; ────────────── reachability notes ──────────────
+;; strlen_mapcommon has an inner null-handling branch
+;;   bool is_null = (keys->attrs & RAY_ATTR_HAS_NULLS) && ray_vec_is_null(keys, p);
+;; which fires only when the partition-key vector itself carries
+;; HAS_NULLS.  ray_read_parted populates kv_data directly from the
+;; directory name (parse_date_dir / parse_int_dir / ray_sym_intern)
+;; and never sets RAY_ATTR_HAS_NULLS on key_values, so this branch
+;; is not reachable from RFL fixtures: there is no public API to
+;; produce a MAPCOMMON column with a null partition key.  Same for
+;; the RAY_STR keys->type branch (sym dirs always intern as SYM,
+;; never STR).  Both are guarded internal-state paths.
+;;
+;; strlen_parted's null-handling branch fires per-segment when a
+;; segment carries HAS_NULLS.  SYM vectors built via .db.splayed.set
+;; from list literals do not carry null bits unless a NULL_I64 sym
+;; id appears, which RFL has no syntax for; reaching this requires
+;; CSV input with empty SYM fields and is covered in csv_splayed.rfl
+;; only for the flat-SYM (non-parted) shape.  Not a happy-path
+;; concern.

--- a/test/rfl/temporal/cross_cast_period.rfl
+++ b/test/rfl/temporal/cross_cast_period.rfl
@@ -1,0 +1,226 @@
+;; Happy-path coverage for non-extract paths in src/ops/temporal.c:
+;;   - ray_temporal_truncate (atom + vector) reached via (date X) / (time X)
+;;     where X is a DATE / TIME / TIMESTAMP value or vector.  These are the
+;;     overloaded `date` / `time` unary builtins registered in src/lang/eval.c
+;;     -> src/ops/temporal.c:ray_date_clock_fn / ray_time_clock_fn.
+;;   - Cross-temporal type casts via (as 'TYPE x): DATE <-> TIME <-> TIMESTAMP.
+;;     These exercise the temporal-unit logic in src/ops/builtins.c (the
+;;     ts_days_floor / ts_ns_in_day helpers above the cast-vector worker)
+;;     plus the day/sub-day projection used by ray_temporal_truncate.
+;;   - Day-of-week / day-of-year for reference dates spanning leap and
+;;     non-leap years, century rules, and the pre-2000 (negative
+;;     days_since_2000) branch.  Sister coverage to extract.rfl but with a
+;;     fuller weekly+yearly grid pinned to known Gregorian calendar values.
+;;
+;; Prior rounds (extract.rfl, arith.rfl, date.rfl, ...) cover extract
+;; helpers and DATE arithmetic; this file fills the truncate / cross-cast
+;; / boundary-DOW gap.
+;;
+;; NB: rfl runner requires each `lhs -- rhs` assertion to fit on one line
+;; (test/main.c:203-205).  Long vector cases below are intentionally wide.
+
+;; ─────────────────────────── ray_temporal_truncate — atom paths ───────────
+;; (date <ts>)  → RAY_TIMESTAMP truncated to day boundary.
+;;   us = ns/1000 floor; bucket = USEC_PER_DAY; r = us % bucket; out_us = us - r
+(date 2024.03.15D12:34:56.789000000) -- 2024.03.15D00:00:00.000000000
+(date 2024.03.15D00:00:00.000000001) -- 2024.03.15D00:00:00.000000000
+(date 2024.03.15D23:59:59.999999999) -- 2024.03.15D00:00:00.000000000
+;; epoch boundary
+(date 2000.01.01D00:00:00.000000000) -- 2000.01.01D00:00:00.000000000
+(date 2000.01.01D12:00:00.000000000) -- 2000.01.01D00:00:00.000000000
+;; pre-epoch — floor toward -infinity, NOT truncate toward zero
+(date 1999.12.31D12:00:00.000000000) -- 1999.12.31D00:00:00.000000000
+(date 1999.12.31D00:00:00.000000001) -- 1999.12.31D00:00:00.000000000
+;; leap day
+(date 2024.02.29D08:30:15.500000000) -- 2024.02.29D00:00:00.000000000
+;; Y2K boundary (2000 is leap, div 400)
+(date 2000.02.29D23:59:59.000000000) -- 2000.02.29D00:00:00.000000000
+
+;; (date <date>) — DATE atom routes through truncate; bucket=DAY, r=0.
+;; Result is a TIMESTAMP at midnight (semantic equivalence with input day).
+(date 2024.07.04) -- 2024.07.04D00:00:00.000000000
+(date 1970.01.01) -- 1970.01.01D00:00:00.000000000
+(date 1999.12.31) -- 1999.12.31D00:00:00.000000000
+
+;; (date <time>) — TIME atom => stored ms since midnight => us within day,
+;; floor to day boundary => 0 us => 2000.01.01D00:00:00.
+(date 00:00:00.000) -- 2000.01.01D00:00:00.000000000
+(date 12:34:56.789) -- 2000.01.01D00:00:00.000000000
+(date 23:59:59.999) -- 2000.01.01D00:00:00.000000000
+
+;; ─────────────────────── (time X) — second-bucket truncate ────────────────
+;; (time <ts>) — strip sub-second, keep day component.
+(time 2024.03.15D12:34:56.789000000) -- 2024.03.15D12:34:56.000000000
+(time 2024.03.15D00:00:00.999999999) -- 2024.03.15D00:00:00.000000000
+(time 2024.03.15D23:59:59.000000001) -- 2024.03.15D23:59:59.000000000
+;; epoch boundary
+(time 2000.01.01D00:00:00.000000000) -- 2000.01.01D00:00:00.000000000
+;; pre-epoch — second-bucket floor toward -infinity
+(time 1999.12.31D23:59:59.999999999) -- 1999.12.31D23:59:59.000000000
+
+;; (time <date>) — DATE atom => midnight => already at second boundary.
+(time 2024.07.04) -- 2024.07.04D00:00:00.000000000
+(time 1999.12.31) -- 1999.12.31D00:00:00.000000000
+
+;; (time <time>) — TIME atom (ms since midnight) => truncate to second.
+;;   ms→us = ms*1000, % SEC=1e6 us, floor.
+(time 12:34:56.000) -- 2000.01.01D12:34:56.000000000
+(time 12:34:56.789) -- 2000.01.01D12:34:56.000000000
+(time 00:00:00.000) -- 2000.01.01D00:00:00.000000000
+(time 23:59:59.999) -- 2000.01.01D23:59:59.000000000
+
+;; ─────────────────────── truncate — vector paths ──────────────────────────
+;; TIMESTAMP vector → (date V) hits the int64 vector branch of
+;; ray_temporal_truncate (t == RAY_TIMESTAMP, !src_has_nulls).
+(date [2024.03.15D12:34:56.000000000 2024.07.04D08:00:00.000000000 2024.12.31D23:59:59.999999999]) -- [2024.03.15D00:00:00.000000000 2024.07.04D00:00:00.000000000 2024.12.31D00:00:00.000000000]
+
+;; DATE vector → (date V) hits the int32 branch (t == RAY_DATE).
+(date [2024.01.01 2024.02.29 2024.12.31 1999.12.31]) -- [2024.01.01D00:00:00.000000000 2024.02.29D00:00:00.000000000 2024.12.31D00:00:00.000000000 1999.12.31D00:00:00.000000000]
+
+;; TIME vector → (date V) hits the int32 branch (t == RAY_TIME).  All entries
+;; floor to the 2000-01-01 midnight (the rayforce epoch).
+(date [00:00:00.000 12:34:56.789 23:59:59.999]) -- [2000.01.01D00:00:00.000000000 2000.01.01D00:00:00.000000000 2000.01.01D00:00:00.000000000]
+
+;; TIMESTAMP vector → (time V) — second-bucket variant of the int64 branch.
+(time [2024.03.15D12:34:56.789000000 2024.07.04D08:00:00.000000001 1999.12.31D23:59:59.999999999]) -- [2024.03.15D12:34:56.000000000 2024.07.04D08:00:00.000000000 1999.12.31D23:59:59.000000000]
+
+;; TIME vector → (time V) — int32 branch, second-bucket.
+(time [00:00:00.000 12:00:00.123 23:59:59.999]) -- [2000.01.01D00:00:00.000000000 2000.01.01D12:00:00.000000000 2000.01.01D23:59:59.000000000]
+
+;; ───────────────────── (as 'TYPE x) cross-temporal casts — atoms ──────────
+;; DATE → TIMESTAMP : days * NS_PER_DAY  (builtins.c:1512-1515).
+(as 'timestamp 2024.07.04) -- 2024.07.04D00:00:00.000000000
+(as 'timestamp 2000.01.01) -- 2000.01.01D00:00:00.000000000
+(as 'timestamp 1970.01.01) -- 1970.01.01D00:00:00.000000000
+(as 'timestamp 1999.12.31) -- 1999.12.31D00:00:00.000000000
+(as 'timestamp 2024.02.29) -- 2024.02.29D00:00:00.000000000
+
+;; TIMESTAMP → DATE : ts_days_floor (floor-div by NS_PER_DAY).
+(as 'date 2024.07.04D12:34:56.789000000) -- 2024.07.04
+(as 'date 2024.07.04D00:00:00.000000000) -- 2024.07.04
+(as 'date 1999.12.31D12:00:00.000000000) -- 1999.12.31
+(as 'date 2000.01.01D00:00:00.000000000) -- 2000.01.01
+;; Leap day round-trip via TIMESTAMP.
+(as 'date (as 'timestamp 2024.02.29)) -- 2024.02.29
+
+;; TIMESTAMP → TIME : ts_ns_in_day(ns) / 1_000_000 ms  (floor-mod within day).
+(as 'time 2024.07.04D12:34:56.000000000) -- 12:34:56.000
+(as 'time 2024.07.04D00:00:00.000000000) -- 00:00:00.000
+(as 'time 2024.07.04D23:59:59.999000000) -- 23:59:59.999
+;; Pre-2000 timestamp: floor-mod gives time-of-day, NOT a negative wrap.
+(as 'time 1999.12.31D23:59:59.999000000) -- 23:59:59.999
+(as 'time 1999.12.31D00:00:00.000000000) -- 00:00:00.000
+
+;; DATE → TIME : raw int32 (days) reinterpreted as TIME (ms-of-day).
+;; Documented direct passthrough in builtins.c:1472.
+;; epoch (days=0) survives as 0 ms / midnight.
+(as 'time 2000.01.01) -- 00:00:00.000
+
+;; TIME → DATE : raw int32 (ms) reinterpreted as DATE (days).
+;; 0 ms → 2000.01.01 (epoch day).
+(as 'date 00:00:00.000) -- 2000.01.01
+
+;; Identity casts — should return the same value via the "type already
+;; matches" fast paths (builtins.c:1431/1465/1504).
+(as 'date 2024.07.04) -- 2024.07.04
+(as 'time 12:34:56.789) -- 12:34:56.789
+(as 'timestamp 2024.07.04D12:34:56.789000000) -- 2024.07.04D12:34:56.789000000
+
+;; ───────────────────── (as 'TYPE x) cross-temporal casts — vectors ────────
+;; DATE vec → TIMESTAMP vec via cast_vec_numeric_fast (RAY_DATE→RAY_TIMESTAMP
+;; branch in cast_range_worker, builtins.c:869-872).
+(as 'timestamp [2024.01.01 2024.07.04 1999.12.31]) -- [2024.01.01D00:00:00.000000000 2024.07.04D00:00:00.000000000 1999.12.31D00:00:00.000000000]
+
+;; TIMESTAMP vec → DATE vec via cast_range_worker (builtins.c:873-878).
+(as 'date [2024.01.01D12:34:56.000000000 2024.07.04D00:00:00.000000000 1999.12.31D23:59:59.999000000]) -- [2024.01.01 2024.07.04 1999.12.31]
+
+;; TIMESTAMP vec → TIME vec via cast_range_worker (builtins.c:879-884) —
+;; ts_ns_in_day floor-mod / 1e6.
+(as 'time [2024.01.01D00:00:00.000000000 2024.07.04D12:34:56.789000000 1999.12.31D23:59:59.999000000]) -- [00:00:00.000 12:34:56.789 23:59:59.999]
+
+;; ───────────────────── (as 'TYPE str) string-form casts ───────────────────
+;; Catches builtins.c:1440-1456 (DATE string parser) and 1479-1495 (TIME
+;; string parser).  Already widely covered for TIMESTAMP in timestamp.rfl.
+(as 'date "2024.07.04")     -- 2024.07.04
+(as 'date "1999.12.31")     -- 1999.12.31
+(as 'date "2000.01.01")     -- 2000.01.01
+(as 'date "2024.02.29")     -- 2024.02.29
+(as 'time "12:34:56")       -- 12:34:56.000
+(as 'time "00:00:00")       -- 00:00:00.000
+(as 'time "23:59:59")       -- 23:59:59.000
+(as 'time "12:34:56.789")   -- 12:34:56.789
+
+;; ───────────────────── DOW reference grid ─────────────────────────────────
+;; rayforce convention: Mon=1 .. Sun=7  (temporal.c rte_extract_one DOW arm).
+;; Pinned against the Gregorian calendar by hand:
+;;   1970.01.01 = Thu, 2000.01.01 = Sat, 2024.02.29 = Thu, 2025.01.01 = Wed,
+;;   2099.12.31 = Thu, 2100.03.01 = Mon (2100 is NOT leap — century non-400).
+(dow 1970.01.01) -- 4
+(dow 2000.01.01) -- 6
+(dow 2024.02.29) -- 4
+(dow 2025.01.01) -- 3
+(dow 2099.12.31) -- 4
+(dow 2100.03.01) -- 1
+
+;; A full Mon→Sun cycle starting on 2024-01-08 (Mon).
+(dow [2024.01.08 2024.01.09 2024.01.10 2024.01.11 2024.01.12 2024.01.13 2024.01.14]) -- [1 2 3 4 5 6 7]
+
+;; Pre-epoch DOW — days_since_2000 < 0 path in ((days % 7) + 7 + 5) % 7 + 1.
+;; 1999.12.31 = Fri, 1999.12.27 = Mon, 1999.01.01 = Fri.
+(dow 1999.12.31) -- 5
+(dow 1999.12.27) -- 1
+(dow 1999.01.01) -- 5
+
+;; ───────────────────── DOY reference grid ─────────────────────────────────
+;; Non-leap (1999, 2025): Mar 1 = day 60, Dec 31 = day 365.
+;; Leap (2000, 2024): Mar 1 = day 61, Dec 31 = day 366.
+;; Century rule: 2100 is NOT leap — DOY 2100.03.01 = 60, 2100.12.31 = 365.
+(doy 1999.01.01) -- 1
+(doy 1999.03.01) -- 60
+(doy 1999.12.31) -- 365
+(doy 2000.01.01) -- 1
+(doy 2000.02.29) -- 60
+(doy 2000.03.01) -- 61
+(doy 2000.12.31) -- 366
+(doy 2025.03.01) -- 60
+(doy 2100.03.01) -- 60
+(doy 2100.12.31) -- 365
+
+;; ───────────────────── Cross-temporal compare ─────────────────────────────
+;; DATE atom == DATE atom, TIME atom == TIME atom, TIMESTAMP == TIMESTAMP.
+(== 2024.07.04 2024.07.04) -- true
+(== 12:34:56.000 12:34:56.000) -- true
+(== 2024.07.04D12:34:56.000000000 2024.07.04D12:34:56.000000000) -- true
+(< 1999.12.31 2000.01.01) -- true
+(< 1999.12.31D23:59:59.000000000 2000.01.01D00:00:00.000000000) -- true
+(> 23:59:59.999 00:00:00.000) -- true
+;; Ordering across an epoch boundary in vectors.
+(< [1999.12.31 2000.01.01 2024.07.04] [2000.01.01 2000.01.02 2024.07.05]) -- [true true true]
+
+;; ───────────────────── Round-trip invariants ──────────────────────────────
+;; DATE → TIMESTAMP → DATE is identity (no time-of-day component lost).
+(as 'date (as 'timestamp 2024.07.04)) -- 2024.07.04
+(as 'date (as 'timestamp 1999.12.31)) -- 1999.12.31
+(as 'date (as 'timestamp 2000.01.01)) -- 2000.01.01
+(as 'date (as 'timestamp 1970.01.01)) -- 1970.01.01
+
+;; TIMESTAMP → DATE drops time-of-day; re-casting to TIMESTAMP gives midnight.
+(as 'timestamp (as 'date 2024.07.04D12:34:56.789000000)) -- 2024.07.04D00:00:00.000000000
+(as 'timestamp (as 'date 1999.12.31D23:59:59.999000000)) -- 1999.12.31D00:00:00.000000000
+
+;; (date X) where X is already a midnight-aligned TIMESTAMP is identity.
+(date (as 'timestamp 2024.07.04)) -- 2024.07.04D00:00:00.000000000
+
+;; Day-component round trip — extracting after a date trunc reproduces
+;; the original calendar fields (truncate preserves them).
+(yyyy (date 2024.03.15D12:34:56.000000000)) -- 2024
+(mm   (date 2024.03.15D12:34:56.000000000)) -- 3
+(dd   (date 2024.03.15D12:34:56.000000000)) -- 15
+(hh   (date 2024.03.15D12:34:56.000000000)) -- 0
+(minute (date 2024.03.15D12:34:56.000000000)) -- 0
+(ss   (date 2024.03.15D12:34:56.000000000)) -- 0
+
+;; Time-component round trip — second truncation keeps hh/mm/ss, drops sub-s.
+(hh     (time 2024.03.15D12:34:56.789000000)) -- 12
+(minute (time 2024.03.15D12:34:56.789000000)) -- 34
+(ss     (time 2024.03.15D12:34:56.789000000)) -- 56

--- a/test/rfl/temporal/parse_format.rfl
+++ b/test/rfl/temporal/parse_format.rfl
@@ -1,0 +1,265 @@
+;; Happy-path coverage for the still-uncovered paths in
+;; src/ops/temporal.c:
+;;
+;;   • ray_temporal_truncate    — atom + vector, all three input types,
+;;                                null-atom branches, DAY / SECOND bucket
+;;   • ray_temporal_trunc_from_sym  — "date" / "time" sym lookups
+;;   • exec_date_trunc          — DAG path with RAY_DATE / RAY_TIME /
+;;                                RAY_TIMESTAMP input vectors, exercised
+;;                                from `select s: col.date` / `col.time`
+;;   • ray_{date,time,timestamp}_clock_fn  — overloaded forms with a
+;;                                temporal argument that route to
+;;                                ray_temporal_truncate
+;;
+;; Reachability notes:
+;;   The DAG-level YEAR/MONTH/HOUR/MINUTE cases of exec_date_trunc are
+;;   not directly callable from rfl: ray_temporal_trunc_from_sym only
+;;   maps "date" → DAY and "time" → SECOND, so DAY+SECOND are the only
+;;   buckets reachable through `.date` / `.time` desugaring.  The other
+;;   field codes inside the switch are dead code from the rfl surface
+;;   and stay covered by direct C unit tests instead.
+;;
+;;   Parsing (string → date / time / timestamp) lives in src/lang/parse.c
+;;   and src/runtime/cast.c, not in temporal.c — the `(as 'timestamp …)`
+;;   probes here only re-enter temporal.c via the subsequent `.date` or
+;;   `(date …)` calls.  See test/rfl/temporal/timestamp.rfl for the
+;;   full string-parse matrix.
+;;
+;;   The `(date 'local)` / `(timestamp 'global)` clock branches return
+;;   wall-clock dependent values; we exercise the call shape and only
+;;   assert on the result type so the test is deterministic.
+
+;; ═══════════════════════════════════════════════════════════════════
+;;                  1.  (date X) — atom overload
+;; ═══════════════════════════════════════════════════════════════════
+;; A temporal atom argument routes through ray_temporal_truncate with
+;; kind=RAY_EXTRACT_DAY and the result is a TIMESTAMP atom at the day
+;; boundary.
+
+;; DATE atom: already day-aligned, so truncating to day is idempotent
+;; in value-space but switches the type to TIMESTAMP.
+(type (date 2024.03.15))                      -- 'timestamp
+(date 2024.03.15)                              -- 2024.03.15D00:00:00.000000000
+(date 2000.01.01)                              -- 2000.01.01D00:00:00.000000000
+(date 1999.12.31)                              -- 1999.12.31D00:00:00.000000000
+(date 2024.02.29)                              -- 2024.02.29D00:00:00.000000000
+
+;; TIMESTAMP atom: truncate to midnight (drops the time-of-day).
+(type (date 2024.03.15D12:34:56.789000000))   -- 'timestamp
+(date 2024.03.15D12:34:56.789000000)          -- 2024.03.15D00:00:00.000000000
+(date 2024.07.04D23:59:59.999999999)          -- 2024.07.04D00:00:00.000000000
+(date 2024.01.01D00:00:00.000000000)          -- 2024.01.01D00:00:00.000000000
+;; Pre-epoch (us < 0): the floor-toward -inf branch in
+;; ray_temporal_truncate (`r < 0 ? bucket : 0`) trims to the prior
+;; midnight, not toward zero.
+(date 1999.12.31D12:00:00.000000000)          -- 1999.12.31D00:00:00.000000000
+
+;; TIME atom: ms since midnight has no date component, so it
+;; truncates to the 2000-01-01 epoch midnight.
+(type (date 12:34:56.789))                     -- 'timestamp
+(date 12:34:56.789)                            -- 2000.01.01D00:00:00.000000000
+(date 00:00:00.000)                            -- 2000.01.01D00:00:00.000000000
+
+;; ═══════════════════════════════════════════════════════════════════
+;;                  2.  (time X) — atom overload
+;; ═══════════════════════════════════════════════════════════════════
+;; Same atom path, kind=RAY_EXTRACT_SECOND.  Sub-second fractions
+;; drop; the result is TIMESTAMP at the second boundary.
+
+(type (time 2024.03.15D12:34:56.789123456))   -- 'timestamp
+(time 2024.03.15D12:34:56.789123456)          -- 2024.03.15D12:34:56.000000000
+(time 2024.03.15D00:00:00.000000000)          -- 2024.03.15D00:00:00.000000000
+(time 2024.03.15D23:59:59.999999999)          -- 2024.03.15D23:59:59.000000000
+
+;; TIME atom: sub-second fraction trims.  12:34:56.789 ms → 12:34:56 at
+;; epoch.
+(type (time 12:34:56.789))                     -- 'timestamp
+(time 12:34:56.789)                            -- 2000.01.01D12:34:56.000000000
+(time 00:00:00.000)                            -- 2000.01.01D00:00:00.000000000
+
+;; DATE atom: no sub-day component to trim, result lands on midnight.
+(time 2024.03.15)                              -- 2024.03.15D00:00:00.000000000
+
+;; ═══════════════════════════════════════════════════════════════════
+;;                  3.  Null atom branches
+;; ═══════════════════════════════════════════════════════════════════
+;; RAY_ATOM_IS_NULL on a typed-null temporal atom routes to
+;; ray_typed_null(-RAY_TIMESTAMP) → 0Np.
+
+(type (date 0Nd))                              -- 'timestamp
+(date 0Nd)                                     -- 0Np
+(date 0Nt)                                     -- 0Np
+(date 0Np)                                     -- 0Np
+(type (time 0Nd))                              -- 'timestamp
+(time 0Nd)                                     -- 0Np
+(time 0Nt)                                     -- 0Np
+(time 0Np)                                     -- 0Np
+
+;; ═══════════════════════════════════════════════════════════════════
+;;                  4.  Vector path — ray_temporal_truncate
+;; ═══════════════════════════════════════════════════════════════════
+;; The non-DAG vector path runs when (date V) / (time V) is invoked
+;; on a temporal vector (the registered unary builtin sees a vector
+;; arg and the ray_temporal_truncate vector branch handles it).  The
+;; result type is RAY_TIMESTAMP regardless of input element type.
+
+;; DATE vector → TIMESTAMP vector at each day's midnight.
+(set DV  [2024.01.01 2024.06.15 2024.12.31])
+(type (date DV))                               -- 'TIMESTAMP
+(count (date DV))                              -- 3
+(at (date DV) 0)                               -- 2024.01.01D00:00:00.000000000
+(at (date DV) 1)                               -- 2024.06.15D00:00:00.000000000
+(at (date DV) 2)                               -- 2024.12.31D00:00:00.000000000
+
+;; TIMESTAMP vector → trim time-of-day.
+(set TV [2024.03.15D12:34:56.789000000 2024.07.04D23:59:59.999999999 2024.01.01D00:00:00.000000000])
+(count (date TV))                              -- 3
+(at (date TV) 0)                               -- 2024.03.15D00:00:00.000000000
+(at (date TV) 1)                               -- 2024.07.04D00:00:00.000000000
+(at (date TV) 2)                               -- 2024.01.01D00:00:00.000000000
+
+;; (time TV) → trim sub-second.
+(count (time TV))                              -- 3
+(at (time TV) 0)                               -- 2024.03.15D12:34:56.000000000
+(at (time TV) 1)                               -- 2024.07.04D23:59:59.000000000
+(at (time TV) 2)                               -- 2024.01.01D00:00:00.000000000
+
+;; TIME vector via (date V) → all rows collapse to epoch midnight
+;; because TIME has no date component.
+(set TmV [00:00:00.000 12:34:56.789 23:59:59.999])
+(count (date TmV))                             -- 3
+(at (date TmV) 0)                              -- 2000.01.01D00:00:00.000000000
+(at (date TmV) 1)                              -- 2000.01.01D00:00:00.000000000
+(at (date TmV) 2)                              -- 2000.01.01D00:00:00.000000000
+
+;; (time TmV) → trim ms → seconds at epoch.
+(at (time TmV) 0)                              -- 2000.01.01D00:00:00.000000000
+(at (time TmV) 1)                              -- 2000.01.01D12:34:56.000000000
+(at (time TmV) 2)                              -- 2000.01.01D23:59:59.000000000
+
+;; ═══════════════════════════════════════════════════════════════════
+;;       5.  DAG path — exec_date_trunc via dotted .date / .time
+;; ═══════════════════════════════════════════════════════════════════
+;; A `select s: col.date` desugars (in src/ops/query.c at compile
+;; time) to scan(col) → date_trunc(DAY), so exec_date_trunc runs
+;; over a real column.  This exercises ray_temporal_trunc_from_sym
+;; ("date" / "time" → field code) and the DAG-level switch case for
+;; RAY_EXTRACT_DAY / RAY_EXTRACT_SECOND.
+
+;; TIMESTAMP source column.
+(set Tts (table [Ts] (list [2024.03.15D12:34:56.789000000 2024.07.04D23:59:59.999999999 2024.01.01D00:00:00.000000000])))
+
+(set Rts_date (select {from: Tts s: Ts.date}))
+(count Rts_date)                               -- 3
+(at (at Rts_date 's) 0)                        -- 2024.03.15D00:00:00.000000000
+(at (at Rts_date 's) 1)                        -- 2024.07.04D00:00:00.000000000
+(at (at Rts_date 's) 2)                        -- 2024.01.01D00:00:00.000000000
+(type (at Rts_date 's))                        -- 'TIMESTAMP
+
+(set Rts_time (select {from: Tts s: Ts.time}))
+(count Rts_time)                               -- 3
+(at (at Rts_time 's) 0)                        -- 2024.03.15D12:34:56.000000000
+(at (at Rts_time 's) 1)                        -- 2024.07.04D23:59:59.000000000
+(at (at Rts_time 's) 2)                        -- 2024.01.01D00:00:00.000000000
+
+;; DATE source column.  exec_date_trunc's int32-path with
+;; RAY_EXTRACT_DAY bucket — already day-aligned, so values
+;; round-trip in TIMESTAMP space.
+(set Tdt (table [D] (list [2024.01.01 2024.06.15 2024.12.31])))
+(set Rdt (select {from: Tdt s: D.date}))
+(count Rdt)                                    -- 3
+(at (at Rdt 's) 0)                             -- 2024.01.01D00:00:00.000000000
+(at (at Rdt 's) 1)                             -- 2024.06.15D00:00:00.000000000
+(at (at Rdt 's) 2)                             -- 2024.12.31D00:00:00.000000000
+
+;; TIME source column.  exec_date_trunc int32-path with
+;; RAY_EXTRACT_SECOND bucket — ms granularity trims to whole seconds.
+(set Ttm (table [T] (list [00:00:00.500 12:34:56.789 23:59:59.999])))
+(set Rtm (select {from: Ttm s: T.time}))
+(count Rtm)                                    -- 3
+(at (at Rtm 's) 0)                             -- 2000.01.01D00:00:00.000000000
+(at (at Rtm 's) 1)                             -- 2000.01.01D12:34:56.000000000
+(at (at Rtm 's) 2)                             -- 2000.01.01D23:59:59.000000000
+
+;; ═══════════════════════════════════════════════════════════════════
+;;       6.  Group-by .date — produces day buckets
+;; ═══════════════════════════════════════════════════════════════════
+;; Two timestamps on 2024-03-15 plus one on 2024-03-16 collapse to
+;; exactly 2 groups, confirming exec_date_trunc emits identical
+;; bucket values for same-day inputs.
+(set Tgb (table [Ts Px] (list [2024.03.15D09:00:00.000000000 2024.03.15D17:30:00.000000000 2024.03.16D12:00:00.000000000] [1.0 2.0 3.0])))
+(count (select {from: Tgb by: Ts.date}))      -- 2
+
+;; ═══════════════════════════════════════════════════════════════════
+;;       7.  Clock builtins — type-only assertions (wall-clock)
+;; ═══════════════════════════════════════════════════════════════════
+;; (date 'local) / (date 'global) — argument is a symbol (non-temporal),
+;; so the clock branch fires.  Result values are time-dependent so we
+;; only check the result type.  'local routes through localtime() and
+;; 'global through gmtime(); both produce DATE / TIME / TIMESTAMP atoms.
+;; The is_global_arg helper inspects the sym text to pick the branch.
+(type (date 'local))                           -- 'date
+(type (time 'local))                           -- 'time
+(type (timestamp 'local))                      -- 'timestamp
+(type (date 'global))                          -- 'date
+(type (time 'global))                          -- 'time
+(type (timestamp 'global))                     -- 'timestamp
+
+;; ═══════════════════════════════════════════════════════════════════
+;;       8.  Duration arithmetic — DATE / TIMESTAMP differences
+;; ═══════════════════════════════════════════════════════════════════
+;; DATE - DATE returns days as an integer (verified type below).
+;; This routes through the binary subtraction kernel, not temporal.c
+;; directly, but the surrounding test suite leaves the exact unit
+;; ambiguous so we lock it in here.
+(- 2024.01.10 2024.01.01)                      -- 9
+(- 2024.03.01 2024.02.01)                      -- 29
+(- 2023.03.01 2023.02.01)                      -- 28
+(- 2000.01.01 1999.12.31)                      -- 1
+
+;; Crossing year boundary (full leap year 2024).
+(- 2025.01.01 2024.01.01)                      -- 366
+
+;; date + days / date - days stays in DATE space.
+(type (+ 2024.01.01 1))                        -- 'date
+(type (- 2024.01.01 1))                        -- 'date
+(+ 2024.02.28 1)                               -- 2024.02.29
+(- 2024.03.01 1)                               -- 2024.02.29
+
+;; Negative-shift sanity: subtracting more than 1 day still produces
+;; a DATE.
+(- 2024.03.01 31)                              -- 2024.01.30
+
+;; ═══════════════════════════════════════════════════════════════════
+;;       9.  Round-trip — (date (date ts)) is idempotent on day-aligned
+;; ═══════════════════════════════════════════════════════════════════
+;; Re-truncating a value that's already on the day boundary returns
+;; the same TIMESTAMP.
+(date (date 2024.03.15D12:34:56.789000000))   -- 2024.03.15D00:00:00.000000000
+(time (time 2024.03.15D12:34:56.789000000))   -- 2024.03.15D12:34:56.000000000
+
+;; (date ∘ time) on a TIMESTAMP still yields the day-boundary because
+;; trimming sub-seconds keeps the date intact, then `(date …)` drops
+;; the hours.
+(date (time 2024.03.15D12:34:56.789000000))   -- 2024.03.15D00:00:00.000000000
+
+;; ═══════════════════════════════════════════════════════════════════
+;;       10. Combined extract → truncate consistency
+;; ═══════════════════════════════════════════════════════════════════
+;; Year/month/day extracted from a TIMESTAMP and from its `(date …)`
+;; truncate must agree.
+(set TSF 2024.07.04D14:25:36.123456789)
+(yyyy TSF)                                     -- 2024
+(yyyy (date TSF))                              -- 2024
+(mm   TSF)                                     -- 7
+(mm   (date TSF))                              -- 7
+(dd   TSF)                                     -- 4
+(dd   (date TSF))                              -- 4
+;; After (date …) the hh/minute/ss are all zero.
+(hh   (date TSF))                              -- 0
+(minute (date TSF))                            -- 0
+(ss   (date TSF))                              -- 0
+;; After (time …) the calendar fields stay intact, only sub-second drops.
+(hh   (time TSF))                              -- 14
+(minute (time TSF))                            -- 25
+(ss   (time TSF))                              -- 36


### PR DESCRIPTION
## Summary

Coverage push across multiple rounds, plus 5 real source bugs surfaced and fixed along the way using TDD (failing test → fix → passing test).

**Tests**: 2519 baseline → **2534 of 2536 PASS, 0 failed** (2 skipped: 1 pre-existing, 1 from PR #207's `public/vec_get_sym_id_w8` happy-path narrowing).

**Coverage (vs PR #207 merged baseline):**

| Metric | Before | After | Δ |
|---|---|---|---|
| Functions | 96.69% (67 missed) | **96.99% (61 missed)** | **−6 missed** |
| Lines | 77.93% | **78.61%** | +0.68 pp |
| Regions | 83.62% | **84.26%** | +0.64 pp |
| Branches | 60.84% | **61.51%** | +0.67 pp |

**Per-file high-impact deltas:**

| File | Before | After | Δ region |
|---|---|---|---|
| `src/ops/strop.c` | 70.93% | **84.32%** | **+13.39 pp** |
| `src/ops/group.c` | 65.20% | **66.78%** | +1.58 pp |
| `src/ops/cmp.c` | 85.62% | **87.06%** | +1.44 pp |
| `src/ops/string.c` | 71.86% | **73.09%** | +1.23 pp |
| `src/ops/query.c` | 76.29% | **77.44%** | +1.15 pp |
| `src/ops/temporal.c` | 55.51% | **56.24%** | +0.73 pp |

## Bug fixes (TDD: failing test → fix → passing test)

### Bug 1: `(min/max SYM_vec)` returned i64 sym-id, not SYM atom
`src/ops/group.c:reduction_i64_result` had cases for DATE/TIME/TIMESTAMP/I32/I16/U8 but missed `RAY_SYM` → fell through to `ray_i64(val)`. Added `case RAY_SYM: return ray_sym(val);`. Regression in `test/rfl/agg/min_max_sym.rfl`.

### Bug 2: `(first (asc v))` etc. in select-by aggregator → `error: domain`
The DAG-level idiom pass in `src/ops/idiom.c` walks `inputs[]` only — it never reaches aggregator subtrees that live in `OP_GROUP`'s `ext->agg_ins[]`. Added an AST-level rewrite (`simplify_agg_idiom` in `query.c`) mirroring the DAG idioms before agg_ins is built. Regression in `test/rfl/ops/idiom_in_select_by.rfl`.

### Bug 3: `(at table 'list-col)` after per-group projection returned `[error: nyi × N]`
`nonagg_eval_per_group_core` stored each cell as a `RAY_LAZY` ray_t. The first `fmt_obj` of the table consumed the lazy's graph; every subsequent cell read hit a half-dead lazy whose execute failed with "nyi". Fix: eagerly materialise lazy cells before storing in the result LIST. Regression in `test/rfl/query/list_col_at_extraction.rfl`.

### Bug 4: single-arg `(and X)` / `(or X)` returned arity / domain
Programmatic AST construction like `(cons 'and preds)` broke when `preds` had length 1. Switched to the monoid-identity rule (Scheme/Haskell): `(and X) == X`, `(or X) == X`. Zero args still rejected. Fixed at both eval level (`cmp.c`) and DAG-compile level (`query.c compile_expr_dag`). Regression in `test/rfl/cmp/and_or_identity.rfl` plus updated docs in `cmp/and.rfl` and `cmp/or.rfl`.

### Bug 5: `dev` had different math in scalar vs select-by contexts
Scalar `(dev V)` was POPULATION stddev. Per-group `select{d:(dev v) by k}` mapped to `OP_STDDEV` → SAMPLE stddev. Aligned planner with scalar (`query.c:316`: `dev → OP_STDDEV_POP`). `dev` is now a true alias of `stddev_pop` / `dev_pop` everywhere. Regression in `test/rfl/agg/per_group_holistic.rfl`.

## New tests (~15 RFL files, ~1800 assertions)

**Aggregators**: `min_max_sym`, `rowform_topk/maxmin/sum_count`, `variance`, `per_group_holistic`, `count_distinct_paths`, `reprobe_stress`.
**Query / planner**: `idiom_in_select_by`, `idiom_in_query`, `list_col_at_extraction`, `per_group_buf`, `parallel_probe`, `where_and_chain`, `expr_typed_fast`, `expr_mixed_types`, `and_or_identity`.
**Strings / temporal**: `strlen_partitioned`, `string_manipulation`, `like_patterns`, `string_par`, `extract`, `arith`, `cross_cast_period`, `parse_format`.
**Storage / graphs / serialization**: `serde_roundtrip`, `fused_topn`, `traverse_weighted`, `graph_algos_advanced`, `hof/wrappers`, `csv_splayed`.

## Test plan
- [x] `make clean && make test` (debug, ASan+UBSan): **2534 of 2536, 0 failed**
- [x] Each bug fix has a TDD test that fails before the fix and passes after
- [x] No `_probes/`, no hidden xfail — observed bugs either fixed or pinned with `--` assertions in the visible pipeline
- [x] No `src/` test-only de-staticing, no internal headers added for tests

## Observations documented (not bugs in this PR's scope)
- **Louvain phase-1 only**: `.graph.louvain` returns 4 communities on a K4+K4+bridge fixture (instead of canonical 2) because the contraction step is unimplemented. Pinned in `graph_algos_advanced.rfl`. Source `src/ops/traverse.c:1166` self-documents this.
- **A* / SCC RFL bindings missing**: `exec_astar` is implemented but has no RFL binding. SCC has zero implementation. Flagged as unreachable from RFL.
- **5 dispatch quirks in expr_mixed_types.rfl**: pinned with `--` assertions; each has a working alternative route exercised in the same file.

## Out of scope (next coverage round)
- More expr.c paths (still ~63% region, biggest absolute gap)
- More group.c (still 67% region)
- traverse.c PageRank/Louvain phase-2, SCC implementation, A* RFL binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
