### PR TITLE
fix(hash): ray_hash_f64 -0.0 normalization immune to -fno-signed-zeros

### DIFF
--- a/src/ops/hash.h
+++ b/src/ops/hash.h
@@ -220,13 +220,20 @@ static inline uint64_t ray_hash_i64(int64_t val) {
  * Normalizes negative zero to positive zero so that -0.0 and +0.0
  * hash identically (they compare equal via ==).
  *
+ * The -0.0 check is done on the bit pattern, NOT via `if (val == 0.0)`:
+ * the release build uses -fno-signed-zeros, under which the compiler
+ * treats -0.0 and +0.0 as interchangeable and optimizes the
+ * `if (val == 0.0) val = 0.0` form into a no-op — leaving -0.0's sign
+ * bit intact, so it hashes differently from +0.0 and `distinct`
+ * over-counts.  Same trap, same fix as clear_neg_zero in ops/internal.h.
+ *
  * Note: different NaN bit patterns hash differently; SQL NULL is
  * handled separately at a higher level and never reaches this path.
  */
 static inline uint64_t ray_hash_f64(double val) {
     uint64_t bits;
-    if (val == 0.0) { uint64_t z = 0; memcpy(&val, &z, sizeof(val)); } /* normalize -0.0 → +0.0 */
     memcpy(&bits, &val, sizeof(bits));
+    if (bits == UINT64_C(0x8000000000000000)) bits = 0; /* -0.0 → +0.0 */
     uint64_t A = bits ^ 0x2d358dccaa6c78a5ULL;
     uint64_t B = bits ^ 0x8bb84b93962eacc9ULL;
     ray__wymum(&A, &B);


### PR DESCRIPTION
## Symptom

Master CI failed on macOS release ([run](https://github.com/RayforceDB/rayforce/actions/runs/27461658367)):

```
test/test_idx_route.c:1846: cnt_no_idx != 3  (got 4, expected 3)   [idx_route/distinct_f64_neg_zero]
```

`distinct` over an F64 column `{-0.0, +0.0, 1.0, 2.0}` returned **4** values instead of 3. **macOS-release-only** — Linux release, Linux debug, and macOS debug all passed.

## Root cause

`ray_hash_f64` (`src/ops/hash.h`) normalized `-0.0 → +0.0` so the two zeros hash alike:

```c
if (val == 0.0) { uint64_t z = 0; memcpy(&val, &z, sizeof(val)); } /* normalize -0.0 → +0.0 */
```

The release build compiles with **`-fno-signed-zeros`** (`RELEASE_CFLAGS`), which licenses the compiler to treat `-0.0` and `+0.0` as interchangeable and optimize that `if (val == 0.0) val = 0.0` into a **no-op**. clang (macOS) does it; gcc (Linux CI) happens not to — hence the platform split. With the normalization elided, `-0.0` keeps its sign bit, hashes differently from `+0.0`, and the distinct hashset treats them as two values.

This is a **latent bug** — `ray_hash_f64` predates the index-routing work; that PR just added the first test exercising `-0.0` distinct, which exposed it.

The codebase already documents this exact trap on `clear_neg_zero` (`ops/internal.h`): *"Immune to -fno-signed-zeros (which makes `if (f==0) f=0` a no-op)"*. `ray_hash_f64` simply never got the same treatment.

## Fix

Detect `-0.0` by its bit pattern — an integer compare the `-fno-signed-zeros` license cannot reach:

```c
uint64_t bits; memcpy(&bits, &val, sizeof(bits));
if (bits == UINT64_C(0x8000000000000000)) bits = 0; /* -0.0 → +0.0 */
```

Correct regardless of compiler or FP flags: there's no floating-point comparison left for the optimizer to reason about.

## Verification

- `idx_route/distinct_f64_neg_zero` and the rest of `idx_route` (56), `distinct`/`count_distinct_paths` (26), and `hash/` (34) all pass.
- Full ASan/UBSan suite green: 3432/3434 (2 platform skips, 0 failures).
- Note: the failure can't be reproduced on the Linux dev box (gcc doesn't fire the optimization, same as Linux CI). The fix's correctness is by construction — it removes the FP comparison entirely — and the existing macOS-release CI job is the real guard.