### PR TITLE
perf(query): route large no-WHERE multi-key SYM groups to exec_group

### DIFF
--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -4808,6 +4808,7 @@ by_dict_done:
                 }
                 int keys_ok = 1;
                 int total_bytes = 0;
+                bool has_sym_key = false;
                 for (uint8_t i = 0; i < n_keys_local && keys_ok; i++) {
                     ray_t* kc = ray_table_get_col(tbl, key_syms_buf[i]);
                     if (!kc) { keys_ok = 0; break; }
@@ -4826,7 +4827,24 @@ by_dict_done:
                      * OP_GROUP, which buckets null keys separately. */
                     if (kc->attrs & RAY_ATTR_HAS_NULLS)
                         { keys_ok = 0; break; }
+                    if (kct == RAY_SYM) has_sym_key = true;
                     total_bytes += ray_sym_elem_size(kct, kc->attrs);
+                }
+                /* SYM keys disable v2 radix-partitioned shards
+                 * (see fused_group.c v2_ok gate), so multi-key SYM
+                 * falls to v1 mk_par_fn — single shard per worker.
+                 * On q18 (no-WHERE, 10M rows × ~2M unique composite
+                 * keys) the shard reaches ~70 MB, every probe is an
+                 * L3 miss.  exec_group's radix scatter (256 partitions,
+                 * per-partition HTs fit L2) runs ~4× faster on this
+                 * shape.  Gate only fires for the no-WHERE case: a
+                 * WHERE-filtered SYM multi-key (q14) already lands on
+                 * a much smaller post-filter row set where the v1
+                 * single-shard fits L2 and the fused fast-path wins. */
+                if (has_sym_key && n_keys_local >= 2 &&
+                    !where_expr &&
+                    ray_table_nrows(tbl) >= 1000000) {
+                    keys_ok = 0;
                 }
                 /* Single-key case fits unconditionally (one key column, one
                  * slot).  Multi-key narrow path (≤ 8 bytes packed) uses a


### PR DESCRIPTION
## Summary

The fused multi-key planner gate in `ray_select_fn` dispatches all
multi-key composite group-bys to `ray_filtered_group` → `mk_par_v2_fn`.
SYM keys are rejected by `mk_par_v2`'s correctness gate so they fall
back to the v1 `mk_par_fn` — one shard per worker, no radix
partitioning.  On large no-WHERE inputs (ClickBench q16, q17, q18 —
10M rows × 1–2M unique composite keys with a `SearchPhrase` SYM key)
the single-shard working set reaches tens of MB per worker, every HT
probe is an L3 miss, and the run dominates the bench.

`exec_group`'s radix scatter (256 partitions, per-partition HTs fit
L2) is the right shape for this load — proven by a manual two-step
(filter+materialise into a narrow table, then group) running ~4×
faster than the fused path.

Add a planner-level bail: when `n_keys ≥ 2`, at least one key is SYM,
there is no WHERE clause, and the table has ≥ 1M rows, mark the keys
gate failed so the multi-key fuse decision falls through.  The
unfused `OP_GROUP` exec then takes the radix path that's already
well-tested for this shape.

**Why the no-WHERE constraint:** a WHERE-filtered SYM multi-key (q14
shape) lands on a much smaller post-filter row set where the v1
single-shard fits L2 and the fused fast-path wins.  The 1 M row
threshold leaves small-input SYM multi-key shapes on the fused path
where its setup cost is cheap and amortised.

## ClickBench 10M

```
q18  ~417 → ~169 ms   (-59%, -248ms)
q17  ~158 →  ~51 ms   (-68%, -107ms)
q16  ~137 →  ~49 ms   (-65%,  -88ms)
```

Full 43-query sum: `-422 ms / -14.7%`.  Remaining ≥5% shifts are all
under 2 ms absolute (run-to-run noise).

Tests: 3249/3251 pass (unchanged).