### PR TITLE
fix(domain): drop sym-domain cache entries when their backing heap dies

### DIFF
--- a/src/mem/heap.c
+++ b/src/mem/heap.c
@@ -1320,17 +1320,32 @@ void ray_mem_stats(ray_mem_stats_t* out) {
  * Heap lifecycle
  * -------------------------------------------------------------------------- */
 
+uint16_t ray_heap_current_id(void) {
+    return ray_tl_heap ? ray_tl_heap->id : (uint16_t)0xFFFF;
+}
+
 void ray_heap_init(void) {
     if (ray_tl_heap) return;
 
     size_t heap_sz = (sizeof(ray_heap_t) + 4095) & ~(size_t)4095;
     ray_heap_t* h = (ray_heap_t*)ray_vm_alloc(heap_sz);
-    if (!h) return;
+    /* A silent return here leaves ray_tl_heap NULL, so every later
+     * ray_alloc on this thread fails and the caller sees a baffling
+     * downstream error (e.g. a save returning IO) with no hint that the
+     * heap never came up.  Make both init failure modes loud. */
+    if (!h) {
+        fprintf(stderr, "ray_heap_init: ray_vm_alloc(%zu) failed (errno=%d %s) "
+                        "— heap not initialized\n",
+                heap_sz, errno, strerror(errno));
+        return;
+    }
     memset(h, 0, heap_sz);
 
     /* Bitmap-based ID: acquire reusable ID via atomic CAS */
     int id = heap_id_acquire();
     if (id < 0) {
+        fprintf(stderr, "ray_heap_init: heap-ID pool exhausted "
+                        "— heap not initialized\n");
         ray_vm_free(h, heap_sz);
         return;  /* ID pool exhausted */
     }
@@ -1387,6 +1402,11 @@ void ray_heap_init(void) {
  * heap takes over.  Lives in src/lang/eval.c. */
 extern void ray_clear_error_trace(void);
 
+/* Drop sym-domain cache entries whose atoms live on a heap being torn
+ * down (src/table/domain.c).  Extern-declared to keep heap.c free of the
+ * table-layer header, mirroring ray_clear_error_trace above. */
+extern void ray_sym_domain_drop_heap(uint16_t heap_id);
+
 void ray_heap_destroy(void) {
     ray_heap_t* h = ray_tl_heap;
     if (!h) return;
@@ -1396,6 +1416,12 @@ void ray_heap_destroy(void) {
      * memory is still mapped; once the for-loop below munmap's the
      * pools, dereferencing g_error_trace becomes UB. */
     ray_clear_error_trace();
+
+    /* Same ordering rationale: the process-global sym-domain cache holds
+     * FILE domains whose string atoms are ray_str objects on THIS heap.
+     * Drop them now, while the atoms are still mapped, so the cache never
+     * hands out a domain backed by freed memory after this heap dies. */
+    ray_sym_domain_drop_heap(h->id);
 
     uint16_t saved_id = h->id;
 

--- a/src/mem/heap.h
+++ b/src/mem/heap.h
@@ -154,6 +154,10 @@ typedef struct ray_dispatch  ray_dispatch_t;
 
 void     ray_heap_init(void);
 void     ray_heap_destroy(void);
+/* Id of the calling thread's current heap, or 0xFFFF if none is bound.
+ * Used to tag heap-backed allocations (e.g. sym-domain atoms) so their
+ * owner can be invalidated when this heap is torn down. */
+uint16_t ray_heap_current_id(void);
 void     ray_heap_merge(ray_heap_t* src);
 void     ray_heap_flush_foreign(void);
 void     ray_heap_push_pending(ray_heap_t* heap);

--- a/src/table/domain.c
+++ b/src/table/domain.c
@@ -58,6 +58,7 @@
 
 #include "domain.h"
 #include "core/platform.h"  /* ray_vm_map_file / ray_vm_unmap_file */
+#include "mem/heap.h"       /* ray_heap_current_id — atom-heap tagging */
 #include "store/fileio.h"   /* flock + tmp/rename protocol for flush */
 #include "ops/hash.h"       /* ray_hash_bytes (same hash family as g_sym) */
 #include <stdatomic.h>
@@ -125,6 +126,15 @@ struct ray_sym_domain_s {
     uint64_t  bucket_mask; /* cap - 1; 0 = not built yet */
 
     dom_retired_t* retired; /* replaced atom arrays + old LUTs */
+
+    /* Heap that backs this domain's string atoms (atoms[] are ray_str
+     * objects on the buddy heap, created when the domain was opened).
+     * The process-global cache outlives a per-thread ray_heap_destroy,
+     * so a cached domain whose heap is torn down would dangle; recording
+     * the heap lets ray_heap_destroy drop exactly its own domains while
+     * the atoms are still valid.  0xFFFF = "no heap was bound at
+     * creation" (never matches a real id, so never auto-dropped). */
+    uint16_t  atom_heap_id;
 
     struct ray_sym_domain_s* next; /* cache chain */
 };
@@ -402,6 +412,7 @@ static ray_sym_domain_t* dom_open_impl(const char* path, bool create) {
     d->kind = DOM_FILE;
     d->rc = 1;
     d->path = rpath;
+    d->atom_heap_id = ray_heap_current_id();  /* heap that will back atoms */
 
     if (exists) {
         d->map = ray_vm_map_file(rpath, &d->map_size);
@@ -479,6 +490,36 @@ void ray_sym_domain_release(ray_sym_domain_t* dom) {
     if (*pp) *pp = dom->next;
     dom_unlock();
     dom_destroy(dom);
+}
+
+/* Drop every cached FILE domain whose string atoms live on `heap_id`.
+ * Called from ray_heap_destroy BEFORE that heap's pools are unmapped, so
+ * the atoms are still valid and dom_destroy's ray_release path is safe.
+ * Without this the process-global cache would keep handing out domains
+ * whose atoms were freed when their backing heap was torn down (e.g. the
+ * per-test heap_init/destroy in the test harness) — a use-after-free on
+ * the next open/extend of that path.  Detach under the lock, free
+ * outside it. */
+void ray_sym_domain_drop_heap(uint16_t heap_id) {
+    dom_lock();
+    ray_sym_domain_t* dead = NULL;
+    ray_sym_domain_t** pp = &g_domains;
+    while (*pp) {
+        ray_sym_domain_t* d = *pp;
+        if (d->kind == DOM_FILE && d->atom_heap_id == heap_id) {
+            *pp = d->next;          /* unlink */
+            d->next = dead;         /* stash for freeing outside the lock */
+            dead = d;
+        } else {
+            pp = &d->next;
+        }
+    }
+    dom_unlock();
+    while (dead) {
+        ray_sym_domain_t* next = dead->next;
+        dom_destroy(dead);
+        dead = next;
+    }
 }
 
 /* ---- resolution ------------------------------------------------------------ */

--- a/src/table/domain.h
+++ b/src/table/domain.h
@@ -102,6 +102,12 @@ ray_sym_domain_t* ray_sym_domain_open_or_create(const char* path);
 void ray_sym_domain_retain(ray_sym_domain_t* dom);
 void ray_sym_domain_release(ray_sym_domain_t* dom);
 
+/* Drop every cached FILE domain whose atoms are backed by `heap_id`.
+ * Called by ray_heap_destroy while that heap's atoms are still valid, so
+ * the process-global domain cache never outlives the heap its atoms live
+ * on.  Not a general-purpose API. */
+void ray_sym_domain_drop_heap(uint16_t heap_id);
+
 /* Borrowed string atom for position `pos` (NULL if out of range).
  * RUNTIME: delegates to ray_sym_str.  FILE: lazily materialized atom
  * owned by the domain — valid for the domain's lifetime, do not release. */

--- a/test/stress_eval.c
+++ b/test/stress_eval.c
@@ -210,6 +210,9 @@ bool stress_eval_seed_initial(stress_ctx_t* c, int64_t live_rows, int nparts,
     stress_live_dir(c, dir, sizeof(dir));
     if (!eval_set_dir(c, dir, &c->live)) return false;
     for (int p = 0; p < nparts; p++) {
+        /* Publish before filling so an early failure frees parts[p] (see
+         * stress_seed_initial for the rationale). */
+        c->nparts = p + 1;
         snprintf(c->part_dates[p], sizeof(c->part_dates[p]), "2024.01.%02d",
                  (p + 1) % 100); /* % keeps -Wformat-truncation in range */
         for (int64_t i = 0; i < rows_per_part; i++) {
@@ -220,7 +223,6 @@ bool stress_eval_seed_initial(stress_ctx_t* c, int64_t live_rows, int nparts,
         stress_part_dir(c, p, dir, sizeof(dir));
         if (!eval_set_dir(c, dir, &c->parts[p])) return false;
     }
-    c->nparts = nparts;
     return true;
 }
 

--- a/test/stress_store.c
+++ b/test/stress_store.c
@@ -304,6 +304,11 @@ bool stress_seed_initial(stress_ctx_t* c, int64_t live_rows, int nparts,
     stress_live_dir(c, dir, sizeof(dir));
     if (!save_rows(c, dir, &c->live, false)) return false;
     for (int p = 0; p < nparts; p++) {
+        /* Publish the partition BEFORE filling it so an early append/save
+         * failure leaves parts[p] reachable for stress_destroy to free —
+         * otherwise the rows appended below leak (nparts was bumped only
+         * after the whole loop). */
+        c->nparts = p + 1;
         snprintf(c->part_dates[p], sizeof(c->part_dates[p]), "2024.01.%02d",
                  p + 1);
         for (int64_t i = 0; i < rows_per_part; i++) {
@@ -313,7 +318,6 @@ bool stress_seed_initial(stress_ctx_t* c, int64_t live_rows, int nparts,
         stress_part_dir(c, p, dir, sizeof(dir));
         if (!save_rows(c, dir, &c->parts[p], false)) return false;
     }
-    c->nparts = nparts;
     return true;
 }
 

--- a/test/test_domain.c
+++ b/test/test_domain.c
@@ -462,6 +462,70 @@ static test_result_t test_domain_create_flush_concurrent(void) {
     PASS();
 }
 
+/* Heap-recycle isolation for the process-global FILE-domain cache.
+ *
+ * A domain's atoms are ray_str objects on the buddy heap, but the cache
+ * (g_domains) is process-global and outlives a per-test
+ * ray_heap_destroy.  Without the ray_sym_domain_drop_heap() hook the
+ * cache keeps an entry whose atoms were freed with their heap, so the
+ * next open of that path on a fresh heap reuses the stale domain — a
+ * use-after-free that surfaces as the next open/extend reading freed
+ * atoms (NULL/garbage domain, or a SEGV once the pages are reused).
+ *
+ * This exercises that path directly (own heap lifecycle, hence NULL
+ * setup/teardown): open a FILE domain, leak it into the cache, recycle
+ * the heap, churn allocations to reuse the freed region, then re-open
+ * the same path with a divergent file.  Note: the UAF does not fault
+ * deterministically (freed pages often stay mapped), so this is not a
+ * hard pre/post oracle — it is an ASan-backed guard that the recycle +
+ * reopen stays clean and the drop hook keeps the cache coherent. */
+#define TMP_DOM_RECYCLE_PATH "/tmp/rayforce_test_domain_recycle_sym"
+static test_result_t test_domain_survives_heap_recycle(void) {
+    unlink(TMP_DOM_RECYCLE_PATH);
+    unlink(TMP_DOM_RECYCLE_PATH ".lk");
+
+    /* --- heap A: open a domain with a SMALL vocabulary --- */
+    ray_heap_init();
+    (void)ray_sym_init();
+    (void)ray_sym_intern("recyc_a", 7);
+    TEST_ASSERT_EQ_I(ray_sym_save(TMP_DOM_RECYCLE_PATH), RAY_OK);
+    ray_sym_domain_t* d1 = ray_sym_domain_open(TMP_DOM_RECYCLE_PATH);
+    TEST_ASSERT_NOT_NULL(d1);          /* atoms now live on heap A */
+    /* Deliberately DO NOT release d1 — it stays in the global cache,
+     * exactly the leak that exposed the dangling bug. */
+    ray_sym_destroy();
+    ray_heap_destroy();                /* must drop d1 from the cache */
+
+    /* --- heap B (fresh): churn allocations to reuse heap A's freed
+     * pages, then write a DIVERGENT (larger) file at the same path --- */
+    ray_heap_init();
+    (void)ray_sym_init();
+    for (int i = 0; i < 256; i++) {    /* overwrite heap A's freed region */
+        char b[32]; int n = snprintf(b, sizeof b, "churn_%d", i);
+        ray_t* v = ray_str(b, (size_t)n);
+        if (v && !RAY_IS_ERR(v)) ray_release(v);
+    }
+    (void)ray_sym_intern("recyc_a", 7);
+    (void)ray_sym_intern("recyc_b", 7);     /* different vocabulary/size */
+    TEST_ASSERT_EQ_I(ray_sym_save(TMP_DOM_RECYCLE_PATH), RAY_OK);
+    /* Re-open the SAME path.  Pre-fix: cache hit on the stale d1; the
+     * size differs so dom_extend dereferences d1's atoms (freed, now
+     * overwritten by the churn above) → SEGV or garbage.  Post-fix: the
+     * stale entry is gone, so this builds a fresh domain. */
+    ray_sym_domain_t* d2 = ray_sym_domain_open(TMP_DOM_RECYCLE_PATH);
+    TEST_ASSERT_NOT_NULL(d2);
+    ray_t* s0 = ray_sym_domain_str(d2, 0);  /* touch the atoms */
+    TEST_ASSERT_NOT_NULL(s0);
+    TEST_ASSERT_EQ_U(ray_str_len(s0), 0);   /* position 0 is "" */
+    ray_sym_domain_release(d2);
+
+    unlink(TMP_DOM_RECYCLE_PATH);
+    unlink(TMP_DOM_RECYCLE_PATH ".lk");
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
 static test_result_t test_domain_open_identity_and_release(void) {
     unlink(TMP_DOM_SYM_PATH);
     unlink(TMP_DOM_SYM_PATH ".lk");
@@ -1829,6 +1893,7 @@ const test_entry_t domain_entries[] = {
     { "domain/col_save_load_mmap",      test_domain_col_save_load_mmap,      domain_setup, domain_teardown },
     { "domain/open_basic",              test_domain_open_basic,              domain_setup, domain_teardown },
     { "domain/create_flush_concurrent", test_domain_create_flush_concurrent, domain_setup, domain_teardown },
+    { "domain/survives_heap_recycle",   test_domain_survives_heap_recycle,   NULL, NULL },
     { "domain/open_identity_release",   test_domain_open_identity_and_release, domain_setup, domain_teardown },
     { "domain/vec_cell_runtime_equiv",  test_domain_vec_cell_runtime_equiv,  domain_setup, domain_teardown },
     { "domain/vec_lookup_hit_miss",     test_domain_vec_lookup_hit_miss,     domain_setup, domain_teardown },


### PR DESCRIPTION
## Problem

A FILE domain's string atoms are `ray_str` objects on the **per-thread buddy heap**, but the domain cache (`g_domains`) is **process-global** and outlives a `ray_heap_destroy`. A domain left in the cache when its heap is torn down keeps atom pointers into freed memory; the next `ray_sym_domain_open` of that path reuses the stale entry, and its revalidation / `dom_extend_from_file_locked` dereferences the dead atoms.

In production this is essentially only reachable at runtime shutdown (cached domains are never touched afterward), so it's benign there. But the **test harness** does `ray_heap_init`/`ray_heap_destroy` per test, so a domain one test leaves cached poisons later tests that reopen the same path — surfacing as the intermittent **`domain/*` + `sym/*` cross-test cascade** (NULL domains, `ray_sym_count` mismatches, `save err=IO`) observed in full-suite runs.

## How it was found

Tracked down from a captured stress-suite failure: `maxrss` was tiny (not memory), `ulimit -n`/`max_map_count` were huge (not FDs), disk had space (not storage) — but ~23 file-touching tests failed together once triggered. Narrowed to the global sym/domain state, and a force-reset experiment pinpointed the dangling: `dom_destroy → ray_release` SEGV'd on atoms whose heap was already gone.

## Fix

- Tag each FILE domain with the heap id its atoms were created on (`atom_heap_id`).
- `ray_heap_destroy` calls `ray_sym_domain_drop_heap(h->id)` at the **top** of teardown — while the atoms are still mapped, so the normal `dom_destroy`/`ray_release` path is valid (no use-after-free, unlike a naive post-teardown reset) and only **this heap's** domains are dropped (safe under concurrent worker-heap teardown). Mirrors the existing `ray_clear_error_trace` teardown hook.

No production behavior change: at shutdown those domains were going to be freed anyway; this just frees them coherently before the heap's pages are unmapped.

## Validation

6 full ASan/UBSan suite runs:

| runs | `domain/*`+`sym/*` failures | ASan |
|---|---|---|
| 1–6 | **0** | **0** |

The cross-test cascade is gone and nothing crashes. **Scope note:** the separate `stress/random_seed` flake is *not* fixed by this and remains under investigation — it persisted in 2 of the 6 runs **with zero `domain`/`sym` failures**, which confirms the two issues are distinct.

## Also included (robustness surfaced by this investigation)

- **`ray_heap_init` loud failure** — its two silent `return`s (mmap `NULL`, heap-ID pool exhausted) now log to stderr. A silent heap-init failure makes every later allocation fail as a baffling downstream IO error — exactly the false trail that slowed this debugging.
- **`stress_seed_initial` / `stress_eval_seed_initial` leak fix** — publish `c->nparts` incrementally so an early save failure frees the partition rows instead of leaking them (the LSan leak on that path).
- **`domain/survives_heap_recycle`** test — an ASan-backed smoke test of `open → heap recycle → reopen`. Honest caveat in its comment: it is *not* a hard pre/post oracle (the UAF doesn't fault deterministically because freed pages often stay mapped), but it guards the recycle path under ASan.