### PR TITLE
feat(ipc): unify connection handles into poll selector ids (server push)

### DIFF
--- a/docs/docs/namespaces/ipc.md
+++ b/docs/docs/namespaces/ipc.md
@@ -1,6 +1,9 @@
-# `.ipc.*` — client IPC
+# `.ipc.*` — connection IPC
 
-Connect to a Rayforce server (`./rayforce -p <port>`) and exchange messages over TCP. The wire format is the same compact binary serialisation used for `ser`/`de`, with automatic delta+RLE compression for payloads larger than 2,000 bytes. All five client builtins live here; the server-side connection hooks (`.ipc.on.open` / `.on.close` / `.on.sync` / `.on.async` / `.on.auth`) live on the [IPC Connection Hooks](../storage/ipc-hooks.md) page — they are user-settable lambda slots, not registered builtins, so they don't appear in the reference table below.
+Connect to a Rayforce server (`./rayforce -p <port>`) and exchange messages over TCP. The wire format is the same compact binary serialisation used for `ser`/`de`, with automatic delta+RLE compression for payloads larger than 2,000 bytes. All five connection builtins live here; the server-side connection hooks (`.ipc.on.open` / `.on.close` / `.on.sync` / `.on.async` / `.on.auth`) live on the [IPC Connection Hooks](../storage/ipc-hooks.md) page — they are user-settable lambda slots, not registered builtins, so they don't appear in the reference table below.
+
+!!! note "One handle namespace"
+    A handle is a handle, whichever side of the wire you are on: the `i64` returned by `.ipc.open` and the `h` a server-side hook receives (or reads via `.ipc.handle`) name connections in the same namespace, and `.ipc.send`, `.ipc.post`, and `.ipc.close` accept either. A server can therefore push messages back through the handle its hooks were given — from inside the hook or any time later — kdb-style. Handles are only meaningful inside the process that owns the connection; they are not stable identifiers across processes or reconnects.
 
 !!! note "Restricted under `-U`"
     `.ipc.open`, `.ipc.close`, `.ipc.send`, and `.ipc.post` are `RAY_FN_RESTRICTED` — IPC chaining is blocked on a `-U` server (a peer cannot dial outward to a third server). `.ipc.handle` is always available so hooks can read the current connection ID.
@@ -38,16 +41,18 @@ The handshake exchanges a 2-byte `{wire_version, auth_flag}` greeting. A wire-ve
 
 ## `.ipc.send` { #ipc-send }
 
-Signature: `(.ipc.send h msg)`. Sends `msg` synchronously — blocks until the server replies.
+Signature: `(.ipc.send h msg)`. Sends `msg` synchronously — blocks until the peer replies.
 
-The server's behaviour depends on `msg`'s type:
+The receiving side's behaviour depends on `msg`'s type:
 
-| Payload | Server behaviour |
+| Payload | Peer behaviour |
 |---|---|
 | `STR` | Parsed as Rayfall, evaluated, result returned. |
 | anything else | Passed straight into `ray_eval` — identity for plain data, execution for an expression list. |
 
-Errors: `type` (`h` not an `i64`/`i32`, or `msg` not serialisable). Server-side errors are returned as error objects too — `.ipc.send` does not raise them, the caller decides what to do.
+Errors: `type` (`h` not an `i64`/`i32`, or `msg` not serialisable), `io` (handle does not name an open connection). Server-side errors are returned as error objects too — `.ipc.send` does not raise them, the caller decides what to do.
+
+While waiting for its response, `.ipc.send` keeps servicing the connection: an async message pushed by the peer in the meantime is dispatched (evaluated, or routed through `.ipc.on.async`) before the round-trip returns, and a sync request arriving from the peer is answered. Frames are never silently swallowed by the wait.
 
 ```lisp
 ;; String-form query
@@ -65,21 +70,26 @@ For async fire-and-forget, see `.ipc.post` below. See [IPC & Serialization](../s
 
 ## `.ipc.post` { #ipc-post }
 
-Signature: `(.ipc.post h msg)`. Sends `msg` asynchronously — fire-and-forget. Unlike `.ipc.send`, it does **not** wait for a reply: the server runs the message through its `.ipc.on.async` hook (or default evaluation) and sends nothing back.
+Signature: `(.ipc.post h msg)`. Sends `msg` asynchronously — fire-and-forget. Unlike `.ipc.send`, it does **not** wait for a reply: the peer runs the message through its `.ipc.on.async` hook (or default evaluation) and sends nothing back.
 
-Because no response is returned, the only failures the caller can observe are **local** ones. A server-side evaluation error is logged on the server and dropped — it never reaches the sender.
+Because no response is returned, the only failures the caller can observe are **local** ones. A remote evaluation error is logged on the receiving side and dropped — it never reaches the sender.
 
 Returns the null object on a successful local send. Errors: `type` (`h` not an `i64`/`i32`, or `msg` not serialisable), `io` (handle invalid / connection closed / socket write failed).
 
 ```lisp
-;; Push a state update to the server and move on — no round-trip.
-;; The string payload is parsed and evaluated server-side, just like `.ipc.send`.
+;; Client → server: push a state update and move on — no round-trip.
+;; The string payload is parsed and evaluated remotely, just like `.ipc.send`.
 (.ipc.post h "(set last-update 42)")
+
+;; Server → client: push through the handle a hook received.  The client
+;; evaluates the message when it next services the connection — in its
+;; poll loop, or while blocked inside one of its own `.ipc.send` waits.
+(set .ipc.on.open (fn [h] (.ipc.post h "(println \"welcome\")")))
 ```
 
 ## `.ipc.close` { #ipc-close }
 
-Signature: `(.ipc.close h)`. Closes the socket for the handle. Returns the null object.
+Signature: `(.ipc.close h)`. Closes the connection for the handle — either an outbound handle from `.ipc.open` or an inbound one a server-side hook received (a server can kick a client). Closing an inbound connection fires `.ipc.on.close` as usual. Returns the null object.
 
 ```lisp
 (.ipc.close h)

--- a/docs/docs/storage/ipc-hooks.md
+++ b/docs/docs/storage/ipc-hooks.md
@@ -2,6 +2,8 @@
 
 Five user-installable lambdas under `.ipc.on.*` that intercept the server-side connection lifecycle, plus the `.ipc.handle` accessor for the current connection's handle.
 
+The handle a hook receives is a first-class connection handle — the same namespace `.ipc.open` allocates from. Pass it to `.ipc.post` (async push to the connected client), `.ipc.send` (sync round-trip), or `.ipc.close` (kick the client), from inside the hook or any time later. Lifecycle hooks fire for **inbound** connections only; connections the process itself opened via `.ipc.open` never trigger `on.open`/`on.close`.
+
 !!! note "See also"
     The [IPC & Serialization](ipc.md) page documents the client-side `.ipc.open` / `.ipc.send` / `.ipc.close` and the wire format. Hooks live on the server and fire in response to inbound connections.
 
@@ -25,6 +27,11 @@ Install with plain `set` or the colon binder:
 ```lisp
 (set .ipc.on.open  (fn [h] (println "+ " h)))
 (set .ipc.on.close (fn [h] (println "- " h)))
+
+;; Server push: greet every client as soon as it connects, and remember
+;; the handle for later pushes from anywhere on the server.
+(set .ipc.on.open
+     (fn [h] (set last-client h) (.ipc.post h "(println \"welcome\")")))
 
 ;; Sync hook receives the raw deserialised payload.  Strings need an
 ;; explicit parse before eval; the default in-server dispatch does this
@@ -77,3 +84,5 @@ Inside any hook, `(.ipc.handle)` returns the handle of the connection that trigg
 ```
 
 The argument `h` passed to `on.open` / `on.close` always equals `(.ipc.handle)` at the moment the hook fires — the builtin is the only way to reach the handle from `on.sync` / `on.async` / `on.auth`, whose signatures don't include it directly.
+
+A handle read here stays valid for the connection's lifetime: store it and `.ipc.post` to it later (publish/subscribe), or `.ipc.close` it to drop the client. After the connection closes, the integer may be reused by a future connection — don't cache handles across `on.close`.

--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -217,6 +217,23 @@ enum {
 
 static _Thread_local int64_t g_current_handle = -1;
 
+/* The poll whose event dispatch is currently on this thread's stack.
+ * Connection handles are selector ids, so resolving one needs the poll
+ * it lives in: inside a hook / inbound eval that's the poll that fired
+ * it; everywhere else (REPL, scripts) it's the runtime's main poll.
+ * Saved/restored exactly like g_current_handle. */
+static _Thread_local ray_poll_t* g_current_poll = NULL;
+
+/* From core/runtime.h — not included here because lang/eval.h (included
+ * below) and core/runtime.h declare conflicting ray_vm_t types; see the
+ * matching note in test/test_ipc.c. */
+extern void* ray_runtime_get_poll(void);
+
+static ray_poll_t* ipc_active_poll(void) {
+    return g_current_poll ? g_current_poll
+                          : (ray_poll_t*)ray_runtime_get_poll();
+}
+
 int64_t ray_ipc_current_handle(void) {
     return g_current_handle;
 }
@@ -238,16 +255,22 @@ static ray_t* hook_lookup(int idx) {
 
 /* Call a single-arg hook for lifecycle events (on.open / on.close).
  * Errors are logged and swallowed — a buggy logging hook must never
- * wedge connection teardown. */
-static void hook_call_lifecycle(int idx, int64_t handle) {
+ * wedge connection teardown.  `poll` is the poll the connection lives
+ * in, exposed thread-locally so the hook body can use the handle with
+ * `.ipc.post` / `.ipc.send` / `.ipc.close`; the legacy server path
+ * passes NULL (its conn-index handles are not selector ids). */
+static void hook_call_lifecycle(ray_poll_t* poll, int idx, int64_t handle) {
     ray_t* fn = hook_lookup(idx);
     if (!fn) return;
     ray_t* arg = make_i64(handle);
     if (!arg || RAY_IS_ERR(arg)) { if (arg) ray_release(arg); return; }
     int64_t prev = g_current_handle;
+    ray_poll_t* prev_poll = g_current_poll;
     g_current_handle = handle;
+    if (poll) g_current_poll = poll;
     ray_t* r = call_fn1(fn, arg);
     g_current_handle = prev;
+    g_current_poll   = prev_poll;
     if (r && RAY_IS_ERR(r)) {
         const char* name = (idx == IPC_HOOK_OPEN) ? ".ipc.on.open" : ".ipc.on.close";
         fprintf(stderr, "ipc: %s hook raised an error (handle=%lld)\n",
@@ -263,8 +286,8 @@ static void hook_call_lifecycle(int idx, int64_t handle) {
  *  - -1 → no hook installed; caller uses the existing pass-through.
  * The constant-time secret compare in validate_creds always runs first,
  * so this hook can only narrow access — never widen it. */
-static int hook_call_auth(int64_t handle, const uint8_t* cred_buf,
-                          uint8_t cred_len) {
+static int hook_call_auth(ray_poll_t* poll, int64_t handle,
+                          const uint8_t* cred_buf, uint8_t cred_len) {
     ray_t* fn = hook_lookup(IPC_HOOK_AUTH);
     if (!fn) return -1;
 
@@ -288,9 +311,12 @@ static int hook_call_auth(int64_t handle, const uint8_t* cred_buf,
         return 0;  /* allocation failure → reject conservatively */
     }
     int64_t prev = g_current_handle;
+    ray_poll_t* prev_poll = g_current_poll;
     g_current_handle = handle;
+    if (poll) g_current_poll = poll;
     ray_t* r = call_fn2(fn, u, p);
     g_current_handle = prev;
+    g_current_poll   = prev_poll;
     ray_release(u);
     ray_release(p);
 
@@ -358,6 +384,35 @@ static void send_response(ray_sock_t fd, ray_t* result)
     if (payload) ray_sys_free(payload);
 }
 
+/* Decompress (when flagged) + de-serialize one framed payload into an
+ * object.  Returns NULL on any decompress/decode failure.  Shared by
+ * the request-eval path below and the RESP-frame path in
+ * ipc_read_payload. */
+static ray_t* deser_frame(uint8_t* payload, size_t payload_len, uint8_t flags)
+{
+    uint8_t* decompressed = NULL;
+    if (flags & RAY_IPC_FLAG_COMPRESSED) {
+        if (payload_len < 4) return NULL;
+        uint32_t uncomp_size;
+        memcpy(&uncomp_size, payload, 4);
+        if (uncomp_size == 0 || uncomp_size > 256u * 1024u * 1024u) return NULL;
+        decompressed = (uint8_t*)ray_sys_alloc(uncomp_size);
+        if (!decompressed) return NULL;
+        size_t dlen = ray_ipc_decompress(payload + 4, payload_len - 4,
+                                         decompressed, uncomp_size);
+        if (dlen != uncomp_size) {
+            ray_sys_free(decompressed);
+            return NULL;
+        }
+        payload     = decompressed;
+        payload_len = uncomp_size;
+    }
+    int64_t de_len = (int64_t)payload_len;
+    ray_t*  msg    = ray_de_raw(payload, &de_len);
+    if (decompressed) ray_sys_free(decompressed);
+    return msg;
+}
+
 /* Run the actual decompress + de-serialize + ray_eval pipeline on a
  * single inbound payload.  The wrapper eval_payload() below decides
  * whether to capture stdout/stderr (RAY_IPC_FLAG_VERBOSE) and whether
@@ -398,27 +453,7 @@ static ray_t* eval_payload_core(uint8_t* payload, size_t payload_len,
         }
     }
 
-    uint8_t* decompressed = NULL;
-    if (hdr->flags & RAY_IPC_FLAG_COMPRESSED) {
-        if (payload_len < 4) return NULL;
-        uint32_t uncomp_size;
-        memcpy(&uncomp_size, payload, 4);
-        if (uncomp_size == 0 || uncomp_size > 256u * 1024u * 1024u) return NULL;
-        decompressed = (uint8_t*)ray_sys_alloc(uncomp_size);
-        if (!decompressed) return NULL;
-        size_t dlen = ray_ipc_decompress(payload + 4, payload_len - 4,
-                                         decompressed, uncomp_size);
-        if (dlen != uncomp_size) {
-            ray_sys_free(decompressed);
-            return NULL;
-        }
-        payload     = decompressed;
-        payload_len = uncomp_size;
-    }
-
-    int64_t de_len = (int64_t)payload_len;
-    ray_t*  msg    = ray_de_raw(payload, &de_len);
-    if (decompressed) ray_sys_free(decompressed);
+    ray_t* msg = deser_frame(payload, payload_len, hdr->flags);
 
     ray_t* result = NULL;
     if (msg && !RAY_IS_ERR(msg)) {
@@ -550,13 +585,23 @@ static ray_t* eval_payload(uint8_t* payload, size_t payload_len,
  * Poll-based IPC (new API)
  * ====================================================================== */
 
-/* Per-connection state stored in selector->data */
+/* Per-connection state stored in selector->data.  Used for BOTH
+ * directions: inbound conns accepted by a listener and outbound conns
+ * registered by ray_ipc_connect — the selector id is the one handle
+ * namespace either side of the wire works with. */
 typedef struct {
     ray_ipc_header_t hdr;
     uint8_t          phase;
-    int64_t          listener_id;  /* id of the listener selector */
+    int64_t          listener_id;  /* id of the listener selector; -1 = outbound */
     bool             auth_required;  /* server has -u/-U */
     bool             restricted;     /* server has -U */
+    /* Sync round-trip state: while a ray_ipc_send waits on this conn it
+     * pumps the rx machinery itself; a RESP frame is deposited here
+     * instead of being evaluated.  Interleaved ASYNC/SYNC frames still
+     * dispatch normally during the wait. */
+    bool             sync_waiting;
+    bool             sync_ready;
+    ray_t*           sync_resp;
 } ray_ipc_conn_data_t;
 
 static ray_t* ipc_read_handshake(ray_poll_t* poll, ray_selector_t* sel);
@@ -639,7 +684,7 @@ static ray_t* ipc_read_handshake(ray_poll_t* poll, ray_selector_t* sel)
     /* No-auth path: connection is now fully ready for inbound messages.
      * Fire `.ipc.on.open` AFTER we've requested the next read, so a
      * hook that calls back into the server can't race the read pump. */
-    hook_call_lifecycle(IPC_HOOK_OPEN, sel->id);
+    hook_call_lifecycle(poll, IPC_HOOK_OPEN, sel->id);
     return NULL;
 }
 
@@ -680,7 +725,7 @@ static ray_t* ipc_read_creds(ray_poll_t* poll, ray_selector_t* sel)
      * falsy returns flip `ok` to false, triggering the same reject byte
      * + deregister the secret-mismatch path would. */
     if (ok) {
-        int hook_ok = hook_call_auth(sel->id, sel->rx.buf->data + 1, cred_len);
+        int hook_ok = hook_call_auth(poll, sel->id, sel->rx.buf->data + 1, cred_len);
         if (hook_ok == 0) ok = false;
     }
 
@@ -698,7 +743,7 @@ static ray_t* ipc_read_creds(ray_poll_t* poll, ray_selector_t* sel)
     /* Auth path: fully handshaked and authed — connection is now ready
      * for inbound messages.  Same ordering as the no-auth branch above:
      * fire AFTER the next read is requested. */
-    hook_call_lifecycle(IPC_HOOK_OPEN, sel->id);
+    hook_call_lifecycle(poll, IPC_HOOK_OPEN, sel->id);
     return NULL;
 }
 
@@ -733,33 +778,70 @@ static ray_t* ipc_read_payload(ray_poll_t* poll, ray_selector_t* sel)
     if (!sel->rx.buf || sel->rx.buf->offset < cd->hdr.size)
         return NULL;
 
-    bool prev_restricted = ray_eval_get_restricted();
-    ray_eval_set_restricted(cd->restricted);
-
-    /* Expose this connection's selector id to `.ipc.handle` for the
-     * duration of any `.ipc.on.sync` / `.ipc.on.async` hook that runs
-     * inside eval_payload.  Save/restore so a hook that itself opens
-     * a nested IPC round-trip doesn't leave the wrong handle visible
-     * when its caller resumes. */
-    int64_t prev_handle = g_current_handle;
-    g_current_handle    = sel->id;
-
-    /* Eval and produce result */
-    ray_t* result = eval_payload(sel->rx.buf->data,
-                                 (size_t)sel->rx.buf->offset, &cd->hdr);
-
-    g_current_handle = prev_handle;
-    ray_eval_set_restricted(prev_restricted);
-
-    /* Send response for sync messages */
-    if (cd->hdr.msgtype == RAY_IPC_MSG_SYNC)
-        send_response((ray_sock_t)sel->fd, result);
-    if (result != RAY_NULL_OBJ) ray_release(result);
-
-    /* Reset for next message */
+    /* Detach the payload buffer and advance the state machine to the
+     * next header BEFORE dispatching: the eval below may re-enter this
+     * connection's rx pump (a hook doing a nested sync round-trip on
+     * the same handle), and that pump must find the selector parked on
+     * a fresh header read — not on this very payload, which would
+     * re-dispatch it.  Same reason for the local header copy: a nested
+     * frame would overwrite cd->hdr under our feet. */
+    ray_ipc_header_t hdr     = cd->hdr;
+    ray_poll_buf_t*  payload = sel->rx.buf;
+    int64_t          id      = sel->id;
+    sel->rx.buf = NULL;
     cd->phase = RAY_IPC_PHASE_HEADER;
     sel->rx.read_fn = ipc_read_header;
     ray_poll_rx_request(poll, sel, sizeof(ray_ipc_header_t));
+
+    /* Response frame: deposit it for the sync send waiting on this
+     * conn instead of evaluating it.  A response nobody waits for has
+     * no defined meaning — log and drop. */
+    if (hdr.msgtype == RAY_IPC_MSG_RESP) {
+        ray_t* obj = deser_frame(payload->data, (size_t)payload->offset,
+                                 hdr.flags);
+        ray_poll_buf_free(payload);
+        if (cd->sync_waiting && !cd->sync_ready) {
+            cd->sync_resp  = obj;
+            cd->sync_ready = true;
+        } else {
+            fprintf(stderr, "ipc: dropping unexpected response frame "
+                            "(handle=%lld)\n", (long long)id);
+            if (obj && obj != RAY_NULL_OBJ) ray_release(obj);
+        }
+        return NULL;
+    }
+
+    bool prev_restricted = ray_eval_get_restricted();
+    ray_eval_set_restricted(cd->restricted);
+
+    /* Expose this connection's selector id to `.ipc.handle` (and its
+     * poll to handle resolution) for the duration of any hook that
+     * runs inside eval_payload.  Save/restore so a hook that itself
+     * opens a nested IPC round-trip doesn't leave the wrong handle
+     * visible when its caller resumes. */
+    int64_t prev_handle = g_current_handle;
+    ray_poll_t* prev_poll = g_current_poll;
+    g_current_handle = id;
+    g_current_poll   = poll;
+
+    /* Eval and produce result */
+    ray_t* result = eval_payload(payload->data,
+                                 (size_t)payload->offset, &hdr);
+
+    g_current_handle = prev_handle;
+    g_current_poll   = prev_poll;
+    ray_eval_set_restricted(prev_restricted);
+    ray_poll_buf_free(payload);
+
+    /* Send response for sync messages.  The eval may have closed this
+     * very connection (`.ipc.close` on its own handle) — revalidate the
+     * selector before writing to its fd. */
+    if (hdr.msgtype == RAY_IPC_MSG_SYNC) {
+        ray_selector_t* cur = ray_poll_get(poll, id);
+        if (cur && cur->data == (void*)cd)
+            send_response((ray_sock_t)cur->fd, result);
+    }
+    if (result != RAY_NULL_OBJ) ray_release(result);
 
     return NULL;
 }
@@ -772,14 +854,24 @@ static void ipc_on_close(ray_poll_t* poll, ray_selector_t* sel)
      * before the listener's own close path (which would otherwise also
      * route through here) runs the hook with a stale fd.  Guard on:
      *   - sel->data: the listener itself has no conn data.
+     *   - listener_id ≥ 0: lifecycle hooks pair with inbound on.open
+     *     only — outbound conns (ray_ipc_connect) never fired on.open,
+     *     so they must not fire on.close either.
      *   - phase ≥ HEADER: the connection actually completed handshake
      *     (otherwise no matching on.open was fired, so on.close must
      *     also stay silent to keep the pair balanced for the user). */
     if (sel->data) {
         ray_ipc_conn_data_t* cd = (ray_ipc_conn_data_t*)sel->data;
-        if (cd->phase == RAY_IPC_PHASE_HEADER ||
-            cd->phase == RAY_IPC_PHASE_PAYLOAD) {
-            hook_call_lifecycle(IPC_HOOK_CLOSE, sel->id);
+        if (cd->listener_id >= 0 &&
+            (cd->phase == RAY_IPC_PHASE_HEADER ||
+             cd->phase == RAY_IPC_PHASE_PAYLOAD)) {
+            hook_call_lifecycle(poll, IPC_HOOK_CLOSE, sel->id);
+        }
+        /* A RESP deposited for a sync wait that never consumed it
+         * (connection died mid-round-trip) would otherwise leak. */
+        if (cd->sync_resp) {
+            if (cd->sync_resp != RAY_NULL_OBJ) ray_release(cd->sync_resp);
+            cd->sync_resp = NULL;
         }
         ray_sys_free(sel->data);
         sel->data = NULL;
@@ -821,7 +913,7 @@ static void conn_close(ray_ipc_server_t* srv, ray_ipc_conn_t* c)
      * Keeps the pair balanced for the user. */
     if (c->phase == RAY_IPC_PHASE_HEADER ||
         c->phase == RAY_IPC_PHASE_PAYLOAD) {
-        hook_call_lifecycle(IPC_HOOK_CLOSE, (int64_t)(c - srv->conns));
+        hook_call_lifecycle(NULL, IPC_HOOK_CLOSE, (int64_t)(c - srv->conns));
     }
 
 #if defined(__linux__)
@@ -873,7 +965,7 @@ static void conn_on_handshake(ray_ipc_server_t* srv, ray_ipc_conn_t* c)
     c->rx_need = sizeof(ray_ipc_header_t);
     c->phase   = RAY_IPC_PHASE_HEADER;
     /* Legacy path mirror of the poll-path post-handshake fire. */
-    hook_call_lifecycle(IPC_HOOK_OPEN, (int64_t)(c - srv->conns));
+    hook_call_lifecycle(NULL, IPC_HOOK_OPEN, (int64_t)(c - srv->conns));
 }
 
 static void conn_on_header(ray_ipc_server_t* srv, ray_ipc_conn_t* c)
@@ -942,7 +1034,7 @@ static void conn_on_creds(ray_ipc_server_t* srv, ray_ipc_conn_t* c)
     /* Legacy path mirror of the poll-path on.auth call: same handle-as-
      * conn-index convention, same narrowing semantics. */
     if (ok) {
-        int hook_ok = hook_call_auth((int64_t)(c - srv->conns),
+        int hook_ok = hook_call_auth(NULL, (int64_t)(c - srv->conns),
                                      c->rx_buf + 1, cred_len);
         if (hook_ok == 0) ok = false;
     }
@@ -960,7 +1052,7 @@ static void conn_on_creds(ray_ipc_server_t* srv, ray_ipc_conn_t* c)
     c->rx_len  = 0;
     c->rx_need = sizeof(ray_ipc_header_t);
     c->phase   = RAY_IPC_PHASE_HEADER;
-    hook_call_lifecycle(IPC_HOOK_OPEN, (int64_t)(c - srv->conns));
+    hook_call_lifecycle(NULL, IPC_HOOK_OPEN, (int64_t)(c - srv->conns));
 }
 
 static void conn_on_readable(ray_ipc_server_t* srv, ray_ipc_conn_t* c)
@@ -1174,18 +1266,14 @@ int ray_ipc_poll(ray_ipc_server_t* srv, int timeout_ms)
     return ready;
 }
 
-/* ===== Client API ===== */
-
-static ray_sock_t g_client_fds[RAY_IPC_MAX_CONNS];
-static int        g_client_count = 0;
-static bool       g_client_init = false;
-
-static void client_init(void) {
-    if (g_client_init) return;
-    for (int i = 0; i < RAY_IPC_MAX_CONNS; i++)
-        g_client_fds[i] = RAY_INVALID_SOCK;
-    g_client_init = true;
-}
+/* ===== Connection-handle API =====
+ *
+ * One handle namespace: a handle is the poll selector id of an IPC
+ * connection — inbound (accepted by a listener) or outbound (opened by
+ * ray_ipc_connect).  Every entry point below resolves the handle in the
+ * "active" poll (the poll dispatching the current hook/eval, else the
+ * runtime's main poll), so server-side code can write to the very
+ * handles its hooks receive — kdb-style server push. */
 
 static int64_t recv_full(ray_sock_t fd, void* buf, size_t len) {
     size_t total = 0;
@@ -1197,13 +1285,63 @@ static int64_t recv_full(ray_sock_t fd, void* buf, size_t len) {
     return (int64_t)total;
 }
 
-static int64_t client_send_msg(int64_t handle, ray_t* msg, uint8_t msgtype,
-                               uint8_t extra_flags)
+/* Resolve `handle` to a handshake-complete IPC connection selector in
+ * the active poll.  Rejects anything else living in the selector table
+ * (listeners, the REPL's stdin, conns still mid-handshake) so a stray
+ * integer can never write to a non-IPC fd. */
+static ray_selector_t* conn_resolve(ray_poll_t** poll_out, int64_t handle)
 {
-    if (handle < 0 || handle >= RAY_IPC_MAX_CONNS) return -2;
-    ray_sock_t fd = g_client_fds[handle];
-    if (fd == RAY_INVALID_SOCK) return -2;
+    ray_poll_t* poll = ipc_active_poll();
+    if (!poll) return NULL;
+    ray_selector_t* sel = ray_poll_get(poll, handle);
+    if (!sel || sel->type != RAY_SEL_SOCKET || !sel->data) return NULL;
+    if (sel->rx.read_fn != ipc_read_header &&
+        sel->rx.read_fn != ipc_read_payload) return NULL;
+    if (poll_out) *poll_out = poll;
+    return sel;
+}
 
+/* Drain whatever is available on one connection's socket through its rx
+ * state machine WITHOUT blocking: fill the requested rx buffer, invoke
+ * read_fn for each completed phase, repeat until the socket is dry.
+ * Mirrors the per-event rx loop in the poll backends; used by sync
+ * sends to wait for their RESP while still dispatching any interleaved
+ * frames (pushed ASYNCs, nested SYNC requests).  Returns 0 when the
+ * socket has no more data right now, -1 if the selector was
+ * deregistered (peer closed or protocol error). */
+static int conn_pump(ray_poll_t* poll, int64_t id)
+{
+    for (;;) {
+        ray_selector_t* sel = ray_poll_get(poll, id);
+        if (!sel) return -1;
+        if (!sel->rx.buf || !sel->rx.recv_fn || !sel->rx.read_fn) return 0;
+        while (sel->rx.buf->offset < sel->rx.buf->size) {
+            int64_t nr = sel->rx.recv_fn(sel->fd,
+                                         sel->rx.buf->data + sel->rx.buf->offset,
+                                         sel->rx.buf->size - sel->rx.buf->offset);
+            if (nr <= 0) {
+                if (nr < 0 && errno == EINTR) continue;
+                if (nr < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+                    return 0;  /* drained — caller decides whether to wait */
+                ray_poll_deregister(poll, id);  /* error or peer closed */
+                return -1;
+            }
+            sel->rx.buf->offset += nr;
+        }
+        /* Phase buffer complete — advance the state machine.  read_fn
+         * may deregister the selector or re-arm it for the next phase;
+         * the loop re-validates from scratch either way. */
+        sel->rx.read_fn(poll, sel);
+    }
+}
+
+/* Serialize + frame + write one message to a connection's fd.
+ * ray_sock_send loops on partial writes/EAGAIN internally, so this is
+ * safe on the nonblocking fds the poll owns.  Returns 0 on success,
+ * -1 on serialization or socket failure. */
+static int64_t conn_write_msg(ray_sock_t fd, ray_t* msg, uint8_t msgtype,
+                              uint8_t extra_flags)
+{
     int64_t ser_size = ray_serde_size(msg);
     if (ser_size <= 0) return -1;
 
@@ -1261,7 +1399,11 @@ static int64_t client_send_msg(int64_t handle, ray_t* msg, uint8_t msgtype,
 int64_t ray_ipc_connect(const char* host, uint16_t port,
                          const char* user, const char* password)
 {
-    client_init();
+    /* The connection lives in the active poll's selector table — its
+     * selector id IS the handle.  No poll, no handle namespace: refuse
+     * up front rather than hand out an integer nothing can resolve. */
+    ray_poll_t* poll = ipc_active_poll();
+    if (!poll) return -1;
 
     ray_sock_t fd = ray_sock_connect(host, port, 5000);
     if (fd == RAY_INVALID_SOCK) return -1;
@@ -1330,27 +1472,58 @@ int64_t ray_ipc_connect(const char* host, uint16_t port,
       setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &z, sizeof(z)); }
 #endif
 
-    for (int i = 0; i < RAY_IPC_MAX_CONNS; i++) {
-        if (g_client_fds[i] == RAY_INVALID_SOCK) {
-            g_client_fds[i] = fd;
-            if (i >= g_client_count) g_client_count = i + 1;
-            return (int64_t)i;
-        }
-    }
+    /* Handshake + auth done (blocking socket).  Hand the fd over to the
+     * poll: nonblocking, parked on a header read, same read pump as an
+     * inbound connection — which is exactly what makes pushed frames
+     * from the server dispatchable on this side. */
+    ray_ipc_conn_data_t* cd = (ray_ipc_conn_data_t*)ray_sys_alloc(
+                                    sizeof(ray_ipc_conn_data_t));
+    if (!cd) { ray_sock_close(fd); return -1; }
+    memset(cd, 0, sizeof(*cd));
+    cd->phase       = RAY_IPC_PHASE_HEADER;
+    cd->listener_id = -1;               /* outbound — no lifecycle hooks */
+    cd->restricted  = poll->restricted; /* -U narrows pushed evals too */
 
-    ray_sock_close(fd);
-    return -1;
+    ray_sock_set_nonblocking(fd);
+
+    ray_poll_reg_t reg = {0};
+    reg.fd       = (int64_t)fd;
+    reg.type     = RAY_SEL_SOCKET;
+    reg.recv_fn  = ipc_recv_fn;
+    reg.read_fn  = ipc_read_header;
+    reg.close_fn = ipc_on_close;
+    reg.data     = cd;
+
+    int64_t id = ray_poll_register(poll, &reg);
+    if (id < 0) {
+        ray_sock_close(fd);
+        ray_sys_free(cd);
+        return -1;
+    }
+    ray_selector_t* ns = ray_poll_get(poll, id);
+    if (ns) ray_poll_rx_request(poll, ns, sizeof(ray_ipc_header_t));
+
+    return id;
 }
 
 void ray_ipc_close(int64_t handle)
 {
-    if (handle < 0 || handle >= RAY_IPC_MAX_CONNS) return;
-    if (g_client_fds[handle] == RAY_INVALID_SOCK) return;
-    ray_sock_close(g_client_fds[handle]);
-    g_client_fds[handle] = RAY_INVALID_SOCK;
+    ray_poll_t* poll;
+    ray_selector_t* sel = conn_resolve(&poll, handle);
+    if (!sel) return;
+    /* Deregister fires ipc_on_close: socket closed, conn data freed,
+     * and the on.close hook for inbound connections — so a server can
+     * kick a client through the same handle its hooks were given. */
+    ray_poll_deregister(poll, sel->id);
 }
 
-ray_t* ray_ipc_send(int64_t handle, ray_t* msg)
+/* Sync round-trip on any connection handle.  Writes a SYNC frame, then
+ * pumps this connection's rx machinery until the matching RESP frame is
+ * deposited — dispatching (not swallowing) any frames that arrive in
+ * between: a pushed ASYNC gets evaluated, a nested SYNC request from
+ * the peer gets evaluated and answered.  Full-duplex, either side of
+ * the wire. */
+static ray_t* sync_send(int64_t handle, ray_t* msg, uint8_t extra_flags)
 {
     bool owned = false;
     if (ray_is_lazy(msg)) {
@@ -1359,73 +1532,69 @@ ray_t* ray_ipc_send(int64_t handle, ray_t* msg)
         if (RAY_IS_ERR(msg)) return msg;
         owned = true;
     }
-    { int64_t sr = client_send_msg(handle, msg, RAY_IPC_MSG_SYNC, 0);
-      if (sr == -2) { if (owned) ray_release(msg); return ray_error("io", "connection closed"); }
-      if (sr < 0)  { if (owned) ray_release(msg); return ray_error("io", "ipc send failed"); } }
 
-    ray_sock_t fd = g_client_fds[handle];
-
-    ray_ipc_header_t hdr;
-    if (recv_full(fd, &hdr, sizeof(hdr)) < 0) {
-        ray_ipc_close(handle);
+    ray_poll_t* poll;
+    ray_selector_t* sel = conn_resolve(&poll, handle);
+    if (!sel) {
         if (owned) ray_release(msg);
-        return ray_error("io", "ipc recv header failed");
+        return ray_error("io", "connection closed");
     }
-    if (hdr.prefix != RAY_SERDE_PREFIX || hdr.size <= 0) {
-        ray_ipc_close(handle);
+    ray_ipc_conn_data_t* cd = (ray_ipc_conn_data_t*)sel->data;
+    if (cd->sync_waiting) {
+        /* A sync wait is already pumping this conn further down the
+         * stack (hook → nested send on the SAME handle).  Two waiters
+         * can't both claim the next RESP — refuse the inner one. */
         if (owned) ray_release(msg);
-        return ray_error("io", "ipc bad response header");
+        return ray_error("io", "nested sync send on busy handle");
     }
-    if (hdr.version != RAY_SERDE_WIRE_VERSION) {
-        ray_ipc_close(handle);
+
+    if (conn_write_msg((ray_sock_t)sel->fd, msg, RAY_IPC_MSG_SYNC,
+                       extra_flags) < 0) {
         if (owned) ray_release(msg);
-        return ray_error("version", "ipc peer wire version mismatch");
+        return ray_error("io", "ipc send failed");
     }
-    if (hdr.size > 256 * 1024 * 1024) {
-        ray_ipc_close(handle);
-        if (owned) ray_release(msg);
-        return ray_error("io", "ipc response too large");
-    }
-
-    uint8_t* payload = (uint8_t*)ray_sys_alloc((size_t)hdr.size);
-    if (!payload) { if (owned) ray_release(msg); return ray_error("oom", NULL); }
-    if (recv_full(fd, payload, (size_t)hdr.size) < 0) {
-        ray_sys_free(payload);
-        ray_ipc_close(handle);
-        if (owned) ray_release(msg);
-        return ray_error("io", "ipc recv payload failed");
-    }
-
-    uint8_t* deser_buf     = payload;
-    size_t   deser_len     = (size_t)hdr.size;
-    uint8_t* decompressed  = NULL;
-
-    if (hdr.flags & RAY_IPC_FLAG_COMPRESSED) {
-        if (deser_len < 4) { ray_sys_free(payload); if (owned) ray_release(msg); return ray_error("io", "ipc compressed payload too short"); }
-        uint32_t uncomp_size;
-        memcpy(&uncomp_size, payload, 4);
-        decompressed = (uint8_t*)ray_sys_alloc(uncomp_size);
-        if (!decompressed) { ray_sys_free(payload); if (owned) ray_release(msg); return ray_error("oom", NULL); }
-        size_t dlen = ray_ipc_decompress(payload + 4, deser_len - 4,
-                                         decompressed, uncomp_size);
-        if (dlen != uncomp_size) {
-            ray_sys_free(decompressed);
-            ray_sys_free(payload);
-            if (owned) ray_release(msg);
-            return ray_error("io", "ipc decompress failed");
-        }
-        deser_buf = decompressed;
-        deser_len = uncomp_size;
-    }
-
-    int64_t de_len = (int64_t)deser_len;
-    ray_t*  result = ray_de_raw(deser_buf, &de_len);
-
-    if (decompressed) ray_sys_free(decompressed);
-    ray_sys_free(payload);
     if (owned) ray_release(msg);
 
-    return result ? result : RAY_NULL_OBJ;
+    cd->sync_waiting = true;
+    cd->sync_ready   = false;
+    cd->sync_resp    = NULL;
+    int64_t id = sel->id;
+
+    for (;;) {
+        /* Process anything already buffered/readable first, then block
+         * for more.  The pump can deregister the selector (peer died) —
+         * conn data is freed with it, so re-resolve every iteration.
+         * The data-pointer compare also guards against this id being
+         * reused by a NEW connection opened inside a dispatched eval:
+         * that conn's state must not be mistaken for ours. */
+        int rc = conn_pump(poll, id);
+        sel = ray_poll_get(poll, id);
+        if (!sel || sel->data != (void*)cd)
+            return ray_error("io", "connection closed");
+        if (cd->sync_ready) {
+            ray_t* result = cd->sync_resp;
+            cd->sync_resp    = NULL;
+            cd->sync_ready   = false;
+            cd->sync_waiting = false;
+            if (!result)
+                return ray_error("io", "ipc bad response");
+            return result;
+        }
+        if (rc < 0) {
+            /* Deregistered but selector still resolves?  Can't happen —
+             * defensive: treat as closed. */
+            return ray_error("io", "connection closed");
+        }
+        if (ray_sock_wait_readable((ray_sock_t)sel->fd, -1) < 0) {
+            cd->sync_waiting = false;
+            return ray_error("io", "ipc recv failed");
+        }
+    }
+}
+
+ray_t* ray_ipc_send(int64_t handle, ray_t* msg)
+{
+    return sync_send(handle, msg, 0);
 }
 
 ray_err_t ray_ipc_send_async(int64_t handle, ray_t* msg)
@@ -1441,92 +1610,19 @@ ray_err_t ray_ipc_send_async(int64_t handle, ray_t* msg)
         }
         owned = true;
     }
-    ray_err_t rc = (client_send_msg(handle, msg, RAY_IPC_MSG_ASYNC, 0) < 0)
+    ray_selector_t* sel = conn_resolve(NULL, handle);
+    ray_err_t rc = (!sel || conn_write_msg((ray_sock_t)sel->fd, msg,
+                                           RAY_IPC_MSG_ASYNC, 0) < 0)
                    ? RAY_ERR_IO : RAY_OK;
     if (owned) ray_release(msg);
     return rc;
 }
 
-/* Verbose-eval client send: sets RAY_IPC_FLAG_VERBOSE on the
- * outbound header so the server captures whatever the eval writes
- * to stdout/stderr and returns a 2-element list [captured_str,
- * result] instead of bare result.  Same wire path as ray_ipc_send
- * otherwise — sync, blocking until response. */
+/* Verbose-eval sync send: sets RAY_IPC_FLAG_VERBOSE on the outbound
+ * header so the peer captures whatever the eval writes to
+ * stdout/stderr and returns a 2-element list [captured_str, result]
+ * instead of bare result.  Same wire path as ray_ipc_send otherwise. */
 ray_t* ray_ipc_send_verbose(int64_t handle, ray_t* msg)
 {
-    bool owned = false;
-    if (ray_is_lazy(msg)) {
-        ray_retain(msg);
-        msg = ray_lazy_materialize(msg); /* consumes the retain */
-        if (RAY_IS_ERR(msg)) return msg;
-        owned = true;
-    }
-    { int64_t sr = client_send_msg(handle, msg, RAY_IPC_MSG_SYNC,
-                                   RAY_IPC_FLAG_VERBOSE);
-      if (sr == -2) { if (owned) ray_release(msg); return ray_error("io", "connection closed"); }
-      if (sr < 0)  { if (owned) ray_release(msg); return ray_error("io", "ipc send failed"); } }
-
-    ray_sock_t fd = g_client_fds[handle];
-
-    ray_ipc_header_t hdr;
-    if (recv_full(fd, &hdr, sizeof(hdr)) < 0) {
-        ray_ipc_close(handle);
-        if (owned) ray_release(msg);
-        return ray_error("io", "ipc recv header failed");
-    }
-    if (hdr.prefix != RAY_SERDE_PREFIX || hdr.size <= 0) {
-        ray_ipc_close(handle);
-        if (owned) ray_release(msg);
-        return ray_error("io", "ipc bad response header");
-    }
-    if (hdr.version != RAY_SERDE_WIRE_VERSION) {
-        ray_ipc_close(handle);
-        if (owned) ray_release(msg);
-        return ray_error("version", "ipc peer wire version mismatch");
-    }
-    if (hdr.size > 256 * 1024 * 1024) {
-        ray_ipc_close(handle);
-        if (owned) ray_release(msg);
-        return ray_error("io", "ipc response too large");
-    }
-
-    uint8_t* payload = (uint8_t*)ray_sys_alloc((size_t)hdr.size);
-    if (!payload) { if (owned) ray_release(msg); return ray_error("oom", NULL); }
-    if (recv_full(fd, payload, (size_t)hdr.size) < 0) {
-        ray_sys_free(payload);
-        ray_ipc_close(handle);
-        if (owned) ray_release(msg);
-        return ray_error("io", "ipc recv payload failed");
-    }
-
-    uint8_t* deser_buf    = payload;
-    size_t   deser_len    = (size_t)hdr.size;
-    uint8_t* decompressed = NULL;
-
-    if (hdr.flags & RAY_IPC_FLAG_COMPRESSED) {
-        if (deser_len < 4) { ray_sys_free(payload); if (owned) ray_release(msg); return ray_error("io", "ipc compressed payload too short"); }
-        uint32_t uncomp_size;
-        memcpy(&uncomp_size, payload, 4);
-        decompressed = (uint8_t*)ray_sys_alloc(uncomp_size);
-        if (!decompressed) { ray_sys_free(payload); if (owned) ray_release(msg); return ray_error("oom", NULL); }
-        size_t dlen = ray_ipc_decompress(payload + 4, deser_len - 4,
-                                         decompressed, uncomp_size);
-        if (dlen != uncomp_size) {
-            ray_sys_free(decompressed);
-            ray_sys_free(payload);
-            if (owned) ray_release(msg);
-            return ray_error("io", "ipc decompress failed");
-        }
-        deser_buf = decompressed;
-        deser_len = uncomp_size;
-    }
-
-    int64_t de_len = (int64_t)deser_len;
-    ray_t*  result = ray_de_raw(deser_buf, &de_len);
-
-    if (decompressed) ray_sys_free(decompressed);
-    ray_sys_free(payload);
-    if (owned) ray_release(msg);
-
-    return result ? result : RAY_NULL_OBJ;
+    return sync_send(handle, msg, RAY_IPC_FLAG_VERBOSE);
 }

--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -50,6 +50,7 @@
   #define RAY_IPC_MAX_EVENTS 64
 #endif
 
+#include "core/runtime.h"
 #include "lang/eval.h"
 #include "lang/env.h"
 #include "lang/internal.h"
@@ -191,10 +192,10 @@ static bool validate_creds(const uint8_t* buf, uint8_t cred_len,
  * Lookup is by interned sym id; we cache the ids in `hook_syms[]` so the
  * fast path is a single ray_env_get + RAY_LAMBDA-type check per dispatch.
  *
- * `g_current_handle` is the thread-local value `.ipc.handle` reads back
- * to Rayfall.  HOOK_SCOPE saves/restores it around each invocation, so a
- * hook that opens its own connection (calling `.ipc.handle` inside a
- * nested `.ipc.send` round-trip) still sees the outer handle when its
+ * `__VM->ipc_handle` is the per-thread value `.ipc.handle` reads back
+ * to Rayfall.  Each dispatch saves/restores it around the invocation,
+ * so a hook that opens its own connection (calling `.ipc.handle` inside
+ * a nested `.ipc.send` round-trip) still sees the outer handle when its
  * body resumes.  Default value -1 means "no hook is currently on the
  * stack" — exposed verbatim through the builtin.
  *
@@ -215,27 +216,35 @@ enum {
     IPC_HOOK_COUNT = 5,
 };
 
-static _Thread_local int64_t g_current_handle = -1;
+/* The IPC dispatch context — which connection's hook/eval is on this
+ * thread's stack, and the poll it lives in — is per-thread state and
+ * therefore lives on the VM (__VM->ipc_handle / __VM->ipc_poll, see
+ * core/runtime.h).  Connection handles are selector ids, so resolving
+ * one needs the poll: inside a hook / inbound eval that's the poll
+ * that fired it; everywhere else (REPL, scripts) it's the runtime's
+ * main poll. */
 
-/* The poll whose event dispatch is currently on this thread's stack.
- * Connection handles are selector ids, so resolving one needs the poll
- * it lives in: inside a hook / inbound eval that's the poll that fired
- * it; everywhere else (REPL, scripts) it's the runtime's main poll.
- * Saved/restored exactly like g_current_handle. */
-static _Thread_local ray_poll_t* g_current_poll = NULL;
+static int64_t ipc_ctx_handle(void) {
+    return __VM ? __VM->ipc_handle : -1;
+}
 
-/* From core/runtime.h — not included here because lang/eval.h (included
- * below) and core/runtime.h declare conflicting ray_vm_t types; see the
- * matching note in test/test_ipc.c. */
-extern void* ray_runtime_get_poll(void);
+static ray_poll_t* ipc_ctx_poll(void) {
+    return __VM ? (ray_poll_t*)__VM->ipc_poll : NULL;
+}
+
+static void ipc_ctx_set(int64_t handle, ray_poll_t* poll) {
+    if (!__VM) return;
+    __VM->ipc_handle = handle;
+    __VM->ipc_poll   = poll;
+}
 
 static ray_poll_t* ipc_active_poll(void) {
-    return g_current_poll ? g_current_poll
-                          : (ray_poll_t*)ray_runtime_get_poll();
+    ray_poll_t* p = ipc_ctx_poll();
+    return p ? p : (ray_poll_t*)ray_runtime_get_poll();
 }
 
 int64_t ray_ipc_current_handle(void) {
-    return g_current_handle;
+    return ipc_ctx_handle();
 }
 
 /* Fetch the hook lambda if one is installed and is in fact a lambda.
@@ -264,13 +273,11 @@ static void hook_call_lifecycle(ray_poll_t* poll, int idx, int64_t handle) {
     if (!fn) return;
     ray_t* arg = make_i64(handle);
     if (!arg || RAY_IS_ERR(arg)) { if (arg) ray_release(arg); return; }
-    int64_t prev = g_current_handle;
-    ray_poll_t* prev_poll = g_current_poll;
-    g_current_handle = handle;
-    if (poll) g_current_poll = poll;
+    int64_t prev = ipc_ctx_handle();
+    ray_poll_t* prev_poll = ipc_ctx_poll();
+    ipc_ctx_set(handle, poll ? poll : prev_poll);
     ray_t* r = call_fn1(fn, arg);
-    g_current_handle = prev;
-    g_current_poll   = prev_poll;
+    ipc_ctx_set(prev, prev_poll);
     if (r && RAY_IS_ERR(r)) {
         const char* name = (idx == IPC_HOOK_OPEN) ? ".ipc.on.open" : ".ipc.on.close";
         fprintf(stderr, "ipc: %s hook raised an error (handle=%lld)\n",
@@ -310,13 +317,11 @@ static int hook_call_auth(ray_poll_t* poll, int64_t handle,
         if (p && !RAY_IS_ERR(p)) ray_release(p);
         return 0;  /* allocation failure → reject conservatively */
     }
-    int64_t prev = g_current_handle;
-    ray_poll_t* prev_poll = g_current_poll;
-    g_current_handle = handle;
-    if (poll) g_current_poll = poll;
+    int64_t prev = ipc_ctx_handle();
+    ray_poll_t* prev_poll = ipc_ctx_poll();
+    ipc_ctx_set(handle, poll ? poll : prev_poll);
     ray_t* r = call_fn2(fn, u, p);
-    g_current_handle = prev;
-    g_current_poll   = prev_poll;
+    ipc_ctx_set(prev, prev_poll);
     ray_release(u);
     ray_release(p);
 
@@ -819,17 +824,15 @@ static ray_t* ipc_read_payload(ray_poll_t* poll, ray_selector_t* sel)
      * runs inside eval_payload.  Save/restore so a hook that itself
      * opens a nested IPC round-trip doesn't leave the wrong handle
      * visible when its caller resumes. */
-    int64_t prev_handle = g_current_handle;
-    ray_poll_t* prev_poll = g_current_poll;
-    g_current_handle = id;
-    g_current_poll   = poll;
+    int64_t prev_handle = ipc_ctx_handle();
+    ray_poll_t* prev_poll = ipc_ctx_poll();
+    ipc_ctx_set(id, poll);
 
     /* Eval and produce result */
     ray_t* result = eval_payload(payload->data,
                                  (size_t)payload->offset, &hdr);
 
-    g_current_handle = prev_handle;
-    g_current_poll   = prev_poll;
+    ipc_ctx_set(prev_handle, prev_poll);
     ray_eval_set_restricted(prev_restricted);
     ray_poll_buf_free(payload);
 
@@ -994,12 +997,13 @@ static void conn_on_payload(ray_ipc_server_t* srv, ray_ipc_conn_t* c)
      * stable for the connection's lifetime, distinct across active
      * connections, freed back to the pool on close.  Mirrored shape
      * of the poll path's sel->id. */
-    int64_t prev_handle = g_current_handle;
-    g_current_handle    = (int64_t)(c - srv->conns);
+    int64_t prev_handle = ipc_ctx_handle();
+    ray_poll_t* prev_poll = ipc_ctx_poll();
+    ipc_ctx_set((int64_t)(c - srv->conns), prev_poll);
 
     ray_t* result = eval_payload(c->rx_buf, c->rx_len, &c->hdr);
 
-    g_current_handle = prev_handle;
+    ipc_ctx_set(prev_handle, prev_poll);
     ray_eval_set_restricted(prev);
 
     if (c->hdr.msgtype == RAY_IPC_MSG_SYNC)

--- a/src/core/ipc.h
+++ b/src/core/ipc.h
@@ -103,7 +103,16 @@ ray_err_t ray_ipc_server_init(ray_ipc_server_t* srv, uint16_t port);
 void      ray_ipc_server_destroy(ray_ipc_server_t* srv);
 int       ray_ipc_poll(ray_ipc_server_t* srv, int timeout_ms);
 
-/* ===== Client API (blocking, no poll needed) ===== */
+/* ===== Connection-handle API =====
+ *
+ * One handle namespace: a handle is the poll selector id of an IPC
+ * connection, inbound or outbound.  ray_ipc_connect registers the new
+ * connection in the active poll (the poll dispatching the current
+ * hook/eval, else the runtime's main poll) and returns its selector
+ * id; send/close resolve handles the same way, so server-side hooks
+ * can write back through the handles they receive.  Sync sends pump
+ * the connection's rx machinery while waiting, dispatching any
+ * interleaved async/sync frames from the peer. */
 
 int64_t   ray_ipc_connect(const char* host, uint16_t port,
                            const char* user, const char* password);

--- a/src/core/runtime.c
+++ b/src/core/runtime.c
@@ -36,7 +36,7 @@
 #include <unistd.h>
 #endif
 
-/* Forward-declare lang init/destroy to avoid eval.h ray_vm_t conflict */
+/* Forward-declare lang init/destroy — keeps runtime.c decoupled from lang/eval.h */
 extern ray_err_t ray_lang_init(void);
 extern void      ray_lang_destroy(void);
 
@@ -47,12 +47,20 @@ _Thread_local ray_vm_t *__VM = NULL;
 
 /* Persistent error message buffer.
  *
- * `__VM->err.msg` lives inside the VM struct, which is freed at the end of
- * every eval (eval.c sets __VM = NULL right after `ray_free(vm_block)`). By
- * the time the FFI caller reaches `ray_error_msg()`, the VM is gone. Stash a
- * copy in a thread-local buffer that outlives the VM so callers can still
- * read what went wrong. */
+ * `__VM->err.msg` is the canonical per-thread slot now that the VM is
+ * stable for the thread's lifetime, but FFI callers can hit errors on
+ * threads that never bound a VM — this thread-local shadow keeps
+ * ray_error_msg() answerable there too. */
 static _Thread_local char ray_last_err_msg[256] = {0};
+
+/* Zero a VM and set the non-zero defaults.  Every VM must go through
+ * here — a bare memset leaves ipc_handle at 0, which is a VALID
+ * connection handle; the "no dispatch on this stack" sentinel is -1. */
+void ray_vm_init(ray_vm_t* vm, int32_t id) {
+    memset(vm, 0, sizeof(*vm));
+    vm->id = id;
+    vm->ipc_handle = -1;
+}
 
 /* Static null singleton — type RAY_NULL, ARENA flag makes retain/release no-ops */
 ray_t __ray_null = { .type = RAY_NULL, .attrs = RAY_ATTR_ARENA, .rc = 0, .len = 0 };
@@ -246,8 +254,7 @@ static ray_runtime_t* runtime_create_impl(const char* sym_path,
     if (!rt->vms) { ray_sys_free(rt); return NULL; }
     rt->vms[0] = (ray_vm_t*)ray_sys_alloc(sizeof(ray_vm_t));
     if (!rt->vms[0]) { ray_sys_free(rt->vms); ray_sys_free(rt); return NULL; }
-    memset(rt->vms[0], 0, sizeof(ray_vm_t));
-    rt->vms[0]->id = 0;
+    ray_vm_init(rt->vms[0], 0);
     __VM = rt->vms[0];
 
     /* Detect memory budget: 80% of physical RAM */

--- a/src/core/runtime.h
+++ b/src/core/runtime.h
@@ -31,61 +31,58 @@ typedef struct {
     char msg[256];
 } ray_err_info_t;
 
-/* ===== Scope Frame (moved from env.c) ===== */
+/* ===== Scope Frame ===== */
 
 #define RAY_SCOPE_CAP  64
 #define RAY_FRAME_CAP  64
 
+/* One lexical scope frame.  keys/vals start out pointing at the inline
+ * arrays and move to heap blocks if the frame grows past RAY_FRAME_CAP
+ * (see env.c).  Self-referential, so a frame must not be relocated
+ * while live. */
 typedef struct {
-    int64_t keys[RAY_FRAME_CAP];
-    ray_t*  vals[RAY_FRAME_CAP];
-    int32_t count;
+    int64_t  keys_inline[RAY_FRAME_CAP];
+    ray_t*   vals_inline[RAY_FRAME_CAP];
+    int64_t* keys;     /* -> keys_inline, or heap once grown */
+    ray_t**  vals;     /* -> vals_inline, or heap once grown */
+    int32_t  cap;
+    int32_t  count;
 } ray_scope_frame_t;
 
-/* ===== VM sub-types ===== */
-
-#define RAY_VM_STACK_SIZE 1024
-#define RAY_VM_TRAP_SIZE  16
-
+/* ===== Per-thread VM =====
+ *
+ * THE per-thread state object — one per thread, stable for the thread's
+ * lifetime, published through `__VM`.  Process-wide state lives on
+ * ray_runtime_t; everything thread-scoped lives here.  Bytecode
+ * execution state is NOT here: the interpreter allocates a private
+ * ray_exec_t (lang/eval.h) per invocation and never touches __VM.
+ *
+ * Always initialize through ray_vm_init() — plain memset(0) leaves
+ * ipc_handle at 0, which is a VALID connection handle; the sentinel
+ * for "no dispatch on this stack" is -1. */
 typedef struct {
-    ray_t   *fn;
-    int32_t  fp;
-    int32_t  ip;
-} ray_vm_ctx_t;
-
-typedef struct {
-    int32_t  rp;
-    int32_t  sp;
-    int32_t  handler_ip;
-    ray_t   *fn;
-    int32_t  fp;
-    int32_t  n_locals;
-} ray_vm_trap_t;
-
-/* ===== Per-thread VM ===== */
-
-typedef struct {
-    /* hot path */
-    int32_t          sp;
-    int32_t          fp;
-    int32_t          rp;
-    int32_t          id;
-    ray_t           *fn;
-    void            *heap;
-    int32_t          tp;
-    /* stacks */
-    ray_t           *ps[RAY_VM_STACK_SIZE];
-    ray_vm_ctx_t     rs[RAY_VM_STACK_SIZE];
-    ray_vm_trap_t    ts[RAY_VM_TRAP_SIZE];
-    /* cold — error/debug */
-    ray_err_info_t   err;
-    ray_t           *nfo;
-    ray_t           *trace;
-    ray_t           *raise_val;
-    /* scope */
-    ray_scope_frame_t scope_stack[RAY_SCOPE_CAP];
+    /* ── hot: touched on every eval step / scope lookup.  Keep this
+     * block within the first 32 bytes — ray_sys_alloc data starts at
+     * page+32, so offsets 0..31 share one cache line. */
+    int32_t          eval_depth;
     int32_t          scope_depth;
+    bool             restricted; /* -U connection on this stack */
+    int32_t          id;
+    ray_t           *nfo;        /* source-info of the eval in progress (borrowed) */
+    void            *heap;
+    /* ── warm: per-dispatch context (core/ipc.c saves/restores) */
+    int64_t          ipc_handle; /* connection handle of the hook/eval on this stack; -1 = none */
+    void            *ipc_poll;   /* opaque ray_poll_t* that dispatched it; NULL = none */
+    /* ── cold: error paths only */
+    ray_t           *trace;      /* error trace list (owned) */
+    ray_t           *raise_val;  /* pending (raise x) value (owned) */
+    ray_err_info_t   err;
+    /* ── big: lexical scope stack, own cache lines */
+    ray_scope_frame_t scope_stack[RAY_SCOPE_CAP];
 } ray_vm_t;
+
+/* Zero the VM and set the non-zero defaults (ipc_handle = -1). */
+void ray_vm_init(ray_vm_t* vm, int32_t id);
 
 /* ===== Runtime ===== */
 
@@ -107,9 +104,7 @@ void           ray_runtime_destroy(ray_runtime_t* rt);
 
 /* Main event-loop accessors.  The host (main.c) registers the poll it
  * created; runtime-level builtins read it back through these to avoid
- * pulling poll.h into runtime.h (and to keep TUs that include
- * runtime.h decoupled from the eval-VM definition that conflicts with
- * the unrelated `ray_vm_t` declared above). */
+ * pulling poll.h into runtime.h. */
 void  ray_runtime_set_poll(void* poll);
 void* ray_runtime_get_poll(void);
 

--- a/src/core/sock.c
+++ b/src/core/sock.c
@@ -175,6 +175,25 @@ int64_t ray_sock_recv(ray_sock_t s, void* buf, size_t len)
     }
 }
 
+int ray_sock_wait_readable(ray_sock_t s, int timeout_ms)
+{
+    /* Same wait primitive ray_sock_send uses for write-readiness. */
+    struct pollfd pfd = { .fd = s, .events = POLLIN };
+    for (;;) {
+#ifdef RAY_OS_WINDOWS
+        int n = WSAPoll(&pfd, 1, timeout_ms);
+#else
+        int n = poll(&pfd, 1, timeout_ms);
+#endif
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        if (n == 0) return 0;
+        return 1;  /* POLLIN/POLLHUP/POLLERR all mean "go recv" */
+    }
+}
+
 void ray_sock_close(ray_sock_t s)
 {
     if (s == RAY_INVALID_SOCK) return;

--- a/src/core/sock.h
+++ b/src/core/sock.h
@@ -41,6 +41,9 @@ ray_sock_t ray_sock_accept(ray_sock_t srv);
 ray_sock_t ray_sock_connect(const char* host, uint16_t port, int timeout_ms);
 int64_t    ray_sock_send(ray_sock_t s, const void* buf, size_t len);
 int64_t    ray_sock_recv(ray_sock_t s, void* buf, size_t len);
+/* Block until s is readable (or hung up).  timeout_ms < 0 = no timeout.
+ * Returns 1 readable, 0 timed out, -1 error. */
+int        ray_sock_wait_readable(ray_sock_t s, int timeout_ms);
 void       ray_sock_close(ray_sock_t s);
 ray_err_t  ray_sock_set_nonblocking(ray_sock_t s);
 

--- a/src/lang/env.c
+++ b/src/lang/env.c
@@ -22,6 +22,7 @@
  */
 
 #include "lang/env.h"
+#include "core/runtime.h"
 #include "table/sym.h"
 #include "table/dict.h"
 #include "ops/temporal.h"
@@ -105,22 +106,13 @@ static struct {
 
 /* ---- Local scope stack ---- */
 
-#define SCOPE_CAP  64
-#define FRAME_CAP  64
+/* The scope stack lives on the per-thread VM (core/runtime.h) — one
+ * per thread, stable across bytecode invocations.  ray_scope_frame_t
+ * and the caps (RAY_SCOPE_CAP / RAY_FRAME_CAP) are defined there.
+ * Callers reach env state through eval, whose entry guard rejects
+ * threads with no bound VM, so plain __VM derefs are safe below. */
 
-typedef struct {
-    int64_t  keys_inline[FRAME_CAP];
-    ray_t*   vals_inline[FRAME_CAP];
-    int64_t* keys;     /* -> keys_inline, or heap once grown past FRAME_CAP */
-    ray_t**  vals;     /* -> vals_inline, or heap once grown */
-    int32_t  cap;
-    int32_t  count;
-} ray_scope_frame_t;
-
-static _Thread_local ray_scope_frame_t scope_stack[SCOPE_CAP];
-static _Thread_local int32_t scope_depth = 0;
-
-int32_t ray_env_scope_depth(void) { return scope_depth; }
+int32_t ray_env_scope_depth(void) { return __VM ? __VM->scope_depth : 0; }
 int32_t ray_env_global_count(void) { return g_env.count; }
 
 /* The five connection-hook sym ids carved out of the reserved-name reject.
@@ -158,7 +150,7 @@ int64_t ray_sym_ipc_hook(int idx) {
 
 ray_err_t ray_env_init(void) {
     memset(&g_env, 0, sizeof(g_env));
-    scope_depth = 0;
+    __VM->scope_depth = 0;
     /* The IPC hook sym IDs are interned lazily on first probe via
      * `ipc_hook_syms_ensure`.  We deliberately do NOT pre-intern here:
      * single-char operator names (`+`, `-`, `*`, …) are registered just
@@ -174,7 +166,7 @@ ray_err_t ray_env_init(void) {
 
 void ray_env_destroy(void) {
     /* Pop any remaining scopes */
-    while (scope_depth > 0) ray_env_pop_scope();
+    while (__VM->scope_depth > 0) ray_env_pop_scope();
     for (int32_t i = 0; i < g_env.count; i++) {
         if (g_env.vals[i]) ray_release(g_env.vals[i]);
     }
@@ -191,8 +183,8 @@ void ray_env_destroy(void) {
  * Returns NULL if not bound.  Always used as the head-segment resolver
  * for dotted paths, and as the fast path for plain names. */
 static ray_t* env_lookup_flat(int64_t sym_id) {
-    for (int32_t d = scope_depth - 1; d >= 0; d--) {
-        ray_scope_frame_t* f = &scope_stack[d];
+    for (int32_t d = __VM->scope_depth - 1; d >= 0; d--) {
+        ray_scope_frame_t* f = &__VM->scope_stack[d];
         for (int32_t i = 0; i < f->count; i++) {
             if (f->keys[i] == sym_id) return f->vals[i];
         }
@@ -295,8 +287,8 @@ ray_t* ray_env_resolve(int64_t sym_id) {
          * pushed into scope by the select fallback) must not shadow
          * the globally-registered accessor function. */
         ray_t* fn = NULL;
-        for (int32_t d = scope_depth - 1; d >= 0 && !fn; d--) {
-            ray_scope_frame_t* f = &scope_stack[d];
+        for (int32_t d = __VM->scope_depth - 1; d >= 0 && !fn; d--) {
+            ray_scope_frame_t* f = &__VM->scope_stack[d];
             for (int32_t k = 0; k < f->count; k++) {
                 if (f->keys[k] == segs[i] && f->vals[k]
                     && f->vals[k]->type == RAY_UNARY) {
@@ -399,7 +391,7 @@ static ray_err_t env_bind_global_user(int64_t sym_id, ray_t* val) {
 }
 
 static ray_err_t env_bind_local(int64_t sym_id, ray_t* val) {
-    ray_scope_frame_t* f = &scope_stack[scope_depth - 1];
+    ray_scope_frame_t* f = &__VM->scope_stack[__VM->scope_depth - 1];
     for (int32_t i = 0; i < f->count; i++) {
         if (f->keys[i] == sym_id) {
             if (val == NULL) {
@@ -563,8 +555,8 @@ static ray_t* lookup_global(int64_t sym_id) {
 }
 
 static ray_t* lookup_top_frame(int64_t sym_id) {
-    if (scope_depth <= 0) return NULL;
-    ray_scope_frame_t* f = &scope_stack[scope_depth - 1];
+    if (__VM->scope_depth <= 0) return NULL;
+    ray_scope_frame_t* f = &__VM->scope_stack[__VM->scope_depth - 1];
     for (int32_t i = 0; i < f->count; i++) {
         if (f->keys[i] == sym_id) return f->vals[i];
     }
@@ -611,20 +603,20 @@ ray_err_t ray_env_set(int64_t sym_id, ray_t* val) {
 }
 
 ray_err_t ray_env_push_scope(void) {
-    if (scope_depth >= SCOPE_CAP) return RAY_ERR_OOM;
-    ray_scope_frame_t* f = &scope_stack[scope_depth];
+    if (__VM->scope_depth >= RAY_SCOPE_CAP) return RAY_ERR_OOM;
+    ray_scope_frame_t* f = &__VM->scope_stack[__VM->scope_depth];
     f->keys = f->keys_inline;
     f->vals = f->vals_inline;
-    f->cap = FRAME_CAP;
+    f->cap = RAY_FRAME_CAP;
     f->count = 0;
-    scope_depth++;
+    __VM->scope_depth++;
     return RAY_OK;
 }
 
 void ray_env_pop_scope(void) {
-    if (scope_depth <= 0) return;
-    scope_depth--;
-    ray_scope_frame_t* f = &scope_stack[scope_depth];
+    if (__VM->scope_depth <= 0) return;
+    __VM->scope_depth--;
+    ray_scope_frame_t* f = &__VM->scope_stack[__VM->scope_depth];
     for (int32_t i = 0; i < f->count; i++) {
         if (f->vals[i]) ray_release(f->vals[i]);
     }
@@ -632,7 +624,7 @@ void ray_env_pop_scope(void) {
     if (f->vals != f->vals_inline) ray_sys_free(f->vals);
     f->keys = f->keys_inline;
     f->vals = f->vals_inline;
-    f->cap = FRAME_CAP;
+    f->cap = RAY_FRAME_CAP;
     f->count = 0;
 }
 
@@ -735,7 +727,7 @@ ray_err_t ray_env_set_local(int64_t sym_id, ray_t* val) {
      * user-settable here too, matching the global `ray_env_set` path. */
     if (ray_sym_is_reserved(sym_id) && !ray_sym_is_ipc_hook(sym_id))
         return RAY_ERR_RESERVED;
-    if (scope_depth <= 0) return ray_env_set(sym_id, val);
+    if (__VM->scope_depth <= 0) return ray_env_set(sym_id, val);
     if (ray_sym_is_dotted(sym_id)) {
         return env_set_dotted(sym_id, val, lookup_top_frame, env_bind_local);
     }

--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -22,6 +22,7 @@
  */
 
 #include "lang/eval.h"
+#include "core/runtime.h"
 #include "lang/internal.h"
 #include "app/repl.h"
 #include "lang/env.h"
@@ -50,9 +51,9 @@
 #include <signal.h>
 #include <time.h>
 
-/* Maximum recursion depth for ray_eval() to prevent stack overflow */
+/* Maximum recursion depth for ray_eval() to prevent stack overflow.
+ * The depth counter lives on the per-thread VM (__VM->eval_depth). */
 #define RAY_EVAL_MAX_DEPTH 512
-_Thread_local static int eval_depth = 0;
 
 typedef struct {
     const ray_t* vec;
@@ -73,11 +74,10 @@ static void affine_sum_cache_clear(void) {
     affine_sum_cache_n = 0;
 }
 
-/* Thread-local nfo for eval context — tracks source locations during evaluation */
-static _Thread_local ray_t* g_eval_nfo = NULL;
-
-/* Thread-local error trace — list of [span_i64, filename, fn_name, source] frames */
-static _Thread_local ray_t* g_error_trace = NULL;
+/* Eval-context nfo (source locations) and the error trace (list of
+ * [span_i64, filename, fn_name, source] frames) live on the per-thread
+ * VM — __VM->nfo / __VM->trace — so they survive across bytecode
+ * invocations and stay one-per-thread, per the runtime/VM state model. */
 
 /* Interrupt flag — set by REPL signal handler, checked by eval/VM loops */
 static volatile sig_atomic_t g_eval_interrupted = 0;
@@ -91,25 +91,23 @@ void ray_eval_request_interrupt(void) { ray_request_interrupt(); }
 void ray_eval_clear_interrupt(void)   { ray_clear_interrupt(); }
 int  ray_eval_is_interrupted(void)    { return ray_interrupted(); }
 
-ray_t* ray_eval_get_nfo(void) { return g_eval_nfo; }
-void   ray_eval_set_nfo(ray_t* nfo) { g_eval_nfo = nfo; }
+ray_t* ray_eval_get_nfo(void) { return __VM ? __VM->nfo : NULL; }
+void   ray_eval_set_nfo(ray_t* nfo) { if (__VM) __VM->nfo = nfo; }
 
-ray_t* ray_get_error_trace(void) { return g_error_trace; }
+ray_t* ray_get_error_trace(void) { return __VM ? __VM->trace : NULL; }
 void   ray_clear_error_trace(void) {
-    if (g_error_trace) { ray_release(g_error_trace); g_error_trace = NULL; }
+    if (__VM && __VM->trace) { ray_release(__VM->trace); __VM->trace = NULL; }
 }
 
 /* ══════════════════════════════════════════
  * Restricted-mode check
  * ══════════════════════════════════════════ */
 
-static _Thread_local bool g_eval_restricted = false;
-
-void ray_eval_set_restricted(bool on) { g_eval_restricted = on; }
-bool ray_eval_get_restricted(void)    { return g_eval_restricted; }
+void ray_eval_set_restricted(bool on) { if (__VM) __VM->restricted = on; }
+bool ray_eval_get_restricted(void)    { return __VM && __VM->restricted; }
 
 static inline bool fn_is_restricted(ray_t* fn_obj) {
-    return g_eval_restricted && (fn_obj->attrs & RAY_FN_RESTRICTED);
+    return __VM->restricted && (fn_obj->attrs & RAY_FN_RESTRICTED);
 }
 
 static ray_t* materialize_owned_args(ray_t** args, int64_t n) {
@@ -256,13 +254,15 @@ static ray_t* try_sum_affine_expr(ray_t* expr, int* handled) {
  * Error handling: try / raise
  * ══════════════════════════════════════════ */
 
-static _Thread_local ray_t *__raise_val = NULL;
+/* The pending (raise x) value lives on the per-thread VM
+ * (__VM->raise_val) — it must survive the unwind across any number of
+ * bytecode invocations on this thread's stack. */
 
 /* (raise value) — raise an error with the given value */
 ray_t* ray_raise_fn(ray_t* val) {
-    if (__raise_val) ray_release(__raise_val);
+    if (__VM->raise_val) ray_release(__VM->raise_val);
     ray_retain(val);
-    __raise_val = val;
+    __VM->raise_val = val;
     return ray_error("domain", NULL);
 }
 
@@ -273,8 +273,8 @@ ray_t* ray_try_fn(ray_t* expr, ray_t* handler_expr) {
     if (!RAY_IS_ERR(result)) return result;
 
     /* Get error value (set by raise, or default for runtime errors) */
-    ray_t* err_val = __raise_val;
-    __raise_val = NULL;
+    ray_t* err_val = __VM->raise_val;
+    __VM->raise_val = NULL;
     if (!err_val) err_val = make_i64(0);
 
     /* Evaluate handler expression */
@@ -1621,9 +1621,9 @@ ray_t* ray_fn(ray_t** args, int64_t n) {
     LAMBDA_NLOCALS(lambda) = 0;
 
     /* Attach source location info from current eval context */
-    if (g_eval_nfo) {
-        LAMBDA_NFO(lambda) = g_eval_nfo;
-        ray_retain(g_eval_nfo);
+    if (__VM->nfo) {
+        LAMBDA_NFO(lambda) = __VM->nfo;
+        ray_retain(__VM->nfo);
     } else {
         LAMBDA_NFO(lambda) = NULL;
     }
@@ -1633,7 +1633,7 @@ ray_t* ray_fn(ray_t** args, int64_t n) {
 }
 
 /* Build a [span_i64, filename, fn_name, source] frame from a resolved span
- * and append it to g_error_trace.  Shared by the bytecode and eval paths. */
+ * and append it to __VM->trace.  Shared by the bytecode and eval paths. */
 static void append_error_frame(ray_t* nfo, ray_span_t span) {
     if (span.id == 0) return;
 
@@ -1658,14 +1658,14 @@ static void append_error_frame(ray_t* nfo, ray_span_t span) {
         fe[3] = ray_str("", 0);
     }
 
-    if (!g_error_trace) {
-        g_error_trace = ray_alloc(sizeof(ray_t*));
-        if (!g_error_trace) { ray_release(frame); return; }
-        g_error_trace->type = RAY_LIST;
-        g_error_trace->len = 1;
-        ((ray_t**)ray_data(g_error_trace))[0] = frame;
+    if (!__VM->trace) {
+        __VM->trace = ray_alloc(sizeof(ray_t*));
+        if (!__VM->trace) { ray_release(frame); return; }
+        __VM->trace->type = RAY_LIST;
+        __VM->trace->len = 1;
+        ((ray_t**)ray_data(__VM->trace))[0] = frame;
     } else {
-        g_error_trace = ray_list_append(g_error_trace, frame);
+        __VM->trace = ray_list_append(__VM->trace, frame);
         ray_release(frame);
     }
 }
@@ -1752,7 +1752,8 @@ ray_t* call_lambda(ray_t* lambda, ray_t** call_args, int64_t argc) {
  * ray_error_msg() reading a NULL pointer on any thread that ran an eval
  * without going through ray_runtime_create — which is every tokio worker
  * thread in ray-exomem. */
-extern _Thread_local ray_vm_t *__VM;
+/* __VM (per-thread VM) comes from core/runtime.h — the executor below
+ * allocates a private ray_exec_t per invocation and leaves __VM alone. */
 
 static ray_t* vm_exec(ray_t* lambda, ray_t** call_args, int64_t argc) {
     /* Computed goto dispatch table */
@@ -1787,11 +1788,13 @@ static ray_t* vm_exec(ray_t* lambda, ray_t** call_args, int64_t argc) {
             return ray_error("arity", "expected %" PRId64 " args, got %" PRId64, param_count, argc);
     }
 
-    ray_t *vm_block = ray_alloc(sizeof(ray_vm_t));
+    if (RAY_UNLIKELY(!__VM))
+        return ray_error("state", "no VM bound to this thread");
+
+    ray_t *vm_block = ray_alloc(sizeof(ray_exec_t));
     if (!vm_block || RAY_IS_ERR(vm_block)) return ray_error("oom", NULL);
-    ray_vm_t *vmp = (ray_vm_t *)ray_data(vm_block);
-    memset(vmp, 0, sizeof(ray_vm_t));
-    __VM = vmp;
+    ray_exec_t *vmp = (ray_exec_t *)ray_data(vm_block);
+    memset(vmp, 0, sizeof(ray_exec_t));
 
 #define vm (*vmp)
 
@@ -2247,7 +2250,6 @@ op_ret: {
     if (vm.rp == 0) {
         /* Top-level return */
         ray_release(vm.fn);
-        __VM = NULL;
 #undef vm
         ray_free(vm_block);
         return result;  /* caller owns the POP'd reference */
@@ -2327,21 +2329,21 @@ vm_error_cleanup: {
             if (v) ray_release(v);
         }
 
-        /* Get error value.  If __raise_val is set, a user (raise x)
+        /* Get error value.  If __VM->raise_val is set, a user (raise x)
          * just ran — its value is the real payload the handler must
          * see.  vm_err_obj is the generic error-sentinel returned
          * from ray_raise_fn (or a VM-detected error like arity);
-         * release it if we picked __raise_val.  For VM-only errors,
-         * __raise_val stays NULL and vm_err_obj is used. */
+         * release it if we picked __VM->raise_val.  For VM-only errors,
+         * __VM->raise_val stays NULL and vm_err_obj is used. */
         ray_t *err_val;
-        if (__raise_val) {
+        if (__VM->raise_val) {
             if (vm_err_obj) ray_release(vm_err_obj);
-            err_val = __raise_val;
+            err_val = __VM->raise_val;
         } else {
             err_val = vm_err_obj;
         }
         vm_err_obj = NULL;
-        __raise_val = NULL;
+        __VM->raise_val = NULL;
         if (!err_val) err_val = make_i64(0);
 
         /* Restore context and push error value */
@@ -2372,7 +2374,6 @@ vm_error_cleanup: {
         if (vm.rs[i].fn) ray_release(vm.rs[i].fn);
     for (int32_t i = 0; i < vm.tp; i++)
         ray_release(vm.ts[i].fn);
-    __VM = NULL;
 #undef vm
     ray_free(vm_block);
     if (vm_err_obj)
@@ -2959,7 +2960,7 @@ ray_err_t ray_lang_init(void) {
 }
 
 void ray_lang_destroy(void) {
-    if (__raise_val) { ray_release(__raise_val); __raise_val = NULL; }
+    if (__VM && __VM->raise_val) { ray_release(__VM->raise_val); __VM->raise_val = NULL; }
     /* Reset global Datalog rule storage */
     ray_dl_reset_rules();
     ray_env_destroy();
@@ -2973,14 +2974,19 @@ void ray_lang_destroy(void) {
 ray_t* ray_eval(ray_t* obj) {
     if (!obj || RAY_IS_ERR(obj)) return obj;
 
-    if (eval_depth == 0)
+    /* All eval-context state (depth, scope, restricted, nfo/trace) lives
+     * on the per-thread VM — a thread must bind one before evaluating. */
+    if (RAY_UNLIKELY(!__VM))
+        return ray_error("state", "no VM bound to this thread");
+
+    if (__VM->eval_depth == 0)
         affine_sum_cache_clear();
 
     /* Check for external interrupt (e.g. Ctrl-C from REPL) */
     if (g_eval_interrupted) return ray_error("limit", "interrupted");
 
-    if (++eval_depth > RAY_EVAL_MAX_DEPTH) {
-        eval_depth--;
+    if (++__VM->eval_depth > RAY_EVAL_MAX_DEPTH) {
+        __VM->eval_depth--;
         return ray_error("limit", "eval depth exceeded");
     }
 
@@ -3234,7 +3240,7 @@ ray_t* ray_eval(ray_t* obj) {
             for (int64_t i = 0; i < argc; i++) ray_release(args[i]);
             ray_release(head);
             if (RAY_IS_ERR(result))
-                add_eval_error_frame(g_eval_nfo, obj);
+                add_eval_error_frame(__VM->nfo, obj);
             ret = result; goto out;
         }
         default:
@@ -3243,14 +3249,14 @@ ray_t* ray_eval(ray_t* obj) {
     }
 
 out:
-    eval_depth--;
+    __VM->eval_depth--;
     /* End-of-top-level-expression cleanup hook. Every path that
      * entered ray_eval — REPL, IPC, ray_eval_str, file mode — exits
      * through here; firing ray_progress_end exactly when the depth
      * returns to 0 guarantees the progress bar is cleared no matter
      * which builtin drove the update (including ray_group_fn etc.
      * that bypass ray_execute). */
-    if (eval_depth == 0) ray_progress_end();
+    if (__VM->eval_depth == 0) ray_progress_end();
     return ret;
 }
 
@@ -3260,10 +3266,10 @@ ray_t* ray_eval_str(const char* source) {
     ray_t* parsed = ray_parse_with_nfo(source, nfo);
     if (RAY_IS_ERR(parsed)) { ray_release(nfo); return parsed; }
 
-    ray_t* prev_nfo = g_eval_nfo;
-    g_eval_nfo = nfo;
+    ray_t* prev_nfo = __VM->nfo;
+    __VM->nfo = nfo;
     ray_t* result = ray_eval(parsed);
-    g_eval_nfo = prev_nfo;
+    __VM->nfo = prev_nfo;
 
     ray_release(parsed);
     ray_release(nfo);

--- a/src/lang/eval.h
+++ b/src/lang/eval.h
@@ -109,7 +109,12 @@ enum {
 
 #define LAMBDA_IS_COMPILED(lam) ((lam)->attrs & RAY_FN_COMPILED)
 
-/* ===== VM Types ===== */
+/* ===== Bytecode execution state =====
+ *
+ * Per-invocation interpreter state, allocated by the executor for each
+ * compiled-lambda call and freed on return.  This is NOT the per-thread
+ * VM — that is ray_vm_t in core/runtime.h, which stays stable for the
+ * thread's lifetime while any number of ray_exec_t frames come and go. */
 
 #define VM_STACK_SIZE 1024
 
@@ -134,14 +139,12 @@ typedef struct {
     int32_t  sp;                    /* stack pointer */
     int32_t  fp;                    /* frame pointer */
     int32_t  rp;                    /* return stack pointer */
-    int32_t  id;                    /* VM identifier */
     ray_t    *fn;                    /* current lambda */
-    void    *heap;                  /* heap pointer (future use) */
     int32_t  tp;                    /* trap stack pointer */
     ray_t    *ps[VM_STACK_SIZE];     /* program stack */
     vm_ctx_t rs[VM_STACK_SIZE];     /* return stack */
     vm_trap_t ts[VM_TRAP_SIZE];     /* trap frames */
-} ray_vm_t;
+} ray_exec_t;
 
 /* ===== Public API ===== */
 

--- a/src/lang/syscmd.c
+++ b/src/lang/syscmd.c
@@ -22,21 +22,19 @@
  */
 
 #include "lang/syscmd.h"
-/* Avoid both lang/internal.h and core/runtime.h here: they each
- * transitively pull a different struct definition for `ray_vm_t`
- * (lang/eval.h vs core/runtime.h) and we don't need the VM internals
- * — only the runtime accessors and the lang-side builtins.  The
- * runtime exposes its main poll via opaque-pointer accessors
- * declared inline below. */
+/* We don't need the VM internals here — only the runtime accessors
+ * and the lang-side builtins.  The runtime exposes its main poll via
+ * opaque-pointer accessors declared inline below.  (Historically this
+ * also dodged a dual ray_vm_t typedef; that's unified in
+ * core/runtime.h now, the externs just keep the TU lean.) */
 #include "core/poll.h"
 #include "core/ipc.h"
 #include "core/profile.h"
 #include "lang/env.h"
 #include "table/sym.h"
 
-/* Forward decls of the bare runtime accessors — these are defined in
- * core/runtime.c.  Pulling the full runtime.h would re-trigger the
- * dual ray_vm_t typedef; one extern keeps us decoupled. */
+/* Forward decls of the bare runtime accessors — defined in
+ * core/runtime.c; one extern keeps this TU decoupled from runtime.h. */
 void* ray_runtime_get_poll(void);
 
 #include <errno.h>

--- a/src/ops/system.c
+++ b/src/ops/system.c
@@ -35,8 +35,8 @@
 #include "core/poll.h"
 #include "core/timer.h"
 
-/* Forward decl: avoids pulling core/runtime.h (which conflicts with
- * lang/eval.h's ray_vm_t typedef in this TU). */
+/* Forward decls: keep this TU decoupled from core/runtime.h — only
+ * the opaque accessors are needed. */
 void* ray_runtime_get_poll(void);
 void  ray_runtime_set_sys_args(void* dict);
 void* ray_runtime_get_sys_args(void);

--- a/test/main.c
+++ b/test/main.c
@@ -56,6 +56,16 @@ extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
 extern void           ray_runtime_destroy(ray_runtime_t* rt);
 extern ray_runtime_t* __RUNTIME;
 
+/* Runtime poll accessors (core/runtime.h) + poll lifecycle (core/poll.h),
+ * forward-declared the same way to avoid the ray_vm_t clash between
+ * core/runtime.h and lang/eval.h (included above). */
+struct ray_poll;
+typedef struct ray_poll ray_poll_t;
+extern ray_poll_t* ray_poll_create(void);
+extern void        ray_poll_destroy(ray_poll_t* poll);
+extern void        ray_runtime_set_poll(void* poll);
+extern void*       ray_runtime_get_poll(void);
+
 /* ─── Shared state ────────────────────────────────────────────────── */
 
 char    ray_test_fail_buf[2048];
@@ -432,8 +442,22 @@ static test_result_t run_rfl_at(int idx) {
     return run_rfl_file(g_rfl_paths[idx]);
 }
 
-static void rfl_setup(void)    { ray_runtime_create(0, NULL); }
-static void rfl_teardown(void) { ray_runtime_destroy(__RUNTIME); }
+/* The runtime poll mirrors main.c: unified IPC handles are selector ids
+ * resolved in it, so .rfl scripts that `.ipc.open` need one published.
+ * Destroy order also mirrors main.c — poll first, runtime second. */
+static void rfl_setup(void) {
+    ray_runtime_create(0, NULL);
+    ray_poll_t* p = ray_poll_create();
+    if (p) ray_runtime_set_poll(p);
+}
+static void rfl_teardown(void) {
+    ray_poll_t* p = (ray_poll_t*)ray_runtime_get_poll();
+    if (p) {
+        ray_runtime_set_poll(NULL);
+        ray_poll_destroy(p);
+    }
+    ray_runtime_destroy(__RUNTIME);
+}
 
 /* Thunk pool — one function per potential .rfl slot. */
 #define RFL_THUNKS(X) \

--- a/test/rfl/system/syscmd_coverage.rfl
+++ b/test/rfl/system/syscmd_coverage.rfl
@@ -117,27 +117,32 @@
 (> (.sys.env 1) 0)  -- true
 (> (.sys.env "x") 0) -- true
 
-;; ────────────── h_listen: domain / type / nyi branches ──────────────
-;; The test runtime (test/main.c) does not register a poll instance,
-;; so any port that passes the range check hits the "nyi: no main
-;; event loop attached" branch (line 133).  Out-of-range ports fail
-;; earlier with `domain` (line 130); non-numeric arg fails earliest
-;; with `type` (line 129).
+;; ────────────── h_listen: domain / type / io branches ──────────────
+;; The test runtime (test/main.c rfl_setup) registers a poll instance —
+;; same as the real binary — so valid ports actually bind and the
+;; "nyi: no main event loop attached" branch is unreachable here.
+;; Out-of-range ports fail with `domain` (range check); non-numeric
+;; arg fails earliest with `type`.  Fixed high port follows the
+;; ipc_diff.rfl precedent (19999).
 (.sys.listen 0)       !- domain
 (.sys.listen -1)      !- domain
 (.sys.listen 65536)   !- domain
 (.sys.listen 99999)   !- domain
-(.sys.listen 8080)    !- nyi
-(.sys.listen 1)       !- nyi
-(.sys.listen 65535)   !- nyi
-;; String coerces through arg_as_i64; numeric string → nyi, junk → type.
-(.sys.listen "8080")  !- nyi
+;; Success path: binds and returns the listener's selector id.  The
+;; listener stays open until rfl_teardown destroys the poll.
+(set listen-id (.sys.listen 38471))
+(>= listen-id 0)      -- true
+;; Same port again — already bound by us → io.
+(.sys.listen 38471)   !- io
+;; String coerces through arg_as_i64; numeric string takes the same
+;; path as the number (out-of-range here → domain), junk → type.
+(.sys.listen "99999") !- domain
 (.sys.listen "abc")   !- type
 
 ;; Same surface via .sys.cmd string dispatch — exercises the dispatcher
 ;; path through to h_listen, which is a separate code path from the
 ;; direct ray_sys_listen_fn entry above.
-(.sys.cmd "listen 8080")  !- nyi
+(.sys.cmd "listen 38471") !- io
 (.sys.cmd "listen -1")    !- domain
 (.sys.cmd "listen 65536") !- domain
 

--- a/test/test_ipc.c
+++ b/test/test_ipc.c
@@ -91,8 +91,24 @@ extern ray_runtime_t* __RUNTIME;
 
 /* ---- Setup / Teardown ---------------------------------------------------- */
 
-static void ipc_setup(void)    { ray_runtime_create(0, NULL); }
-static void ipc_teardown(void) { ray_runtime_destroy(__RUNTIME); }
+/* Unified IPC handles are poll selector ids, so the client side needs a
+ * runtime poll for ray_ipc_connect to register outbound connections in —
+ * mirrors what main.c does at startup.  Destroy order mirrors main.c too:
+ * poll first (fires close hooks while the env is still alive), then the
+ * runtime. */
+static void ipc_setup(void) {
+    ray_runtime_create(0, NULL);
+    ray_poll_t* p = ray_poll_create();
+    if (p) ray_runtime_set_poll(p);
+}
+static void ipc_teardown(void) {
+    ray_poll_t* p = (ray_poll_t*)ray_runtime_get_poll();
+    if (p) {
+        ray_runtime_set_poll(NULL);
+        ray_poll_destroy(p);
+    }
+    ray_runtime_destroy(__RUNTIME);
+}
 
 /* ---- Helpers ------------------------------------------------------------- */
 
@@ -1780,6 +1796,100 @@ static test_result_t test_ipc_post_non_serializable(void) {
     PASS();
 }
 
+/* ---- test_ipc_server_push ------------------------------------------------ */
+/*
+ * Unified-handle server push: the handle a server-side hook receives is a
+ * first-class connection handle, so `.ipc.post` on it delivers an async
+ * message BACK to the connecting client — both from inside `.ipc.on.open`
+ * and later from any other server-side eval that kept the handle around.
+ *
+ * Flow:
+ *   1. Server `.ipc.on.open` saves the handle in `_srvh` and posts
+ *      `(set _pushed 7)` back through it.
+ *   2. The client connects, then issues a sync round-trip.  The server is
+ *      single-threaded and processes one connection's frames in order, so
+ *      the pushed ASYNC frame precedes the sync RESP on the wire and the
+ *      client's sync wait dispatches (evals) the push before the barrier
+ *      returns.
+ *   3. A second round-trip calls `_doit`, which posts AGAIN through the
+ *      saved `_srvh` — the "post outside any hook" path.  Same ordering
+ *      argument: that push is drained before the round-trip returns.
+ *
+ * `_pushed` / `_pushed2` are written by the CLIENT thread (this thread)
+ * while it pumps its own connection, so reading them back after the join
+ * is race-free; `_srvh` is written by the server thread, read only after
+ * ray_thread_join.
+ */
+static test_result_t test_ipc_server_push(void) {
+    const char* setup =
+        "(set _pushed 0)"
+        "(set _pushed2 0)"
+        "(set _srvh (- 0 1))"
+        "(set .ipc.on.open (fn [h] (set _srvh h) (.ipc.post h \"(set _pushed 7)\")))"
+        "(set _doit (fn [x] (.ipc.post _srvh \"(set _pushed2 9)\") 42))";
+    ray_t* r = ray_eval_str(setup);
+    TEST_ASSERT_NOT_NULL(r);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(r));
+    if (r != RAY_NULL_OBJ) ray_release(r);
+
+    ray_poll_t* poll = ray_poll_create();
+    TEST_ASSERT_NOT_NULL(poll);
+
+    int64_t listener_id = ray_ipc_listen(poll, 0);
+    TEST_ASSERT((listener_id) >= (0), "listener_id >= 0");
+    ray_selector_t* listener_sel = ray_poll_get(poll, listener_id);
+    TEST_ASSERT_NOT_NULL(listener_sel);
+    uint16_t port = get_listen_port((ray_sock_t)listener_sel->fd);
+    TEST_ASSERT((port) > (0), "port > 0");
+
+    ray_vm_t* srv_vm = make_server_vm();
+    TEST_ASSERT_NOT_NULL(srv_vm);
+
+    poll_thread_ctx_t pctx = { .poll = poll, .vm = srv_vm, .running = 1 };
+    ray_thread_t tid;
+    ray_thread_create(&tid, (void(*)(void*))poll_server_thread_fn, &pctx);
+    sleep_ms(20);
+
+    int64_t h = ray_ipc_connect("127.0.0.1", port, NULL, NULL);
+    TEST_ASSERT((h) >= (0), "h >= 0");
+
+    /* Barrier 1: drains the on.open push before returning. */
+    ray_t* msg = ray_str("(+ 0 0)", 7);
+    ray_t* resp = ray_ipc_send(h, msg);
+    ray_release(msg);
+    bool resp1_ok = (resp != NULL) && !RAY_IS_ERR(resp);
+    if (resp && !RAY_IS_ERR(resp)) ray_release(resp);
+
+    /* Barrier 2: server posts through the SAVED handle, outside any
+     * lifecycle hook, then returns 42. */
+    ray_t* msg2 = ray_str("(_doit 0)", 9);
+    ray_t* resp2 = ray_ipc_send(h, msg2);
+    ray_release(msg2);
+    bool resp2_ok = (resp2 != NULL) && !RAY_IS_ERR(resp2)
+                    && resp2->type == -RAY_I64 && resp2->i64 == 42;
+    if (resp2 && !RAY_IS_ERR(resp2)) ray_release(resp2);
+
+    ray_ipc_close(h);
+    poll_stop(poll, port);
+    ray_thread_join(tid);
+    ray_poll_destroy(poll);
+    ray_sys_free(srv_vm);
+
+    TEST_ASSERT_TRUE(resp1_ok);
+    TEST_ASSERT_TRUE(resp2_ok);
+
+    int64_t sym1 = ray_sym_intern("_pushed",  strlen("_pushed"));
+    int64_t sym2 = ray_sym_intern("_pushed2", strlen("_pushed2"));
+    int64_t symh = ray_sym_intern("_srvh",    strlen("_srvh"));
+    ray_t* vh = ray_env_get(symh); TEST_ASSERT_NOT_NULL(vh);
+    ray_t* v1 = ray_env_get(sym1); TEST_ASSERT_NOT_NULL(v1);
+    ray_t* v2 = ray_env_get(sym2); TEST_ASSERT_NOT_NULL(v2);
+    TEST_ASSERT((vh->i64) >= (0), "server hook handle >= 0");
+    TEST_ASSERT_EQ_I(v1->i64, 7);
+    TEST_ASSERT_EQ_I(v2->i64, 9);
+    PASS();
+}
+
 /* ---- Registry ------------------------------------------------------------ */
 
 const test_entry_t ipc_entries[] = {
@@ -1816,5 +1926,6 @@ const test_entry_t ipc_entries[] = {
     { "ipc/post_delivery",               test_ipc_post_delivery,                  ipc_setup, ipc_teardown },
     { "ipc/post_invalid_handle",         test_ipc_post_invalid_handle,            ipc_setup, ipc_teardown },
     { "ipc/post_non_serializable",       test_ipc_post_non_serializable,          ipc_setup, ipc_teardown },
+    { "ipc/server_push",                 test_ipc_server_push,                    ipc_setup, ipc_teardown },
     { NULL, NULL, NULL, NULL },
 };

--- a/test/test_ipc.c
+++ b/test/test_ipc.c
@@ -65,10 +65,9 @@
 #include "store/journal.h"
 #include "ops/ops.h"
 
-/* `.ipc.post` C wrapper — declared in src/lang/internal.h, but that header
- * pulls in a conflicting ray_vm_t (via lang/eval.h) that clashes with the
- * core/runtime.h ray_vm_t already included above, so forward-declare just
- * the one symbol the guard tests call. */
+/* `.ipc.post` C wrapper — declared in src/lang/internal.h; forward-
+ * declare just the one symbol the guard tests call instead of pulling
+ * that whole header in. */
 extern ray_t* ray_hpost_fn(ray_t* handle, ray_t* msg);
 
 #ifndef RAY_OS_WINDOWS
@@ -159,8 +158,7 @@ static void poll_stop(ray_poll_t* poll, uint16_t port) {
 static ray_vm_t* make_server_vm(void) {
     ray_vm_t* vm = (ray_vm_t*)ray_sys_alloc(sizeof(ray_vm_t));
     if (!vm) return NULL;
-    memset(vm, 0, sizeof(ray_vm_t));
-    vm->id = 99;
+    ray_vm_init(vm, 99);
     return vm;
 }
 

--- a/test/test_public_api.c
+++ b/test/test_public_api.c
@@ -544,7 +544,9 @@ static test_result_t test_public_eval_nfo_roundtrip(void) {
     PASS();
 }
 
-/* Restricted-mode API — pure data store with no side effects on benign arith. */
+/* Restricted-mode API — round-trips through the per-thread VM
+ * (__VM->restricted), so a runtime must be live; without a bound VM the
+ * setter is a no-op and the getter reports false. */
 static test_result_t test_public_eval_restricted_setget(void) {
     ray_eval_set_restricted(false);
     TEST_ASSERT_FALSE(ray_eval_get_restricted());
@@ -655,7 +657,7 @@ const test_entry_t public_api_entries[] = {
     { "public/eval_interrupt_wrappers",        test_public_eval_interrupt_wrappers,        NULL, NULL },
     { "public/interrupt_cross_path",           test_public_interrupt_cross_path,           NULL, NULL },
     { "public/eval_nfo_roundtrip",             test_public_eval_nfo_roundtrip,             public_api_setup, public_api_teardown },
-    { "public/eval_restricted_setget",         test_public_eval_restricted_setget,         NULL, NULL },
+    { "public/eval_restricted_setget",         test_public_eval_restricted_setget,         public_api_setup, public_api_teardown },
     { "public/eval_restricted_allows_arith",   test_public_eval_restricted_allows_arith,   public_api_setup, public_api_teardown },
     { "public/get_error_trace_populated",      test_public_get_error_trace_populated,      public_api_setup, public_api_teardown },
     { "public/get_error_trace_cleared_on_eval",test_public_get_error_trace_cleared_on_eval,public_api_setup, public_api_teardown },

--- a/test/test_repl.c
+++ b/test/test_repl.c
@@ -919,8 +919,7 @@ static int repl_start_server(repl_server_t* s) {
     if (s->port == 0) { ray_ipc_server_destroy(&s->srv); return -1; }
     s->srv_vm = (ray_vm_t*)ray_sys_alloc(sizeof(ray_vm_t));
     if (!s->srv_vm) { ray_ipc_server_destroy(&s->srv); return -1; }
-    memset(s->srv_vm, 0, sizeof(ray_vm_t));
-    s->srv_vm->id = 1;
+    ray_vm_init(s->srv_vm, 1);
     s->ctx.srv = &s->srv;
     s->ctx.vm  = s->srv_vm;
     if (ray_thread_create(&s->tid, repl_server_thread_fn, &s->ctx) != RAY_OK) {

--- a/test/test_repl.c
+++ b/test/test_repl.c
@@ -80,11 +80,20 @@ extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
 extern void           ray_runtime_destroy(ray_runtime_t* rt);
 extern ray_runtime_t* __RUNTIME;
 extern void           ray_runtime_set_poll(void* poll);
+extern void*          ray_runtime_get_poll(void);
 
 /* ─── Setup / Teardown ────────────────────────────────────────────── */
 
+/* Unified IPC handles are poll selector ids resolved in the runtime
+ * poll, so the remote-REPL tests' ray_repl_connect_fn needs one
+ * published — mirroring main.c.  Teardown order also mirrors main.c:
+ * poll first (closes any leftover conns), runtime second. */
 static void repl_setup(void) {
     ray_runtime_create(0, NULL);
+#ifndef RAY_OS_WINDOWS
+    ray_poll_t* p = ray_poll_create();
+    if (p) ray_runtime_set_poll(p);
+#endif
 }
 
 static void repl_teardown(void) {
@@ -96,6 +105,15 @@ static void repl_teardown(void) {
         ray_t* args = NULL;
         ray_release(ray_repl_disconnect_fn(&args, 0));
     }
+#ifndef RAY_OS_WINDOWS
+    {
+        ray_poll_t* p = (ray_poll_t*)ray_runtime_get_poll();
+        if (p) {
+            ray_runtime_set_poll(NULL);
+            ray_poll_destroy(p);
+        }
+    }
+#endif
     ray_runtime_destroy(__RUNTIME);
 }
 

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -3192,9 +3192,23 @@ static void server_thread_fn(void* arg) {
         ray_ipc_poll(ctx->srv, 10);
 }
 
+/* Unified IPC handles are poll selector ids resolved in the runtime
+ * poll, so every client-side ray_ipc_connect below needs one published —
+ * mirroring what main.c does at startup. */
+static ray_poll_t* ipc_client_poll(void) {
+    ray_poll_t* p = ray_poll_create();
+    if (p) ray_runtime_set_poll(p);
+    return p;
+}
+static void ipc_client_poll_done(void) {
+    ray_poll_t* p = (ray_poll_t*)ray_runtime_get_poll();
+    if (p) { ray_runtime_set_poll(NULL); ray_poll_destroy(p); }
+}
+
 static test_result_t test_ipc_sync_roundtrip(void) {
     /* Full runtime needed for ray_eval_str in server thread */
     ray_runtime_t* rt = ray_runtime_create(0, NULL);
+    ipc_client_poll();
     TEST_ASSERT_NOT_NULL(rt);
 
     ray_ipc_server_t srv;
@@ -3240,6 +3254,7 @@ static test_result_t test_ipc_sync_roundtrip(void) {
     ray_thread_join(tid);
     ray_ipc_server_destroy(&srv);
     ray_sys_free(srv_vm);
+    ipc_client_poll_done();
     ray_runtime_destroy(rt);
 
     PASS();
@@ -3250,6 +3265,7 @@ static test_result_t test_ipc_sync_roundtrip(void) {
 static test_result_t test_ipc_async_send(void) {
     /* Full runtime needed for eval on server side */
     ray_runtime_t* rt = ray_runtime_create(0, NULL);
+    ipc_client_poll();
     TEST_ASSERT_NOT_NULL(rt);
 
     ray_ipc_server_t srv;
@@ -3284,6 +3300,7 @@ static test_result_t test_ipc_async_send(void) {
     ray_thread_join(tid);
     ray_ipc_server_destroy(&srv);
     ray_sys_free(srv_vm);
+    ipc_client_poll_done();
     ray_runtime_destroy(rt);
 
     PASS();
@@ -3293,6 +3310,7 @@ static test_result_t test_ipc_async_send(void) {
 
 static test_result_t test_ipc_auth_success(void) {
     ray_runtime_t* rt = ray_runtime_create(0, NULL);
+    ipc_client_poll();
     TEST_ASSERT_NOT_NULL(rt);
 
     ray_ipc_server_t srv;
@@ -3328,6 +3346,7 @@ static test_result_t test_ipc_auth_success(void) {
     ray_thread_join(tid);
     ray_ipc_server_destroy(&srv);
     ray_sys_free(srv_vm);
+    ipc_client_poll_done();
     ray_runtime_destroy(rt);
 
     PASS();
@@ -3337,6 +3356,7 @@ static test_result_t test_ipc_auth_success(void) {
 
 static test_result_t test_ipc_auth_reject(void) {
     ray_runtime_t* rt = ray_runtime_create(0, NULL);
+    ipc_client_poll();
     TEST_ASSERT_NOT_NULL(rt);
 
     ray_ipc_server_t srv;
@@ -3362,6 +3382,7 @@ static test_result_t test_ipc_auth_reject(void) {
     ray_thread_join(tid);
     ray_ipc_server_destroy(&srv);
     ray_sys_free(srv_vm);
+    ipc_client_poll_done();
     ray_runtime_destroy(rt);
 
     PASS();
@@ -3371,6 +3392,7 @@ static test_result_t test_ipc_auth_reject(void) {
 
 static test_result_t test_ipc_auth_no_creds(void) {
     ray_runtime_t* rt = ray_runtime_create(0, NULL);
+    ipc_client_poll();
     TEST_ASSERT_NOT_NULL(rt);
 
     ray_ipc_server_t srv;
@@ -3396,6 +3418,7 @@ static test_result_t test_ipc_auth_no_creds(void) {
     ray_thread_join(tid);
     ray_ipc_server_destroy(&srv);
     ray_sys_free(srv_vm);
+    ipc_client_poll_done();
     ray_runtime_destroy(rt);
 
     PASS();
@@ -3405,6 +3428,7 @@ static test_result_t test_ipc_auth_no_creds(void) {
 
 static test_result_t test_ipc_restricted(void) {
     ray_runtime_t* rt = ray_runtime_create(0, NULL);
+    ipc_client_poll();
     TEST_ASSERT_NOT_NULL(rt);
 
     ray_ipc_server_t srv;
@@ -3467,6 +3491,7 @@ static test_result_t test_ipc_restricted(void) {
     ray_thread_join(tid);
     ray_ipc_server_destroy(&srv);
     ray_sys_free(srv_vm);
+    ipc_client_poll_done();
     ray_runtime_destroy(rt);
 
     PASS();
@@ -3480,6 +3505,7 @@ static test_result_t test_ipc_handshake_version_mismatch(void) {
      * to any framed payload.  This is the defense-in-depth layer that
      * protects an old peer from ever seeing a new-format message. */
     ray_runtime_t* rt = ray_runtime_create(0, NULL);
+    ipc_client_poll();
     TEST_ASSERT_NOT_NULL(rt);
 
     ray_ipc_server_t srv;
@@ -3528,6 +3554,7 @@ static test_result_t test_ipc_handshake_version_mismatch(void) {
     ray_thread_join(tid);
     ray_ipc_server_destroy(&srv);
     ray_sys_free(srv_vm);
+    ipc_client_poll_done();
     ray_runtime_destroy(rt);
     PASS();
 }

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -3221,8 +3221,7 @@ static test_result_t test_ipc_sync_roundtrip(void) {
     /* Create a VM for the server thread */
     ray_vm_t* srv_vm = (ray_vm_t*)ray_sys_alloc(sizeof(ray_vm_t));
     TEST_ASSERT_NOT_NULL(srv_vm);
-    memset(srv_vm, 0, sizeof(ray_vm_t));
-    srv_vm->id = 1;
+    ray_vm_init(srv_vm, 1);
 
     ipc_thread_ctx_t ctx = { .srv = &srv, .vm = srv_vm };
 
@@ -3275,8 +3274,7 @@ static test_result_t test_ipc_async_send(void) {
 
     ray_vm_t* srv_vm = (ray_vm_t*)ray_sys_alloc(sizeof(ray_vm_t));
     TEST_ASSERT_NOT_NULL(srv_vm);
-    memset(srv_vm, 0, sizeof(ray_vm_t));
-    srv_vm->id = 1;
+    ray_vm_init(srv_vm, 1);
 
     ipc_thread_ctx_t ctx = { .srv = &srv, .vm = srv_vm };
 
@@ -3322,8 +3320,7 @@ static test_result_t test_ipc_auth_success(void) {
 
     ray_vm_t* srv_vm = (ray_vm_t*)ray_sys_alloc(sizeof(ray_vm_t));
     TEST_ASSERT_NOT_NULL(srv_vm);
-    memset(srv_vm, 0, sizeof(ray_vm_t));
-    srv_vm->id = 1;
+    ray_vm_init(srv_vm, 1);
 
     ipc_thread_ctx_t ctx = { .srv = &srv, .vm = srv_vm };
     ray_thread_t tid;
@@ -3368,8 +3365,7 @@ static test_result_t test_ipc_auth_reject(void) {
 
     ray_vm_t* srv_vm = (ray_vm_t*)ray_sys_alloc(sizeof(ray_vm_t));
     TEST_ASSERT_NOT_NULL(srv_vm);
-    memset(srv_vm, 0, sizeof(ray_vm_t));
-    srv_vm->id = 1;
+    ray_vm_init(srv_vm, 1);
 
     ipc_thread_ctx_t ctx = { .srv = &srv, .vm = srv_vm };
     ray_thread_t tid;
@@ -3404,8 +3400,7 @@ static test_result_t test_ipc_auth_no_creds(void) {
 
     ray_vm_t* srv_vm = (ray_vm_t*)ray_sys_alloc(sizeof(ray_vm_t));
     TEST_ASSERT_NOT_NULL(srv_vm);
-    memset(srv_vm, 0, sizeof(ray_vm_t));
-    srv_vm->id = 1;
+    ray_vm_init(srv_vm, 1);
 
     ipc_thread_ctx_t ctx = { .srv = &srv, .vm = srv_vm };
     ray_thread_t tid;
@@ -3441,8 +3436,7 @@ static test_result_t test_ipc_restricted(void) {
 
     ray_vm_t* srv_vm = (ray_vm_t*)ray_sys_alloc(sizeof(ray_vm_t));
     TEST_ASSERT_NOT_NULL(srv_vm);
-    memset(srv_vm, 0, sizeof(ray_vm_t));
-    srv_vm->id = 1;
+    ray_vm_init(srv_vm, 1);
 
     ipc_thread_ctx_t ctx = { .srv = &srv, .vm = srv_vm };
     ray_thread_t tid;
@@ -3516,8 +3510,7 @@ static test_result_t test_ipc_handshake_version_mismatch(void) {
 
     ray_vm_t* srv_vm = (ray_vm_t*)ray_sys_alloc(sizeof(ray_vm_t));
     TEST_ASSERT_NOT_NULL(srv_vm);
-    memset(srv_vm, 0, sizeof(ray_vm_t));
-    srv_vm->id = 1;
+    ray_vm_init(srv_vm, 1);
 
     ipc_thread_ctx_t ctx = { .srv = &srv, .vm = srv_vm };
     ray_thread_t tid;


### PR DESCRIPTION
## Problem

A user hit this on `2.1.0`:

```
‣ (set .ipc.on.open (fn [h] (.ipc.post h "(+ 1 1")))
lambda
‣ ipc: .ipc.on.open hook raised an error (handle=2)
```

Posting on the handle a hook receives always failed — inside the hook **and** later with a stored handle. Root cause: two disjoint handle namespaces. `.ipc.open` returned an index into a private client fd table (`g_client_fds[]`), while hooks received the inbound connection's **poll selector id**. `.ipc.send`/`.ipc.post`/`.ipc.close` only consulted the client table, so server-side handles never resolved — and since both namespaces are small integers, a server with its own outbound connections could even deliver to the **wrong peer** silently.

## Change

A handle is now one thing: the poll selector id of an IPC connection, inbound or outbound.

- `ray_ipc_connect` does the blocking handshake/auth as before, then hands the socket to the active poll with the same read pump inbound connections use, returning the selector id. The client fd table is deleted.
- `.ipc.send` / `.ipc.post` / `.ipc.close` resolve any handle in the active poll (thread-local poll of the dispatching hook/eval, else the runtime's main poll). Hooks can push through — or close — the handles they receive, kdb-style (`neg[h]` analog). Resolution validates the target is a handshake-complete IPC connection, so a stray integer can't write to the listener, stdin, or a mid-handshake socket.
- `.ipc.send` now **pumps** the connection while waiting for its response: interleaved pushed asyncs are dispatched, and sync requests from the peer are answered — full duplex. This also fixes a latent corruption bug: the old response reader never checked `hdr.msgtype`, so a pushed frame would have been consumed as the next sync response.
- `ipc_read_payload` detaches the payload buffer and advances the state machine before evaluating, making nested round-trips on the same connection re-entrancy-safe; `RESP` frames are deposited for the waiting sender instead of being evaluated.
- Lifecycle hooks remain inbound-only, preserving the documented `on.open`/`on.close` 1:1 pairing.

## Behaviour notes

- Wire format unchanged; old and new peers interoperate.
- `.ipc.open` handle values shift (selector ids instead of table indices) — they were always opaque.
- Idle interactive/server processes dispatch pushes via the poll loop; script-mode clients drain them during their next `.ipc.send` wait.
- Selector ids are reused after close (like kdb fds): don't cache handles past `on.close`. A generation tag could harden this later.
- A corrupt compressed request now produces a null response instead of leaving the sync caller hanging.

## Tests

- New `ipc/server_push` test: push from inside `.ipc.on.open` **and** push later through a stored handle, delivered across a real round-trip.
- Test fixtures (`test_ipc.c`, `test_store.c`, `test_repl.c`, `.rfl` runner) now publish a runtime poll, mirroring `main.c`.
- `syscmd_coverage.rfl` updated: its `.sys.listen → nyi` assertions relied on the test runner having no poll; valid ports now genuinely bind, so it asserts the success and double-bind `io` branches instead.
- Full suite under ASan/UBSan: **3375 of 3377 passed, 2 skipped, 0 failed**.
- Verified end-to-end with two processes: hook-installed push and out-of-hook push both delivered and evaluated client-side.

Fixes the reported async-IPC-from-server bug.