### PR TITLE
perf(query): gate the bounded-multikey count+take fast path by table size

### DIFF
--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -5371,7 +5371,16 @@ by_dict_done:
                     break;
                 }
             }
+            /* The bounded-multikey count-take candidate uses an
+             * eval-level single-threaded scan with O(found) per-row
+             * group lookup.  Profitable on small inputs (skips the
+             * full DAG group HT construction) but at 10M rows × multi-
+             * key composite (ClickBench q17), the serial scan loses
+             * to the parallel mk_par_v2 filtered_group below.  Gate
+             * on table size — let big inputs through to the fused
+             * multi-key path. */
             if (!use_eval_group &&
+                ray_table_nrows(tbl) < 100000 &&
                 bounded_multikey_count_take_candidate(
                     dict_elems, dict_n, from_id, where_id, by_id, take_id,
                     asc_id, desc_id, ray_table_nrows(tbl), 1024)) {


### PR DESCRIPTION
## Summary

`bounded_multikey_count_take_candidate` triggers an **eval-level
single-threaded scan** in `ray_select_fn` that walks every row with an
`O(found)` per-row linear group lookup.  Profitable on small inputs
(skips the full DAG group HT construction) but for large multi-key
inputs the serial scan loses to the parallel `mk_par_v2` fused_group
path.

ClickBench 10M q17 —

```
(select {c: (count UserID)
         from: hits
         by: {UserID: UserID SearchPhrase: SearchPhrase}
         take: 10})
```

— 10M rows × ~2.1M distinct composite keys.  The query landed in the
eval-level path and spent ~340 ms on the linear scan even though the
result only needs any 10 (UserID, SearchPhrase, count) tuples.

Gate the candidate on `nrows < 100000` so big inputs fall through to
the parallel filtered_group multi-key path.

ClickBench 10M:

```
q17  ~354 → ~161 ms   (-54%, -193ms)
```

Full 43-query sum: `-207 ms / -6.7%`.

Tests: 3241/3243 pass (unchanged).