### PR TITLE
fix(hof): map materialises a lazy lambda result before collecting it

### DIFF
--- a/src/ops/collection.c
+++ b/src/ops/collection.c
@@ -357,6 +357,11 @@ ray_t* ray_map_fn(ray_t** args, int64_t n) {
         ray_t** elems = (ray_t**)ray_data(vec);
         for (int64_t i = 0; i < len; i++) {
             out[i] = call_fn1(fn, elems[i]);
+            /* Materialise a lazy result (e.g. the lambda returned
+             * (count (distinct x)) — distinct/count of a vec is lazy).  A LIST
+             * of unforced lazy nodes breaks every downstream consumer that
+             * doesn't force per element (sum, ==, +). */
+            if (ray_is_lazy(out[i])) out[i] = ray_lazy_materialize(out[i]);
             if (RAY_IS_ERR(out[i])) {
                 for (int64_t j = 0; j < i; j++) ray_release(out[j]);
                 result->len = 0; ray_release(result); if (_bx) ray_release(_bx);
@@ -385,6 +390,7 @@ ray_t* ray_map_fn(ray_t** args, int64_t n) {
     ray_t** elems = (ray_t**)ray_data(vec);
     for (int64_t i = 0; i < len; i++) {
         out[i] = call_fn2(fn, val, elems[i]);
+        if (ray_is_lazy(out[i])) out[i] = ray_lazy_materialize(out[i]);
         if (RAY_IS_ERR(out[i])) {
             for (int64_t j = 0; j < i; j++) ray_release(out[j]);
             result->len = 0; ray_release(result); if (_bx) ray_release(_bx);

--- a/test/rfl/hof/map_lazy_result.rfl
+++ b/test/rfl/hof/map_lazy_result.rfl
@@ -1,0 +1,27 @@
+;; map must materialise a LAZY result from its lambda before collecting it.
+;; distinct/count/reverse of a concrete vec return a lazy node; if the lambda
+;; body produces one (e.g. (count (distinct x))), map used to collect the
+;; unforced lazy into its result LIST, so any downstream consumer that does
+;; not force per element (sum, ==, +) hit an unmaterialised node ("?"/nyi).
+;; ray_map_fn now forces lazy results, so the LIST holds concrete values.
+
+;; ─── count(distinct) in a map lambda — the reported case ─────────────
+(sum (map (fn [_] (count (distinct [1 2 2 3]))) (til 3)))   -- 9
+(sum (map (fn [_] (count (distinct [1 2 3 4 5]))) (til 2))) -- 10
+;; the collected results are concrete i64, usable element-wise
+(set Lm (map (fn [_] (count (distinct [1 2 3]))) (til 3)))
+(+ 0 Lm)            -- [3 3 3]
+(== Lm [3 3 3])     -- [true true true]
+(type (at Lm 1))    -- 'i64
+
+;; ─── other lazy-returning ops in a map lambda ───────────────────────
+;; distinct of a vec is lazy too; the result list holds materialised vecs.
+(sum (map (fn [_] (sum (distinct [1 2 2 3 3]))) (til 2)))   -- 12
+;; reverse is lazy; first-of-reverse per element
+(sum (map (fn [_] (first (reverse [10 20 30]))) (til 3)))  -- 90
+
+;; ─── binary map (map fn val vec) forces results too ─────────────────
+(sum (map (fn [a x] (count (distinct [a x a]))) 7 [1 2 3])) -- 6
+
+;; ─── plain (non-lazy) map results unaffected ────────────────────────
+(sum (map (fn [_] (count [1 2 3])) (til 3)))                -- 9


### PR DESCRIPTION
## Problem

`distinct` / `count` / `reverse` of a concrete vector return a **lazy** node (`ray_lazy_wrap` / `ray_lazy_append`). When a `map` lambda produced one — e.g. `(map (fn [_] (count (distinct x))) range)`, where `distinct(x)` is lazy and `count(lazy)` appends to the lazy chain — `ray_map_fn` collected the **unforced lazy node** straight into its result LIST. It already materialises lazy *inputs* (`args[i]`) but not the per-element *results*. Any downstream consumer that does not force per element then hit an unmaterialised node:

```
(sum (map (fn [_] (count (distinct [1 2 3]))) (til 3)))  -> error: type
(+ 0 <that list>)                                        -> "cannot add i64 and ?"   ('?' = the unforced lazy)
(type (at <that list> 1))                                -> error: nyi
```

…while `(sum (at … 0))` and `(fold + 0 …)` worked (they force per element), and `(sum (map (fn [_] (count v)) …))` worked (plain `count` is not lazy). This is what made it look type-dependent: the result LIST printed as `[3 3 3]` and `(type (at … 0))` reported `i64`, but the stored elements were deferred lazy graphs.

## Fix

`ray_map_fn` now forces a lazy result via `ray_lazy_materialize` after each `call_fn1`/`call_fn2` (before the error check), for both unary and binary map — and thus `pmap`, which delegates. The result LIST holds concrete values, so `sum` / `==` / `+` over it behave correctly; non-lazy results are unaffected.

## Verification

- `hof/map_lazy_result.rfl` covers `count(distinct)` / `sum(distinct)` / `first(reverse)` in unary and binary map lambdas, plus the element-wise consumers (`+`, `==`, `at`/`type`).
- Full suite green under gcc debug+ASan/UBSan, 0 failed — no leak from the materialise (it consumes the lazy node).

Found while writing sym-file/enum coverage; the reduction-of-scalar half of the same investigation landed in #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)