### PR TITLE
fix: exact COUNT DISTINCT — remove HLL auto-switch + repair SEGV fallout

### DIFF
--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -725,15 +725,6 @@ ray_t* exec_count_distinct(ray_graph_t* g, ray_op_t* op, ray_t* input) {
      * and constant-memory per worker.  Below the threshold the exact
      * path is fast enough and avoids approximation entirely — so small
      * tests still match `len-after-distinct` byte-for-byte. */
-    if (len >= (1 << 20)) {
-        bool hashable = (in_type == RAY_I64 || in_type == RAY_I32 ||
-                          in_type == RAY_I16 || in_type == RAY_U8 ||
-                          in_type == RAY_BOOL || in_type == RAY_F64 ||
-                          in_type == RAY_DATE || in_type == RAY_TIME ||
-                          in_type == RAY_TIMESTAMP || in_type == RAY_STR ||
-                          RAY_IS_SYM(in_type));
-        if (hashable) return ray_count_distinct_approx(input);
-    }
 
     switch (in_type) {
     case RAY_BOOL: case RAY_U8:
@@ -1248,7 +1239,7 @@ static ray_t* count_distinct_per_group_parallel(
  * Returns the populated `out` vector on success, NULL on type miss /
  * dispatch failure.  Caller (ray_count_distinct_per_group) falls back
  * to the exact partitioned dedup. */
-static ray_t* count_distinct_per_group_hll(ray_t* src, const int64_t* row_gid,
+__attribute__((unused)) static ray_t* count_distinct_per_group_hll(ray_t* src, const int64_t* row_gid,
                                            int64_t n_rows, int64_t n_groups,
                                            ray_t* out) {
     if (!src || n_rows <= 0 || n_groups <= 0) return NULL;
@@ -1359,53 +1350,9 @@ ray_t* ray_count_distinct_per_group(ray_t* src, const int64_t* row_gid,
      * is n_workers × 17 KB instead of n_groups × 16 KB.  Returns a
      * ~0.8 % std-error estimate; callers that need exact counts at
      * this scale must not hit this gate. */
-    if (n_rows >= (1 << 20)) {
-        /* Streaming HLL: skip the (idx_buf + offsets + counts) CSR build
-         * by accumulating directly into n_groups sketches per worker in
-         * a single pass over (row_gid[r], val[r]).  The CSR build cost
-         * (two passes of int64 reads over n_rows) is ~30 % of wall time
-         * on q10/q08 ClickBench, while the HLL pass itself is ~7 %.
-         *
-         * Gated on a per-worker memory budget: each worker keeps a bank
-         * of n_groups sketches whose sparse + dense buffers come from
-         * one pre-allocated slab.  At P=14 that's ~17 KB per group;
-         * with the 8 MB-per-worker budget below, n_groups must be ≤
-         * 482 (at one worker) and shrinks pro-rata with worker count
-         * — i.e. the *total* concurrent footprint is bounded at
-         * n_workers * 8 MB ≤ ~64 MB on a 16-thread box.
-         *
-         * Lower bound (n_groups < 16) avoids the dispatch overhead of
-         * n_workers-fold bank merges when there's only a handful of
-         * groups — the CSR path's per-group task dispatch dominates
-         * there anyway, but the streaming bank merge has its own fixed
-         * cost.  Below the bound we fall through to the CSR HLL path. */
-        const size_t RAY_HLL_STREAM_BUDGET_PER_WORKER = (size_t)8 * 1024 * 1024;
-        /* Per-sketch slab footprint at the precision the kernel uses
-         * (RAY_HLL_DEFAULT_P → m = 16384).  sizeof(ray_hll_t) is small
-         * relative to the buffers; rounded into the count. */
-        size_t hll_per_group =
-            sizeof(ray_hll_t) +
-            RAY_HLL_SPARSE_CAP * sizeof(uint32_t) +
-            ((size_t)1u << RAY_HLL_DEFAULT_P);
-        bool stream_ok = (n_groups >= 16) &&
-                         ((size_t)n_groups * hll_per_group
-                          <= RAY_HLL_STREAM_BUDGET_PER_WORKER);
-        if (stream_ok) {
-            int rc = ray_count_distinct_approx_pg_stream(
-                src, row_gid, n_rows, n_groups,
-                RAY_HLL_DEFAULT_P, odata);
-            if (rc == 0) return out;
-            /* Streaming failed (OOM / unsupported type) — fall through
-             * to the CSR HLL path with odata still zeroed. */
-            memset(odata, 0, (size_t)n_groups * sizeof(int64_t));
-        }
-
-        ray_t* approx = count_distinct_per_group_hll(src, row_gid,
-                                                     n_rows, n_groups, out);
-        if (approx) return approx;
-        /* Fall through on dispatch failure — counts not yet written. */
-        memset(odata, 0, (size_t)n_groups * sizeof(int64_t));
-    }
+    /* COUNT(DISTINCT col) per group is EXACT.  Earlier streaming HLL
+     * and CSR HLL fast paths returned approximation; removed.  The
+     * partitioned exact path below handles all sizes. */
 
     /* Parallel partitioned path for sizes where the serial global hash
      * blows L3.  Threshold tuned so the partition / scatter / dedup

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -3010,76 +3010,11 @@ static ray_t* count_distinct_per_group_buf(ray_t* inner_expr, ray_t* tbl,
     out->len = n_groups;
     int64_t* odata = (int64_t*)ray_data(out);
 
-    /* Streaming HLL — one parallel pass over rows (each worker owns a
-     * private bank of n_groups sparse sketches) instead of n_groups
-     * separate tasks each rebuilding a sketch.  Wins when n_groups is
-     * small enough that the per-group banks stay roughly L2-resident
-     * (~17 KB per group at p=14, so n_groups ≤ 500 caps a worker bank
-     * at ~8 MB).  Builds row_gid[] by inverting idx_buf/offsets;
-     * n_total_rows is the largest source row index referenced. */
-    if (n_groups > 0) {
-        int64_t total_rows = 0;
-        for (int64_t g = 0; g < n_groups; g++) total_rows += grp_cnt[g];
-
-        int8_t st = src->type;
-        bool hashable = (st == RAY_BOOL || st == RAY_U8 ||
-                          st == RAY_I16  || st == RAY_I32 || st == RAY_I64 ||
-                          st == RAY_F64  || st == RAY_DATE || st == RAY_TIME ||
-                          st == RAY_TIMESTAMP || RAY_IS_SYM(st));
-        if (hashable && total_rows >= (1 << 20) &&
-            n_groups >= 16 && n_groups <= 500)
-        {
-            /* Largest source row index in idx_buf — sets the row_gid
-             * span.  For unfiltered queries every row gets a gid; for
-             * filtered queries non-passing rows stay at the -1 sentinel
-             * and the streaming task skips them. */
-            int64_t n_max_row = 0;
-            for (int64_t gi = 0; gi < n_groups; gi++) {
-                int64_t end_off = offsets[gi] + grp_cnt[gi];
-                for (int64_t j = offsets[gi]; j < end_off; j++) {
-                    if (idx_buf[j] >= n_max_row) n_max_row = idx_buf[j] + 1;
-                }
-            }
-            if (n_max_row > 0) {
-                ray_t* rg_hdr = NULL;
-                int64_t* row_gid = (int64_t*)scratch_alloc(&rg_hdr,
-                    (size_t)n_max_row * sizeof(int64_t));
-                if (row_gid) {
-                    for (int64_t r = 0; r < n_max_row; r++) row_gid[r] = -1;
-                    for (int64_t gi = 0; gi < n_groups; gi++) {
-                        int64_t end_off = offsets[gi] + grp_cnt[gi];
-                        for (int64_t j = offsets[gi]; j < end_off; j++) {
-                            row_gid[idx_buf[j]] = gi;
-                        }
-                    }
-                    if (ray_count_distinct_approx_pg_stream(
-                            src, row_gid, n_max_row, n_groups, 14, odata) == 0)
-                    {
-                        scratch_free(rg_hdr);
-                        ray_release(src);
-                        return out;
-                    }
-                    scratch_free(rg_hdr);
-                    memset(odata, 0, (size_t)n_groups * sizeof(int64_t));
-                }
-            }
-        }
-
-        /* Per-group HLL fallback — one task per group, private sketch
-         * per task.  Triggered when streaming doesn't apply (too many
-         * groups, non-hashable col) but the row count still justifies
-         * approximation. */
-        if (total_rows >= (1 << 20)) {
-            if (ray_count_distinct_approx_pg_buf(src, idx_buf, offsets,
-                                                  grp_cnt, n_groups,
-                                                  14, odata) == 0) {
-                ray_release(src);
-                return out;
-            }
-            /* Fall through on type miss; out still zeroed. */
-            memset(odata, 0, (size_t)n_groups * sizeof(int64_t));
-        }
-    }
+    /* COUNT(DISTINCT col) per group is EXACT.  Streaming HLL +
+     * per-group HLL buf fast paths returned approximation here and
+     * have been removed.  HLL remains in the codebase for explicit
+     * opt-in approximate entries and internal cardinality estimation
+     * only.  Exact parallel dedup follows below. */
 
     /* Parallel path: dispatch one task per group when src has a flat
      * numeric / SYM layout we can read with a typed pointer.  Each task
@@ -8673,31 +8608,11 @@ by_dict_done:
                             }
                         }
                         if (src_for_global) {
-                            /* Streaming per-group HLL: skips the idx_buf
-                             * scatter and re-walk by running one pass
-                             * over (row_gid, hash(src[r])).  Each worker
-                             * owns a private bank of n_groups sparse
-                             * sketches; gated by a memory budget so the
-                             * banks stay roughly L2-resident.  Falls
-                             * through to the buf-form on type miss / OOM. */
-                            if (n_groups >= 16 && n_groups <= 500
-                                && nrows >= (1 << 20)
-                                && !RAY_IS_PARTED(src_for_global->type)
-                                && src_for_global->type != RAY_MAPCOMMON)
-                            {
-                                ray_t* out_hll = ray_vec_new(RAY_I64, n_groups);
-                                if (out_hll && !RAY_IS_ERR(out_hll)) {
-                                    out_hll->len = n_groups;
-                                    int64_t* odata = (int64_t*)ray_data(out_hll);
-                                    if (ray_count_distinct_approx_pg_stream(
-                                            src_for_global, row_gid, nrows,
-                                            n_groups, 14, odata) == 0) {
-                                        col = out_hll;
-                                    } else {
-                                        ray_release(out_hll);
-                                    }
-                                }
-                            }
+                            /* COUNT(DISTINCT) is exact per SQL/DSL
+                             * semantics — the streaming HLL fast path
+                             * here silently returned an approximate
+                             * result and was removed.  Exact dedup
+                             * follows below. */
                             /* Path selection: global-hash kernel scales
                              * with n_rows (per-row probe of one shared
                              * hash table); per-group-slice scales with

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -8423,22 +8423,13 @@ by_dict_done:
                  * If any non-agg falls outside that, we still need the
                  * index. */
                 /* Decide whether we need to materialise the per-group
-                 * idx_buf scatter.  Two routes avoid it entirely:
-                 *
-                 *   - simple_cd_global: count(distinct col_ref) with
-                 *     n_groups > 50 000 — the high-card path walks
-                 *     row_gid directly.
-                 *   - cd_streaming: count(distinct col_ref) with a
-                 *     hashable column and 16 ≤ n_groups ≤ 500 — the
-                 *     streaming HLL kernel walks (row_gid, hash(src[r]))
-                 *     into per-worker sparse-sketch banks; no scatter
-                 *     needed.  Saves the ~10 % of q08/q10-class
-                 *     queries that idxbuf_scat + idxbuf_hist eats
-                 *     when the downstream HLL path doesn't read it.
-                 *
-                 * Either skips the scatter only when EVERY non-agg
-                 * qualifies — if any non-agg needs idx_buf the
-                 * scatter still has to run. */
+                 * idx_buf scatter.  Skipped only when EVERY non-agg
+                 * is count(distinct col_ref) routed to the global-hash
+                 * kernel (n_groups > 50 000) — that path walks row_gid
+                 * directly and never reads the slice index.  Any other
+                 * non-agg shape — including count(distinct) on small
+                 * group counts — falls into count_distinct_per_group_buf
+                 * which requires idx_buf+offsets+grp_cnt. */
                 int needs_slice_idx = 0;
                 for (uint8_t ni = 0; ni < n_nonaggs && !needs_slice_idx; ni++) {
                     ray_t* cd_inner = match_count_distinct(nonagg_exprs[ni]);
@@ -8446,24 +8437,7 @@ by_dict_done:
                                             cd_inner->type == -RAY_SYM &&
                                             (cd_inner->attrs & RAY_ATTR_NAME) &&
                                             n_groups > 50000);
-                    int cd_streaming = 0;
-                    if (cd_inner && cd_inner->type == -RAY_SYM &&
-                        (cd_inner->attrs & RAY_ATTR_NAME) &&
-                        n_groups >= 16 && n_groups <= 500 &&
-                        nrows >= (1 << 20)) {
-                        ray_t* sc = ray_table_get_col(tbl, cd_inner->i64);
-                        if (sc && !RAY_IS_PARTED(sc->type) &&
-                            sc->type != RAY_MAPCOMMON) {
-                            int8_t st = sc->type;
-                            cd_streaming = (st == RAY_I64 || st == RAY_I32 ||
-                                            st == RAY_I16 || st == RAY_U8 ||
-                                            st == RAY_BOOL || st == RAY_F64 ||
-                                            st == RAY_DATE || st == RAY_TIME ||
-                                            st == RAY_TIMESTAMP ||
-                                            RAY_IS_SYM(st));
-                        }
-                    }
-                    if (!simple_cd_global && !cd_streaming) needs_slice_idx = 1;
+                    if (!simple_cd_global) needs_slice_idx = 1;
                 }
 
                 int64_t* idx_buf = NULL;


### PR DESCRIPTION
COUNT(DISTINCT col) returned HLL approximations at three sites:
- exec_count_distinct (global)
- ray_count_distinct_per_group (per-group)
- count_distinct_per_group_buf (streaming + per-group HLL buf in query.c)

All three silently switched to the sketch above row/group thresholds.
Result drifted ~0.2% from the contractually exact value. Removed.

Removing the streaming-HLL consumer in query.c left the cd_streaming
gate (n_groups 16-500, nrows ≥ 1M, hashable col) skipping idx_buf
allocation — the consumer that read it no longer existed. Per-group
parallel worker hit a NULL idxs[i] → SEGV. Drop the gate; the slice
index is now built whenever a per-group-slice consumer needs it.

HLL kernels stay in the codebase for explicit opt-in approximate
entries and internal cardinality estimation only.