### PR TITLE
fix(agg): reduction of a scalar sub-expression matches the scalar builtin

### DIFF
--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -2011,16 +2011,36 @@ ray_t* exec_reduction(ray_graph_t* g, ray_op_t* op, ray_t* input) {
         return ray_error("type", NULL);
     }
 
-    /* Atom input: count returns 1 (or the string length for RAY_STR
-     * since strings are length-prefixed atoms).  Other reductions on
-     * a scalar are a type error — they need a column. */
+    /* Atom input: a reduction of a scalar sub-expression (e.g.
+     * (sum (max v)), (sum (count (distinct v)))) reaches here when the
+     * reduction is compiled as a DAG node whose input materialises to an
+     * atom.  Delegate to the scalar builtin so the DAG agrees with the
+     * direct scalar form — (sum 6) and (sum (max v)) must behave the same.
+     * The builtins handle the atom in place (no recursion back here) and
+     * return an owned value without consuming `input` (the caller releases
+     * it).  COUNT keeps its column-cardinality semantics (1 / strlen). */
     if (ray_is_atom(input)) {
-        if (op->opcode == OP_COUNT) {
-            if ((-input->type) == RAY_STR)
-                return ray_i64((int64_t)ray_str_len(input));
-            return ray_i64(1);
+        switch (op->opcode) {
+            case OP_COUNT:
+                if ((-input->type) == RAY_STR)
+                    return ray_i64((int64_t)ray_str_len(input));
+                return ray_i64(1);
+            case OP_SUM:        return ray_sum_fn(input);
+            case OP_AVG:        return ray_avg_fn(input);
+            case OP_MIN:        return ray_min_fn(input);
+            case OP_MAX:        return ray_max_fn(input);
+            case OP_FIRST:      return ray_first_fn(input);
+            case OP_LAST:       return ray_last_fn(input);
+            case OP_MEDIAN:     return ray_med_fn(input);
+            case OP_VAR:        return ray_var_fn(input);
+            case OP_VAR_POP:    return ray_var_pop_fn(input);
+            case OP_STDDEV:     return ray_stddev_fn(input);
+            case OP_STDDEV_POP: return ray_stddev_pop_fn(input);
+            /* OP_PROD has no scalar builtin; prod of a single element is
+             * that element. */
+            case OP_PROD:       ray_retain(input); return input;
+            default:            return ray_error("type", NULL);
         }
-        return ray_error("type", NULL);
     }
 
     int8_t in_type = input->type;

--- a/test/rfl/agg/reduce_scalar_subexpr.rfl
+++ b/test/rfl/agg/reduce_scalar_subexpr.rfl
@@ -1,0 +1,36 @@
+;; A reduction applied to a SCALAR sub-expression — (sum (max v)),
+;; (sum (count (distinct v))), (sum (sum v)) — compiles to a DAG whose
+;; reduction input materialises to an atom.  exec_reduction used to reject
+;; that atom with a type error while the direct scalar form ((sum 6))
+;; accepted it — a scalar<->DAG divergence.  exec_reduction's atom branch now
+;; delegates to the scalar builtins, so the two forms agree.
+
+;; ─── reduction of a scalar reduction ─────────────────────────────────
+(sum (max [1 2 3]))        -- 3
+(sum (min [3 1 2]))        -- 1
+(sum (first [5 6 7]))      -- 5
+(sum (last [5 6 7]))       -- 7
+(sum (sum [1 2 3]))        -- 6
+(max (sum [1 2 3]))        -- 6
+(min (max [10 20 30]))     -- 30
+(avg (max [1 2 3]))        -- 3.0
+(avg (sum [2 4 6]))        -- 12.0
+(first (sum [1 2 3]))      -- 6
+(last (max [4 5 6]))       -- 6
+
+;; ─── reduction of count(distinct) ────────────────────────────────────
+(sum (count (distinct [1 2 2 3 3 3]))) -- 3
+(max (count (distinct [1 1 1])))       -- 1
+(avg (count (distinct [5 6 7 8])))     -- 4.0
+
+;; ─── scalar<->DAG parity: the reduction-of-scalar equals the scalar ──
+;; (sum (max v)) must equal (max v); a single SYM atom reduces to itself,
+;; matching the scalar builtin (sum 'c) == 'c.
+(== (sum (max [1 2 3])) (max [1 2 3]))        -- true
+(== (sum (max ['a 'c 'b])) (max ['a 'c 'b]))  -- true
+(sum (max ['a 'c 'b]))     -- 'c
+
+;; ─── type preservation through the scalar delegate ───────────────────
+(type (sum (max [1 2 3])))            -- 'i64
+(type (avg (max [1 2 3])))            -- 'f64
+(type (sum (max [09:00:00.000 10:00:00.000]))) -- 'time


### PR DESCRIPTION
## Problem

A reduction applied to a **scalar sub-expression** raised a spurious `type` error, while the same reduction on a literal scalar worked:

```
(sum (max [1 2 3]))            -> error: type     (expected 3)
(sum (count (distinct v)))     -> error: type     (expected the distinct count)
(sum (sum [1 2 3]))            -> error: type     (expected 6)
(avg (max [1 2 3]))            -> error: type     (expected 3.0)
(sum 6)                        -> 6               (literal works)
```

These compile to a DAG whose `OP_SUM`/`OP_MIN`/… input materialises to an **atom** (the inner reduction's scalar result). `exec_reduction`'s atom branch handled only `COUNT` and returned a `type` error for everything else — a scalar↔DAG divergence in the same family as the M1–M5 aggregation reconciliation. Materialising the inner value out of the DAG (`(set x (count (distinct v)))` then `(sum x)`, or `(sum (+ 0 (max v)))`) already worked, confirming it is purely the DAG atom-input path that diverged.

## Fix

`exec_reduction`'s atom branch now **delegates to the scalar aggregate builtins** (`ray_sum_fn` / `ray_avg_fn` / `ray_min_fn` / `ray_max_fn` / `ray_first_fn` / `ray_last_fn` / `ray_med_fn` / `ray_var*_fn` / `ray_stddev*_fn`), so the DAG agrees with the direct scalar form **by construction** — including type/admission: sum of a `SYM` atom reduces to itself exactly as the scalar `(sum 'c)` does, and sum of a `TIME` atom stays `TIME`. `OP_PROD` (no scalar builtin) returns the lone element. The builtins handle the atom in place (no recursion back into `exec_reduction`) and return an owned value without consuming `input`.

## Verification

- `agg/reduce_scalar_subexpr.rfl` pins the reduction-of-scalar forms, the scalar↔DAG parity (`(sum (max v)) == (max v)`), and type preservation (i64 / f64 / time).
- Full suite green under gcc debug+ASan/UBSan, 0 failed — no leak/UAF from the delegation.

## Not included

A separate, distinct issue remains open and is **not** addressed here: `(sum (map (fn […] (count (distinct v))) range))` still errors, but that is `sum` over a `map`-produced LIST (a LIST→vector coercion path), not the atom-input path fixed here — `(sum (at … 0))` and `(fold + … )` over the same map result both work. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)