### PR TITLE
Fix #240 GC crash on 16K-page systems + five use-after-free fixes found by new RAY_DFD detector

### DIFF
--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -323,9 +323,14 @@ ray_t* to_boxed_list(ray_t* x) {
         int alloc = 0;
         dst[i] = collection_elem(x, i, &alloc);
         if (RAY_IS_ERR(dst[i])) {
-            for (int64_t j = 0; j < i; j++) ray_release(dst[j]);
+            /* Trim len to the initialized prefix so the list free
+             * releases exactly dst[0..i) — leaving len at the full
+             * length would re-release them and then touch the
+             * uninitialized tail. */
+            ray_t* err = dst[i];
+            list->len = i;
             ray_release(list);
-            return dst[i];
+            return err;
         }
         /* collection_elem always allocates for typed vecs, so ownership transfers */
     }
@@ -957,7 +962,12 @@ ray_t* atomic_map_binary_op(ray_binary_fn fn, uint16_t dag_opcode, ray_t* left, 
         if (la) ray_release(a);
         if (ra) ray_release(b);
         if (RAY_IS_ERR(elem)) {
-            for (int64_t j = 0; j < i; j++) ray_release(out[j]);
+            /* Only out[0..i) are initialized.  Trim len so the list free
+             * releases exactly the filled prefix — with len still at the
+             * full length it would re-release those children after this
+             * path already had (double free) and then "release" the
+             * uninitialized garbage pointers in out[i..len). */
+            result->len = i;
             ray_release(result);
             return elem;
         }
@@ -1036,7 +1046,11 @@ ray_t* atomic_map_unary(ray_unary_fn fn, ray_t* arg) {
         ray_t* elem = RAY_IS_ERR(e) ? e : fn(e);
         if (alloc) ray_release(e);
         if (RAY_IS_ERR(elem)) {
-            for (int64_t j = 0; j < i; j++) ray_release(out[j]);
+            /* Trim to the initialized prefix — see atomic_map_binary_op:
+             * the list free releases len children, so leaving len at the
+             * full length double-freed out[0..i) and released garbage
+             * pointers from the uninitialized tail. */
+            result->len = i;
             ray_release(result);
             return elem;
         }

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -776,7 +776,14 @@ static ray_t* dl_table_add_computed_col(ray_t* tbl, ray_t* new_col, const char* 
 
 /* before(S, E, T): keep rows where T < S */
 static ray_t* dl_builtin_before(ray_t* tbl, int s_col, int t_col) {
-    if (!tbl || RAY_IS_ERR(tbl) || ray_table_nrows(tbl) == 0) return tbl;
+    if (!tbl || RAY_IS_ERR(tbl)) return tbl;
+    /* Empty accum: nothing to filter, but the caller releases its input
+     * unconditionally and adopts the return value as a new owned ref —
+     * hand back a retained tbl exactly like the all-rows-pass path below.
+     * Returning it bare let the caller's release free the table while
+     * still in use; the recycled block then resurfaced as dl_project's
+     * output and was freed a second time via release(accum). */
+    if (ray_table_nrows(tbl) == 0) { ray_retain(tbl); return tbl; }
 
     int64_t nrows = ray_table_nrows(tbl);
     int64_t ncols = ray_table_ncols(tbl);

--- a/src/ops/filter.c
+++ b/src/ops/filter.c
@@ -408,7 +408,15 @@ ray_t* exec_filter(ray_graph_t* g, ray_op_t* op, ray_t* input, ray_t* pred) {
 ray_t* exec_filter_head(ray_t* input, ray_t* pred, int64_t limit) {
     if (!input || RAY_IS_ERR(input)) return input;
     if (!pred || RAY_IS_ERR(pred)) return pred;
-    if (input->type != RAY_TABLE || pred->type != RAY_BOOL) return input;
+    /* Pass-through must hand back an OWNED ref: the exec.c caller
+     * releases its own input ref and returns this value as the node
+     * result, so a bare `input` would leave the result dangling once
+     * that release dropped the last ref.  (NULL/error above stay bare —
+     * retain/release are no-ops for both.) */
+    if (input->type != RAY_TABLE || pred->type != RAY_BOOL) {
+        ray_retain(input);
+        return input;
+    }
 
     int64_t ncols = ray_table_ncols(input);
     int64_t nrows = ray_table_nrows(input);

--- a/src/ops/sort.c
+++ b/src/ops/sort.c
@@ -3242,6 +3242,15 @@ static ray_t* topk_take_vec(ray_t* v, int64_t k, uint8_t desc) {
      * STR-compare reach this — still O(N log N) but correct. */
     ray_t* sorted = desc ? ray_desc_fn(v) : ray_asc_fn(v);
     if (!sorted || RAY_IS_ERR(sorted)) return sorted;
+    /* asc/desc on a concrete vector returns a LAZY handle, and
+     * ray_take_fn materializes lazy args at entry — which CONSUMES the
+     * handle (ray_lazy_materialize releases its input).  Materialize
+     * here instead so take borrows a concrete vector and our release
+     * below drops the ref we actually own; releasing the handle after
+     * take had consumed it was a double free that resurfaced as
+     * cascading stale releases once the slab recycled the block. */
+    if (ray_is_lazy(sorted)) sorted = ray_lazy_materialize(sorted);
+    if (!sorted || RAY_IS_ERR(sorted)) return sorted;
     ray_t* k_atom = ray_i64(k);
     ray_t* out = ray_take_fn(sorted, k_atom);
     ray_release(sorted);

--- a/test/test_csr.c
+++ b/test/test_csr.c
@@ -574,9 +574,12 @@ static test_result_t test_sip_expand(void) {
     ray_op_t* src = ray_const_vec(g, start_vec);
     ray_op_t* expand = ray_expand(g, src, rel, 0);
 
-    /* Attach SIP selection to the expand ext node */
+    /* Attach SIP selection to the expand ext node.  The graph owns a ref
+     * to sip_sel (ray_graph_free releases it), so retain here — the test
+     * keeps and releases its own ref below. */
     for (uint32_t i = 0; i < g->ext_count; i++) {
         if (g->ext_nodes[i] && g->ext_nodes[i]->base.id == expand->id) {
+            ray_retain(src_sel);
             g->ext_nodes[i]->graph.sip_sel = src_sel;
             break;
         }

--- a/test/test_domain.c
+++ b/test/test_domain.c
@@ -158,8 +158,9 @@ static test_result_t test_domain_append_growth_and_cow(void) {
     TEST_ASSERT_EQ_PTR(w->sym_domain, rt);
     TEST_ASSERT_EQ_PTR(v->sym_domain, rt);
 
+    /* ray_vec_append COW'd the shared vec and already dropped the extra
+     * retain via ray_cow's release — one release here drops our ref. */
     ray_release(w);
-    ray_release(v);  /* drops the extra retain */
     ray_release(v);
     PASS();
 }

--- a/test/test_exec.c
+++ b/test/test_exec.c
@@ -7499,8 +7499,15 @@ static ray_t* exec_make_mapcommon(ray_t* key_values, ray_t* row_counts) {
     if (!mc) return NULL;
     mc->type = RAY_MAPCOMMON;
     mc->len  = 2;
+    /* The container owns a ref to each child (ray_release_owned_refs
+     * releases them on free), so take one — the caller keeps its own
+     * ref and releases it in teardown. */
+    if (key_values) ray_retain(key_values);
+    if (row_counts) ray_retain(row_counts);
     ((ray_t**)ray_data(mc))[0] = key_values;
+    ray_retain(key_values);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(mc))[1] = row_counts;
+    ray_retain(row_counts);  /* container owns a ref; teardown releases ours */
     return mc;
 }
 
@@ -7952,7 +7959,9 @@ static test_result_t test_exec_streaming_concat_scan(void) {
     pcol_str->type = (int8_t)(RAY_PARTED_BASE + RAY_STR);
     pcol_str->len  = 2;
     ((ray_t**)ray_data(pcol_str))[0] = seg0_str;
+    ray_retain(seg0_str);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol_str))[1] = seg1_str;
+    ray_retain(seg1_str);  /* container owns a ref; teardown releases ours */
 
     /* MAPCOMMON key column */
     int64_t mc_keys[]   = {1, 2};
@@ -8028,6 +8037,7 @@ static test_result_t test_exec_streaming_all_segments_pruned(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 1;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
 
     ray_t* kv = ray_vec_from_raw(RAY_I64, mc_keys, 1);
     ray_t* rc = ray_vec_from_raw(RAY_I64, mc_counts, 1);
@@ -8279,7 +8289,9 @@ static test_result_t test_exec_streaming_select_root(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     /* MAPCOMMON key column: 2 segments of sizes 3, 2 */
     int64_t mc_keys[]   = {10, 20};
@@ -8352,7 +8364,9 @@ static test_result_t test_exec_streaming_if_root(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     int64_t mc_keys[]   = {1, 2};
     int64_t mc_counts[] = {3, 2};
@@ -8425,7 +8439,9 @@ static test_result_t test_exec_streaming_mapcommon_i32_key(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     /* MAPCOMMON with I32 keys (esz==4): triggers build_segment_table L1892 */
     int32_t kv_data[] = {100, 200};
@@ -8486,8 +8502,11 @@ static test_result_t test_exec_streaming_mapcommon_kv_too_short(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 3;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[2] = seg2;
+    ray_retain(seg2);  /* container owns a ref; teardown releases ours */
 
     /* MAPCOMMON with only 2 keys — mismatches the 3-segment column */
     int64_t kv_data[] = {10, 20};
@@ -8548,7 +8567,9 @@ static test_result_t test_exec_streaming_mismatched_seg_counts(void) {
     pcol_a->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol_a->len  = 2;
     ((ray_t**)ray_data(pcol_a))[0] = a0;
+    ray_retain(a0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol_a))[1] = a1;
+    ray_retain(a1);  /* container owns a ref; teardown releases ours */
 
     /* Parted column B: 3 segments — mismatches column A's seg count */
     int64_t b0d[] = {10};
@@ -8562,8 +8583,11 @@ static test_result_t test_exec_streaming_mismatched_seg_counts(void) {
     pcol_b->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol_b->len  = 3;
     ((ray_t**)ray_data(pcol_b))[0] = b0;
+    ray_retain(b0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol_b))[1] = b1;
+    ray_retain(b1);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol_b))[2] = b2;
+    ray_retain(b2);  /* container owns a ref; teardown releases ours */
 
     int64_t col_a = ray_sym_intern("a", 1);
     int64_t col_b = ray_sym_intern("b", 1);
@@ -8612,7 +8636,9 @@ static test_result_t test_exec_streaming_mapcommon_too_short(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     /* Malformed MAPCOMMON: len=1 (expects 2 pointers [kv, rc]).
      * build_segment_table checks col->len < 2 → schema error (L1864).  */
@@ -8623,6 +8649,7 @@ static test_result_t test_exec_streaming_mapcommon_too_short(void) {
     mc->type = RAY_MAPCOMMON;
     mc->len  = 1;                                /* < 2 → triggers L1864 */
     ((ray_t**)ray_data(mc))[0] = kv;
+    ray_retain(kv);  /* container owns a ref; teardown releases ours */
 
     int64_t col_k = ray_sym_intern("k", 1);
     int64_t col_v = ray_sym_intern("v", 1);
@@ -8667,6 +8694,7 @@ static test_result_t test_exec_streaming_parted_null_segment(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = NULL;  /* NULL segment at index 1 */
 
     /* Valid MAPCOMMON with 2 keys */
@@ -8725,7 +8753,9 @@ static test_result_t test_exec_streaming_mapcommon_i16_key(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     /* MAPCOMMON with I16 keys (esz==2): triggers L1896 else path */
     int16_t kv_data[] = {100, 200};
@@ -8948,7 +8978,9 @@ static test_result_t test_exec_streaming_large_dag(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     int64_t mc_keys[]   = {1, 2};
     int64_t mc_counts[] = {2, 2};
@@ -9015,6 +9047,7 @@ static test_result_t test_exec_filter_group_parted_empty(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 1;  /* 1 segment, but 0 rows total */
     ((ray_t**)ray_data(pcol))[0] = empty_seg;
+    ray_retain(empty_seg);  /* container owns a ref; teardown releases ours */
 
     int64_t col_a = ray_sym_intern("a", 1);
     ray_t* tbl = ray_table_new(1);
@@ -9086,7 +9119,9 @@ static test_result_t test_exec_head_parted_sym_wrong_esz(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_SYM);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     int64_t col_s = ray_sym_intern("s", 1);
     ray_t* tbl = ray_table_new(1);
@@ -9148,7 +9183,9 @@ static test_result_t test_exec_tail_parted_sym_wrong_esz(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_SYM);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     int64_t col_s = ray_sym_intern("s", 1);
     ray_t* tbl = ray_table_new(1);
@@ -9241,7 +9278,9 @@ static test_result_t test_exec_streaming_seg_mask_mismatch(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     int64_t mc_keys[]   = {1, 2};
     int64_t mc_counts[] = {2, 2};
@@ -9329,7 +9368,9 @@ static test_result_t test_exec_scan_parted_sym_wrong_esz(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_SYM);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     int64_t col_s = ray_sym_intern("s", 1);
     ray_t* tbl = ray_table_new(1);
@@ -9376,7 +9417,9 @@ static test_result_t test_exec_streaming_mapcommon_sel_key(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     /* MAPCOMMON where kv->type = RAY_SEL (type 14, esz=0) */
     int64_t mc_counts[] = {2, 2};
@@ -9393,7 +9436,9 @@ static test_result_t test_exec_streaming_mapcommon_sel_key(void) {
     mc->type = RAY_MAPCOMMON;
     mc->len  = 2;
     ((ray_t**)ray_data(mc))[0] = kv;
+    ray_retain(kv);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(mc))[1] = rc;
+    ray_retain(rc);  /* container owns a ref; teardown releases ours */
 
     int64_t col_grp = ray_sym_intern("grp", 3);
     int64_t col_v   = ray_sym_intern("v",   1);
@@ -9443,7 +9488,9 @@ static test_result_t test_exec_streaming_mapcommon_list_kv_type(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     /* MAPCOMMON where kv->type = RAY_LIST(0): esz=8, but ray_vec_new(0,n)
      * fails because type<=0 is rejected → L1882 fires.                */
@@ -9461,7 +9508,9 @@ static test_result_t test_exec_streaming_mapcommon_list_kv_type(void) {
     mc->type = RAY_MAPCOMMON;
     mc->len  = 2;
     ((ray_t**)ray_data(mc))[0] = kv;
+    ray_retain(kv);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(mc))[1] = rc;
+    ray_retain(rc);  /* container owns a ref; teardown releases ours */
 
     int64_t col_grp = ray_sym_intern("grp", 3);
     int64_t col_v   = ray_sym_intern("v",   1);
@@ -9518,7 +9567,9 @@ static test_result_t test_exec_streaming_mapcommon_list_key_empty(void) {
     pcol->type = (int8_t)(RAY_PARTED_BASE + RAY_I64);
     pcol->len  = 2;
     ((ray_t**)ray_data(pcol))[0] = seg0;
+    ray_retain(seg0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(pcol))[1] = seg1;
+    ray_retain(seg1);  /* container owns a ref; teardown releases ours */
 
     /* Create a MAPCOMMON where kv (mc[0]) has type=RAY_LIST=0.
      * rc (mc[1]) is a normal I64 counts vector.                        */
@@ -9538,7 +9589,9 @@ static test_result_t test_exec_streaming_mapcommon_list_key_empty(void) {
     mc->type = RAY_MAPCOMMON;
     mc->len  = 2;
     ((ray_t**)ray_data(mc))[0] = kv;
+    ray_retain(kv);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(mc))[1] = rc;
+    ray_retain(rc);  /* container owns a ref; teardown releases ours */
 
     int64_t col_grp = ray_sym_intern("grp", 3);
     int64_t col_v   = ray_sym_intern("v",   1);

--- a/test/test_heap.c
+++ b/test/test_heap.c
@@ -673,7 +673,9 @@ static test_result_t test_mapcommon_owned_ref(void) {
     ray_t** slots = (ray_t**)ray_data(mc);
     slots[0] = a;
     slots[1] = b;
-    /* mc takes the only refs; we already own one each. */
+    /* mc owns a ref to each child (released on free); keep our own too. */
+    ray_retain(a);
+    ray_retain(b);
 
     uint32_t a_rc = a->rc, b_rc = b->rc;
 
@@ -801,7 +803,9 @@ static test_result_t test_alloc_copy_table_block(void) {
     tbl->len  = 0;
     ray_t** slots = (ray_t**)ray_data(tbl);
     slots[0] = schema; slots[1] = cols;
-    /* tbl owns one ref each — we already have one ref each from alloc. */
+    /* tbl owns a ref to each child (released on free); keep our own too. */
+    ray_retain(schema);
+    ray_retain(cols);
 
     uint32_t s_rc = schema->rc, c_rc = cols->rc;
 
@@ -1020,6 +1024,9 @@ static test_result_t test_alloc_copy_dict_block(void) {
     dict->len  = 0;
     ray_t** sl = (ray_t**)ray_data(dict);
     sl[0] = keys; sl[1] = vals;
+    /* dict owns a ref to each child (released on free); keep our own too. */
+    ray_retain(keys);
+    ray_retain(vals);
 
     uint32_t k_rc = keys->rc, v_rc = vals->rc;
 

--- a/test/test_partition_exec.c
+++ b/test/test_partition_exec.c
@@ -66,20 +66,32 @@ static ray_t* make_mapcommon(ray_t* key_values, ray_t* row_counts) {
     if (!mc) return NULL;
     mc->type = RAY_MAPCOMMON;
     mc->len = 2;
+    /* The container owns a ref to each child (ray_release_owned_refs
+     * releases them on free), so take one — the caller keeps its own
+     * ref and releases it in teardown. */
+    if (key_values) ray_retain(key_values);
+    if (row_counts) ray_retain(row_counts);
     ((ray_t**)ray_data(mc))[0] = key_values;
+    ray_retain(key_values);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(mc))[1] = row_counts;
+    ray_retain(row_counts);  /* container owns a ref; teardown releases ours */
     return mc;
 }
 
 /* Build a parted column wrapping `n_segs` segment vectors of `base` type.
- * Segments are referenced (not retained) so caller still owns them. */
+ * Each segment is retained — the parted container owns a ref per segment
+ * (released by ray_release_owned_refs on free), and the caller still owns
+ * and releases its own refs in teardown. */
 static ray_t* make_parted(int8_t base, ray_t** segs, int64_t n_segs) {
     ray_t* p = ray_alloc((size_t)n_segs * sizeof(ray_t*));
     if (!p) return NULL;
     p->type = RAY_PARTED_BASE + base;
     p->len = n_segs;
     ray_t** out = (ray_t**)ray_data(p);
-    for (int64_t i = 0; i < n_segs; i++) out[i] = segs[i];
+    for (int64_t i = 0; i < n_segs; i++) {
+        if (segs[i] && !RAY_IS_ERR(segs[i])) ray_retain(segs[i]);
+        out[i] = segs[i];
+    }
     return p;
 }
 
@@ -1831,7 +1843,9 @@ static test_result_t test_filter_parted_esz_mismatch(void) {
     parted_em->type = RAY_PARTED_BASE + RAY_SYM;
     parted_em->len = 2;
     ((ray_t**)ray_data(parted_em))[0] = segs_em[0];
+    ray_retain(segs_em[0]);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(parted_em))[1] = segs_em[1];
+    ray_retain(segs_em[1]);
 
     /* Flat I64 companion */
     ray_t* flat_em = ray_vec_new(RAY_I64, 10); flat_em->len = 10;
@@ -2384,7 +2398,11 @@ static test_result_t test_parted_gather_col_null_seg(void) {
     parted_ns->type = RAY_PARTED_BASE + RAY_I64;
     parted_ns->len  = N_SEGS;
     ray_t** slot_ns = (ray_t**)ray_data(parted_ns);
-    for (int s = 0; s < N_SEGS; s++) slot_ns[s] = segs_ns[s];
+    for (int s = 0; s < N_SEGS; s++) {
+        slot_ns[s] = segs_ns[s];
+        /* container owns a ref per (non-NULL) segment; teardown releases ours */
+        if (segs_ns[s]) ray_retain(segs_ns[s]);
+    }
 
     /* ray_parted_nrows counts only non-null segs = 75000.
      * The flat companion and pred must also be 75000. */
@@ -2505,7 +2523,9 @@ static test_result_t test_filter_head_parted_esz_skip(void) {
     parted_he->type = RAY_PARTED_BASE + RAY_SYM;
     parted_he->len  = 2;
     ((ray_t**)ray_data(parted_he))[0] = seg_h0;
+    ray_retain(seg_h0);  /* container owns a ref; teardown releases ours */
     ((ray_t**)ray_data(parted_he))[1] = seg_h1;
+    ray_retain(seg_h1);  /* container owns a ref; teardown releases ours */
 
     ray_t* flat_he = ray_vec_new(RAY_I64, 10); flat_he->len = 10;
     int64_t* fhed = (int64_t*)ray_data(flat_he);
@@ -2583,6 +2603,8 @@ static test_result_t test_parted_gather_col_esz_mismatch(void) {
     parted_em2->len  = 4;
     ray_t** slot_em2 = (ray_t**)ray_data(parted_em2);
     slot_em2[0] = seg_a; slot_em2[1] = seg_b; slot_em2[2] = seg_c; slot_em2[3] = seg_d;
+    /* container owns a ref per segment; teardown releases ours */
+    ray_retain(seg_a); ray_retain(seg_b); ray_retain(seg_c); ray_retain(seg_d);
 
     /* Total rows from ray_parted_nrows = 75000 + 100 = 75100 > 65536 */
     const int64_t N = SEG_W16 * 3 + SEG_W8;

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -2048,7 +2048,7 @@ static test_result_t test_serde_table_roundtrip(void) {
     TEST_ASSERT_EQ_I(outd[0], 10);
     TEST_ASSERT_EQ_I(outd[1], 20);
     TEST_ASSERT_EQ_I(outd[2], 30);
-    ray_release(col_out);
+    /* col_out is a borrowed pointer (ray_table_get_col does not retain) */
 
     ray_release(b); ray_release(w); ray_release(tbl);
     PASS();
@@ -2358,10 +2358,8 @@ static test_result_t test_serde_list_with_null_elem(void) {
     TEST_ASSERT_TRUE(RAY_IS_NULL(be[1]));
 
     ray_release(b); ray_release(w);
-    /* Release list elements manually since list owns them */
-    ray_release(elems[0]);
-    /* elems[1] is RAY_NULL_OBJ — do not release */
-    ray_release(elems[2]);
+    /* The list owns the element refs — releasing it releases them.
+     * (RAY_NULL_OBJ at [1] is ARENA-flagged; release is a no-op.) */
     ray_release(list);
     PASS();
 }


### PR DESCRIPTION
## Summary

Started as the fix for #240 (segfault in `ray_heap_gc` on Apple Silicon) and grew into a memory-safety sweep: the investigation produced an opt-in use-after-free detector for the pool allocator, which then surfaced five more genuine bugs (four core, one large family of test-code double frees). The full suite is now detector-clean.

### Fixes #240 — `a850a767`

GC pass 5 madvises the interior of freelist-linked blocks, skipping a hardcoded 4096-byte "first page" to protect the `fl_prev`/`fl_next` links. macOS arm64 has 16K pages and Darwin's `madvise` rounds unaligned ranges *outward* (`trunc_page`/`round_page` in xnu), so the start fell back to `blk` and `MADV_FREE` hit the header page of a live freelist node. Once the kernel reclaimed the page, `fl_next` read back as zero and the next GC walk crashed dereferencing `NULL + 8` — exactly the reporter's `EXC_BAD_ACCESS (address=0x8)`. Now the release range is rounded inward to whole pages of the real `sysconf(_SC_PAGESIZE)`, making the kernel's rounding a no-op everywhere. Mechanism + fix verified with a harness emulating Darwin's rounding.

### RAY_DFD detector — `c6f4e7c5`

ASan can't see use-after-free inside the mmap-backed pool allocator (why #240 and everything below survived sanitized builds). Debug builds now have an opt-in (`RAY_DFD=1`) shadow set of currently-free blocks, checked on every `ray_free`/`ray_release`/`ray_retain`; hits report a backtrace and abort before allocator state corrupts. `RAY_DFD_NO_ABORT=1` collects instead. GC entry also validates all freelists for NULL links/cycles.

### Core use-after-free fixes — `ab5ff350`, `7e0ed7e6`

All flagged by the detector, all reproduce in isolation:

- **datalog `dl_builtin_before`**: returned its input unretained on empty tables; the caller releases its input unconditionally (`DL_BUILTIN` helpers' contract is "return a NEW owned table").
- **eval.c boxed-list maps** (`atomic_map_binary_op`, `atomic_map_unary`, `to_boxed_list`): mid-loop error cleanup double-released the filled prefix and "released" uninitialized tail pointers, because `len` was set to the full length before filling. Reachable from any error midway through an atomic map, e.g. `(+ [[1 2] [3]] [[1 2] "x"])`.
- **filter.c `exec_filter_head`**: non-table/non-BOOL pass-through returned `input` unretained while the exec OP_HEAD call site releases its input and returns the value — dangling node result for head-limited filters with a non-BOOL predicate.
- **sort.c `topk_take_vec`**: passed the lazy asc/desc handle into `ray_take_fn`, which materializes lazy args at entry and thereby *consumes* the handle; the subsequent release double-freed it. Hit by `(top v n)` / `(bot v n)` on STR/GUID/LIST vectors (rfl/sort coverage).

### Interactive crash fix — `6842ae04`

Found by pty-fuzzing the REPL during the #240 hunt: stale completion word span after an early return in `ray_term_update_ghost` made TAB compute a negative tail in `comp_cycle_insert` — a huge `memmove`. Repro: type a long line, Ctrl-C, type `t`, TAB.

### Test-code double frees — `db74191a`

~60 sites hand-assembled containers (PARTED/MAPCOMMON/TABLE/DICT/LIST via raw `ray_alloc`) without retaining children, then released both container and children in teardown. Also: `sip_sel` ownership in test_csr, a duplicate release in test_domain, and releasing `ray_table_get_col`'s borrowed pointer in test_store.

## Validation

- Full suite: 3358/3360 passed (2 skipped, 0 failed), repeated runs.
- `RAY_DFD=1` full-suite runs: **364 hits before → 0 after**, verified across consecutive runs (hit visibility varies with slab recycling/thread timing, so single clean runs aren't trusted).
- Release build runs the #240 repro (interactive and piped) cleanly.
- Issue comment with the root-cause analysis: #240.