### PR TITLE
test(stress): per-process scratch paths so concurrent runs don't collide

### DIFF
--- a/test/stress_store.c
+++ b/test/stress_store.c
@@ -13,6 +13,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>  /* getpid — per-process scratch paths */
+
+const char* stress_db_path(const char* name) {
+    static char buf[256];
+    snprintf(buf, sizeof(buf), "/tmp/rayforce_stress_%s.%d", name, (int)getpid());
+    return buf;
+}
 
 /* ---- prng (xorshift64*) ------------------------------------------------ */
 

--- a/test/stress_store.h
+++ b/test/stress_store.h
@@ -56,6 +56,15 @@ typedef struct {
     bool          failed;          /* set on verify failure; keeps db dir */
 } stress_ctx_t;
 
+/* Per-process scratch db path: "/tmp/rayforce_stress_<name>.<pid>".
+ * Each stress test rm -rf's its db_root in stress_init, so two test
+ * binaries sharing a fixed path race destructively (one deletes the
+ * other's dir mid-save → spurious CORRUPT/IO failures).  The pid suffix
+ * keeps concurrent runs isolated.  Returns a pointer to a static buffer
+ * reused on every call; stress_init copies the string immediately, so
+ * back-to-back calls (e.g. two fixtures in one test) are safe. */
+const char* stress_db_path(const char* name);
+
 /* lifecycle */
 bool stress_init(stress_ctx_t* c, const char* db_root, uint64_t seed);
 void stress_destroy(stress_ctx_t* c);  /* rm -rf db_root unless c->failed */

--- a/test/test_stress_eval.c
+++ b/test/test_stress_eval.c
@@ -11,7 +11,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define STRESS_EVAL_DB "/tmp/rayforce_stress_eval"
 
 /* ray_runtime_create() implies ray_heap_init() + ray_sym_init(), and
  * ray_runtime_destroy() tears both down (src/core/runtime.c) — so setup/
@@ -33,7 +32,7 @@ static test_result_t test_eval_fixture_roundtrip_impl(stress_ctx_t* c) {
 
 static test_result_t test_eval_fixture_roundtrip(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_EVAL_DB, 200), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("eval"), 200), "init");
     test_result_t r = test_eval_fixture_roundtrip_impl(&c);
     stress_destroy(&c);
     return r;
@@ -93,7 +92,7 @@ static test_result_t test_eval_matrix_ops_impl(stress_ctx_t* c) {
 
 static test_result_t test_eval_matrix_ops(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_EVAL_DB, 201), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("eval"), 201), "init");
     test_result_t r = test_eval_matrix_ops_impl(&c);
     stress_destroy(&c);
     return r;
@@ -137,7 +136,7 @@ static test_result_t test_eval_query_oracle_detects_impl(stress_ctx_t* c) {
 
 static test_result_t test_eval_query_oracle_detects(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_EVAL_DB, 203), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("eval"), 203), "init");
     test_result_t r = test_eval_query_oracle_detects_impl(&c);
     stress_destroy(&c);
     return r;
@@ -240,8 +239,8 @@ static test_result_t test_eval_equiv_impl(stress_ctx_t* cc, stress_ctx_t* ce) {
 
 static test_result_t test_eval_equiv_with_c_driver(void) {
     stress_ctx_t cc, ce;
-    TEST_ASSERT(stress_init(&cc, STRESS_EVAL_DB "_eqc", 202), "init C fixture");
-    if (!stress_init(&ce, STRESS_EVAL_DB "_eqe", 202)) {
+    TEST_ASSERT(stress_init(&cc, stress_db_path("eval_eqc"), 202), "init C fixture");
+    if (!stress_init(&ce, stress_db_path("eval_eqe"), 202)) {
         stress_destroy(&cc);
         TEST_ASSERT(false, "init eval fixture");
     }
@@ -299,7 +298,7 @@ static test_result_t test_eval_client_layout_impl(stress_ctx_t* c) {
 
 static test_result_t test_eval_client_layout(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_EVAL_DB, 204), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("eval"), 204), "init");
     test_result_t r = test_eval_client_layout_impl(&c);
     stress_destroy(&c);
     return r;
@@ -443,7 +442,7 @@ static test_result_t test_eval_determinism(void) {
     memset(&s, 0, sizeof(s));
 
     stress_ctx_t c1;
-    TEST_ASSERT(stress_init(&c1, STRESS_EVAL_DB, 205), "init run 1");
+    TEST_ASSERT(stress_init(&c1, stress_db_path("eval"), 205), "init run 1");
     bool ok1 = det_run(&c1) && !c1.failed && det_snapshot(&c1, &s);
     stress_destroy(&c1);
     if (!ok1) {
@@ -460,7 +459,7 @@ static test_result_t test_eval_determinism(void) {
     }
 
     stress_ctx_t c2;
-    if (!stress_init(&c2, STRESS_EVAL_DB, 205)) {
+    if (!stress_init(&c2, stress_db_path("eval"), 205)) {
         det_snap_free(&s);
         TEST_ASSERT(false, "init run 2");
     }

--- a/test/test_stress_matrix.c
+++ b/test/test_stress_matrix.c
@@ -11,7 +11,6 @@
 #include "mem/heap.h"
 #include "table/sym.h"
 
-#define STRESS_DB "/tmp/rayforce_stress_matrix"
 
 static void stress_setup(void) {
     ray_heap_init();
@@ -32,7 +31,9 @@ static test_result_t test_fixture_roundtrip_impl(stress_ctx_t* c) {
     TEST_ASSERT(stress_seed_initial(c, 100, 3, 50), "seed");
 
     /* live splayed table loads with the shared symfile */
-    ray_t* live = ray_splay_load(STRESS_DB "/live", STRESS_DB "/sym");
+    char livedir[512];
+    stress_live_dir(c, livedir, sizeof(livedir));
+    ray_t* live = ray_splay_load(livedir, c->sym_path);
     TEST_ASSERT_NOT_NULL(live);
     TEST_ASSERT_FALSE(RAY_IS_ERR(live));
     TEST_ASSERT_EQ_I(ray_table_nrows(live), 100);
@@ -40,7 +41,7 @@ static test_result_t test_fixture_roundtrip_impl(stress_ctx_t* c) {
     ray_release(live);
 
     /* parted table loads and skips the non-date `live` dir */
-    ray_t* parted = ray_read_parted(STRESS_DB, "hist");
+    ray_t* parted = ray_read_parted(c->db_root, "hist");
     TEST_ASSERT_NOT_NULL(parted);
     TEST_ASSERT_FALSE(RAY_IS_ERR(parted));
     ray_release(parted);
@@ -50,7 +51,7 @@ static test_result_t test_fixture_roundtrip_impl(stress_ctx_t* c) {
 
 static test_result_t test_fixture_roundtrip(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_DB, 42), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("matrix"), 42), "init");
     test_result_t r = test_fixture_roundtrip_impl(&c);
     stress_destroy(&c);
     return r;
@@ -66,7 +67,7 @@ static test_result_t test_verify_clean_impl(stress_ctx_t* c) {
 
 static test_result_t test_verify_clean(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_DB, 43), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("matrix"), 43), "init");
     test_result_t r = test_verify_clean_impl(&c);
     stress_destroy(&c);
     return r;
@@ -102,7 +103,7 @@ static test_result_t test_verify_detects_divergence_impl(stress_ctx_t* c) {
 
 static test_result_t test_verify_detects_divergence(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_DB, 44), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("matrix"), 44), "init");
     test_result_t r = test_verify_detects_divergence_impl(&c);
     stress_destroy(&c);
     return r;
@@ -136,7 +137,7 @@ static test_result_t test_matrix_insert_impl(stress_ctx_t* c) {
 
 static test_result_t test_matrix_insert(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_DB, 100), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("matrix"), 100), "init");
     test_result_t r = test_matrix_insert_impl(&c);
     stress_destroy(&c);
     return r;
@@ -160,7 +161,7 @@ static test_result_t test_matrix_upsert_impl(stress_ctx_t* c) {
 
 static test_result_t test_matrix_upsert(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_DB, 101), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("matrix"), 101), "init");
     test_result_t r = test_matrix_upsert_impl(&c);
     stress_destroy(&c);
     return r;
@@ -189,7 +190,7 @@ static test_result_t test_matrix_trim_impl(stress_ctx_t* c) {
 
 static test_result_t test_matrix_trim(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_DB, 102), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("matrix"), 102), "init");
     test_result_t r = test_matrix_trim_impl(&c);
     stress_destroy(&c);
     return r;
@@ -215,7 +216,7 @@ static test_result_t test_matrix_parted_ops_impl(stress_ctx_t* c) {
 
 static test_result_t test_matrix_parted_ops(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_DB, 103), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("matrix"), 103), "init");
     test_result_t r = test_matrix_parted_ops_impl(&c);
     stress_destroy(&c);
     return r;
@@ -262,7 +263,7 @@ static test_result_t test_matrix_restart_after_each_op_impl(stress_ctx_t* c) {
 
 static test_result_t test_matrix_restart_after_each_op(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_DB, 104), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("matrix"), 104), "init");
     test_result_t r = test_matrix_restart_after_each_op_impl(&c);
     stress_destroy(&c);
     return r;
@@ -335,7 +336,7 @@ static test_result_t test_matrix_shared_domain_layout_impl(stress_ctx_t* c) {
 
 static test_result_t test_matrix_shared_domain_layout(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_DB, 106), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("matrix"), 106), "init");
     test_result_t r = test_matrix_shared_domain_layout_impl(&c);
     stress_destroy(&c);
     return r;
@@ -447,7 +448,7 @@ static test_result_t test_matrix_vocab_width_impl(stress_ctx_t* c) {
 
 static test_result_t test_matrix_vocab_width(void) {
     stress_ctx_t c;
-    TEST_ASSERT(stress_init(&c, STRESS_DB, 107), "init");
+    TEST_ASSERT(stress_init(&c, stress_db_path("matrix"), 107), "init");
     test_result_t r = test_matrix_vocab_width_impl(&c);
     stress_destroy(&c);
     return r;

--- a/test/test_stress_random.c
+++ b/test/test_stress_random.c
@@ -26,7 +26,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define STRESS_RND_DB     "/tmp/rayforce_stress_random"
 #define DEFAULT_ITERS     500
 #define FULL_VERIFY_EVERY 25
 
@@ -128,7 +127,7 @@ static test_result_t run_seed(uint64_t seed) {
     int64_t iters = env_i64("RAY_STRESS_ITERS", DEFAULT_ITERS);
     bool    ev    = eval_mode(); /* read once; fixed for the whole run */
     stress_ctx_t c;
-    if (!stress_init(&c, STRESS_RND_DB, seed)) FAILF("init failed");
+    if (!stress_init(&c, stress_db_path("random"), seed)) FAILF("init failed");
     if (!(ev ? stress_eval_seed_initial(&c, 64, 3, 32)
              : stress_seed_initial(&c, 64, 3, 32))) {
         stress_destroy(&c);


### PR DESCRIPTION
## What

The stress tests hardcoded shared `/tmp` scratch dirs — `/tmp/rayforce_stress_{random,matrix,eval}` — and each test's `stress_init` does `rm -rf` + recreate on its `db_root`. So **two test binaries running at once** (a dev running the suite twice, overlapping ad-hoc runs, or a parallel CI matrix sharing a runner) delete and rewrite each other's directory mid-save.

That surfaces as intermittent, hard-to-explain save failures deep in `ray_splay_save`:
- `RAY_ERR_CORRUPT` — the sym-domain's "another writer replaced the symfile under us" detection firing.
- `RAY_ERR_IO` / `ENOENT` — the directory disappeared between `mkdir` and the column/sym write.

In true isolation the stress tests are deterministic and pass every time; the failures only ever appeared under concurrent invocation (confirmed by capturing the exact `errno=2` / CORRUPT signatures and correlating every failure with a second live `rayforce.test` process).

## Fix

Each process gets its own scratch root: `stress_db_path("name")` → `/tmp/rayforce_stress_<name>.<pid>`.

- `stress_db_path` returns a static buffer reused per call; `stress_init` copies the path immediately, so back-to-back calls (e.g. the eval equivalence test's two fixtures) are safe.
- The matrix round-trip load-back derives paths from the ctx (`stress_live_dir` + `c->sym_path` + `c->db_root`) instead of the literal macro.
- The eval equivalence test gets distinct `eval_eqc` / `eval_eqe` roots.

No behavior change for a single run; concurrent runs are now isolated.

## Verification

Two concurrent `./rayforce.test --filter stress/` runs both pass **13/13, zero failures** (pre-change they collide and fail). Stress tests also pass standalone.

## Note

This is test-isolation hygiene, not a product bug — the engine's save/sym/domain code is correct; the tests just weren't safe to run as multiple concurrent processes. Other test groups still use fixed `/tmp` paths and would have the same constraint under concurrency, but the stress group is where it actually bit (its `rm -rf`-per-op makes the collision destructive); narrowing this PR to that.