### PR TITLE
test(pool): drop racy main-thread-participation assert

### DIFF
--- a/test/test_pool.c
+++ b/test/test_pool.c
@@ -775,10 +775,14 @@ static test_result_t test_dispatch_workers_participate(void) {
 
     TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), n);
     TEST_ASSERT_EQ_I(atomic_load(&ctx.elem_sum), n);
-    /* Worker 0 (main) always sees activity; we don't hard-assert worker 1+
-     * participation as it depends on scheduling — but the test still
-     * exercises the multi-worker claim contention. */
-    TEST_ASSERT_TRUE((atomic_load(&ctx.saw_worker) & 0x1u) != 0);
+    /* No per-id participation assert: WHICH claimants win is pure
+     * scheduling.  Workers 1+ may never wake on a loaded runner — and
+     * the inverse race is just as real: on a fast box the workers can
+     * drain all 256 tasks before main enters its claim loop, leaving
+     * bit 0 (main) unset — observed on macOS CI.  The test's value is
+     * driving the multi-claimant contention paths; completion is
+     * asserted above, and some bit is necessarily set once calls == n. */
+    TEST_ASSERT_TRUE(atomic_load(&ctx.saw_worker) != 0);
 
     ray_pool_free(&pool);
     ray_heap_destroy();


### PR DESCRIPTION
Post-merge master CI for #245 failed on `pool/workers_participate` (macOS debug):

```
test/test_pool.c:781: ((atomic_load(&ctx.saw_worker) & 0x1u) != 0): expected true
```

The test asserts that **worker 0 (the main thread)** claimed at least one of the 256 tasks, while its own comment declines to assert workers 1+ because participation "depends on scheduling". The same caveat applies to main: on a fast runner the three workers can drain all 256 tiny tasks before main enters its claim loop, leaving bit 0 unset. The identical commit passed macOS debug on the PR run minutes earlier — pure scheduling flake, unrelated to the merged change (neither PR touches the pool).

Fix: keep the exact completion asserts (`calls == n`, `elem_sum == n`) and assert only that *some* participant recorded itself. The test's purpose — driving the multi-claimant contention/cancelled-skip paths — is unaffected.

(For the record, I also re-ran the failed master job to confirm flakiness.)