### PR TITLE
ci: feature-oriented release changelog generator

### DIFF
--- a/.github/release-notes.sh
+++ b/.github/release-notes.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Generate a FEATURE-oriented changelog for a release, not a contributor ledger.
+#
+# Buckets conventional-commit subjects (feat/fix/perf/docs/...) since the
+# previous release tag into readable sections. Author names and PR-merge noise
+# are intentionally dropped — the "Full changelog" compare link at the bottom is
+# the exhaustive, per-commit view for anyone who wants it.
+#
+# Usage: release-notes.sh <X.Y.Z> <target-sha>
+# Writes the notes (Markdown) to stdout. Requires full git history + tags
+# (checkout with fetch-depth: 0).
+set -euo pipefail
+
+VERSION="${1:?usage: release-notes.sh X.Y.Z <target-sha>}"
+SHA="${2:?usage: release-notes.sh X.Y.Z <target-sha>}"
+REPO="${GITHUB_REPOSITORY:-RayforceDB/rayforce}"
+
+# Previous-release boundary: the highest semver tag strictly below this release.
+# Falls back to the pre-v2 rollup marker, then to the repo root (no boundary).
+prev="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -vxF "v$VERSION" | head -1 || true)"
+if [ -z "$prev" ] && git rev-parse -q --verify "pre-v2-rollup^{commit}" >/dev/null 2>&1; then
+  prev="pre-v2-rollup"
+fi
+range="${prev:+$prev..}$SHA"
+
+feats=""; fixes=""; perfs=""; docs=""; other=""
+while IFS= read -r s; do
+  [ -n "$s" ] || continue
+  type="$(printf '%s' "$s" | sed -nE 's/^([a-zA-Z]+)(\([^)]*\))?!?:.*/\1/p')"
+  desc="$(printf '%s' "$s" | sed -E 's/^[a-zA-Z]+(\([^)]*\))?!?:[[:space:]]*//')"
+  case "$type" in
+    feat) feats+="- ${desc}"$'\n';;
+    fix)  fixes+="- ${desc}"$'\n';;
+    perf) perfs+="- ${desc}"$'\n';;
+    docs) docs+="- ${desc}"$'\n';;
+    *)    other+="- ${s}"$'\n';;   # non-conventional / internal: keep full subject
+  esac
+done < <(git log --no-merges --reverse --pretty=tformat:'%s' "$range")
+
+emit() { [ -n "$2" ] && printf '### %s\n\n%s\n' "$1" "$2"; return 0; }
+
+emit "✨ Features"      "$feats"
+emit "🐛 Bug fixes"    "$fixes"
+emit "⚡ Performance"   "$perfs"
+emit "📚 Documentation" "$docs"
+if [ -n "$other" ]; then
+  printf '<details>\n<summary>🔧 Maintenance &amp; internal</summary>\n\n%s\n</details>\n' "$other"
+fi
+
+if [ -n "$prev" ]; then
+  printf '\n**Full changelog**: https://github.com/%s/compare/%s...v%s\n' "$REPO" "$prev" "$VERSION"
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,19 @@ jobs:
       version: ${{ steps.parse.outputs.version }}
       sha: ${{ steps.parse.outputs.sha }}
     steps:
+      # Full history + tags so the changelog generator can scope to the previous
+      # release tag.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
       - name: Resolve version + target, ensure draft release
         id: parse
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           EVENT: ${{ github.event_name }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
@@ -73,10 +81,13 @@ jobs:
             SHA="$(gh release view "v$VERSION" --json targetCommitish -q .targetCommitish)"
             echo "Release v$VERSION already exists — building from its target $SHA."
           else
+            # Feature-oriented changelog (grouped by conventional-commit type),
+            # not GitHub's default author/PR ledger.
+            bash .github/release-notes.sh "$VERSION" "$SHA" > "$RUNNER_TEMP/notes.md"
             gh release create "v$VERSION" \
               --target "$SHA" \
               --title "v$VERSION" \
-              --generate-notes \
+              --notes-file "$RUNNER_TEMP/notes.md" \
               --draft
             echo "Created draft release v$VERSION at $SHA."
           fi

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,7 +25,8 @@ truth for the version** — no version literal is ever hand-edited in source.
    - builds the optimized binary for Linux and macOS with the version injected
      at compile time (`make dist RAY_VERSION=X.Y.Z`),
    - packages `rayforce-X.Y.Z-<os>-<arch>.tar.gz` + a `.sha256` checksum,
-   - publishes a GitHub Release with auto-generated notes and the artifacts.
+   - publishes a GitHub Release with a feature-oriented changelog and the
+     artifacts.
 
 That's the whole ritual. **Never edit the version in source to make a release** —
 the tag is authoritative.
@@ -44,6 +45,20 @@ manual dispatch with no prior draft tags the current `master` HEAD.
 > published (`--draft=false`). So `build` checks out the release's target
 > **commit**; the `publish` job is what creates the tag `vX.Y.Z`. Checking out
 > `ref: vX.Y.Z` during build would fail (the tag does not exist yet).
+
+## Release notes
+
+Notes are a **feature changelog, not a contributor ledger**. The `prepare` job
+runs [`.github/release-notes.sh`](.github/release-notes.sh), which groups
+conventional-commit subjects since the previous release tag into sections —
+**✨ Features** (`feat`), **🐛 Bug fixes** (`fix`), **⚡ Performance** (`perf`),
+**📚 Documentation** (`docs`) — with everything else collapsed under
+*Maintenance & internal*. Author names and merge-commit noise are dropped; a
+**Full changelog** compare link at the bottom is the exhaustive per-commit view.
+
+Because notes are scoped to `previousTag..thisRelease`, they only read well once
+there is a previous release tag to diff against — the first release (`v2.1.0`)
+spans the entire v2 line and was given a hand-written highlights summary instead.
 
 ## How the version reaches the binary
 


### PR DESCRIPTION
Replaces GitHub's `--generate-notes` (a `<PR title> by @author` ledger) with
`.github/release-notes.sh`, which groups conventional-commit subjects since the
previous release tag into **Features / Bug fixes / Performance / Documentation**,
collapses the rest under *Maintenance & internal*, strips author/merge noise, and
appends a **Full changelog** compare link.

- `prepare` now checks out full history + tags and feeds `--notes-file`.
- Notes are scoped `previousTag..thisRelease`, so they read well from the first
  incremental release onward. v2.1.0 (no prior tag) got a hand-written highlights
  summary out of band.

Non-release title by design → `check-version` will be red. Per decision, this is
**admin-merged** once `ci-success` is green, so the generator is active for the
next release. (master is otherwise releases-only.)