### PR TITLE
ci(release): announce published releases to Zulip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,3 +137,35 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: gh release edit "v${{ needs.prepare.outputs.version }}" --draft=false
+
+  # Post the release announcement to Zulip (#Announcements > Rayforce) once the
+  # release is public. Best-effort: skipped when ZULIP_API_KEY isn't configured,
+  # and continue-on-error so a Zulip hiccup never reds an already-shipped release.
+  announce:
+    needs: [prepare, publish]
+    runs-on: ubuntu-latest
+    env:
+      ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+    steps:
+      - name: Announce on Zulip
+        if: ${{ env.ZULIP_API_KEY != '' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          url="https://github.com/${GH_REPO}/releases/tag/v${VERSION}"
+          # Changelog highlights = the release body minus the collapsed
+          # "Maintenance & internal" <details> block (Zulip won't render it).
+          notes="$(gh release view "v$VERSION" --json body -q .body | sed '/<details>/,/<\/details>/d')"
+          content="$(printf '🚀 **Rayforce v%s** is out!\n\n%s\n\n📦 Release & downloads: %s' "$VERSION" "$notes" "$url")"
+          resp="$(curl -sS -X POST 'https://rayforcedb.zulipchat.com/api/v1/messages' \
+            -u "releases-bot@rayforcedb.zulipchat.com:${ZULIP_API_KEY}" \
+            --data-urlencode 'type=stream' \
+            --data-urlencode 'to=Announcements' \
+            --data-urlencode 'topic=Rayforce' \
+            --data-urlencode "content=${content}")"
+          echo "Zulip response: $resp"
+          echo "$resp" | grep -q '"result": *"success"'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -89,6 +89,13 @@ make dist RAY_VERSION=2.1.3
 - No release secret or bypass token is needed — the default `GITHUB_TOKEN`
   (`contents: write`) creates the tag and the release. The release workflow never
   pushes a commit to `master`, only a tag ref.
+- **Optional — Zulip announcement**: add a repository secret **`ZULIP_API_KEY`**
+  (the API key of the `releases-bot@rayforcedb.zulipchat.com` bot). The `announce`
+  job then posts each published release — title + changelog highlights + link —
+  to **#Announcements** under the **Rayforce** topic. Without the secret the job
+  is skipped, and a Zulip error never fails the release (`continue-on-error`).
+  If Zulip rejects the post, the bot may need to be a *Generic bot* (not just an
+  incoming-webhook) and subscribed to the Announcements channel.
 
 ## Platform support
 


### PR DESCRIPTION
Adds an `announce` job to `release.yml` that posts each **published** release to
Zulip **#Announcements › Rayforce** via `releases-bot@rayforcedb.zulipchat.com`.

- **Content**: `🚀 Rayforce vX.Y.Z is out!` + the changelog highlights (release
  body, minus the collapsed *Maintenance & internal* `<details>` block Zulip
  won't render) + a link to the release.
- **Safe**: gated on the `ZULIP_API_KEY` secret (skipped when unset), and
  `continue-on-error` so a Zulip hiccup never fails an already-shipped release.
- `needs: [prepare, publish]` → runs only after the release goes public.

**Setup (one-time):** add repo secret `ZULIP_API_KEY` (the bot's API key).
Documented in RELEASE.md, including the fallback if the incoming-webhook bot
can't post (use a Generic bot / subscribe it to the channel).

Rides to master with the next release; first announcement will be that release.