### PR TITLE
fix(compile): special-form calls in compiled lambdas can't see locals

### DIFF
--- a/src/lang/compile.c
+++ b/src/lang/compile.c
@@ -194,6 +194,7 @@ static void patch_jump(compiler_t *c, int32_t pos) {
 
 /* Cached sym IDs for special forms */
 static _Thread_local int64_t sf_set = -1, sf_let = -1, sf_if = -1, sf_do = -1, sf_fn = -1, sf_self = -1, sf_try = -1, sf_return = -1;
+static _Thread_local int64_t sf_eval = -1, sf_resolve = -1;
 
 static void init_sf_syms(void) {
     if (sf_set >= 0) return;
@@ -205,7 +206,47 @@ static void init_sf_syms(void) {
     sf_self = ray_sym_intern("self", 4);
     sf_try  = ray_sym_intern("try",  3);
     sf_return = ray_sym_intern("return", 6);
+    sf_eval    = ray_sym_intern("eval", 4);
+    sf_resolve = ray_sym_intern("resolve", 7);
 }
+
+/* Does `ast` mention any of the current locals — or `self`, or a
+ * dynamic resolver (`eval` / `resolve`) that could reach them by a
+ * constructed name?  Decides whether a special-form call needs its
+ * locals materialized into a scope frame around the dynamic eval.
+ * Quoted syms count: forms like (alter 'v ...) resolve them through
+ * the env, where a tree-walk local would shadow a global.  Conservative
+ * by construction — descends lists, dicts, and sym vectors. */
+static bool ast_refs_locals(compiler_t *c, ray_t *ast);
+static bool sym_is_local_ref(compiler_t *c, int64_t id) {
+    if (id == sf_self || id == sf_eval || id == sf_resolve) return true;
+    for (int32_t i = c->n_locals - 1; i >= 0; i--)
+        if (c->locals[i].sym_id == id) return true;
+    return false;
+}
+static bool ast_refs_locals(compiler_t *c, ray_t *ast) {
+    if (!ast) return false;
+    if (ast->type == -RAY_SYM)
+        return sym_is_local_ref(c, ast->i64);
+    if (ast->type == RAY_SYM) {  /* sym vector */
+        const int64_t *ids = (const int64_t*)ray_data(ast);
+        for (int64_t i = 0; i < ast->len; i++)
+            if (sym_is_local_ref(c, ids[i])) return true;
+        return false;
+    }
+    if (ast->type == RAY_LIST) {
+        ray_t **elems = (ray_t**)ray_data(ast);
+        for (int64_t i = 0; i < ast->len; i++)
+            if (ast_refs_locals(c, elems[i])) return true;
+        return false;
+    }
+    if (ast->type == RAY_DICT) {  /* slot[0]=keys, slot[1]=vals */
+        ray_t **slots = (ray_t**)ray_data(ast);
+        return ast_refs_locals(c, slots[0]) || ast_refs_locals(c, slots[1]);
+    }
+    return false;
+}
+
 
 /* ── Compile a list (special form or function call) ── */
 static void compile_list(compiler_t *c, ray_t *ast) {
@@ -386,12 +427,43 @@ static void compile_list(compiler_t *c, ray_t *ast) {
     if (head->type == -RAY_SYM && !(head->attrs & ATTR_QUOTED))
         fn = ray_env_get(head->i64);
 
-    /* Unrecognized special form: dynamic eval on entire form */
+    /* Unrecognized special form: dynamic eval on the entire form.  The
+     * special form re-evaluates its argument ASTs via the tree walker,
+     * which resolves names through scope frames + globals and cannot
+     * see this frame's local slots — so materialize the locals known
+     * at this point (plus self) into a scope frame around the eval,
+     * and sync any let-updates back into the slots afterwards. */
     if (fn && (fn->attrs & RAY_FN_SPECIAL_FORM)) {
+        /* Fast path: a form that mentions no local (the common
+         * globals-only case) needs no materialization — emit the bare
+         * dynamic eval exactly as before. */
+        if (!ast_refs_locals(c, ast)) {
+            int32_t idx = add_constant(c, ast);
+            emit_const(c, idx);
+            emit(c, OP_CALLD);
+            emit(c, 0);
+            return;
+        }
+
+        ray_t *syms = ray_alloc((size_t)c->n_locals * sizeof(int64_t));
+        if (!syms || RAY_IS_ERR(syms)) { c->error = true; return; }
+        syms->type = RAY_I64;
+        syms->len  = c->n_locals;
+        int64_t *ids = (int64_t*)ray_data(syms);
+        for (int32_t i = 0; i < c->n_locals; i++)
+            ids[i] = c->locals[i].sym_id;   /* slot i <-> ids[i] */
+        int32_t syms_idx = add_constant(c, syms);
+        ray_release(syms);
+        if (c->error) return;
+
+        emit_const(c, syms_idx);
+        emit(c, OP_SCOPE_BEGIN);
         int32_t idx = add_constant(c, ast);
         emit_const(c, idx);
         emit(c, OP_CALLD);
         emit(c, 0);
+        emit_const(c, syms_idx);
+        emit(c, OP_SCOPE_END);
         return;
     }
 
@@ -563,4 +635,5 @@ ray_span_t ray_bc_dbg_get(ray_t* dbg, int32_t ip) {
 
 void ray_compile_reset(void) {
     sf_set = sf_let = sf_if = sf_do = sf_fn = sf_self = sf_try = sf_return = -1;
+    sf_eval = sf_resolve = -1;
 }

--- a/src/lang/env.c
+++ b/src/lang/env.c
@@ -125,6 +125,10 @@ int32_t ray_env_global_count(void) { return g_env.count; }
 static int64_t g_ipc_hook_syms[5] = {0};
 static bool    g_ipc_hook_syms_ready = false;
 
+/* Cached `self` sym id for ray_env_scope_bind — interned once per sym
+ * table generation; invalidated alongside the hook syms below. */
+static int64_t g_self_sym = -1;
+
 static void ipc_hook_syms_ensure(void) {
     if (g_ipc_hook_syms_ready) return;
     g_ipc_hook_syms[0] = ray_sym_intern(".ipc.on.open",  strlen(".ipc.on.open"));
@@ -177,6 +181,7 @@ void ray_env_destroy(void) {
      * so the next ray_env_init re-interns fresh IDs from the new sym
      * table. */
     g_ipc_hook_syms_ready = false;
+    g_self_sym = -1;
 }
 
 /* Flat (non-dotted) lookup — scope stack top-down, then global env.
@@ -626,6 +631,56 @@ void ray_env_pop_scope(void) {
     f->vals = f->vals_inline;
     f->cap = RAY_FRAME_CAP;
     f->count = 0;
+}
+
+/* Materialize compiled-lambda locals into a fresh scope frame — the
+ * compiled counterpart of call_lambda's tree-walk frame.  A runtime
+ * special form re-evaluates its argument ASTs via ray_eval, which
+ * resolves names through scope frames + globals and cannot see the
+ * caller's bytecode slots; this bridges the two.  NULL slots are
+ * let-locals whose initializer hasn't executed yet: in the tree walker
+ * they wouldn't be bound at this point either, so they're skipped. */
+ray_err_t ray_env_scope_bind(const int64_t* syms, int32_t n, ray_t** slots,
+                             ray_t* self_obj) {
+    ray_err_t err = ray_env_push_scope();
+    if (err != RAY_OK) return err;
+    if (self_obj) {
+        if (g_self_sym < 0) g_self_sym = ray_sym_intern("self", 4);
+        (void)ray_env_set_local(g_self_sym, self_obj);
+    }
+    for (int32_t i = 0; i < n; i++) {
+        if (!slots[i]) continue;
+        ray_err_t e = ray_env_set_local(syms[i], slots[i]);
+        if (e != RAY_OK && e != RAY_ERR_RESERVED) {
+            ray_env_pop_scope();
+            return e;
+        }
+    }
+    return RAY_OK;
+}
+
+/* Sync the materialized frame back into the slots and pop it.  Only
+ * syms from the compiler's table sync — a `let` inside the dynamic
+ * eval that introduced a name the compiler never saw has no slot to
+ * land in (the tree walker would keep it in the lambda frame; compiled
+ * code drops it with this frame — names must be introduced lexically
+ * for the compiler to allocate a slot, same as before). */
+void ray_env_scope_sync(const int64_t* syms, int32_t n, ray_t** slots) {
+    if (__VM->scope_depth > 0) {
+        ray_scope_frame_t* f = &__VM->scope_stack[__VM->scope_depth - 1];
+        for (int32_t i = 0; i < n; i++) {
+            for (int32_t k = 0; k < f->count; k++) {
+                if (f->keys[k] != syms[i]) continue;
+                if (f->vals[k] != slots[i]) {
+                    ray_retain(f->vals[k]);
+                    if (slots[i]) ray_release(slots[i]);
+                    slots[i] = f->vals[k];
+                }
+                break;
+            }
+        }
+    }
+    ray_env_pop_scope();
 }
 
 /* ---- Iteration ---- */

--- a/src/lang/env.h
+++ b/src/lang/env.h
@@ -134,6 +134,18 @@ int32_t ray_env_global_count(void);
 /* Local scope stack for lexical binding (let, do, lambda) */
 ray_err_t ray_env_push_scope(void);
 void ray_env_pop_scope(void);
+int32_t   ray_env_scope_depth(void);
 ray_err_t ray_env_set_local(int64_t sym_id, ray_t* val);
+
+/* Compiled-lambda local materialization (OP_SCOPE_BEGIN / OP_SCOPE_END).
+ * bind: push a fresh frame and bind syms[i] -> slots[i] (NULL slots —
+ * let-locals whose initializer hasn't run yet — are skipped) plus
+ * `self` -> self_obj, so a dynamic tree-walk eval inside bytecode
+ * resolves the same names the tree-walk fallback would.
+ * sync: write the frame's (possibly let-updated) values back into the
+ * slots, then pop the frame. */
+ray_err_t ray_env_scope_bind(const int64_t* syms, int32_t n, ray_t** slots,
+                             ray_t* self_obj);
+void      ray_env_scope_sync(const int64_t* syms, int32_t n, ray_t** slots);
 
 #endif /* RAY_ENV_H */

--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -1779,6 +1779,8 @@ static ray_t* vm_exec(ray_t* lambda, ray_t** call_args, int64_t argc) {
         [OP_TRAP_END]   = &&op_trap_end,
         [OP_STOREGLOBAL]   = &&op_storeglobal,
         [OP_STOREGLOBAL_W] = &&op_storeglobal_w,
+        [OP_SCOPE_BEGIN]   = &&op_scope_begin,
+        [OP_SCOPE_END]     = &&op_scope_end,
     };
 
     /* Arity check before allocating VM state */
@@ -1790,6 +1792,11 @@ static ray_t* vm_exec(ray_t* lambda, ray_t** call_args, int64_t argc) {
 
     if (RAY_UNLIKELY(!__VM))
         return ray_error("state", "no VM bound to this thread");
+
+    /* Scope-stack baseline: OP_SCOPE_BEGIN windows that error out before
+     * their OP_SCOPE_END leave materialized frames behind — the error
+     * paths unwind back to this depth. */
+    int32_t scope_base = ray_env_scope_depth();
 
     ray_t *vm_block = ray_alloc(sizeof(ray_exec_t));
     if (!vm_block || RAY_IS_ERR(vm_block)) return ray_error("oom", NULL);
@@ -2279,7 +2286,8 @@ op_trap: {
     if (vm.tp >= VM_TRAP_SIZE) goto vm_error_limit;
     vm.ts[vm.tp++] = (vm_trap_t){
         .rp = vm.rp, .sp = vm.sp, .handler_ip = ip + offset,
-        .fn = vm.fn, .fp = vm.fp, .n_locals = n_locals
+        .fn = vm.fn, .fp = vm.fp, .n_locals = n_locals,
+        .scope_depth = ray_env_scope_depth()
     };
     ray_retain(vm.fn);
     DISPATCH();
@@ -2290,6 +2298,29 @@ op_trap_end: {
         vm.tp--;
         ray_release(vm.ts[vm.tp].fn);
     }
+    DISPATCH();
+}
+
+op_scope_begin: {
+    /* Stack: [.., syms_vec] — materialize the live locals (slot i holds
+     * the value of syms[i]) plus self into a fresh scope frame so the
+     * OP_CALLD that follows can resolve them via the tree walker. */
+    ray_t *syms = POP();
+    ray_err_t err = ray_env_scope_bind((const int64_t*)ray_data(syms),
+                                       (int32_t)syms->len,
+                                       &vm.ps[vm.fp], vm.fn);
+    ray_release(syms);
+    if (err != RAY_OK) goto vm_error_limit;
+    DISPATCH();
+}
+
+op_scope_end: {
+    /* Stack: [.., calld_result, syms_vec] — sync the frame back into the
+     * slots and pop it; the dynamic eval's result stays on the stack. */
+    ray_t *syms = POP();
+    ray_env_scope_sync((const int64_t*)ray_data(syms),
+                       (int32_t)syms->len, &vm.ps[vm.fp]);
+    ray_release(syms);
     DISPATCH();
 }
 
@@ -2329,6 +2360,12 @@ vm_error_cleanup: {
             if (v) ray_release(v);
         }
 
+        /* Unwind scope frames materialized after the trap was armed
+         * (an error inside an OP_SCOPE_BEGIN..END window skips its
+         * OP_SCOPE_END) */
+        while (ray_env_scope_depth() > trap.scope_depth)
+            ray_env_pop_scope();
+
         /* Get error value.  If __VM->raise_val is set, a user (raise x)
          * just ran — its value is the real payload the handler must
          * see.  vm_err_obj is the generic error-sentinel returned
@@ -2359,6 +2396,10 @@ vm_error_cleanup: {
     }
 
     /* No trap frame — regular error cleanup */
+
+    /* Unwind any scope frames this exec materialized and didn't end */
+    while (ray_env_scope_depth() > scope_base)
+        ray_env_pop_scope();
 
     /* Build error trace: current frame + callers from return stack */
     add_error_frame(vm.fn, ip > 0 ? ip - 1 : 0);

--- a/src/lang/eval.h
+++ b/src/lang/eval.h
@@ -80,6 +80,12 @@ enum {
     OP_TRAP_END,      /* pop trap frame (success path) */
     OP_STOREGLOBAL,   /* bind global: cpool[operand] is sym_id; value stays on stack (1-byte index) */
     OP_STOREGLOBAL_W, /* bind global: 2-byte constant pool index */
+    OP_SCOPE_BEGIN,   /* pop sym-id vec; push scope frame binding the live
+                       * locals (+ self) so a following OP_CALLD's tree-walk
+                       * eval can resolve them */
+    OP_SCOPE_END,     /* pop sym-id vec; sync frame values back into the
+                       * local slots, pop the frame (leaves the CALLD result
+                       * on the stack) */
     OP__COUNT
 };
 
@@ -131,6 +137,9 @@ typedef struct {
     ray_t    *fn;        /* function containing handler code */
     int32_t  fp;        /* frame pointer at trap point */
     int32_t  n_locals;  /* n_locals at trap point */
+    int32_t  scope_depth; /* env scope depth at trap point — an error inside
+                           * an OP_SCOPE_BEGIN..END window must unwind the
+                           * materialized frame(s) before the handler runs */
 } vm_trap_t;
 
 #define VM_TRAP_SIZE 16

--- a/test/rfl/lang/special_form_locals.rfl
+++ b/test/rfl/lang/special_form_locals.rfl
@@ -1,0 +1,46 @@
+;; Runtime special forms (alter / and / or / select / insert / ...)
+;; re-evaluate their argument ASTs through the tree walker.  Inside a
+;; COMPILED lambda the params and let-locals live in bytecode slots, so
+;; the compiler materializes them into a scope frame around the dynamic
+;; eval (OP_SCOPE_BEGIN / OP_SCOPE_END) and syncs let-updates back.
+;; Regression test for "name: 'v' undefined" on (alter 'data concat v)
+;; inside a lambda.
+
+;; alter with a let-local and with a param
+(set data (list))
+((fn [] (let v 42) (alter 'data concat v)))
+(count data) -- 1
+(at data 0)  -- 42
+((fn [x] (alter 'data concat x)) 7)
+(count data) -- 2
+(at data 1)  -- 7
+
+;; and/or with params — must match the top-level (tree-walk) results:
+;; scalar-falsy short-circuit returns the accumulator, otherwise the
+;; element-wise combine yields a boolean
+((fn [x] (and x 1)) 5) -- true
+((fn [x] (and x 1)) 0) -- 0
+((fn [x] (or x 9)) 0)  -- true
+((fn [x] (or x 9)) 3)  -- 3
+
+;; nested: local used in a special form deeper in the body
+((fn [x] (let y (+ x 1)) (and y (or y 0))) 4) -- true
+
+;; parameterized queries — table as a lambda argument
+(set tbl (table [k v] (list (til 3) (til 3))))
+(count (at ((fn [t] (select {from: t take: 2})) tbl) 'k)) -- 2
+
+;; local scalar in a where clause
+(count (at ((fn [n] (select {from: tbl where: (> v n)})) 0) 'k)) -- 2
+
+;; insert with a local row
+((fn [r] (insert 'tbl r)) (list 9 9))
+(count (at tbl 'k)) -- 4
+
+;; let-update inside a special form syncs back to the slot
+((fn [] (let v 1) (and (let v 2) 1) v)) -- 2
+
+;; errors inside the dynamic eval unwind the materialized frame: the
+;; trap handler runs with a balanced scope stack, and the local slots
+;; are still intact afterwards
+((fn [x] (try (and x (undefined-name-xyz)) (fn [e] 0)) x) 6) -- 6


### PR DESCRIPTION
## Problem

```
‣ (set data (list))
‣ ((fn [] (let v 42) (alter 'data concat v)))
  × Error: name — 'v' undefined
```

The blast radius is much wider than `alter`. **Every runtime special form** — `and`, `or`, `select`, `insert`, `update`, `upsert`, `alter`, `del`, `rule`, … — fails with a name error when its arguments reference a lambda param or `let`-local, because of how the compiler lowers those calls. Concretely, all of these were broken:

```lisp
((fn [x] (and x 1)) 5)                            ;; 'x' undefined
((fn [t] (select {from: t})) tbl)                  ;; 't' undefined
((fn [n] (select {from: tbl where: (> v n)})) 1)   ;; 'n' undefined
((fn [r] (insert 'tbl r)) (list 9 9))              ;; 'r' undefined
```

i.e. **parameterized queries through lambda arguments did not work at all.** Only the compiler-native forms (`if`/`do`/`let`/`set`/`try`/`fn`/`return`/`self`) handled locals. Pre-existing (reproduced on `32ba03b8`), unrelated to the recent VM work.

## Root cause

`compile.c` lowers a call to a runtime special form to `OP_CALLD` with the whole original AST as a constant; at runtime that re-evaluates the form through the tree walker, which resolves names via scope frames + globals. The compiled lambda's locals live in bytecode frame slots — invisible to that lookup.

## Fix: scoped dynamic eval

The compiler already knows the (sym → slot) table at every such site. When the form actually references a local (or `self`, or a dynamic resolver — `eval`/`resolve` — that could reach one by a constructed name), it emits that table as a constant and brackets the dynamic eval with two new opcodes:

- **`OP_SCOPE_BEGIN`** — push a scope frame binding the live locals (NULL slots, i.e. `let`-locals whose initializer hasn't run, are skipped — same as the tree walker) plus `self` → `vm.fn`.
- **`OP_SCOPE_END`** — sync the frame's (possibly `let`-updated) values back into the slots, pop the frame, leave the result on the stack.

This converges compiled and tree-walk semantics, including `let`-updates made inside the special form (`((fn [] (let v 1) (and (let v 2) 1) v))` → 2 in both modes). Error paths unwind materialized frames: trap frames record scope depth at arm time and the catch path pops back to it; the terminal error path unwinds to the exec's entry baseline.

## Performance

Forms that mention no local — the common globals-only pattern — take the old bare-`OP_CALLD` path via a compile-time AST scan (descends lists, dicts, sym vectors; quoted syms count, since e.g. `(alter 'v …)` resolves them through the env where a local would shadow). Release benchmark, 300k calls of `(fn [x] (and g 1))`:

| | master | branch |
|---|---|---|
| globals-only special form | ~198 ms | ~198 ms |
| (bracket always-on, for reference) | — | ~240 ms |

General eval benchmark (fib + map-lambda + recursion) unchanged.

## Tests

New `test/rfl/lang/special_form_locals.rfl`: alter with let-local and with param, `and`/`or` with params, `select` with table-as-param and local-in-where, `insert` with a local row, let-writeback through a special form, and trap-handler scope unwinding. Full ASan/UBSan suite green (3376/3378, 2 platform skips; the only intermittent is the known pre-existing `stress/random_seed*` in-suite flake that reproduces on master).

Known limitation (unchanged from tree-walk asymmetry): a `let` *inside* a special-form argument that introduces a name the compiler never allocated a slot for doesn't persist past the form — names must be introduced lexically for the compiler to see them, as before.