### PR TITLE
packaging: portable .deb + Homebrew tap on each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,32 @@ jobs:
           gh release upload "v${{ needs.prepare.outputs.version }}" \
             dist/*.tar.gz dist/*.sha256 --clobber
 
+      # The tarball above is -march=native (built for THIS runner's CPU). For a
+      # redistributable .deb we rebuild a PORTABLE binary (x86-64-v3 = AVX2,
+      # ~2013+) so it can't SIGILL on a different/older CPU; `make clean` first
+      # so the native .o files aren't reused.
+      - name: Build portable .deb (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          RAY_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          make clean
+          make release RAY_VERSION="$RAY_VERSION" RAY_MARCH=x86-64-v3
+          ver="$(curl -fsSL https://api.github.com/repos/goreleaser/nfpm/releases/latest | grep -oP '"tag_name":\s*"\K[^"]+')"
+          curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/${ver}/nfpm_${ver#v}_amd64.deb" -o /tmp/nfpm.deb
+          sudo dpkg -i /tmp/nfpm.deb
+          mkdir -p dist
+          nfpm pkg --packager deb --config packaging/nfpm.yaml --target dist/
+          ls -l dist/*.deb
+
+      - name: Upload .deb to release (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release upload "v${{ needs.prepare.outputs.version }}" dist/*.deb --clobber
+
   publish:
     needs: [prepare, build]
     runs-on: ubuntu-latest
@@ -169,3 +195,40 @@ jobs:
             --data-urlencode "content=${content}")"
           echo "Zulip response: $resp"
           echo "$resp" | grep -q '"result": *"success"'
+
+  # Bump the Homebrew tap (RayforceDB/homebrew-tap → Formula/rayforce.rb) to this
+  # release. Best-effort: skipped when HOMEBREW_TAP_TOKEN isn't configured, and
+  # continue-on-error so a tap hiccup never reds an already-shipped release.
+  homebrew:
+    needs: [prepare, publish]
+    runs-on: ubuntu-latest
+    env:
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+      - name: Update tap formula
+        if: ${{ env.HOMEBREW_TAP_TOKEN != '' }}
+        continue-on-error: true
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          GH_REPO: ${{ github.repository }}
+          TAP_REPO: RayforceDB/homebrew-tap
+        run: |
+          set -euo pipefail
+          # Build-from-source formula: point at the GitHub source tarball for the
+          # tag and pin its sha256.
+          url="https://github.com/${GH_REPO}/archive/refs/tags/v${VERSION}.tar.gz"
+          sha="$(curl -fsSL "$url" | sha256sum | cut -d' ' -f1)"
+          tmp="$(mktemp -d)"
+          git clone --depth 1 "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${TAP_REPO}.git" "$tmp"
+          mkdir -p "$tmp/Formula"
+          sed -e "s|__URL__|${url}|" -e "s|__SHA256__|${sha}|" \
+            packaging/homebrew-formula.rb.tmpl > "$tmp/Formula/rayforce.rb"
+          cd "$tmp"
+          git config user.name  "rayforce-release"
+          git config user.email "release@rayforcedb.com"
+          git add Formula/rayforce.rb
+          git commit -m "rayforce ${VERSION}" || { echo "formula unchanged — nothing to push"; exit 0; }
+          git push origin HEAD

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,16 @@ DEPFLAGS = -MMD -MP
 
 UNAME_S := $(shell uname -s)
 
-DEBUG_CFLAGS   = -fPIC $(WARNS) -std=$(STD) -g -O0 -march=native -DDEBUG \
+# Target microarchitecture.  Default `native` = build for THIS machine (fastest;
+# right for local builds and the per-machine release tarballs).  Override for
+# REDISTRIBUTABLE packages (.deb) that must run on any CPU, e.g.
+# `make release RAY_MARCH=x86-64-v3` (AVX2 baseline, ~2013+) — a -march=native
+# binary handed to a different/older CPU dies with SIGILL.
+RAY_MARCH ?= native
+
+DEBUG_CFLAGS   = -fPIC $(WARNS) -std=$(STD) -g -O0 -march=$(RAY_MARCH) -DDEBUG \
   -fsanitize=address,undefined -fno-omit-frame-pointer
-RELEASE_CFLAGS = -fPIC $(WARNS) -std=$(STD) -O3 -march=native \
+RELEASE_CFLAGS = -fPIC $(WARNS) -std=$(STD) -O3 -march=$(RAY_MARCH) \
   -funroll-loops -fomit-frame-pointer -fno-math-errno \
   -fassociative-math -ffp-contract=fast -fno-signed-zeros -fno-trapping-math
 # -fassociative-math: license to reorder FP additions/multiplications.
@@ -52,7 +59,7 @@ RELEASE_CFLAGS = -fPIC $(WARNS) -std=$(STD) -O3 -march=native \
 # with the profile runtime, so we drop them; -O0 keeps line numbers
 # and avoids dead-code regions getting marked uncovered for the
 # wrong reason.  See `make coverage` below.
-COVERAGE_CFLAGS = -fPIC $(WARNS) -std=$(STD) -g -O0 -march=native -DDEBUG \
+COVERAGE_CFLAGS = -fPIC $(WARNS) -std=$(STD) -g -O0 -march=$(RAY_MARCH) -DDEBUG \
   -fno-omit-frame-pointer -fprofile-instr-generate -fcoverage-mapping
 COVERAGE_LDFLAGS = -fprofile-instr-generate -fcoverage-mapping
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ analytics and graph traversals share a single operation DAG, pass through a
 multi-pass optimizer, and execute as morsel-driven bytecode compiled at
 execution time. No malloc.
 
+## Install
+
+**Homebrew** (macOS & Linux):
+
+```bash
+brew install rayforcedb/tap/rayforce
+```
+
+**Debian / Ubuntu** (`.deb`, x86-64) — grab the `.deb` from the
+[latest release](https://github.com/RayforceDB/rayforce/releases/latest):
+
+```bash
+curl -LO https://github.com/RayforceDB/rayforce/releases/download/vX.Y.Z/rayforce_X.Y.Z_amd64.deb
+sudo dpkg -i rayforce_X.Y.Z_amd64.deb
+```
+
+**Prebuilt tarball** (Linux x86-64 / macOS arm64) is also attached to each
+release. Or build [from source](#quick-start) below — zero dependencies, just
+`make`.
+
 ## Quick Start
 
 ```bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -96,6 +96,35 @@ make dist RAY_VERSION=2.1.3
   is skipped, and a Zulip error never fails the release (`continue-on-error`).
   If Zulip rejects the post, the bot may need to be a *Generic bot* (not just an
   incoming-webhook) and subscribed to the Announcements channel.
+- **Optional — Homebrew tap**: create an empty repo **`RayforceDB/homebrew-tap`**
+  and add a repository secret **`HOMEBREW_TAP_TOKEN`** (a PAT — fine-grained or
+  classic — with **contents: write** on `homebrew-tap`; the default
+  `GITHUB_TOKEN` can't push to a *different* repo). The `homebrew` job then
+  rewrites `Formula/rayforce.rb` in the tap on every release. Without the secret
+  the job is skipped. Users install with `brew install rayforcedb/tap/rayforce`.
+
+## Packaging / install channels
+
+Each release publishes, in addition to the source:
+
+- **Tarballs** — `rayforce-X.Y.Z-linux-x86_64.tar.gz` and
+  `…-darwin-arm64.tar.gz` (+ `.sha256`), built `-march=native` for *that*
+  runner. Fast, but per-machine — fine to download and run on a similar box.
+- **`.deb`** (`rayforce_X.Y.Z_amd64.deb`) — built **portable** via the Makefile
+  `RAY_MARCH=x86-64-v3` knob ([`packaging/nfpm.yaml`](packaging/nfpm.yaml)), so
+  it runs on any AVX2-era (~2013+) x86-64 CPU instead of SIGILL'ing on a
+  mismatch. No setup needed (uses `GITHUB_TOKEN`).
+- **Homebrew** (`rayforcedb/tap`) — a **build-from-source** formula
+  ([`packaging/homebrew-formula.rb.tmpl`](packaging/homebrew-formula.rb.tmpl)),
+  auto-bumped by the `homebrew` job. Compiling on the user's machine means all
+  Mac arches work and there's no redistribution-portability footgun.
+
+> **Note — the tarballs are still `-march=native`.** That's a latent
+> SIGILL-on-a-different-CPU risk if someone downloads one for a machine unlike
+> the runner. If you'd rather they were portable too, build them with
+> `RAY_MARCH=x86-64-v3` in the `build` job (like the `.deb`); the trade-off is
+> losing `-march=native`'s last bit of per-CPU tuning. Source builds (`make`,
+> Homebrew) always get native.
 
 ## Platform support
 

--- a/packaging/homebrew-formula.rb.tmpl
+++ b/packaging/homebrew-formula.rb.tmpl
@@ -1,0 +1,30 @@
+# Homebrew formula TEMPLATE for the rayforcedb/tap tap.
+#
+# release.yml substitutes __URL__ and __SHA256__ (the GitHub source tarball for
+# the tag and its sha256) and pushes the result to RayforceDB/homebrew-tap as
+# Formula/rayforce.rb on every release.
+#
+# Build-from-source on purpose: it compiles for the user's own CPU (so it works
+# on every Mac arch and never SIGILLs the way a redistributed -march=native
+# binary can), and a zero-dependency `make` build needs no `depends_on`.
+class Rayforce < Formula
+  desc "Embeddable columnar analytics and graph traversal engine in pure C"
+  homepage "https://rayforcedb.com/"
+  url "__URL__"
+  sha256 "__SHA256__"
+  license "MIT"
+  head "https://github.com/RayforceDB/rayforce.git", branch: "master"
+
+  def install
+    # Inject the release version (no .git in a source tarball, so git-describe
+    # can't), build optimized for the user's machine, install binary + header.
+    system "make", "release", "RAY_VERSION=#{version}"
+    bin.install "rayforce"
+    include.install "include/rayforce.h"
+  end
+
+  test do
+    assert_match "usage", shell_output("#{bin}/rayforce --help")
+    assert_match version.to_s, pipe_output("#{bin}/rayforce", "(.sys.build)\n")
+  end
+end

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,0 +1,32 @@
+# nfpm config — produces the Rayforce .deb.
+#
+# Driven by .github/workflows/release.yml on the Linux build, which first
+# rebuilds a PORTABLE binary (`make release RAY_MARCH=x86-64-v3`, NOT the
+# default -march=native) so the package runs on any modern x86-64 CPU, then
+# runs `nfpm pkg --packager deb`.  $RAY_VERSION is expanded from the env.
+#
+# To also emit .rpm / .apk later, just run nfpm with --packager rpm / apk
+# (same config) — no changes needed here.
+name: "rayforce"
+arch: "amd64"
+platform: "linux"
+version: "${RAY_VERSION}"
+maintainer: "Anton Kundenko <anton.kundenko@gmail.com>"
+description: |
+  Embeddable columnar analytics and graph traversal engine in pure C.
+  Built-in Rayfall query language, IPC, datalog, and vector search. Zero deps.
+vendor: "RayforceDB"
+homepage: "https://rayforcedb.com/"
+license: "MIT"
+section: "database"
+priority: "optional"
+
+contents:
+  - src: ./rayforce
+    dst: /usr/bin/rayforce
+  - src: ./include/rayforce.h
+    dst: /usr/include/rayforce.h
+  - src: ./LICENSE
+    dst: /usr/share/doc/rayforce/copyright
+  - src: ./README.md
+    dst: /usr/share/doc/rayforce/README.md


### PR DESCRIPTION
Adds two install channels to the release pipeline. Both extend the existing flow and are best-effort (never fail an already-shipped release).

## .deb (amd64)
- New Makefile knob **`RAY_MARCH ?= native`** (default unchanged). The release `build` job rebuilds a **portable** binary (`RAY_MARCH=x86-64-v3`, AVX2/~2013+) and packages it with **nfpm** (`packaging/nfpm.yaml`), uploaded as a release asset. No setup (uses `GITHUB_TOKEN`).
- **Why portable:** a `-march=native` binary built on a GH runner can `SIGILL` on a user's different/older CPU. The per-machine tarballs stay native (flagged in RELEASE.md).
- **Smoke-tested locally** with nfpm v2.46.3: `rayforce_2.1.3_amd64.deb`, version env-expanded, layout `/usr/bin/rayforce` + `/usr/include/rayforce.h` + doc/copyright.

## Homebrew tap
- **Build-from-source** formula (`packaging/homebrew-formula.rb.tmpl`) auto-bumped into `RayforceDB/homebrew-tap` (`Formula/rayforce.rb`) by a new `homebrew` job. From-source = all Mac arches work, no redistribution footgun, no `depends_on` (zero deps).
- **One-time setup:** create repo `RayforceDB/homebrew-tap` + add `HOMEBREW_TAP_TOKEN` secret (PAT, contents:write on the tap). Skipped without it. → `brew install rayforcedb/tap/rayforce`.

## Also
- README **Install** section; RELEASE.md packaging docs + setup.

Activates on the next release (v2.1.3): `.deb` immediately; brew once the tap repo + token exist.