### PR TITLE
v2.1.4

### DIFF
--- a/src/ops/agg_engine.c
+++ b/src/ops/agg_engine.c
@@ -36,8 +36,8 @@ bool agg_v2_can_handle(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     /* Factorized-EXPAND result (synthetic _src key + _count weight column) needs
      * exec_group's dedicated factorized handling (COUNT/SUM(_count) weight by
      * _count). v2 would compute a plain count — defer the whole shape. */
-    if (ext->n_keys == 1 && ext->keys[0] && ext->keys[0]->opcode == OP_SCAN) {
-        ray_op_ext_t* ke = find_ext(g, ext->keys[0]->id);
+    if (ext->n_keys == 1 && op_node(g, ext->keys[0]) && op_node(g, ext->keys[0])->opcode == OP_SCAN) {
+        ray_op_ext_t* ke = find_ext(g, ext->keys[0]);
         if (ke && ke->sym == ray_sym_intern("_src", 4)) {
             ray_t* cnt = ray_table_get_col(tbl, ray_sym_intern("_count", 6));
             if (cnt && cnt->type == RAY_I64) return false;
@@ -46,7 +46,7 @@ bool agg_v2_can_handle(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
 
     /* every key must be a plain column scan of a supported type */
     for (uint8_t k = 0; k < ext->n_keys; k++) {
-        ray_op_t* key = ext->keys[k];
+        ray_op_t* key = op_node(g, ext->keys[k]);
         if (!key || key->opcode != OP_SCAN) return false;
         ray_op_ext_t* kext = find_ext(g, key->id);
         ray_t* kc = kext ? ray_table_get_col(tbl, kext->sym) : NULL;
@@ -64,16 +64,16 @@ bool agg_v2_can_handle(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
         if (ext->agg_k && ext->agg_k[a]) {
             if (ext->agg_ops[a] != OP_TOP_N && ext->agg_ops[a] != OP_BOT_N) return false;
             if (ext->agg_k[a] < 1) return false;
-            ray_op_t* in = ext->agg_ins[a];
+            ray_op_t* in = op_node(g, ext->agg_ins[a]);
             if (!in || in->opcode != OP_SCAN) return false;
             ray_op_ext_t* ie = find_ext(g, in->id);
             ray_t* ic = ie ? ray_table_get_col(tbl, ie->sym) : NULL;
             if (!ic || !agg_resolve(ext->agg_ops[a], ic->type)) return false;
             continue;  /* admitted */
         }
-        if (ext->agg_ins2 && ext->agg_ins2[a]) {
+        if (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE) {
             if (ext->agg_ops[a] != OP_PEARSON_CORR) return false; /* only pearson in 2b */
-            ray_op_t* xin = ext->agg_ins[a]; ray_op_t* yin = ext->agg_ins2[a];
+            ray_op_t* xin = op_node(g, ext->agg_ins[a]); ray_op_t* yin = op_node(g, ext->agg_ins2[a]);
             if (!xin || xin->opcode != OP_SCAN || !yin || yin->opcode != OP_SCAN) return false;
             ray_op_ext_t* xe = find_ext(g, xin->id); ray_op_ext_t* ye = find_ext(g, yin->id);
             ray_t* xc = xe ? ray_table_get_col(tbl, xe->sym) : NULL;
@@ -90,7 +90,7 @@ bool agg_v2_can_handle(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
             if (!agg_resolve(OP_COUNT, RAY_I64)) return false;
             continue;
         }
-        ray_op_t* in = ext->agg_ins[a];
+        ray_op_t* in = op_node(g, ext->agg_ins[a]);
         if (!in || in->opcode != OP_SCAN) return false;
         ray_op_ext_t* ie = find_ext(g, in->id);
         ray_t* ic = (ie) ? ray_table_get_col(tbl, ie->sym) : NULL;
@@ -699,7 +699,7 @@ static ray_t* exec_group_v2_parallel(
     const void* val2_data[16]; int8_t val2_types[16]; bool val2_hasnull[16]; uint8_t val2_esz[16];
     int64_t agg_syms[16];
     for (uint8_t a = 0; a < n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]->id);
+        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
         agg_syms[a] = ie->sym;
         ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
         val_data[a]    = vc ? ray_data(vc) : NULL;
@@ -707,8 +707,8 @@ static ray_t* exec_group_v2_parallel(
         val_hasnull[a] = vc ? ((vc->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
         val_esz[a]     = vc ? col_esz(vc) : 0;
         /* Binary agg (pearson): resolve the y-side column from agg_ins2[a]. */
-        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a])
-            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a]->id)->sym) : NULL;
+        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE)
+            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a])->sym) : NULL;
         val2_data[a]    = vc2 ? ray_data(vc2) : NULL;
         val2_types[a]   = vc2 ? vc2->type : RAY_I64;
         val2_hasnull[a] = vc2 ? ((vc2->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
@@ -1019,7 +1019,7 @@ static ray_t* exec_group_v2_parallel_dense(
     /* Re-derive the AoS layout (same order as exec_group_v2). */
     const agg_vtable_t* vts[16]; size_t off[16]; size_t block = 0;
     for (uint8_t a = 0; a < n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]->id);
+        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
         ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
         int8_t in_type = vc ? vc->type : RAY_I64;
         vts[a] = agg_resolve(ext->agg_ops[a], in_type);
@@ -1034,15 +1034,15 @@ static ray_t* exec_group_v2_parallel_dense(
     const void* val2_data[16]; int8_t val2_types[16]; bool val2_hasnull[16]; uint8_t val2_esz[16];
     int64_t agg_syms[16];
     for (uint8_t a = 0; a < n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]->id);
+        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
         agg_syms[a] = ie->sym;
         ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
         val_data[a]    = vc ? ray_data(vc) : NULL;
         val_types[a]   = vc ? vc->type : RAY_I64;
         val_hasnull[a] = vc ? ((vc->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
         val_esz[a]     = vc ? col_esz(vc) : 0;
-        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a])
-            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a]->id)->sym) : NULL;
+        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE)
+            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a])->sym) : NULL;
         val2_data[a]    = vc2 ? ray_data(vc2) : NULL;
         val2_types[a]   = vc2 ? vc2->type : RAY_I64;
         val2_hasnull[a] = vc2 ? ((vc2->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
@@ -1505,15 +1505,15 @@ static ray_t* exec_group_v2_parallel_smallhash(
     const void* val2_data[16]; int8_t val2_types[16]; bool val2_hasnull[16]; uint8_t val2_esz[16];
     int64_t agg_syms[16];
     for (uint8_t a = 0; a < n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]->id);
+        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
         agg_syms[a] = ie->sym;
         ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
         val_data[a]    = vc ? ray_data(vc) : NULL;
         val_types[a]   = vc ? vc->type : RAY_I64;
         val_hasnull[a] = vc ? ((vc->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
         val_esz[a]     = vc ? col_esz(vc) : 0;
-        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a])
-            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a]->id)->sym) : NULL;
+        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE)
+            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a])->sym) : NULL;
         val2_data[a]    = vc2 ? ray_data(vc2) : NULL;
         val2_types[a]   = vc2 ? vc2->type : RAY_I64;
         val2_hasnull[a] = vc2 ? ((vc2->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
@@ -2044,15 +2044,15 @@ static ray_t* exec_group_v2_parallel_radix(
     const void* val2_data[16]; int8_t val2_types[16]; bool val2_hasnull[16]; uint8_t val2_esz[16];
     int64_t agg_syms[16];
     for (uint8_t a = 0; a < n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]->id);
+        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
         agg_syms[a] = ie->sym;
         ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
         val_data[a]    = vc ? ray_data(vc) : NULL;
         val_types[a]   = vc ? vc->type : RAY_I64;
         val_hasnull[a] = vc ? ((vc->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
         val_esz[a]     = vc ? col_esz(vc) : 0;
-        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a])
-            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a]->id)->sym) : NULL;
+        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE)
+            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a])->sym) : NULL;
         val2_data[a]    = vc2 ? ray_data(vc2) : NULL;
         val2_types[a]   = vc2 ? vc2->type : RAY_I64;
         val2_hasnull[a] = vc2 ? ((vc2->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
@@ -2275,7 +2275,7 @@ static ray_t* exec_group_v2_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
 
     ray_t* key_cols[16]; int64_t key_syms[16];
     for (uint8_t k = 0; k < ext->n_keys; k++) {
-        ray_op_ext_t* kext = find_ext(g, ext->keys[k]->id);
+        ray_op_ext_t* kext = find_ext(g, ext->keys[k]);
         key_cols[k] = ray_table_get_col(tbl, kext->sym);
         key_syms[k] = kext->sym;
     }
@@ -2283,7 +2283,7 @@ static ray_t* exec_group_v2_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
     /* Precompute AoS state layout for the admitted aggregates. */
     const agg_vtable_t* vts[16]; size_t off[16]; size_t block = 0;
     for (uint8_t a = 0; a < ext->n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]->id);
+        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
         ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
         int8_t in_type = vc ? vc->type : RAY_I64;
         vts[a] = agg_resolve(ext->agg_ops[a], in_type);
@@ -2433,11 +2433,11 @@ static ray_t* exec_group_v2_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
     }
 
     for (uint8_t a = 0; a < ext->n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]->id);
+        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
         int64_t kparam = (ext->agg_k ? ext->agg_k[a] : 0);
         ray_t* col;
-        if (ext->agg_ins2 && ext->agg_ins2[a]) {       /* binary agg (pearson) */
-            ray_op_ext_t* ye = find_ext(g, ext->agg_ins2[a]->id);
+        if (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE) {       /* binary agg (pearson) */
+            ray_op_ext_t* ye = find_ext(g, ext->agg_ins2[a]);
             ray_t* x_col = ray_table_get_col(tbl, ie->sym);
             ray_t* y_col = ray_table_get_col(tbl, ye->sym);
             const agg_vtable_t* vt = agg_resolve(ext->agg_ops[a], x_col->type);
@@ -2473,16 +2473,16 @@ static ray_t* agg_build_compact(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
     /* Collect the distinct syms this group needs from the source table. */
     int64_t want[48]; uint8_t n_want = 0;   /* <=16 keys + <=16 aggs*2 inputs */
     for (uint8_t k = 0; k < ext->n_keys; k++) {
-        int64_t s = find_ext(g, ext->keys[k]->id)->sym;
+        int64_t s = find_ext(g, ext->keys[k])->sym;
         bool seen = false;
         for (uint8_t i = 0; i < n_want; i++) if (want[i] == s) { seen = true; break; }
         if (!seen) want[n_want++] = s;
     }
     for (uint8_t a = 0; a < ext->n_aggs; a++) {
-        if (ext->agg_ops[a] == OP_COUNT && !(ext->agg_ins && ext->agg_ins[a]))
+        if (ext->agg_ops[a] == OP_COUNT && !(ext->agg_ins && ext->agg_ins[a] != RAY_OP_NONE))
             continue;                       /* COUNT needs no typed input */
-        ray_op_t* ins[2] = { ext->agg_ins ? ext->agg_ins[a] : NULL,
-                             ext->agg_ins2 ? ext->agg_ins2[a] : NULL };
+        ray_op_t* ins[2] = { ext->agg_ins ? op_node(g, ext->agg_ins[a]) : NULL,
+                             ext->agg_ins2 ? op_node(g, ext->agg_ins2[a]) : NULL };
         for (int j = 0; j < 2; j++) {
             if (!ins[j]) continue;
             int64_t s = find_ext(g, ins[j]->id)->sym;

--- a/src/ops/dump.c
+++ b/src/ops/dump.c
@@ -33,6 +33,16 @@ static ray_op_ext_t* find_ext(ray_graph_t* g, uint32_t node_id) {
     return NULL;
 }
 
+/* Local node-id accessors (this TU includes neither ops/internal.h nor
+ * ops/opt.h, and it carries its own find_ext above, so we mirror the
+ * internal.h helpers rather than risk a find_ext redefinition). */
+static inline ray_op_t* op_node(ray_graph_t* g, uint32_t id) {
+    return id == RAY_OP_NONE ? NULL : &g->nodes[id];
+}
+static inline ray_op_t* op_child(ray_graph_t* g, const ray_op_t* op, int i) {
+    return op_node(g, op->in_id[i]);
+}
+
 const char* ray_opcode_name(uint16_t op) {
     switch (op) {
         case OP_SCAN:          return "SCAN";
@@ -229,27 +239,27 @@ static void dump_node(FILE* f, ray_graph_t* g, ray_op_t* node, int depth) {
             if (ext) {
                 /* keys */
                 for (uint8_t i = 0; i < ext->n_keys; i++)
-                    dump_node(f, g, ext->keys[i], depth + 1);
+                    dump_node(f, g, op_node(g, ext->keys[i]), depth + 1);
                 /* agg inputs */
                 for (uint8_t i = 0; i < ext->n_aggs; i++)
-                    dump_node(f, g, ext->agg_ins[i], depth + 1);
+                    dump_node(f, g, op_node(g, ext->agg_ins[i]), depth + 1);
             }
             /* Also recurse into standard inputs */
             for (uint8_t i = 0; i < node->arity && i < 2; i++)
-                dump_node(f, g, node->inputs[i], depth + 1);
+                dump_node(f, g, op_child(g, node, i), depth + 1);
             break;
         case OP_SORT:
         case OP_SELECT:
             if (ext) {
                 for (uint8_t i = 0; i < ext->sort.n_cols; i++)
-                    dump_node(f, g, ext->sort.columns[i], depth + 1);
+                    dump_node(f, g, op_node(g, ext->sort.columns[i]), depth + 1);
             }
             for (uint8_t i = 0; i < node->arity && i < 2; i++)
-                dump_node(f, g, node->inputs[i], depth + 1);
+                dump_node(f, g, op_child(g, node, i), depth + 1);
             break;
         default:
             for (uint8_t i = 0; i < node->arity && i < 2; i++)
-                dump_node(f, g, node->inputs[i], depth + 1);
+                dump_node(f, g, op_child(g, node, i), depth + 1);
             break;
     }
 }

--- a/src/ops/exec.c
+++ b/src/ops/exec.c
@@ -927,8 +927,8 @@ static int idx_filter_decode(ray_graph_t* g, ray_op_t* pred_op,
         opc != OP_LT && opc != OP_LE &&
         opc != OP_GT && opc != OP_GE) return 0;
 
-    ray_op_t* lhs = pred_op->inputs[0];
-    ray_op_t* rhs = pred_op->inputs[1];
+    ray_op_t* lhs = op_child(g, pred_op, 0);
+    ray_op_t* rhs = op_child(g, pred_op, 1);
     if (!lhs || !rhs) return 0;
     if (lhs->opcode != OP_SCAN || rhs->opcode != OP_CONST) return 0;
     ray_op_ext_t* lext = find_ext(g, lhs->id);
@@ -1004,8 +1004,8 @@ static int idx_filter_in_decode(ray_graph_t* g, ray_op_t* pred_op,
     if (!pred_op || pred_op->arity != 2) return 0;
     if (pred_op->opcode != OP_IN) return 0;
 
-    ray_op_t* lhs = pred_op->inputs[0];  /* SCAN(col) */
-    ray_op_t* rhs = pred_op->inputs[1];  /* CONST(set_vec) */
+    ray_op_t* lhs = op_child(g, pred_op, 0);  /* SCAN(col) */
+    ray_op_t* rhs = op_child(g, pred_op, 1);  /* CONST(set_vec) */
     if (!lhs || !rhs) return 0;
     if (lhs->opcode != OP_SCAN || rhs->opcode != OP_CONST) return 0;
 
@@ -1156,9 +1156,9 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
 
         /* Membership: col IN set_vec */
         case OP_IN: case OP_NOT_IN: {
-            ray_t* col = exec_node(g, op->inputs[0]);
+            ray_t* col = exec_node(g, op_child(g, op, 0));
             if (!col || RAY_IS_ERR(col)) return col;
-            ray_t* set = exec_node(g, op->inputs[1]);
+            ray_t* set = exec_node(g, op_child(g, op, 1));
             if (!set || RAY_IS_ERR(set)) { ray_release(col); return set; }
             ray_t* result = exec_in(g, op, col, set);
             ray_release(col);
@@ -1188,14 +1188,14 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
             }
             /* Fallback: recursive per-node evaluation */
             if (op->arity == 1) {
-                ray_t* input = exec_node(g, op->inputs[0]);
+                ray_t* input = exec_node(g, op_child(g, op, 0));
                 if (!input || RAY_IS_ERR(input)) return input;
                 ray_t* result = exec_elementwise_unary(g, op, input);
                 ray_release(input);
                 return result;
             } else {
-                ray_t* lhs = exec_node(g, op->inputs[0]);
-                ray_t* rhs = exec_node(g, op->inputs[1]);
+                ray_t* lhs = exec_node(g, op_child(g, op, 0));
+                ray_t* rhs = exec_node(g, op_child(g, op, 1));
                 if (!lhs || RAY_IS_ERR(lhs)) { if (rhs && !RAY_IS_ERR(rhs)) ray_release(rhs); return lhs; }
                 if (!rhs || RAY_IS_ERR(rhs)) { ray_release(lhs); return rhs; }
                 ray_t* result = exec_elementwise_binary(g, op, lhs, rhs);
@@ -1209,7 +1209,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         case OP_SUM: case OP_PROD: case OP_MIN: case OP_MAX:
         case OP_COUNT: case OP_AVG: case OP_FIRST: case OP_LAST:
         case OP_STDDEV: case OP_STDDEV_POP: case OP_VAR: case OP_VAR_POP: {
-            ray_t* input = exec_node(g, op->inputs[0]);
+            ray_t* input = exec_node(g, op_child(g, op, 0));
             if (!input || RAY_IS_ERR(input)) return input;
             /* Compact lazy selection before reducing — filters may have
              * set g->selection without materializing a compacted table. */
@@ -1240,7 +1240,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_COUNT_DISTINCT: {
-            ray_t* input = exec_node(g, op->inputs[0]);
+            ray_t* input = exec_node(g, op_child(g, op, 0));
             if (!input || RAY_IS_ERR(input)) return input;
             ray_t* result = exec_count_distinct(g, op, input);
             ray_release(input);
@@ -1248,7 +1248,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_DISTINCT: {
-            ray_t* input = exec_node(g, op->inputs[0]);
+            ray_t* input = exec_node(g, op_child(g, op, 0));
             if (!input || RAY_IS_ERR(input)) return input;
             if (!ray_is_vec(input)) {
                 ray_release(input);
@@ -1260,7 +1260,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_ASC: {
-            ray_t* input = exec_node(g, op->inputs[0]);
+            ray_t* input = exec_node(g, op_child(g, op, 0));
             if (!input || RAY_IS_ERR(input)) return input;
             if (!ray_is_vec(input)) {
                 ray_release(input);
@@ -1272,7 +1272,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_DESC: {
-            ray_t* input = exec_node(g, op->inputs[0]);
+            ray_t* input = exec_node(g, op_child(g, op, 0));
             if (!input || RAY_IS_ERR(input)) return input;
             if (!ray_is_vec(input)) {
                 ray_release(input);
@@ -1284,7 +1284,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_REVERSE: {
-            ray_t* input = exec_node(g, op->inputs[0]);
+            ray_t* input = exec_node(g, op_child(g, op, 0));
             if (!input || RAY_IS_ERR(input)) return input;
             if (!ray_is_vec(input)) {
                 ray_release(input);
@@ -1300,7 +1300,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
              * the GROUP result rather than the original input table.
              * SCAN nodes in the predicate tree resolve column names via
              * g->table, so we temporarily swap it to the GROUP output. */
-            ray_op_t* filter_child = op->inputs[0];
+            ray_op_t* filter_child = op_child(g, op, 0);
             if (filter_child && filter_child->opcode == OP_GROUP) {
                 ray_t* group_result = exec_node(g, filter_child);
                 if (!group_result || RAY_IS_ERR(group_result))
@@ -1311,7 +1311,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
                 g->table     = group_result;
                 g->selection = NULL;
 
-                ray_t* pred = exec_node(g, op->inputs[1]);
+                ray_t* pred = exec_node(g, op_child(g, op, 1));
 
                 g->table     = saved_table;
                 g->selection = saved_sel;
@@ -1327,7 +1327,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
                 return result;
             }
 
-            ray_t* input = exec_node(g, op->inputs[0]);
+            ray_t* input = exec_node(g, op_child(g, op, 0));
             if (!input || RAY_IS_ERR(input)) return input;
             /* Hash-index point-lookup fast path: when the predicate is
              * `col == K` on a column with RAY_IDX_HASH attached and
@@ -1343,7 +1343,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
                 int64_t  key_i    = 0;
                 double   key_f    = 0.0;
                 int      is_float = 0;
-                if (idx_filter_decode(g, op->inputs[1], &col, &cmp_op,
+                if (idx_filter_decode(g, op_child(g, op, 1), &col, &cmp_op,
                                       &key_i, &key_f, &is_float)) {
                     /* 1. Zone index: O(1) all/none short-circuit. */
                     if (ray_index_kind(col) == RAY_IDX_ZONE)
@@ -1419,7 +1419,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
                 {
                     ray_t* in_col     = NULL;
                     ray_t* in_set_lit = NULL;
-                    if (idx_filter_in_decode(g, op->inputs[1], &in_col, &in_set_lit)) {
+                    if (idx_filter_in_decode(g, op_child(g, op, 1), &in_col, &in_set_lit)) {
                         bool in_col_is_float = (in_col->type == RAY_F32 ||
                                                in_col->type == RAY_F64);
                         if (ray_index_kind(in_col) == RAY_IDX_HASH &&
@@ -1437,7 +1437,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
                 }
             }
 
-            ray_t* pred = exec_node(g, op->inputs[1]);
+            ray_t* pred = exec_node(g, op_child(g, op, 1));
             if (!pred || RAY_IS_ERR(pred)) { ray_release(input); return pred; }
 
             /* Lazy filter: convert predicate to a rowsel (morsel-local
@@ -1472,7 +1472,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_SORT: {
-            ray_t* input = exec_node(g, op->inputs[0]);
+            ray_t* input = exec_node(g, op_child(g, op, 0));
             if (!input || RAY_IS_ERR(input)) return input;
             ray_t* tbl = (input->type == RAY_TABLE) ? input : g->table;
             /* Compact lazy selection before sort (needs dense data) */
@@ -1501,7 +1501,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
             {
                 ray_op_ext_t* gext = find_ext(g, op->id);
                 if (gext && gext->n_keys == 1) {
-                    ray_op_ext_t* kext = find_ext(g, gext->keys[0]->id);
+                    ray_op_ext_t* kext = find_ext(g, gext->keys[0]);
                     int64_t src_sym = ray_sym_intern("_src", 4);
                     if (kext && kext->base.opcode == OP_SCAN && kext->sym == src_sym) {
                         /* Find the factorized OP_EXPAND connected to this GROUP.
@@ -1535,8 +1535,9 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
             /* Pushed-down predicate (GROUP pushdown, opt.c): the optimizer
              * may interpose an OP_FILTER as inputs[0] (normally the first
              * key op).  Execute it first via the shared helper. */
-            if (op->inputs[0] && op->inputs[0]->opcode == OP_FILTER) {
-                ray_t* res = exec_pushed_group_filter(g, op->inputs[0]);
+            ray_op_t* group_in0 = op_child(g, op, 0);
+            if (group_in0 && group_in0->opcode == OP_FILTER) {
+                ray_t* res = exec_pushed_group_filter(g, group_in0);
                 if (res && RAY_IS_ERR(res)) return res;
                 if (res) { owned_tbl = res; tbl = res; }
                 /* NULL → lazy path; g->selection installed, tbl unchanged */
@@ -1574,8 +1575,8 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_JOIN: {
-            ray_t* left = exec_node(g, op->inputs[0]);
-            ray_t* right = exec_node(g, op->inputs[1]);
+            ray_t* left = exec_node(g, op_child(g, op, 0));
+            ray_t* right = exec_node(g, op_child(g, op, 1));
             if (!left || RAY_IS_ERR(left)) { if (right && !RAY_IS_ERR(right)) ray_release(right); return left; }
             if (!right || RAY_IS_ERR(right)) { ray_release(left); return right; }
             /* Compact lazy selection before join (needs dense data) */
@@ -1593,8 +1594,8 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_ANTIJOIN: {
-            ray_t* left = exec_node(g, op->inputs[0]);
-            ray_t* right = exec_node(g, op->inputs[1]);
+            ray_t* left = exec_node(g, op_child(g, op, 0));
+            ray_t* right = exec_node(g, op_child(g, op, 1));
             if (!left || RAY_IS_ERR(left)) { if (right && !RAY_IS_ERR(right)) ray_release(right); return left; }
             if (!right || RAY_IS_ERR(right)) { ray_release(left); return right; }
             if (g->selection && left && !RAY_IS_ERR(left) && left->type == RAY_TABLE) {
@@ -1611,8 +1612,8 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_WINDOW_JOIN: {
-            ray_t* left = exec_node(g, op->inputs[0]);
-            ray_t* right = exec_node(g, op->inputs[1]);
+            ray_t* left = exec_node(g, op_child(g, op, 0));
+            ray_t* right = exec_node(g, op_child(g, op, 1));
             if (!left || RAY_IS_ERR(left)) { if (right && !RAY_IS_ERR(right)) ray_release(right); return left; }
             if (!right || RAY_IS_ERR(right)) { ray_release(left); return right; }
             if (g->selection && left && !RAY_IS_ERR(left) && left->type == RAY_TABLE) {
@@ -1629,7 +1630,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_WINDOW: {
-            ray_t* input = exec_node(g, op->inputs[0]);
+            ray_t* input = exec_node(g, op_child(g, op, 0));
             if (!input || RAY_IS_ERR(input)) return input;
             ray_t* wdf = (input->type == RAY_TABLE) ? input : g->table;
             /* Compact lazy selection before window (needs dense data) */
@@ -1651,9 +1652,9 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
             int64_t n = ext ? ext->sym : 10;
 
             /* Fused sort+limit: detect SORT child → only gather N rows */
-            ray_op_t* child_op = op->inputs[0];
+            ray_op_t* child_op = op_child(g, op, 0);
             if (child_op && child_op->opcode == OP_SORT) {
-                ray_t* sort_input = exec_node(g, child_op->inputs[0]);
+                ray_t* sort_input = exec_node(g, op_child(g, child_op, 0));
                 if (!sort_input || RAY_IS_ERR(sort_input)) return sort_input;
                 ray_t* tbl = (sort_input->type == RAY_TABLE) ? sort_input : g->table;
                 /* Compact lazy selection before sort */
@@ -1686,9 +1687,9 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
                 if (!tbl || RAY_IS_ERR(tbl)) return tbl;
                 ray_t* owned_tbl = NULL;
                 /* Pushed-down filter: execute it first via the shared helper. */
-                if (child_op->inputs[0] &&
-                    child_op->inputs[0]->opcode == OP_FILTER) {
-                    ray_t* res = exec_pushed_group_filter(g, child_op->inputs[0]);
+                ray_op_t* child_in0 = op_child(g, child_op, 0);
+                if (child_in0 && child_in0->opcode == OP_FILTER) {
+                    ray_t* res = exec_pushed_group_filter(g, child_in0);
                     if (res && RAY_IS_ERR(res)) return res;
                     if (res) { owned_tbl = res; tbl = res; }
                     /* NULL → lazy path; g->selection installed, tbl unchanged */
@@ -1720,7 +1721,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
             } else if (child_op && child_op->opcode == OP_FILTER) {
                 /* HEAD(FILTER): early-termination filter — gather only
                  * the first N matching rows instead of all matches. */
-                ray_t* filter_input = exec_node(g, child_op->inputs[0]);
+                ray_t* filter_input = exec_node(g, op_child(g, child_op, 0));
                 if (!filter_input || RAY_IS_ERR(filter_input))
                     return filter_input;
 
@@ -1739,7 +1740,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
                 /* Swap table for predicate evaluation */
                 ray_t* saved_table = g->table;
                 g->table = ftbl;
-                ray_t* pred = exec_node(g, child_op->inputs[1]);
+                ray_t* pred = exec_node(g, op_child(g, child_op, 1));
                 g->table = saved_table;
 
                 if (!pred || RAY_IS_ERR(pred)) {
@@ -1755,7 +1756,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
                 /* Top-level statement GC catches intermediates. */
                 return result;
             } else {
-                input = exec_node(g, op->inputs[0]);
+                input = exec_node(g, op_child(g, op, 0));
             }
             if (!input || RAY_IS_ERR(input)) return input;
             if (input->type == RAY_TABLE) {
@@ -1853,7 +1854,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
 
         case OP_TAIL: {
             ray_op_ext_t* ext = find_ext(g, op->id);
-            ray_t* input = exec_node(g, op->inputs[0]);
+            ray_t* input = exec_node(g, op_child(g, op, 0));
             if (!input || RAY_IS_ERR(input)) return input;
             int64_t n = ext ? ext->sym : 10;
             if (input->type == RAY_TABLE) {
@@ -2013,16 +2014,16 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_ALIAS: {
-            return exec_node(g, op->inputs[0]);
+            return exec_node(g, op_child(g, op, 0));
         }
 
         case OP_MATERIALIZE: {
-            return exec_node(g, op->inputs[0]);
+            return exec_node(g, op_child(g, op, 0));
         }
 
         case OP_SELECT: {
             /* Column projection: select/compute columns from input table */
-            ray_t* input = exec_node(g, op->inputs[0]);
+            ray_t* input = exec_node(g, op_child(g, op, 0));
             if (!input || RAY_IS_ERR(input)) return input;
             if (input->type != RAY_TABLE) {
                 ray_release(input);
@@ -2031,7 +2032,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
             ray_op_ext_t* ext = find_ext(g, op->id);
             if (!ext) { ray_release(input); return ray_error("nyi", NULL); }
             uint8_t n_cols = ext->sort.n_cols;
-            ray_op_t** columns = ext->sort.columns;
+            uint32_t* columns = ext->sort.columns;
             ray_t* result = ray_table_new(n_cols);
 
             /* Set g->table so SCAN nodes inside expressions resolve correctly */
@@ -2039,9 +2040,10 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
             g->table = input;
 
             for (uint8_t c = 0; c < n_cols; c++) {
-                if (columns[c]->opcode == OP_SCAN) {
+                ray_op_t* col_op = op_node(g, columns[c]);
+                if (col_op->opcode == OP_SCAN) {
                     /* Direct column reference — copy from input table */
-                    ray_op_ext_t* col_ext = find_ext(g, columns[c]->id);
+                    ray_op_ext_t* col_ext = find_ext(g, columns[c]);
                     if (!col_ext) continue;
                     int64_t name_id = col_ext->sym;
                     ray_t* src_col = ray_table_get_col(input, name_id);
@@ -2052,7 +2054,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
                     }
                 } else {
                     /* Expression column — evaluate against input table */
-                    ray_t* vec = exec_node(g, columns[c]);
+                    ray_t* vec = exec_node(g, col_op);
                     if (!vec || RAY_IS_ERR(vec)) {
                         ray_release(result);
                         g->table = saved_table;
@@ -2091,7 +2093,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_EXPAND: {
-            ray_t* src = exec_node(g, op->inputs[0]);
+            ray_t* src = exec_node(g, op_child(g, op, 0));
             if (!src || RAY_IS_ERR(src)) return src;
             ray_t* result = exec_expand(g, op, src);
             ray_release(src);
@@ -2099,7 +2101,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_VAR_EXPAND: {
-            ray_t* start = exec_node(g, op->inputs[0]);
+            ray_t* start = exec_node(g, op_child(g, op, 0));
             if (!start || RAY_IS_ERR(start)) return start;
             ray_t* result = exec_var_expand(g, op, start);
             ray_release(start);
@@ -2107,8 +2109,8 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_SHORTEST_PATH: {
-            ray_t* src = exec_node(g, op->inputs[0]);
-            ray_t* dst = exec_node(g, op->inputs[1]);
+            ray_t* src = exec_node(g, op_child(g, op, 0));
+            ray_t* dst = exec_node(g, op_child(g, op, 1));
             if (!src || RAY_IS_ERR(src)) {
                 if (dst && !RAY_IS_ERR(dst)) ray_release(dst);
                 return src;
@@ -2133,9 +2135,10 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_DIJKSTRA: {
-            ray_t* src = exec_node(g, op->inputs[0]);
+            ray_t* src = exec_node(g, op_child(g, op, 0));
             if (!src || RAY_IS_ERR(src)) return src;
-            ray_t* dst = op->inputs[1] ? exec_node(g, op->inputs[1]) : NULL;
+            ray_op_t* dij_in1 = op_child(g, op, 1);
+            ray_t* dst = dij_in1 ? exec_node(g, dij_in1) : NULL;
             if (dst && RAY_IS_ERR(dst)) { ray_release(src); return dst; }
             ray_t* result = exec_dijkstra(g, op, src, dst);
             ray_release(src);
@@ -2156,7 +2159,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_DFS: {
-            ray_t* src = exec_node(g, op->inputs[0]);
+            ray_t* src = exec_node(g, op_child(g, op, 0));
             if (!src || RAY_IS_ERR(src)) return src;
             ray_t* result = exec_dfs(g, op, src);
             ray_release(src);
@@ -2180,7 +2183,7 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_RANDOM_WALK: {
-            ray_t* src = exec_node(g, op->inputs[0]);
+            ray_t* src = exec_node(g, op_child(g, op, 0));
             if (!src || RAY_IS_ERR(src)) return src;
             ray_t* result = exec_random_walk(g, op, src);
             ray_release(src);
@@ -2188,9 +2191,9 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_ASTAR: {
-            ray_t* src = exec_node(g, op->inputs[0]);
+            ray_t* src = exec_node(g, op_child(g, op, 0));
             if (!src || RAY_IS_ERR(src)) return src;
-            ray_t* dst = exec_node(g, op->inputs[1]);
+            ray_t* dst = exec_node(g, op_child(g, op, 1));
             if (!dst || RAY_IS_ERR(dst)) { ray_release(src); return dst; }
             ray_t* result = exec_astar(g, op, src, dst);
             ray_release(src); ray_release(dst);
@@ -2198,9 +2201,9 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_K_SHORTEST: {
-            ray_t* src = exec_node(g, op->inputs[0]);
+            ray_t* src = exec_node(g, op_child(g, op, 0));
             if (!src || RAY_IS_ERR(src)) return src;
-            ray_t* dst = exec_node(g, op->inputs[1]);
+            ray_t* dst = exec_node(g, op_child(g, op, 1));
             if (!dst || RAY_IS_ERR(dst)) { ray_release(src); return dst; }
             ray_t* result = exec_k_shortest(g, op, src, dst);
             ray_release(src); ray_release(dst);
@@ -2208,14 +2211,14 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
         }
 
         case OP_ANN_RERANK: {
-            ray_t* src = exec_node(g, op->inputs[0]);
+            ray_t* src = exec_node(g, op_child(g, op, 0));
             if (!src || RAY_IS_ERR(src)) return src;
             ray_t* result = exec_ann_rerank(g, op, src);
             ray_release(src);
             return result;
         }
         case OP_KNN_RERANK: {
-            ray_t* src = exec_node(g, op->inputs[0]);
+            ray_t* src = exec_node(g, op_child(g, op, 0));
             if (!src || RAY_IS_ERR(src)) return src;
             ray_t* result = exec_knn_rerank(g, op, src);
             ray_release(src);
@@ -2407,9 +2410,9 @@ static bool op_streamable(uint16_t opc) {
  * Several streamable ops store extra operands in ext nodes rather than in
  * the standard inputs[] array.  These hidden children must be walked too:
  *   OP_SELECT  — ext->sort.columns[0..n_cols-1]
- *   OP_IF      — else branch: g->nodes[(uint32_t)(uintptr_t)ext->literal]
- *   OP_SUBSTR  — length arg:  g->nodes[(uint32_t)(uintptr_t)ext->literal]
- *   OP_REPLACE — replacement: g->nodes[(uint32_t)(uintptr_t)ext->literal]
+ *   OP_IF      — else branch: g->nodes[ext->third_in]
+ *   OP_SUBSTR  — length arg:  g->nodes[ext->third_in]
+ *   OP_REPLACE — replacement: g->nodes[ext->third_in]
  *   OP_CONCAT  — args 2+:    g->nodes[trail[i-2]] (uint32_t[] after ext) */
 static bool subtree_has_default_scan(ray_graph_t* g, ray_op_t* op, bool* ok,
                                      uint64_t* visited) {
@@ -2440,20 +2443,20 @@ static bool subtree_has_default_scan(ray_graph_t* g, ray_op_t* op, bool* ok,
     if (!op_streamable(opc)) { *ok = false; return false; }
     bool found = false;
     for (uint8_t i = 0; i < op->arity && i < 2; i++)
-        found |= subtree_has_default_scan(g, op->inputs[i], ok, visited);
+        found |= subtree_has_default_scan(g, op_child(g, op, i), ok, visited);
 
     /* Walk hidden operands stored in ext nodes */
     if (opc == OP_SELECT) {
         ray_op_ext_t* ext = find_ext(g, op->id);
         if (ext) {
             for (uint8_t c = 0; c < ext->sort.n_cols && *ok; c++)
-                found |= subtree_has_default_scan(g, ext->sort.columns[c], ok, visited);
+                found |= subtree_has_default_scan(g, op_node(g, ext->sort.columns[c]), ok, visited);
         }
     } else if (opc == OP_IF || opc == OP_SUBSTR || opc == OP_REPLACE) {
-        /* 3rd operand stored as node index in ext->literal */
+        /* 3rd operand stored as node index in ext->third_in */
         ray_op_ext_t* ext = find_ext(g, op->id);
         if (ext) {
-            uint32_t child_id = (uint32_t)(uintptr_t)ext->literal;
+            uint32_t child_id = ext->third_in;
             if (child_id < g->node_count)
                 found |= subtree_has_default_scan(g, &g->nodes[child_id], ok, visited);
         }

--- a/src/ops/expr.c
+++ b/src/ops/expr.c
@@ -78,11 +78,11 @@ static bool eval_const_numeric_expr(ray_graph_t* g, ray_op_t* op,
         return atom_to_numeric(ext->literal, out_f, out_i, out_is_f64);
     }
 
-    if ((op->opcode == OP_NEG || op->opcode == OP_ABS) && op->arity == 1 && op->inputs[0]) {
+    if ((op->opcode == OP_NEG || op->opcode == OP_ABS) && op->arity == 1 && op_child(g, op, 0)) {
         double af = 0.0;
         int64_t ai = 0;
         bool a_is_f64 = false;
-        if (!eval_const_numeric_expr(g, op->inputs[0], &af, &ai, &a_is_f64)) return false;
+        if (!eval_const_numeric_expr(g, op_child(g, op, 0), &af, &ai, &a_is_f64)) return false;
         if (a_is_f64 || op->out_type == RAY_F64) {
             double v = a_is_f64 ? af : (double)ai;
             double r = (op->opcode == OP_NEG) ? -v : fabs(v);
@@ -102,14 +102,14 @@ static bool eval_const_numeric_expr(ray_graph_t* g, ray_op_t* op,
         return true;
     }
 
-    if (op->arity != 2 || !op->inputs[0] || !op->inputs[1]) return false;
+    if (op->arity != 2 || !op_child(g, op, 0) || !op_child(g, op, 1)) return false;
     if ((op->opcode < OP_ADD || op->opcode > OP_MAX2) && op->opcode != OP_IDIV) return false;
 
     double lf = 0.0, rf = 0.0;
     int64_t li = 0, ri = 0;
     bool l_is_f64 = false, r_is_f64 = false;
-    if (!eval_const_numeric_expr(g, op->inputs[0], &lf, &li, &l_is_f64)) return false;
-    if (!eval_const_numeric_expr(g, op->inputs[1], &rf, &ri, &r_is_f64)) return false;
+    if (!eval_const_numeric_expr(g, op_child(g, op, 0), &lf, &li, &l_is_f64)) return false;
+    if (!eval_const_numeric_expr(g, op_child(g, op, 1), &rf, &ri, &r_is_f64)) return false;
 
     if (op->out_type == RAY_F64 || l_is_f64 || r_is_f64 || op->opcode == OP_DIV) {
         double lv = l_is_f64 ? lf : (double)li;
@@ -249,35 +249,35 @@ static bool parse_linear_i64_expr(ray_graph_t* g, ray_op_t* op, linear_expr_i64_
         return true;
     }
 
-    if (op->opcode == OP_NEG && op->arity == 1 && op->inputs[0]) {
+    if (op->opcode == OP_NEG && op->arity == 1 && op_child(g, op, 0)) {
         linear_expr_i64_t inner;
-        if (!parse_linear_i64_expr(g, op->inputs[0], &inner)) return false;
+        if (!parse_linear_i64_expr(g, op_child(g, op, 0), &inner)) return false;
         linear_expr_scale(&inner, -1);
         *out = inner;
         return true;
     }
 
     if ((op->opcode == OP_ADD || op->opcode == OP_SUB) &&
-        op->arity == 2 && op->inputs[0] && op->inputs[1]) {
+        op->arity == 2 && op_child(g, op, 0) && op_child(g, op, 1)) {
         linear_expr_i64_t lhs;
         linear_expr_i64_t rhs;
-        if (!parse_linear_i64_expr(g, op->inputs[0], &lhs)) return false;
-        if (!parse_linear_i64_expr(g, op->inputs[1], &rhs)) return false;
+        if (!parse_linear_i64_expr(g, op_child(g, op, 0), &lhs)) return false;
+        if (!parse_linear_i64_expr(g, op_child(g, op, 1), &rhs)) return false;
         *out = lhs;
         return linear_expr_add_scaled(out, &rhs, op->opcode == OP_ADD ? 1 : -1);
     }
 
-    if (op->opcode == OP_MUL && op->arity == 2 && op->inputs[0] && op->inputs[1]) {
+    if (op->opcode == OP_MUL && op->arity == 2 && op_child(g, op, 0) && op_child(g, op, 1)) {
         int64_t k = 0;
         linear_expr_i64_t side;
-        if (const_expr_to_i64(g, op->inputs[0], &k) &&
-            parse_linear_i64_expr(g, op->inputs[1], &side)) {
+        if (const_expr_to_i64(g, op_child(g, op, 0), &k) &&
+            parse_linear_i64_expr(g, op_child(g, op, 1), &side)) {
             linear_expr_scale(&side, k);
             *out = side;
             return true;
         }
-        if (const_expr_to_i64(g, op->inputs[1], &k) &&
-            parse_linear_i64_expr(g, op->inputs[0], &side)) {
+        if (const_expr_to_i64(g, op_child(g, op, 1), &k) &&
+            parse_linear_i64_expr(g, op_child(g, op, 0), &side)) {
             linear_expr_scale(&side, k);
             *out = side;
             return true;
@@ -320,10 +320,10 @@ bool try_affine_sumavg_input(ray_graph_t* g, ray_t* tbl, ray_op_t* input_op,
                                     ray_t** out_vec, agg_affine_t* out_affine) {
     if (!g || !tbl || !input_op || !out_vec || !out_affine) return false;
     if (input_op->opcode != OP_ADD && input_op->opcode != OP_SUB) return false;
-    if (input_op->arity != 2 || !input_op->inputs[0] || !input_op->inputs[1]) return false;
+    if (input_op->arity != 2 || !op_child(g, input_op, 0) || !op_child(g, input_op, 1)) return false;
 
-    ray_op_t* lhs = input_op->inputs[0];
-    ray_op_t* rhs = input_op->inputs[1];
+    ray_op_t* lhs = op_child(g, input_op, 0);
+    ray_op_t* rhs = op_child(g, input_op, 1);
     ray_op_t* base_op = NULL;
     int sign = 1;
     double c_f = 0.0;
@@ -530,7 +530,7 @@ bool expr_compile(ray_graph_t* g, ray_t* tbl, ray_op_t* root, ray_expr_t* out) {
         if (top->phase == 0) {
             top->phase = 1;
             for (int i = node->arity - 1; i >= 0; i--) {
-                ray_op_t* ch = node->inputs[i];
+                ray_op_t* ch = op_child(g, node, i);
                 if (!ch) continue;
                 if (ch->id < nc && node_reg[ch->id] != 0xFF) continue;
                 if (sp >= 64) EXPR_BAIL(EXPR_BAIL_DEPTH);
@@ -630,12 +630,12 @@ bool expr_compile(ray_graph_t* g, ray_t* tbl, ray_op_t* root, ray_expr_t* out) {
                 out->regs[r].const_f64 = cf;
                 out->regs[r].const_i64 = ci;
             } else if (expr_is_elementwise(node->opcode)) {
-                if (!node->inputs[0]) EXPR_BAIL(EXPR_BAIL_OTHER);
-                uint8_t s1 = node_reg[node->inputs[0]->id];
+                if (!op_child(g, node, 0)) EXPR_BAIL(EXPR_BAIL_OTHER);
+                uint8_t s1 = node_reg[node->in_id[0]];
                 if (s1 == 0xFF) EXPR_BAIL(EXPR_BAIL_OTHER);
                 uint8_t s2 = 0xFF;
-                if (node->arity >= 2 && node->inputs[1]) {
-                    s2 = node_reg[node->inputs[1]->id];
+                if (node->arity >= 2 && op_child(g, node, 1)) {
+                    s2 = node_reg[node->in_id[1]];
                     if (s2 == 0xFF) EXPR_BAIL(EXPR_BAIL_OTHER);
                 }
 

--- a/src/ops/fused_pred.c
+++ b/src/ops/fused_pred.c
@@ -667,8 +667,8 @@ static int fp_compile_cmp(ray_graph_t* g, ray_op_t* pred_op, ray_t* tbl,
     default: return -1;
     }
 
-    ray_op_t* lhs = pred_op->inputs[0];
-    ray_op_t* rhs = pred_op->inputs[1];
+    ray_op_t* lhs = op_child(g, pred_op, 0);
+    ray_op_t* rhs = op_child(g, pred_op, 1);
     if (!lhs || !rhs) return -1;
     if (lhs->opcode != OP_SCAN || rhs->opcode != OP_CONST) return -1;
 
@@ -874,8 +874,8 @@ static int fp_compile_pred_dag(ray_graph_t* g, ray_op_t* node, ray_t* tbl,
 {
     if (!node) return -1;
     if (node->opcode == OP_AND) {
-        if (fp_compile_pred_dag(g, node->inputs[0], tbl, out) != 0) return -1;
-        if (fp_compile_pred_dag(g, node->inputs[1], tbl, out) != 0) return -1;
+        if (fp_compile_pred_dag(g, op_child(g, node, 0), tbl, out) != 0) return -1;
+        if (fp_compile_pred_dag(g, op_child(g, node, 1), tbl, out) != 0) return -1;
         return 0;
     }
     if (out->n_children >= FP_PRED_MAX_CHILDREN) return -1;

--- a/src/ops/graph.c
+++ b/src/ops/graph.c
@@ -34,97 +34,14 @@
 
 #define GRAPH_INIT_CAP 4096
 
-static inline ray_op_t* graph_fix_ptr(ray_op_t* p, ptrdiff_t delta) {
-    return p ? (ray_op_t*)((char*)p + delta) : NULL;
-}
-
-static void graph_fixup_ext_ptrs(ray_graph_t* g, ptrdiff_t delta) {
-    for (uint32_t i = 0; i < g->ext_count; i++) {
-        ray_op_ext_t* ext = g->ext_nodes[i];
-        if (!ext) continue;
-
-        ext->base.inputs[0] = graph_fix_ptr(ext->base.inputs[0], delta);
-        ext->base.inputs[1] = graph_fix_ptr(ext->base.inputs[1], delta);
-
-        switch (ext->base.opcode) {
-            case OP_SORT:
-                for (uint8_t k = 0; k < ext->sort.n_cols; k++)
-                    ext->sort.columns[k] = graph_fix_ptr(ext->sort.columns[k], delta);
-                break;
-            case OP_GROUP:
-                for (uint8_t k = 0; k < ext->n_keys; k++)
-                    ext->keys[k] = graph_fix_ptr(ext->keys[k], delta);
-                for (uint8_t a = 0; a < ext->n_aggs; a++)
-                    ext->agg_ins[a] = graph_fix_ptr(ext->agg_ins[a], delta);
-                if (ext->agg_ins2) {
-                    for (uint8_t a = 0; a < ext->n_aggs; a++) {
-                        if (ext->agg_ins2[a])
-                            ext->agg_ins2[a] = graph_fix_ptr(ext->agg_ins2[a], delta);
-                    }
-                }
-                break;
-            case OP_JOIN:
-            case OP_ANTIJOIN:
-                for (uint8_t k = 0; k < ext->join.n_join_keys; k++)
-                    ext->join.left_keys[k] = graph_fix_ptr(ext->join.left_keys[k], delta);
-                if (ext->join.right_keys) {
-                    for (uint8_t k = 0; k < ext->join.n_join_keys; k++)
-                        ext->join.right_keys[k] = graph_fix_ptr(ext->join.right_keys[k], delta);
-                }
-                break;
-            case OP_WINDOW_JOIN:
-                ext->asof.time_key = graph_fix_ptr(ext->asof.time_key, delta);
-                for (uint8_t k = 0; k < ext->asof.n_eq_keys; k++)
-                    ext->asof.eq_keys[k] = graph_fix_ptr(ext->asof.eq_keys[k], delta);
-                break;
-            case OP_WINDOW:
-                for (uint8_t k = 0; k < ext->window.n_part_keys; k++)
-                    ext->window.part_keys[k] = graph_fix_ptr(ext->window.part_keys[k], delta);
-                for (uint8_t k = 0; k < ext->window.n_order_keys; k++)
-                    ext->window.order_keys[k] = graph_fix_ptr(ext->window.order_keys[k], delta);
-                for (uint8_t f = 0; f < ext->window.n_funcs; f++)
-                    ext->window.func_inputs[f] = graph_fix_ptr(ext->window.func_inputs[f], delta);
-                break;
-            case OP_SELECT:
-                for (uint8_t k = 0; k < ext->sort.n_cols; k++)
-                    ext->sort.columns[k] = graph_fix_ptr(ext->sort.columns[k], delta);
-                break;
-            case OP_PIVOT:
-                for (uint8_t k = 0; k < ext->pivot.n_index; k++)
-                    ext->pivot.index_cols[k] = graph_fix_ptr(ext->pivot.index_cols[k], delta);
-                ext->pivot.pivot_col = graph_fix_ptr(ext->pivot.pivot_col, delta);
-                ext->pivot.value_col = graph_fix_ptr(ext->pivot.value_col, delta);
-                break;
-            /* Graph ops: no ray_op_t* pointers in ext union to fix */
-            case OP_EXPAND:
-            case OP_VAR_EXPAND:
-            case OP_SHORTEST_PATH:
-            case OP_WCO_JOIN:
-                break;
-            default:
-                break;
-        }
-    }
-}
-
-/* After realloc moves g->nodes, fix up all stored input pointers.
-   old_base is saved as uintptr_t before realloc to avoid GCC 14
-   -Wuse-after-free on the stale pointer. */
-static void graph_fixup_ptrs(ray_graph_t* g, uintptr_t old_base) {
-    ptrdiff_t delta = (ptrdiff_t)((uintptr_t)g->nodes - old_base);
-    if (delta == 0) return;
-    for (uint32_t i = 0; i < g->node_count; i++) {
-        g->nodes[i].inputs[0] = graph_fix_ptr(g->nodes[i].inputs[0], delta);
-        g->nodes[i].inputs[1] = graph_fix_ptr(g->nodes[i].inputs[1], delta);
-    }
-    graph_fixup_ext_ptrs(g, delta);
-}
+/* Graph edges are stable uint32 node ids (indices into g->nodes), so a
+   realloc of g->nodes needs no pointer fixups — the former graph_fix_ptr /
+   graph_fixup_ptrs / graph_fixup_ext_ptrs machinery is gone entirely. */
 
 /* L3: node_count is uint32_t — theoretical overflow at 2^32 nodes is
    unreachable in practice (would require ~128 GB for the nodes array). */
-static ray_op_t* graph_alloc_node(ray_graph_t* g) {
+ray_op_t* graph_alloc_node(ray_graph_t* g) {
     if (g->node_count >= g->node_cap) {
-        uintptr_t old_base = (uintptr_t)g->nodes;
         /* H2: Overflow guard — if node_cap is already > UINT32_MAX/2,
            doubling would wrap around to a smaller value. */
         if (g->node_cap > UINT32_MAX / 2) return NULL;
@@ -134,11 +51,11 @@ static ray_op_t* graph_alloc_node(ray_graph_t* g) {
         if (!new_nodes) return NULL;
         g->nodes = new_nodes;
         g->node_cap = new_cap;
-        graph_fixup_ptrs(g, old_base);
     }
     ray_op_t* n = &g->nodes[g->node_count];
     memset(n, 0, sizeof(ray_op_t));
     n->id = g->node_count;
+    n->in_id[0] = n->in_id[1] = RAY_OP_NONE;
     g->node_count++;
     return n;
 }
@@ -148,24 +65,25 @@ ray_op_ext_t* graph_alloc_ext_node_ex(ray_graph_t* g, size_t extra) {
     ray_op_ext_t* ext = (ray_op_ext_t*)ray_sys_alloc(sizeof(ray_op_ext_t) + extra);
     if (!ext) return NULL;
     memset(ext, 0, sizeof(ray_op_ext_t) + extra);
+    ext->base.in_id[0] = ext->base.in_id[1] = RAY_OP_NONE;
+    ext->third_in = RAY_OP_NONE;
 
     /* Also add a placeholder in the nodes array for ID tracking */
     if (g->node_count >= g->node_cap) {
         if (g->node_cap > UINT32_MAX / 2) { ray_sys_free(ext); return NULL; }
-        uintptr_t old_base = (uintptr_t)g->nodes;
         uint32_t new_cap = g->node_cap * 2;
         ray_op_t* new_nodes = (ray_op_t*)ray_sys_realloc(g->nodes,
                                                       new_cap * sizeof(ray_op_t));
         if (!new_nodes) { ray_sys_free(ext); return NULL; }
         g->nodes = new_nodes;
         g->node_cap = new_cap;
-        graph_fixup_ptrs(g, old_base);
     }
     ext->base.id = g->node_count;
     /* H4: Do NOT copy ext->base to nodes[] here — the caller fills in
        fields first and then syncs via g->nodes[ext->base.id] = ext->base. */
     memset(&g->nodes[g->node_count], 0, sizeof(ray_op_t));
     g->nodes[g->node_count].id = g->node_count;
+    g->nodes[g->node_count].in_id[0] = g->nodes[g->node_count].in_id[1] = RAY_OP_NONE;
     g->node_count++;
 
     /* Track ext node for cleanup */
@@ -433,7 +351,7 @@ static ray_op_t* make_unary(ray_graph_t* g, uint16_t opcode, ray_op_t* a, int8_t
 
     n->opcode = opcode;
     n->arity = 1;
-    n->inputs[0] = a;
+    n->in_id[0] = a->id;
     n->out_type = out_type;
     n->est_rows = est;
     return n;
@@ -451,8 +369,8 @@ static ray_op_t* make_binary(ray_graph_t* g, uint16_t opcode, ray_op_t* a, ray_o
 
     n->opcode = opcode;
     n->arity = 2;
-    n->inputs[0] = a;
-    n->inputs[1] = b;
+    n->in_id[0] = a->id;
+    n->in_id[1] = b->id;
     n->out_type = out_type;
     n->est_rows = est;
     return n;
@@ -552,13 +470,12 @@ ray_op_t* ray_if(ray_graph_t* g, ray_op_t* cond, ray_op_t* then_val, ray_op_t* e
 
     ext->base.opcode = OP_IF;
     ext->base.arity = 2;  /* inputs[0]=cond, inputs[1]=then; else via ext */
-    ext->base.inputs[0] = cond;
-    ext->base.inputs[1] = then_val;
+    ext->base.in_id[0] = cond->id;
+    ext->base.in_id[1] = then_val->id;
     ext->base.out_type = out_type;
     ext->base.est_rows = est;
-    /* Store else_val as a node ID (not a pointer) in the literal field.
-     * Recovered via (uint32_t)(uintptr_t)ext->literal in expr.c/exec.c. */
-    ext->literal = (ray_t*)(uintptr_t)else_id;
+    /* Store else_val as a node ID in the dedicated third_in field. */
+    ext->third_in = else_id;
 
     g->nodes[ext->base.id] = ext->base;
     return &g->nodes[ext->base.id];
@@ -592,11 +509,11 @@ ray_op_t* ray_substr(ray_graph_t* g, ray_op_t* str, ray_op_t* start, ray_op_t* l
 
     ext->base.opcode = OP_SUBSTR;
     ext->base.arity = 2;
-    ext->base.inputs[0] = str;
-    ext->base.inputs[1] = start;
+    ext->base.in_id[0] = str->id;
+    ext->base.in_id[1] = start->id;
     ext->base.out_type = (str->out_type == RAY_STR) ? RAY_STR : RAY_SYM;
     ext->base.est_rows = est;
-    ext->literal = (ray_t*)(uintptr_t)l_id;
+    ext->third_in = l_id;
 
     g->nodes[ext->base.id] = ext->base;
     return &g->nodes[ext->base.id];
@@ -616,11 +533,11 @@ ray_op_t* ray_replace(ray_graph_t* g, ray_op_t* str, ray_op_t* from, ray_op_t* t
 
     ext->base.opcode = OP_REPLACE;
     ext->base.arity = 2;
-    ext->base.inputs[0] = str;
-    ext->base.inputs[1] = from;
+    ext->base.in_id[0] = str->id;
+    ext->base.in_id[1] = from->id;
     ext->base.out_type = (str->out_type == RAY_STR) ? RAY_STR : RAY_SYM;
     ext->base.est_rows = est;
-    ext->literal = (ray_t*)(uintptr_t)t_id;
+    ext->third_in = t_id;
 
     g->nodes[ext->base.id] = ext->base;
     return &g->nodes[ext->base.id];
@@ -645,8 +562,8 @@ ray_op_t* ray_concat(ray_graph_t* g, ray_op_t** args, int n) {
 
     ext->base.opcode = OP_CONCAT;
     ext->base.arity = 2;
-    ext->base.inputs[0] = &g->nodes[ids[0]];
-    ext->base.inputs[1] = &g->nodes[ids[1]];
+    ext->base.in_id[0] = ids[0];
+    ext->base.in_id[1] = ids[1];
     /* RAY_STR if any input is RAY_STR, else RAY_SYM */
     int8_t out_type = RAY_SYM;
     for (int i = 0; i < n; i++) {
@@ -715,8 +632,8 @@ ray_op_t* ray_filter(ray_graph_t* g, ray_op_t* input, ray_op_t* predicate) {
 
     n->opcode = OP_FILTER;
     n->arity = 2;
-    n->inputs[0] = input;
-    n->inputs[1] = predicate;
+    n->in_id[0] = input->id;
+    n->in_id[1] = predicate->id;
     n->out_type = input->out_type;
     n->est_rows = est;
     return n;
@@ -740,15 +657,15 @@ ray_op_t* ray_sort_op(ray_graph_t* g, ray_op_t* table_node,
 
     ext->base.opcode = OP_SORT;
     ext->base.arity = 1;
-    ext->base.inputs[0] = table_node;
+    ext->base.in_id[0] = table_node->id;
     ext->base.out_type = RAY_TABLE;
     ext->base.est_rows = table_node->est_rows;
 
     /* Arrays embedded in trailing space — freed with ext node */
     char* trail = EXT_TRAIL(ext);
-    ext->sort.columns = (ray_op_t**)trail;
+    ext->sort.columns = (uint32_t*)trail;
     for (uint8_t i = 0; i < n_cols; i++)
-        ext->sort.columns[i] = &g->nodes[key_ids[i]];
+        ext->sort.columns[i] = key_ids[i];
     ext->sort.desc = (uint8_t*)(trail + keys_sz);
     memcpy(ext->sort.desc, descs, descs_sz);
     ext->sort.nulls_first = (uint8_t*)(trail + keys_sz + descs_sz);
@@ -781,7 +698,7 @@ static ray_op_t* ray_group_impl(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
     for (uint8_t i = 0; i < n_keys; i++) key_ids[i] = keys[i]->id;
     for (uint8_t i = 0; i < n_aggs; i++) {
         agg_ids[i]  = agg_ins[i]->id;
-        agg_ids2[i] = 0;
+        agg_ids2[i] = RAY_OP_NONE;
         if (agg_ins2 && agg_ins2[i]) {
             agg_ids2[i] = agg_ins2[i]->id;
             has_ins2 = true;
@@ -811,22 +728,22 @@ static ray_op_t* ray_group_impl(ray_graph_t* g, ray_op_t** keys, uint8_t n_keys,
     ext->base.out_type = RAY_TABLE;
     if (n_keys > 0 && keys[0])
         ext->base.est_rows = g->nodes[key_ids[0]].est_rows / 10;  /* rough estimate */
-    ext->base.inputs[0] = n_keys > 0 ? &g->nodes[key_ids[0]] : NULL;
+    ext->base.in_id[0] = n_keys > 0 ? key_ids[0] : RAY_OP_NONE;
 
     /* Arrays embedded in trailing space — freed with ext node */
     char* trail = EXT_TRAIL(ext);
-    ext->keys = (ray_op_t**)trail;
+    ext->keys = (uint32_t*)trail;
     for (uint8_t i = 0; i < n_keys; i++)
-        ext->keys[i] = &g->nodes[key_ids[i]];
+        ext->keys[i] = key_ids[i];
     ext->agg_ops = (uint16_t*)(trail + ops_off);
     if (ops_sz > 0) memcpy(ext->agg_ops, agg_ops, ops_sz);
-    ext->agg_ins = (ray_op_t**)(trail + ins_off);
+    ext->agg_ins = (uint32_t*)(trail + ins_off);
     for (uint8_t i = 0; i < n_aggs; i++)
-        ext->agg_ins[i] = &g->nodes[agg_ids[i]];
+        ext->agg_ins[i] = agg_ids[i];
     if (has_ins2) {
-        ext->agg_ins2 = (ray_op_t**)(trail + ins2_off);
+        ext->agg_ins2 = (uint32_t*)(trail + ins2_off);
         for (uint8_t i = 0; i < n_aggs; i++)
-            ext->agg_ins2[i] = agg_ids2[i] ? &g->nodes[agg_ids2[i]] : NULL;
+            ext->agg_ins2[i] = agg_ids2[i] != RAY_OP_NONE ? agg_ids2[i] : RAY_OP_NONE;
     } else {
         ext->agg_ins2 = NULL;
     }
@@ -886,11 +803,11 @@ ray_op_t* ray_pivot_op(ray_graph_t* g,
     ext->base.est_rows = 0; /* unknown until execution */
 
     char* trail = EXT_TRAIL(ext);
-    ext->pivot.index_cols = (ray_op_t**)trail;
+    ext->pivot.index_cols = (uint32_t*)trail;
     for (uint8_t i = 0; i < n_index; i++)
-        ext->pivot.index_cols[i] = &g->nodes[idx_ids[i]];
-    ext->pivot.pivot_col = &g->nodes[pcol_id];
-    ext->pivot.value_col = &g->nodes[vcol_id];
+        ext->pivot.index_cols[i] = idx_ids[i];
+    ext->pivot.pivot_col = pcol_id;
+    ext->pivot.value_col = vcol_id;
     ext->pivot.agg_op = agg_op;
     ext->pivot.n_index = n_index;
 
@@ -920,19 +837,19 @@ ray_op_t* ray_join(ray_graph_t* g,
 
     ext->base.opcode = OP_JOIN;
     ext->base.arity = 2;
-    ext->base.inputs[0] = left_table;
-    ext->base.inputs[1] = right_table;
+    ext->base.in_id[0] = left_table->id;
+    ext->base.in_id[1] = right_table->id;
     ext->base.out_type = RAY_TABLE;
     ext->base.est_rows = left_table->est_rows;
 
     /* Arrays embedded in trailing space — freed with ext node */
     char* trail = EXT_TRAIL(ext);
-    ext->join.left_keys = (ray_op_t**)trail;
+    ext->join.left_keys = (uint32_t*)trail;
     for (uint8_t i = 0; i < n_keys; i++)
-        ext->join.left_keys[i] = &g->nodes[lkey_ids[i]];
-    ext->join.right_keys = (ray_op_t**)(trail + (size_t)n_keys * sizeof(ray_op_t*));
+        ext->join.left_keys[i] = lkey_ids[i];
+    ext->join.right_keys = (uint32_t*)(trail + (size_t)n_keys * sizeof(ray_op_t*));
     for (uint8_t i = 0; i < n_keys; i++)
-        ext->join.right_keys[i] = &g->nodes[rkey_ids[i]];
+        ext->join.right_keys[i] = rkey_ids[i];
     ext->join.n_join_keys = n_keys;
     ext->join.join_type = join_type;
 
@@ -962,18 +879,18 @@ ray_op_t* ray_antijoin(ray_graph_t* g,
 
     ext->base.opcode = OP_ANTIJOIN;
     ext->base.arity = 2;
-    ext->base.inputs[0] = left_table;
-    ext->base.inputs[1] = right_table;
+    ext->base.in_id[0] = left_table->id;
+    ext->base.in_id[1] = right_table->id;
     ext->base.out_type = RAY_TABLE;
     ext->base.est_rows = left_table->est_rows;
 
     char* trail = EXT_TRAIL(ext);
-    ext->join.left_keys = (ray_op_t**)trail;
+    ext->join.left_keys = (uint32_t*)trail;
     for (uint8_t i = 0; i < n_keys; i++)
-        ext->join.left_keys[i] = &g->nodes[lkey_ids[i]];
-    ext->join.right_keys = (ray_op_t**)(trail + (size_t)n_keys * sizeof(ray_op_t*));
+        ext->join.left_keys[i] = lkey_ids[i];
+    ext->join.right_keys = (uint32_t*)(trail + (size_t)n_keys * sizeof(ray_op_t*));
     for (uint8_t i = 0; i < n_keys; i++)
-        ext->join.right_keys[i] = &g->nodes[rkey_ids[i]];
+        ext->join.right_keys[i] = rkey_ids[i];
     ext->join.n_join_keys = n_keys;
     ext->join.join_type = 3;  /* anti */
 
@@ -1002,17 +919,17 @@ ray_op_t* ray_asof_join(ray_graph_t* g,
 
     ext->base.opcode  = OP_WINDOW_JOIN;
     ext->base.arity   = 2;
-    ext->base.inputs[0] = left_table;
-    ext->base.inputs[1] = right_table;
+    ext->base.in_id[0] = left_table->id;
+    ext->base.in_id[1] = right_table->id;
     ext->base.out_type = RAY_TABLE;
     ext->base.est_rows = left_table->est_rows;
 
-    ext->asof.time_key   = &g->nodes[time_id];
+    ext->asof.time_key   = time_id;
     ext->asof.n_eq_keys  = n_eq_keys;
     ext->asof.join_type  = join_type;
-    ext->asof.eq_keys    = (ray_op_t**)EXT_TRAIL(ext);
+    ext->asof.eq_keys    = (uint32_t*)EXT_TRAIL(ext);
     for (uint8_t i = 0; i < n_eq_keys; i++)
-        ext->asof.eq_keys[i] = &g->nodes[eq_ids[i]];
+        ext->asof.eq_keys[i] = eq_ids[i];
 
     g->nodes[ext->base.id] = ext->base;
     return &g->nodes[ext->base.id];
@@ -1066,26 +983,26 @@ ray_op_t* ray_window_op(ray_graph_t* g, ray_op_t* table_node,
 
     ext->base.opcode   = OP_WINDOW;
     ext->base.arity    = 1;
-    ext->base.inputs[0] = table_node;
+    ext->base.in_id[0] = table_node->id;
     ext->base.out_type = RAY_TABLE;
     ext->base.est_rows = est;  /* window preserves row count */
 
     /* Fill trailing arrays */
     char* trail = EXT_TRAIL(ext);
-    ext->window.part_keys = (ray_op_t**)trail;
+    ext->window.part_keys = (uint32_t*)trail;
     for (uint8_t i = 0; i < n_part; i++)
-        ext->window.part_keys[i] = &g->nodes[part_ids[i]];
+        ext->window.part_keys[i] = part_ids[i];
 
-    ext->window.order_keys = (ray_op_t**)(trail + pk_sz);
+    ext->window.order_keys = (uint32_t*)(trail + pk_sz);
     for (uint8_t i = 0; i < n_order; i++)
-        ext->window.order_keys[i] = &g->nodes[order_ids[i]];
+        ext->window.order_keys[i] = order_ids[i];
 
     ext->window.order_descs = (uint8_t*)(trail + pk_sz + ok_sz);
     if (n_order) memcpy(ext->window.order_descs, order_descs, od_sz);
 
-    ext->window.func_inputs = (ray_op_t**)(trail + fi_off);
+    ext->window.func_inputs = (uint32_t*)(trail + fi_off);
     for (uint8_t i = 0; i < n_funcs; i++)
-        ext->window.func_inputs[i] = &g->nodes[func_ids[i]];
+        ext->window.func_inputs[i] = func_ids[i];
 
     ext->window.func_kinds = (uint8_t*)(trail + fk_off);
     if (n_funcs) memcpy(ext->window.func_kinds, func_kinds, fk_sz);
@@ -1120,14 +1037,14 @@ ray_op_t* ray_select_op(ray_graph_t* g, ray_op_t* input,
 
     ext->base.opcode = OP_SELECT;
     ext->base.arity = 1;
-    ext->base.inputs[0] = input;
+    ext->base.in_id[0] = input->id;
     ext->base.out_type = RAY_TABLE;
     ext->base.est_rows = input->est_rows;
 
     /* Array embedded in trailing space — freed with ext node */
-    ext->sort.columns = (ray_op_t**)EXT_TRAIL(ext);
+    ext->sort.columns = (uint32_t*)EXT_TRAIL(ext);
     for (uint8_t i = 0; i < n_cols; i++)
-        ext->sort.columns[i] = &g->nodes[col_ids[i]];
+        ext->sort.columns[i] = col_ids[i];
     ext->sort.n_cols = n_cols;
 
     g->nodes[ext->base.id] = ext->base;
@@ -1145,7 +1062,7 @@ ray_op_t* ray_head(ray_graph_t* g, ray_op_t* input, int64_t n) {
 
     ext->base.opcode = OP_HEAD;
     ext->base.arity = 1;
-    ext->base.inputs[0] = input;
+    ext->base.in_id[0] = input->id;
     ext->base.out_type = input->out_type;
     ext->base.est_rows = (uint32_t)n;
     ext->sym = n;
@@ -1163,7 +1080,7 @@ ray_op_t* ray_tail(ray_graph_t* g, ray_op_t* input, int64_t n) {
 
     ext->base.opcode = OP_TAIL;
     ext->base.arity = 1;
-    ext->base.inputs[0] = input;
+    ext->base.in_id[0] = input->id;
     ext->base.out_type = input->out_type;
     ext->base.est_rows = (uint32_t)n;
     ext->sym = n;
@@ -1181,7 +1098,7 @@ ray_op_t* ray_alias(ray_graph_t* g, ray_op_t* input, const char* name) {
 
     ext->base.opcode = OP_ALIAS;
     ext->base.arity = 1;
-    ext->base.inputs[0] = input;
+    ext->base.in_id[0] = input->id;
     ext->base.out_type = input->out_type;
     ext->base.est_rows = input->est_rows;
     ext->sym = ray_sym_intern(name, strlen(name));
@@ -1200,7 +1117,7 @@ ray_op_t* ray_extract(ray_graph_t* g, ray_op_t* col, int64_t field) {
 
     ext->base.opcode = OP_EXTRACT;
     ext->base.arity = 1;
-    ext->base.inputs[0] = col;
+    ext->base.in_id[0] = col->id;
     ext->base.out_type = RAY_I64;
     ext->base.est_rows = est;
     ext->sym = field;
@@ -1219,7 +1136,7 @@ ray_op_t* ray_date_trunc(ray_graph_t* g, ray_op_t* col, int64_t field) {
 
     ext->base.opcode = OP_DATE_TRUNC;
     ext->base.arity = 1;
-    ext->base.inputs[0] = col;
+    ext->base.in_id[0] = col->id;
     ext->base.out_type = RAY_TIMESTAMP;  /* returns timestamp (microseconds) */
     ext->base.est_rows = est;
     ext->sym = field;
@@ -1237,7 +1154,7 @@ ray_op_t* ray_materialize(ray_graph_t* g, ray_op_t* input) {
 
     n->opcode = OP_MATERIALIZE;
     n->arity = 1;
-    n->inputs[0] = input;
+    n->in_id[0] = input->id;
     n->out_type = input->out_type;
     n->est_rows = input->est_rows;
     return n;
@@ -1307,7 +1224,7 @@ ray_op_t* ray_expand(ray_graph_t* g, ray_op_t* src_nodes,
 
     ext->base.opcode = OP_EXPAND;
     ext->base.arity = 1;
-    ext->base.inputs[0] = src_nodes;
+    ext->base.in_id[0] = src_nodes->id;
     ext->base.out_type = RAY_TABLE;
     ext->base.est_rows = est * 10;  /* rough estimate: 10x fan-out */
     ext->graph.rel = rel;
@@ -1333,7 +1250,7 @@ ray_op_t* ray_var_expand(ray_graph_t* g, ray_op_t* start_nodes,
 
     ext->base.opcode = OP_VAR_EXPAND;
     ext->base.arity = 1;
-    ext->base.inputs[0] = start_nodes;
+    ext->base.in_id[0] = start_nodes->id;
     ext->base.out_type = RAY_TABLE;
     ext->base.est_rows = est * 100;  /* rough estimate */
     ext->graph.rel = rel;
@@ -1358,8 +1275,8 @@ ray_op_t* ray_shortest_path(ray_graph_t* g, ray_op_t* src, ray_op_t* dst,
 
     ext->base.opcode = OP_SHORTEST_PATH;
     ext->base.arity = 2;
-    ext->base.inputs[0] = src;
-    ext->base.inputs[1] = dst;
+    ext->base.in_id[0] = src->id;
+    ext->base.in_id[1] = dst->id;
     ext->base.out_type = RAY_TABLE;
     ext->base.est_rows = max_depth;
     ext->graph.rel = rel;
@@ -1430,8 +1347,8 @@ ray_op_t* ray_dijkstra(ray_graph_t* g, ray_op_t* src, ray_op_t* dst,
 
     ext->base.opcode    = OP_DIJKSTRA;
     ext->base.arity     = dst ? 2 : 1;
-    ext->base.inputs[0] = src;
-    ext->base.inputs[1] = dst;
+    ext->base.in_id[0] = src->id;
+    ext->base.in_id[1] = dst ? dst->id : RAY_OP_NONE;
     ext->base.out_type  = RAY_TABLE;
     ext->base.est_rows  = (uint32_t)rel->fwd.n_nodes;
     ext->graph.rel       = rel;
@@ -1504,7 +1421,7 @@ ray_op_t* ray_dfs(ray_graph_t* g, ray_op_t* src, ray_rel_t* rel, uint8_t max_dep
 
     ext->base.opcode     = OP_DFS;
     ext->base.arity      = 1;
-    ext->base.inputs[0]  = src;
+    ext->base.in_id[0]   = src->id;
     ext->base.out_type   = RAY_TABLE;
     ext->base.est_rows   = (uint32_t)rel->fwd.n_nodes;
     ext->graph.rel       = rel;
@@ -1561,7 +1478,7 @@ ray_op_t* ray_random_walk(ray_graph_t* g, ray_op_t* src, ray_rel_t* rel,
     src = &g->nodes[src_id];
     ext->base.opcode    = OP_RANDOM_WALK;
     ext->base.arity     = 1;
-    ext->base.inputs[0] = src;
+    ext->base.in_id[0] = src->id;
     ext->base.out_type  = RAY_TABLE;
     ext->base.est_rows  = walk_length + 1;
     ext->graph.rel      = rel;
@@ -1590,8 +1507,8 @@ ray_op_t* ray_astar(ray_graph_t* g, ray_op_t* src, ray_op_t* dst,
 
     ext->base.opcode    = OP_ASTAR;
     ext->base.arity     = 2;
-    ext->base.inputs[0] = src;
-    ext->base.inputs[1] = dst;
+    ext->base.in_id[0] = src->id;
+    ext->base.in_id[1] = dst->id;
     ext->base.out_type  = RAY_TABLE;
     ext->base.est_rows  = (uint32_t)rel->fwd.n_nodes;
     ext->graph.rel       = rel;
@@ -1623,8 +1540,8 @@ ray_op_t* ray_k_shortest(ray_graph_t* g, ray_op_t* src, ray_op_t* dst,
 
     ext->base.opcode    = OP_K_SHORTEST;
     ext->base.arity     = 2;
-    ext->base.inputs[0] = src;
-    ext->base.inputs[1] = dst;
+    ext->base.in_id[0] = src->id;
+    ext->base.in_id[1] = dst->id;
     ext->base.out_type  = RAY_TABLE;
     ext->base.est_rows  = (uint32_t)(k * rel->fwd.n_nodes);
     ext->graph.rel       = rel;
@@ -1693,7 +1610,7 @@ ray_op_t* ray_ann_rerank(ray_graph_t* g, ray_op_t* src,
 
     ext->base.opcode     = OP_ANN_RERANK;
     ext->base.arity      = 1;
-    ext->base.inputs[0]  = src;
+    ext->base.in_id[0]   = src->id;
     ext->base.out_type   = RAY_TABLE;
     ext->base.est_rows   = (uint32_t)k;
     ext->rerank.hnsw_idx  = idx;
@@ -1720,7 +1637,7 @@ ray_op_t* ray_knn_rerank(ray_graph_t* g, ray_op_t* src,
 
     ext->base.opcode     = OP_KNN_RERANK;
     ext->base.arity      = 1;
-    ext->base.inputs[0]  = src;
+    ext->base.in_id[0]   = src->id;
     ext->base.out_type   = RAY_TABLE;
     ext->base.est_rows   = (uint32_t)k;
     ext->rerank.hnsw_idx  = NULL;

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -3756,7 +3756,7 @@ static void emit_agg_columns(ray_t** result, ray_graph_t* g, const ray_op_ext_t*
                  * materializing the input vector), so recover the source type
                  * from the aggregation input op when the vector is absent. */
                 int8_t src_t = agg_col ? agg_col->type
-                             : (ext->agg_ins[a] ? ext->agg_ins[a]->out_type : 0);
+                             : (op_node(g, ext->agg_ins[a]) ? op_node(g, ext->agg_ins[a])->out_type : 0);
                 out_type = is_f64 ? RAY_F64 : (src_t == RAY_TIME ? RAY_TIME : RAY_I64);
                 break;
             }
@@ -3868,7 +3868,7 @@ static void emit_agg_columns(ray_t** result, ray_graph_t* g, const ray_op_ext_t*
             }
         }
         /* Generate unique column name: base_name + agg suffix (e.g. "v1_sum") */
-        ray_op_ext_t* agg_ext = find_ext(g, ext->agg_ins[a]->id);
+        ray_op_ext_t* agg_ext = find_ext(g, ext->agg_ins[a]);
         int64_t name_id;
         if (agg_ext && agg_ext->base.opcode == OP_SCAN) {
             /* Shared with exec_group_v2 (agg_engine.c) — parity by
@@ -4254,9 +4254,9 @@ static inline int64_t group_strlen_at_cached(const ray_t* col, int64_t row,
 static bool try_strlen_sumavg_input(ray_graph_t* g, ray_t* tbl,
                                     ray_op_t* input_op, ray_t** out_vec) {
     if (!g || !tbl || !input_op || !out_vec) return false;
-    if (input_op->opcode != OP_STRLEN || input_op->arity != 1 || !input_op->inputs[0])
+    if (input_op->opcode != OP_STRLEN || input_op->arity != 1 || !op_child(g, input_op, 0))
         return false;
-    ray_op_t* child = input_op->inputs[0];
+    ray_op_t* child = op_child(g, input_op, 0);
     ray_op_ext_t* child_ext = find_ext(g, child->id);
     if (!child_ext || child_ext->base.opcode != OP_SCAN) return false;
     ray_t* col = ray_table_get_col(tbl, child_ext->sym);
@@ -5127,7 +5127,7 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
     int has_stddev = 0;
     int64_t key_syms[8];
     for (uint8_t k = 0; k < n_keys && can_partition; k++) {
-        ray_op_ext_t* ke = find_ext(g, ext->keys[k]->id);
+        ray_op_ext_t* ke = find_ext(g, ext->keys[k]);
         if (!ke || ke->base.opcode != OP_SCAN) { can_partition = 0; break; }
         key_syms[k] = ke->sym;
     }
@@ -5148,7 +5148,7 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
         if (aop == OP_AVG) has_avg = 1;
         if (aop == OP_STDDEV || aop == OP_STDDEV_POP ||
             aop == OP_VAR || aop == OP_VAR_POP) has_stddev = 1;
-        ray_op_ext_t* ae = find_ext(g, ext->agg_ins[a]->id);
+        ray_op_ext_t* ae = find_ext(g, ext->agg_ins[a]);
         if (!ae || ae->base.opcode != OP_SCAN) { can_partition = 0; break; }
         agg_syms[a] = ae->sym;
     }
@@ -5238,7 +5238,7 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
         int64_t needed[16];
         int n_needed = 0;
         for (uint8_t k = 0; k < n_keys; k++) {
-            ray_op_ext_t* ke = find_ext(g, ext->keys[k]->id);
+            ray_op_ext_t* ke = find_ext(g, ext->keys[k]);
             if (ke && ke->base.opcode == OP_SCAN) {
                 int dup = 0;
                 for (int i = 0; i < n_needed; i++)
@@ -5247,7 +5247,7 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
             }
         }
         for (uint8_t a = 0; a < n_aggs; a++) {
-            ray_op_ext_t* ae = find_ext(g, ext->agg_ins[a]->id);
+            ray_op_ext_t* ae = find_ext(g, ext->agg_ins[a]);
             if (ae && ae->base.opcode == OP_SCAN) {
                 int dup = 0;
                 for (int i = 0; i < n_needed; i++)
@@ -5410,7 +5410,7 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
     if (g->selection && n_keys == 1 && n_aggs > 0 && nrows > 0) {
         int64_t cnt_sym_probe = ray_sym_intern("_count", 6);
         ray_t*  cnt_col_probe = ray_table_get_col(tbl, cnt_sym_probe);
-        ray_op_ext_t* key_ext_probe = find_ext(g, ext->keys[0]->id);
+        ray_op_ext_t* key_ext_probe = find_ext(g, ext->keys[0]);
         int64_t src_sym_probe = ray_sym_intern("_src", 4);
         if (cnt_col_probe && cnt_col_probe->type == RAY_I64 &&
             key_ext_probe && key_ext_probe->base.opcode == OP_SCAN &&
@@ -5435,7 +5435,7 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
                 bool needs_weighting = false;
                 for (uint8_t a = 0; a < n_aggs; a++) {
                     uint16_t aop = ext->agg_ops[a];
-                    ray_op_ext_t* agg_ext = find_ext(g, ext->agg_ins[a]->id);
+                    ray_op_ext_t* agg_ext = find_ext(g, ext->agg_ins[a]);
                     if (aop == OP_COUNT) { needs_weighting = true; break; }
                     if (aop == OP_SUM && agg_ext &&
                         agg_ext->base.opcode == OP_SCAN &&
@@ -5454,7 +5454,7 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
         int64_t cnt_sym = ray_sym_intern("_count", 6);
         ray_t* cnt_col = ray_table_get_col(tbl, cnt_sym);
         if (cnt_col && cnt_col->type == RAY_I64) {
-            ray_op_ext_t* key_ext = find_ext(g, ext->keys[0]->id);
+            ray_op_ext_t* key_ext = find_ext(g, ext->keys[0]);
             int64_t src_sym = ray_sym_intern("_src", 4);
             if (key_ext && key_ext->base.opcode == OP_SCAN &&
                 key_ext->sym == src_sym) {
@@ -5464,7 +5464,7 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
                 bool all_compat = true;
                 for (uint8_t a = 0; a < n_aggs; a++) {
                     uint16_t aop = ext->agg_ops[a];
-                    ray_op_ext_t* agg_ext = find_ext(g, ext->agg_ins[a]->id);
+                    ray_op_ext_t* agg_ext = find_ext(g, ext->agg_ins[a]);
                     if (aop == OP_COUNT) continue;
                     if (aop == OP_SUM && agg_ext &&
                         agg_ext->base.opcode == OP_SCAN &&
@@ -5534,7 +5534,7 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
     uint8_t key_owned[vla_keys]; /* 1 = we allocated via exec_node, must free */
     memset(key_owned, 0, vla_keys * sizeof(uint8_t));
     for (uint8_t k = 0; k < n_keys; k++) {
-        ray_op_t* key_op = ext->keys[k];
+        ray_op_t* key_op = op_node(g, ext->keys[k]);
         ray_op_ext_t* key_ext = find_ext(g, key_op->id);
         if (key_ext && key_ext->base.opcode == OP_SCAN) {
             key_vecs[k] = ray_table_get_col(tbl, key_ext->sym);
@@ -5578,7 +5578,7 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
     memset(agg_linear, 0, vla_aggs * sizeof(agg_linear_t));
 
     for (uint8_t a = 0; a < n_aggs; a++) {
-        ray_op_t* agg_input_op = ext->agg_ins[a];
+        ray_op_t* agg_input_op = op_node(g, ext->agg_ins[a]);
         ray_op_ext_t* agg_ext = find_ext(g, agg_input_op->id);
 
         /* SUM/AVG(scan +/- const): aggregate base scan and apply bias at emit. */
@@ -5640,8 +5640,8 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
          * above for the y-side input.  Same OP_SCAN / OP_CONST / expr
          * fallback ladder, separate ownership flag because each side
          * may have come from a different source. */
-        if (ext->agg_ins2 && ext->agg_ins2[a]) {
-            ray_op_t* agg_input_op2 = ext->agg_ins2[a];
+        if (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE) {
+            ray_op_t* agg_input_op2 = op_node(g, ext->agg_ins2[a]);
             ray_op_ext_t* agg_ext2 = find_ext(g, agg_input_op2->id);
             if (agg_ext2 && agg_ext2->base.opcode == OP_SCAN) {
                 agg_vecs2[a] = ray_table_get_col(tbl, agg_ext2->sym);
@@ -6705,7 +6705,7 @@ da_path:;
                     write_col_i64(ray_data(key_col), gi, key_val, src_col->type, key_col->attrs);
                     gi++;
                 }
-                ray_op_ext_t* key_ext = find_ext(g, ext->keys[k]->id);
+                ray_op_ext_t* key_ext = find_ext(g, ext->keys[k]);
                 int64_t name_id = key_ext ? key_ext->sym : (int64_t)k;
                 result = ray_table_add_col(result, name_id, key_col);
                 ray_release(key_col);
@@ -7062,7 +7062,7 @@ dyn_dense_done:
 #undef DYN_DENSE_SUM_ROW
                     }
 
-                    ray_op_ext_t* key_ext = find_ext(g, ext->keys[0]->id);
+                    ray_op_ext_t* key_ext = find_ext(g, ext->keys[0]);
                     int64_t name_id = key_ext ? key_ext->sym : 0;
                     result = ray_table_add_col(result, name_id, key_col);
                     ray_release(key_col);
@@ -7265,7 +7265,7 @@ dyn_dense_done:
 
                     scratch_free(range_sum_hdr);
                     scratch_free(cnt_hdr);
-                    ray_op_ext_t* key_ext = find_ext(g, ext->keys[0]->id);
+                    ray_op_ext_t* key_ext = find_ext(g, ext->keys[0]);
                     int64_t name_id = key_ext ? key_ext->sym : 0;
                     result = ray_table_add_col(result, name_id, key_col);
                     ray_release(key_col);
@@ -7490,7 +7490,7 @@ dyn_dense_done:
                 }
             }
             sparse_i64_free(&heavy_ht);
-            ray_op_ext_t* key_ext = find_ext(g, ext->keys[0]->id);
+            ray_op_ext_t* key_ext = find_ext(g, ext->keys[0]);
             int64_t name_id = key_ext ? key_ext->sym : 0;
             result = ray_table_add_col(result, name_id, key_col);
             ray_release(key_col);
@@ -8285,7 +8285,7 @@ v2_emit:;
         /* Add key columns to result */
         for (uint8_t k = 0; k < n_keys; k++) {
             if (!key_cols[k]) continue;
-            ray_op_ext_t* key_ext = find_ext(g, ext->keys[k]->id);
+            ray_op_ext_t* key_ext = find_ext(g, ext->keys[k]);
             int64_t name_id = key_ext ? key_ext->sym : k;
             result = ray_table_add_col(result, name_id, key_cols[k]);
             ray_release(key_cols[k]);
@@ -8295,7 +8295,7 @@ v2_emit:;
         for (uint8_t a = 0; a < n_aggs; a++) {
             if (!agg_cols[a]) continue;
             uint16_t agg_op = ext->agg_ops[a];
-            ray_op_ext_t* agg_ext = find_ext(g, ext->agg_ins[a]->id);
+            ray_op_ext_t* agg_ext = find_ext(g, ext->agg_ins[a]);
             int64_t name_id;
             if (agg_ext && agg_ext->base.opcode == OP_SCAN) {
                 ray_t* name_atom = ray_sym_str(agg_ext->sym);
@@ -8419,7 +8419,7 @@ sequential_fallback:;
             }
         }
 
-        ray_op_ext_t* key_ext = find_ext(g, ext->keys[k]->id);
+        ray_op_ext_t* key_ext = find_ext(g, ext->keys[k]);
         int64_t name_id = key_ext ? key_ext->sym : k;
         result = ray_table_add_col(result, name_id, new_col);
         ray_release(new_col);
@@ -8578,7 +8578,7 @@ sequential_fallback:;
                  * materializing the input vector), so recover the source type
                  * from the aggregation input op when the vector is absent. */
                 int8_t src_t = agg_col ? agg_col->type
-                             : (ext->agg_ins[a] ? ext->agg_ins[a]->out_type : 0);
+                             : (op_node(g, ext->agg_ins[a]) ? op_node(g, ext->agg_ins[a])->out_type : 0);
                 out_type = is_f64 ? RAY_F64 : (src_t == RAY_TIME ? RAY_TIME : RAY_I64);
                 break;
             }
@@ -8707,7 +8707,7 @@ sequential_fallback:;
 
     med_attach:;
         /* Generate unique column name */
-        ray_op_ext_t* agg_ext = find_ext(g, ext->agg_ins[a]->id);
+        ray_op_ext_t* agg_ext = find_ext(g, ext->agg_ins[a]);
         int64_t name_id;
         if (agg_ext && agg_ext->base.opcode == OP_SCAN) {
             /* Shared with exec_group_v2 (agg_engine.c) — parity by

--- a/src/ops/idiom.c
+++ b/src/ops/idiom.c
@@ -27,6 +27,17 @@
 #include "mem/heap.h"
 #include <string.h>
 
+/* Local accessors mirroring ops/internal.h.  idiom.c includes "opt.h" (which
+ * provides a non-static find_ext); including internal.h here would redefine
+ * find_ext as static inline.  So we copy the id->node accessors locally, the
+ * same way opt.c does. */
+static inline ray_op_t* op_node(ray_graph_t* g, uint32_t id) {
+    return id == RAY_OP_NONE ? NULL : &g->nodes[id];
+}
+static inline ray_op_t* op_child(ray_graph_t* g, const ray_op_t* op, int i) {
+    return op_node(g, op->in_id[i]);
+}
+
 #define RAY_IDIOM_OPCODE_CAP 128
 #define RAY_IDIOM_MAX_ROWS    64
 
@@ -38,19 +49,19 @@
 /* (count (distinct v)) → OP_COUNT_DISTINCT(v)
  *
  * node     = OP_COUNT
- * node->inputs[0] = OP_DISTINCT
- * Returns  OP_COUNT_DISTINCT(distinct->inputs[0])
+ * node's input[0] = OP_DISTINCT
+ * Returns  OP_COUNT_DISTINCT(distinct's input[0])
  */
 static ray_op_t* rw_count_distinct(ray_graph_t* g, ray_op_t* node) {
-    ray_op_t* distinct = node->inputs[0];
-    if (!distinct || !distinct->inputs[0]) return NULL;
-    ray_op_t* src = distinct->inputs[0];
+    ray_op_t* distinct = op_child(g, node, 0);
+    if (!distinct || !op_child(g, distinct, 0)) return NULL;
+    ray_op_t* src = op_child(g, distinct, 0);
 
     ray_op_t* repl = graph_alloc_node_opt(g);
     if (!repl) return NULL;
     repl->opcode    = OP_COUNT_DISTINCT;
     repl->arity     = 1;
-    repl->inputs[0] = src;
+    repl->in_id[0]  = src ? src->id : RAY_OP_NONE;
     repl->out_type  = RAY_I64;
     repl->est_rows  = 1;
     return repl;
@@ -61,15 +72,15 @@ static ray_op_t* rw_count_distinct(ray_graph_t* g, ray_op_t* node) {
  * letting the orphaned sort/reverse node be swept by pass_dce.
  */
 static ray_op_t* rw_count_passthrough(ray_graph_t* g, ray_op_t* node) {
-    ray_op_t* inner = node->inputs[0];
-    if (!inner || !inner->inputs[0]) return NULL;
-    ray_op_t* src = inner->inputs[0];
+    ray_op_t* inner = op_child(g, node, 0);
+    if (!inner || !op_child(g, inner, 0)) return NULL;
+    ray_op_t* src = op_child(g, inner, 0);
 
     ray_op_t* repl = graph_alloc_node_opt(g);
     if (!repl) return NULL;
     repl->opcode    = OP_COUNT;
     repl->arity     = 1;
-    repl->inputs[0] = src;
+    repl->in_id[0]  = src ? src->id : RAY_OP_NONE;
     repl->out_type  = RAY_I64;
     repl->est_rows  = 1;
     return repl;
@@ -102,11 +113,11 @@ static ray_t* scan_source_col(ray_graph_t* g, ray_op_t* src) {
    its out_attrs (if tracked) or out_type+constness. Returns false on
    uncertainty (safe default — slow path runs). */
 static bool pre_no_nulls_on_asc_input(ray_graph_t* g, ray_op_t* node) {
-    /* node = OP_FIRST (or OP_LAST); node->inputs[0] = OP_ASC;
-       inspect node->inputs[0]->inputs[0] (the source vector). */
-    ray_op_t* asc = node->inputs[0];
-    if (!asc || !asc->inputs[0]) return false;
-    ray_op_t* src = asc->inputs[0];
+    /* node = OP_FIRST (or OP_LAST); node's input[0] = OP_ASC;
+       inspect the OP_ASC's input[0] (the source vector). */
+    ray_op_t* asc = op_child(g, node, 0);
+    if (!asc || !op_child(g, asc, 0)) return false;
+    ray_op_t* src = op_child(g, asc, 0);
 
     /* OP_CONST: read the literal from the ext data and check its attrs.
        For other opcodes (computed inputs), bail — false negative is fine. */
@@ -134,15 +145,15 @@ static bool pre_no_nulls_on_asc_input(ray_graph_t* g, ray_op_t* node) {
  * OP_MIN skips nulls and returns smallest non-null.  The precondition
  * pre_no_nulls_on_asc_input ensures we only rewrite when null-free. */
 static ray_op_t* rw_first_asc_to_min(ray_graph_t* g, ray_op_t* node) {
-    ray_op_t* asc = node->inputs[0];
-    if (!asc || !asc->inputs[0]) return NULL;
-    ray_op_t* src = asc->inputs[0];
+    ray_op_t* asc = op_child(g, node, 0);
+    if (!asc || !op_child(g, asc, 0)) return NULL;
+    ray_op_t* src = op_child(g, asc, 0);
 
     ray_op_t* repl = graph_alloc_node_opt(g);
     if (!repl) return NULL;
     repl->opcode    = OP_MIN;
     repl->arity     = 1;
-    repl->inputs[0] = src;
+    repl->in_id[0]  = src ? src->id : RAY_OP_NONE;
     repl->out_type  = src->out_type;
     repl->est_rows  = 1;
     return repl;
@@ -152,15 +163,15 @@ static ray_op_t* rw_first_asc_to_min(ray_graph_t* g, ray_op_t* node) {
  * xasc puts nulls first, so last(asc(null-free)) = largest element;
  * OP_MAX also returns the largest non-null element — semantics match. */
 static ray_op_t* rw_last_asc_to_max(ray_graph_t* g, ray_op_t* node) {
-    ray_op_t* asc = node->inputs[0];
-    if (!asc || !asc->inputs[0]) return NULL;
-    ray_op_t* src = asc->inputs[0];
+    ray_op_t* asc = op_child(g, node, 0);
+    if (!asc || !op_child(g, asc, 0)) return NULL;
+    ray_op_t* src = op_child(g, asc, 0);
 
     ray_op_t* repl = graph_alloc_node_opt(g);
     if (!repl) return NULL;
     repl->opcode    = OP_MAX;
     repl->arity     = 1;
-    repl->inputs[0] = src;
+    repl->in_id[0]  = src ? src->id : RAY_OP_NONE;
     repl->out_type  = src->out_type;
     repl->est_rows  = 1;
     return repl;
@@ -218,7 +229,8 @@ static ray_op_t* try_rewrite(ray_graph_t* g, ray_op_t* node) {
     int idx = first_idiom[node->opcode];
     while (idx >= 0) {
         const ray_idiom_t* row = &ray_idioms[idx];
-        if (node->inputs[0] && node->inputs[0]->opcode == row->child0_op) {
+        ray_op_t* c0 = op_child(g, node, 0);
+        if (c0 && c0->opcode == row->child0_op) {
             if (!row->pre || row->pre(g, node)) {
                 ray_op_t* repl = row->rewrite(g, node);
                 if (repl) {
@@ -276,8 +288,9 @@ ray_op_t* ray_idiom_pass(ray_graph_t* g, ray_op_t* root) {
         ray_op_t* n = &g->nodes[nid];
         if (n->flags & OP_FLAG_DEAD) continue;
         for (int i = 0; i < n->arity && i < 2; i++) {
-            if (n->inputs[i] && sp1 < (int)cap)
-                stk1[sp1++] = n->inputs[i]->id;
+            ray_op_t* ci = op_child(g, n, i);
+            if (ci && sp1 < (int)cap)
+                stk1[sp1++] = ci->id;
         }
     }
 

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -486,6 +486,10 @@ static inline bool pool_cancelled(ray_pool_t* pool) {
  * struct.  Use EXT_TRAIL() to find the trailing bytes. */
 ray_op_ext_t* graph_alloc_ext_node_ex(ray_graph_t* g, size_t extra);
 
+/* Allocate a plain 32-byte node, growing g->nodes if needed.  Defined in
+ * graph.c.  Shared with opt.c (no second copy of the realloc logic). */
+ray_op_t* graph_alloc_node(ray_graph_t* g);
+
 /* Compile a Rayfall AST sub-expression to a DAG node.  Defined in
  * query.c.  Used by fused_* operators that need to evaluate a small
  * predicate without going through the full select planner. */
@@ -500,6 +504,19 @@ static inline ray_op_ext_t* find_ext(ray_graph_t* g, uint32_t node_id) {
             return g->ext_nodes[i];
     }
     return NULL;
+}
+
+/* Resolve a node id to its ray_op_t* in g->nodes.  Returns NULL for the
+ * RAY_OP_NONE sentinel.  Node ids are stable indices, so the returned
+ * pointer is only valid until the next g->nodes realloc — never store it
+ * across a node allocation; re-resolve from the id instead. */
+static inline ray_op_t* op_node(ray_graph_t* g, uint32_t id) {
+    return id == RAY_OP_NONE ? NULL : &g->nodes[id];
+}
+
+/* Resolve input edge i (0 or 1) of op to its child node, or NULL if unused. */
+static inline ray_op_t* op_child(ray_graph_t* g, const ray_op_t* op, int i) {
+    return op_node(g, op->in_id[i]);
 }
 
 /* ══════════════════════════════════════════

--- a/src/ops/join.c
+++ b/src/ops/join.c
@@ -871,8 +871,8 @@ ray_t* exec_join(ray_graph_t* g, ray_op_t* op, ray_t* left_table, ray_t* right_t
     memset(r_key_vecs, 0, key_slots * sizeof(ray_t*));
 
     for (uint8_t k = 0; k < n_keys; k++) {
-        ray_op_ext_t* lk = find_ext(g, ext->join.left_keys[k]->id);
-        ray_op_ext_t* rk = find_ext(g, ext->join.right_keys[k]->id);
+        ray_op_ext_t* lk = find_ext(g, ext->join.left_keys[k]);
+        ray_op_ext_t* rk = find_ext(g, ext->join.right_keys[k]);
         if (lk && lk->base.opcode == OP_SCAN)
             l_key_vecs[k] = ray_table_get_col(left_table, lk->sym);
         if (rk && rk->base.opcode == OP_SCAN)
@@ -1388,7 +1388,7 @@ join_gather:;
         if (!col) continue;
         bool is_key = false;
         for (uint8_t k = 0; k < n_keys; k++) {
-            ray_op_ext_t* rk = find_ext(g, ext->join.right_keys[k]->id);
+            ray_op_ext_t* rk = find_ext(g, ext->join.right_keys[k]);
             if (rk && rk->base.opcode == OP_SCAN && rk->sym == name_id) {
                 is_key = true; break;
             }
@@ -1551,8 +1551,8 @@ ray_t* exec_antijoin(ray_graph_t* g, ray_op_t* op,
     memset(r_key_vecs, 0, n_keys * sizeof(ray_t*));
 
     for (uint8_t k = 0; k < n_keys; k++) {
-        ray_op_ext_t* lk = find_ext(g, ext->join.left_keys[k]->id);
-        ray_op_ext_t* rk = find_ext(g, ext->join.right_keys[k]->id);
+        ray_op_ext_t* lk = find_ext(g, ext->join.left_keys[k]);
+        ray_op_ext_t* rk = find_ext(g, ext->join.right_keys[k]);
         if (lk && lk->base.opcode == OP_SCAN)
             l_key_vecs[k] = ray_table_get_col(left_table, lk->sym);
         if (rk && rk->base.opcode == OP_SCAN)
@@ -1760,7 +1760,7 @@ ray_t* exec_window_join(ray_graph_t* g, ray_op_t* op,
     int64_t right_n = ray_table_nrows(right_table);
 
     /* Resolve time key */
-    ray_op_ext_t* time_ext = find_ext(g, ext->asof.time_key->id);
+    ray_op_ext_t* time_ext = find_ext(g, ext->asof.time_key);
     if (!time_ext || time_ext->base.opcode != OP_SCAN)
         return ray_error("nyi", NULL);
     int64_t time_sym = time_ext->sym;
@@ -1768,7 +1768,7 @@ ray_t* exec_window_join(ray_graph_t* g, ray_op_t* op,
     /* Resolve equality keys */
     int64_t eq_syms[256];
     for (uint8_t k = 0; k < n_eq; k++) {
-        ray_op_ext_t* ek = find_ext(g, ext->asof.eq_keys[k]->id);
+        ray_op_ext_t* ek = find_ext(g, ext->asof.eq_keys[k]);
         if (!ek || ek->base.opcode != OP_SCAN)
             return ray_error("nyi", NULL);
         eq_syms[k] = ek->sym;

--- a/src/ops/ops.h
+++ b/src/ops/ops.h
@@ -322,16 +322,22 @@ static inline bool agg_type_admitted(uint16_t op, int8_t t) {
 #define OP_FLAG_PUSHED       0x01  /* filter interposed below a GROUP by predicate pushdown */
 #define OP_FLAG_DEAD         0x02
 
-/* Operation node (32 bytes, fits one cache line) */
+/* Sentinel node id for "no input".  Node id 0 is a valid node (the first
+ * one allocated), so zero cannot mean "none" — use the max value.  All
+ * graph edges are stable uint32 ids (indices into g->nodes), never raw
+ * pointers, so g->nodes may realloc freely with no fixup. */
+#define RAY_OP_NONE  ((uint32_t)0xFFFFFFFFu)
+
+/* Operation node (fits one cache line) */
 typedef struct ray_op {
     uint16_t       opcode;     /* OP_ADD, OP_SCAN, OP_FILTER, etc. */
     uint8_t        arity;      /* 0, 1, or 2 */
     uint8_t        flags;      /* PUSHED, DEAD */
     int8_t         out_type;   /* inferred output type */
     uint8_t        pad[3];
-    uint32_t       id;         /* unique node ID */
+    uint32_t       id;         /* unique node ID (== index into g->nodes) */
     uint32_t       est_rows;   /* estimated row count */
-    struct ray_op*  inputs[2];  /* NULL if unused */
+    uint32_t       in_id[2];   /* input node ids; RAY_OP_NONE if unused */
 } ray_op_t;
 
 /* Extended operation node for N-ary ops (heap-allocated, variable size) */
@@ -341,16 +347,16 @@ typedef struct ray_op_ext {
         ray_t*   literal;       /* OP_CONST: inline literal value */
         int64_t sym;           /* OP_SCAN: column name symbol ID */
         struct {               /* OP_GROUP: group-by specification */
-            ray_op_t**  keys;
+            uint32_t*  keys;        /* node ids */
             uint8_t    n_keys;
             uint8_t    n_aggs;
             uint16_t*  agg_ops;
-            ray_op_t**  agg_ins;
+            uint32_t*  agg_ins;     /* node ids */
             /* Optional second input per agg — non-NULL only for binary
              * aggregators (currently: OP_PEARSON_CORR). NULL for all
              * unary aggs and for the whole pointer when no binary agg
              * is present in this group. */
-            ray_op_t**  agg_ins2;
+            uint32_t*  agg_ins2;    /* node ids */
             /* Optional integer parameter per agg — used by holistic
              * aggregators that take a scalar literal alongside the
              * column (currently OP_TOP_N / OP_BOT_N: K).  NULL for
@@ -358,28 +364,28 @@ typedef struct ray_op_ext {
             int64_t*    agg_k;
         };
         struct {               /* OP_SORT: multi-column sort */
-            ray_op_t**  columns;
+            uint32_t*  columns;     /* node ids */
             uint8_t*   desc;
             uint8_t*   nulls_first; /* 1=nulls first, 0=nulls last */
             uint8_t    n_cols;
         } sort;
         struct {               /* OP_JOIN: join specification */
-            ray_op_t**  left_keys;
-            ray_op_t**  right_keys;
+            uint32_t*  left_keys;   /* node ids */
+            uint32_t*  right_keys;  /* node ids */
             uint8_t    n_join_keys;
             uint8_t    join_type;  /* 0=inner, 1=left, 2=full, 3=anti */
         } join;
         struct {               /* OP_WINDOW_JOIN: ASOF join */
-            ray_op_t*   time_key;      /* time/ordered key column */
-            ray_op_t**  eq_keys;       /* equality partition keys */
+            uint32_t   time_key;       /* time/ordered key column (node id) */
+            uint32_t*  eq_keys;        /* equality partition keys (node ids) */
             uint8_t    n_eq_keys;     /* number of equality keys */
             uint8_t    join_type;     /* 0=inner, 1=left outer */
         } asof;
         struct {               /* OP_WINDOW: window functions */
-            ray_op_t**  part_keys;
-            ray_op_t**  order_keys;
+            uint32_t*  part_keys;   /* node ids */
+            uint32_t*  order_keys;  /* node ids */
             uint8_t*   order_descs;
-            ray_op_t**  func_inputs;
+            uint32_t*  func_inputs; /* node ids */
             uint8_t*   func_kinds;    /* RAY_WIN_ROW_NUMBER etc. */
             int64_t*   func_params;   /* NTILE(n), LAG offset, etc. */
             uint8_t    n_part_keys;
@@ -420,13 +426,17 @@ typedef struct ray_op_ext {
             int32_t   ef_search;      /* ANN only */
         } rerank;
         struct {  /* OP_PIVOT */
-            ray_op_t**  index_cols;   /* OP_SCAN nodes for index columns */
-            ray_op_t*   pivot_col;    /* OP_SCAN node for pivot column */
-            ray_op_t*   value_col;    /* OP_SCAN node for value column */
+            uint32_t*   index_cols;   /* OP_SCAN node ids for index columns */
+            uint32_t    pivot_col;    /* OP_SCAN node id for pivot column */
+            uint32_t    value_col;    /* OP_SCAN node id for value column */
             uint16_t    agg_op;       /* OP_SUM, OP_AVG, etc. */
             uint8_t     n_index;      /* number of index columns */
         } pivot;
     };
+    /* Third input node id for 3-ary ops (OP_IF else-branch, OP_SUBSTR length,
+     * table-valued third arg).  RAY_OP_NONE if unused.  Replaces the former
+     * (ray_t*)(uintptr_t) punning of `literal`. */
+    uint32_t  third_in;
     uint64_t* seg_mask;   /* partition pruning bitmap (NULL = all active) */
     int64_t   seg_mask_count; /* number of partitions the mask covers */
 } ray_op_ext_t;

--- a/src/ops/opt.c
+++ b/src/ops/opt.c
@@ -36,6 +36,20 @@
 /* Forward declaration — defined below, used by type inference and DCE passes. */
 ray_op_ext_t* find_ext(ray_graph_t* g, uint32_t node_id);
 
+/* Shared 32-byte node allocator (graph.c).  Forwarded by graph_alloc_node_opt;
+ * node ids are realloc-stable so no pointer fixups are needed. */
+ray_op_t* graph_alloc_node(ray_graph_t* g);
+
+/* Node-id edge accessors (mirror src/ops/internal.h).  Local copies keep opt.c
+ * self-contained — same rationale as the duplicated find_ext below.  Resolve a
+ * stable uint32 node id (or input edge) to its ray_op_t*, NULL for RAY_OP_NONE. */
+static inline ray_op_t* op_node(ray_graph_t* g, uint32_t id) {
+    return id == RAY_OP_NONE ? NULL : &g->nodes[id];
+}
+static inline ray_op_t* op_child(ray_graph_t* g, const ray_op_t* op, int i) {
+    return op_node(g, op->in_id[i]);
+}
+
 /* Test knob: disable the GROUP predicate-pushdown arm so the differential
  * harness and the perf gate can compare pushed vs unpushed plans. */
 bool ray_opt_no_group_pushdown = false;
@@ -70,7 +84,7 @@ static int8_t promote_type(int8_t a, int8_t b) {
     return RAY_BOOL;
 }
 
-static void infer_type_for_node(ray_op_t* node) {
+static void infer_type_for_node(ray_graph_t* g, ray_op_t* node) {
     if (node->out_type == 0 && node->opcode != OP_SCAN && node->opcode != OP_CONST) {
         /* Comparison and boolean ops always produce BOOL */
         if (node->opcode >= OP_EQ && node->opcode <= OP_GE) {
@@ -81,11 +95,12 @@ static void infer_type_for_node(ray_op_t* node) {
             node->out_type = RAY_BOOL;
             return;
         }
-        if (node->arity >= 2 && node->inputs[0] && node->inputs[1]) {
-            node->out_type = promote_type(node->inputs[0]->out_type,
-                                           node->inputs[1]->out_type);
-        } else if (node->arity >= 1 && node->inputs[0]) {
-            node->out_type = node->inputs[0]->out_type;
+        ray_op_t* in0 = op_child(g, node, 0);
+        ray_op_t* in1 = op_child(g, node, 1);
+        if (node->arity >= 2 && in0 && in1) {
+            node->out_type = promote_type(in0->out_type, in1->out_type);
+        } else if (node->arity >= 1 && in0) {
+            node->out_type = in0->out_type;
         }
     }
 }
@@ -123,8 +138,8 @@ static void pass_type_inference(ray_graph_t* g, ray_op_t* root) {
         visited[nid] = true;
         order[oc++] = nid;
         for (int i = 0; i < 2 && i < n->arity; i++) {
-            if (n->inputs[i] && sp < (int)stack_cap)
-                stack[sp++] = n->inputs[i]->id;
+            if (op_child(g, n, i) && sp < (int)stack_cap)
+                stack[sp++] = n->in_id[i];
         }
         /* M3: Traverse ext node children so type inference reaches all
            referenced nodes (GROUP keys/aggs, SORT/PROJECT/SELECT columns,
@@ -134,55 +149,55 @@ static void pass_type_inference(ray_graph_t* g, ray_op_t* root) {
             switch (n->opcode) {
                 case OP_GROUP:
                     for (uint8_t k = 0; k < ext->n_keys; k++)
-                        if (ext->keys[k] && !visited[ext->keys[k]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->keys[k]->id;
+                        if (op_node(g, ext->keys[k]) && !visited[ext->keys[k]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->keys[k];
                     for (uint8_t a = 0; a < ext->n_aggs; a++)
-                        if (ext->agg_ins[a] && !visited[ext->agg_ins[a]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->agg_ins[a]->id;
+                        if (op_node(g, ext->agg_ins[a]) && !visited[ext->agg_ins[a]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->agg_ins[a];
                     break;
                 case OP_SORT:
                 case OP_SELECT:
                     for (uint8_t k = 0; k < ext->sort.n_cols; k++)
-                        if (ext->sort.columns[k] && !visited[ext->sort.columns[k]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->sort.columns[k]->id;
+                        if (op_node(g, ext->sort.columns[k]) && !visited[ext->sort.columns[k]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->sort.columns[k];
                     break;
                 case OP_JOIN:
                     for (uint8_t k = 0; k < ext->join.n_join_keys; k++) {
-                        if (ext->join.left_keys[k] && !visited[ext->join.left_keys[k]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->join.left_keys[k]->id;
-                        if (ext->join.right_keys && ext->join.right_keys[k] &&
-                            !visited[ext->join.right_keys[k]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->join.right_keys[k]->id;
+                        if (op_node(g, ext->join.left_keys[k]) && !visited[ext->join.left_keys[k]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->join.left_keys[k];
+                        if (ext->join.right_keys && op_node(g, ext->join.right_keys[k]) &&
+                            !visited[ext->join.right_keys[k]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->join.right_keys[k];
                     }
                     break;
                 case OP_WINDOW_JOIN: {
                     ray_op_ext_t* wj_ext = find_ext(g, n->id);
                     if (wj_ext) {
-                        if (wj_ext->asof.time_key && !visited[wj_ext->asof.time_key->id] && sp < (int)stack_cap)
-                            stack[sp++] = wj_ext->asof.time_key->id;
+                        if (op_node(g, wj_ext->asof.time_key) && !visited[wj_ext->asof.time_key] && sp < (int)stack_cap)
+                            stack[sp++] = wj_ext->asof.time_key;
                         for (uint8_t k = 0; k < wj_ext->asof.n_eq_keys; k++) {
-                            if (wj_ext->asof.eq_keys[k] && !visited[wj_ext->asof.eq_keys[k]->id] && sp < (int)stack_cap)
-                                stack[sp++] = wj_ext->asof.eq_keys[k]->id;
+                            if (op_node(g, wj_ext->asof.eq_keys[k]) && !visited[wj_ext->asof.eq_keys[k]] && sp < (int)stack_cap)
+                                stack[sp++] = wj_ext->asof.eq_keys[k];
                         }
                     }
                     break;
                 }
                 case OP_WINDOW:
                     for (uint8_t k = 0; k < ext->window.n_part_keys; k++)
-                        if (ext->window.part_keys[k] && !visited[ext->window.part_keys[k]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->window.part_keys[k]->id;
+                        if (op_node(g, ext->window.part_keys[k]) && !visited[ext->window.part_keys[k]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->window.part_keys[k];
                     for (uint8_t k = 0; k < ext->window.n_order_keys; k++)
-                        if (ext->window.order_keys[k] && !visited[ext->window.order_keys[k]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->window.order_keys[k]->id;
+                        if (op_node(g, ext->window.order_keys[k]) && !visited[ext->window.order_keys[k]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->window.order_keys[k];
                     for (uint8_t f = 0; f < ext->window.n_funcs; f++)
-                        if (ext->window.func_inputs[f] && !visited[ext->window.func_inputs[f]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->window.func_inputs[f]->id;
+                        if (op_node(g, ext->window.func_inputs[f]) && !visited[ext->window.func_inputs[f]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->window.func_inputs[f];
                     break;
-                /* M3b: 3-input ops store third operand node ID in ext->literal */
+                /* M3b: 3-input ops store third operand node ID in ext->third_in */
                 case OP_IF:
                 case OP_SUBSTR:
                 case OP_REPLACE: {
-                    uint32_t third_id = (uint32_t)(uintptr_t)ext->literal;
+                    uint32_t third_id = ext->third_in;
                     if (third_id < nc && !visited[third_id] && sp < (int)stack_cap)
                         stack[sp++] = third_id;
                     break;
@@ -206,7 +221,7 @@ static void pass_type_inference(ray_graph_t* g, ray_op_t* root) {
     }
     /* Process in reverse order (children before parents) */
     for (int i = oc - 1; i >= 0; i--)
-        infer_type_for_node(&g->nodes[order[i]]);
+        infer_type_for_node(g, &g->nodes[order[i]]);
 
     { if (stack_cap > 256) ray_sys_free(stack); if (nc > 256) { ray_sys_free(order); ray_sys_free(visited); } }
 }
@@ -315,8 +330,8 @@ static bool replace_with_const(ray_graph_t* g, ray_op_t* node, ray_t* literal) {
     ext->base = *node;
     ext->base.opcode = OP_CONST;
     ext->base.arity = 0;
-    ext->base.inputs[0] = NULL;
-    ext->base.inputs[1] = NULL;
+    ext->base.in_id[0] = RAY_OP_NONE;
+    ext->base.in_id[1] = RAY_OP_NONE;
     ext->base.out_type = literal->type < 0 ? (int8_t)(-(int)literal->type) : literal->type;
     ext->literal = literal;
 
@@ -326,7 +341,7 @@ static bool replace_with_const(ray_graph_t* g, ray_op_t* node, ray_t* literal) {
 }
 
 static bool fold_unary_const(ray_graph_t* g, ray_op_t* node) {
-    ray_op_t* operand = node->inputs[0];
+    ray_op_t* operand = op_child(g, node, 0);
     if (!is_const(operand)) return false;
 
     ray_op_ext_t* oe = find_ext(g, operand->id);
@@ -381,8 +396,8 @@ static bool fold_unary_const(ray_graph_t* g, ray_op_t* node) {
 }
 
 static bool fold_binary_const(ray_graph_t* g, ray_op_t* node) {
-    ray_op_t* lhs = node->inputs[0];
-    ray_op_t* rhs = node->inputs[1];
+    ray_op_t* lhs = op_child(g, node, 0);
+    ray_op_t* rhs = op_child(g, node, 1);
     if (!is_const(lhs) || !is_const(rhs)) return false;
 
     ray_op_ext_t* le = find_ext(g, lhs->id);
@@ -520,8 +535,8 @@ static bool const_node_bool(ray_graph_t* g, ray_op_t* n, bool* out) {
 static bool simplify_and_or_const(ray_graph_t* g, ray_op_t* node) {
     if (node->opcode != OP_AND && node->opcode != OP_OR) return false;
     if (node->arity != 2) return false;
-    ray_op_t* lhs = node->inputs[0];
-    ray_op_t* rhs = node->inputs[1];
+    ray_op_t* lhs = op_child(g, node, 0);
+    ray_op_t* rhs = op_child(g, node, 1);
     if (!lhs || !rhs) return false;
 
     bool lhs_b = false, rhs_b = false;
@@ -541,8 +556,8 @@ static bool simplify_and_or_const(ray_graph_t* g, ray_op_t* node) {
         if (find_ext(g, node->id)) return false;  /* shouldn't happen for AND/OR */
         node->opcode = OP_ALIAS;
         node->arity = 1;
-        node->inputs[0] = X;
-        node->inputs[1] = NULL;
+        node->in_id[0] = X ? X->id : RAY_OP_NONE;
+        node->in_id[1] = RAY_OP_NONE;
         node->out_type = RAY_BOOL;
         node->est_rows = X->est_rows;
         g->nodes[node->id] = *node;
@@ -564,7 +579,7 @@ static bool simplify_and_or_const(ray_graph_t* g, ray_op_t* node) {
 
 static bool fold_filter_const_predicate(ray_graph_t* g, ray_op_t* node) {
     if (node->opcode != OP_FILTER || node->arity != 2) return false;
-    ray_op_t* pred = node->inputs[1];
+    ray_op_t* pred = op_child(g, node, 1);
     if (!is_const(pred)) return false;
 
     ray_op_ext_t* pred_ext = find_ext(g, pred->id);
@@ -576,7 +591,7 @@ static bool fold_filter_const_predicate(ray_graph_t* g, ray_op_t* node) {
     if (keep_rows) {
         node->opcode = OP_MATERIALIZE;
         node->arity = 1;
-        node->inputs[1] = NULL;
+        node->in_id[1] = RAY_OP_NONE;
         g->nodes[node->id] = *node;
         return true;
     }
@@ -586,7 +601,7 @@ static bool fold_filter_const_predicate(ray_graph_t* g, ray_op_t* node) {
     ext->base = *node;
     ext->base.opcode = OP_HEAD;
     ext->base.arity = 1;
-    ext->base.inputs[1] = NULL;
+    ext->base.in_id[1] = RAY_OP_NONE;
     ext->base.est_rows = 0;
     ext->sym = 0;
 
@@ -645,8 +660,8 @@ static void pass_constant_fold(ray_graph_t* g, ray_op_t* root) {
         visited[nid] = true;
         order[oc++] = nid;
         for (int i = 0; i < 2 && i < n->arity; i++) {
-            if (n->inputs[i] && sp < (int)stack_cap)
-                stack[sp++] = n->inputs[i]->id;
+            if (op_child(g, n, i) && sp < (int)stack_cap)
+                stack[sp++] = n->in_id[i];
         }
         /* H1: Traverse ext-node children so constant folding reaches all
            referenced nodes (GROUP keys/aggs, SORT/PROJECT/SELECT columns,
@@ -656,55 +671,55 @@ static void pass_constant_fold(ray_graph_t* g, ray_op_t* root) {
             switch (n->opcode) {
                 case OP_GROUP:
                     for (uint8_t k = 0; k < ext->n_keys; k++)
-                        if (ext->keys[k] && !visited[ext->keys[k]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->keys[k]->id;
+                        if (op_node(g, ext->keys[k]) && !visited[ext->keys[k]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->keys[k];
                     for (uint8_t a = 0; a < ext->n_aggs; a++)
-                        if (ext->agg_ins[a] && !visited[ext->agg_ins[a]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->agg_ins[a]->id;
+                        if (op_node(g, ext->agg_ins[a]) && !visited[ext->agg_ins[a]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->agg_ins[a];
                     break;
                 case OP_SORT:
                 case OP_SELECT:
                     for (uint8_t k = 0; k < ext->sort.n_cols; k++)
-                        if (ext->sort.columns[k] && !visited[ext->sort.columns[k]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->sort.columns[k]->id;
+                        if (op_node(g, ext->sort.columns[k]) && !visited[ext->sort.columns[k]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->sort.columns[k];
                     break;
                 case OP_JOIN:
                     for (uint8_t k = 0; k < ext->join.n_join_keys; k++) {
-                        if (ext->join.left_keys[k] && !visited[ext->join.left_keys[k]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->join.left_keys[k]->id;
-                        if (ext->join.right_keys && ext->join.right_keys[k] &&
-                            !visited[ext->join.right_keys[k]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->join.right_keys[k]->id;
+                        if (op_node(g, ext->join.left_keys[k]) && !visited[ext->join.left_keys[k]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->join.left_keys[k];
+                        if (ext->join.right_keys && op_node(g, ext->join.right_keys[k]) &&
+                            !visited[ext->join.right_keys[k]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->join.right_keys[k];
                     }
                     break;
                 case OP_WINDOW_JOIN: {
                     ray_op_ext_t* wj_ext = find_ext(g, n->id);
                     if (wj_ext) {
-                        if (wj_ext->asof.time_key && !visited[wj_ext->asof.time_key->id] && sp < (int)stack_cap)
-                            stack[sp++] = wj_ext->asof.time_key->id;
+                        if (op_node(g, wj_ext->asof.time_key) && !visited[wj_ext->asof.time_key] && sp < (int)stack_cap)
+                            stack[sp++] = wj_ext->asof.time_key;
                         for (uint8_t k = 0; k < wj_ext->asof.n_eq_keys; k++) {
-                            if (wj_ext->asof.eq_keys[k] && !visited[wj_ext->asof.eq_keys[k]->id] && sp < (int)stack_cap)
-                                stack[sp++] = wj_ext->asof.eq_keys[k]->id;
+                            if (op_node(g, wj_ext->asof.eq_keys[k]) && !visited[wj_ext->asof.eq_keys[k]] && sp < (int)stack_cap)
+                                stack[sp++] = wj_ext->asof.eq_keys[k];
                         }
                     }
                     break;
                 }
                 case OP_WINDOW:
                     for (uint8_t k = 0; k < ext->window.n_part_keys; k++)
-                        if (ext->window.part_keys[k] && !visited[ext->window.part_keys[k]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->window.part_keys[k]->id;
+                        if (op_node(g, ext->window.part_keys[k]) && !visited[ext->window.part_keys[k]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->window.part_keys[k];
                     for (uint8_t k = 0; k < ext->window.n_order_keys; k++)
-                        if (ext->window.order_keys[k] && !visited[ext->window.order_keys[k]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->window.order_keys[k]->id;
+                        if (op_node(g, ext->window.order_keys[k]) && !visited[ext->window.order_keys[k]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->window.order_keys[k];
                     for (uint8_t f = 0; f < ext->window.n_funcs; f++)
-                        if (ext->window.func_inputs[f] && !visited[ext->window.func_inputs[f]->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->window.func_inputs[f]->id;
+                        if (op_node(g, ext->window.func_inputs[f]) && !visited[ext->window.func_inputs[f]] && sp < (int)stack_cap)
+                            stack[sp++] = ext->window.func_inputs[f];
                     break;
-                /* H1b: 3-input ops store third operand node ID in ext->literal */
+                /* H1b: 3-input ops store third operand node ID in ext->third_in */
                 case OP_IF:
                 case OP_SUBSTR:
                 case OP_REPLACE: {
-                    uint32_t third_id = (uint32_t)(uintptr_t)ext->literal;
+                    uint32_t third_id = ext->third_in;
                     if (third_id < nc && !visited[third_id] && sp < (int)stack_cap)
                         stack[sp++] = third_id;
                     break;
@@ -758,15 +773,15 @@ static void mark_live(ray_graph_t* g, ray_op_t* root, bool* live) {
         live[nid] = true;
         ray_op_t* n = &g->nodes[nid];
         for (int i = 0; i < 2; i++) {
-            if (n->inputs[i] && sp < (int)stack_cap)
-                stack[sp++] = n->inputs[i]->id;
+            if (op_child(g, n, i) && sp < (int)stack_cap)
+                stack[sp++] = n->in_id[i];
         }
         /* H4: 3-input ops (OP_IF, OP_SUBSTR, OP_REPLACE) store the third
-           operand node ID as (uintptr_t)ext->literal. */
+           operand node ID in ext->third_in. */
         if (n->opcode == OP_IF || n->opcode == OP_SUBSTR || n->opcode == OP_REPLACE) {
             ray_op_ext_t* ext = find_ext(g, nid);
             if (ext) {
-                uint32_t third_id = (uint32_t)(uintptr_t)ext->literal;
+                uint32_t third_id = ext->third_in;
                 if (third_id < nc && sp < (int)stack_cap)
                     stack[sp++] = third_id;
             }
@@ -800,65 +815,65 @@ static void mark_live(ray_graph_t* g, ray_op_t* root, bool* live) {
                 switch (n->opcode) {
                     case OP_GROUP:
                         for (uint8_t k = 0; k < ext->n_keys; k++) {
-                            if (ext->keys[k] && !live[ext->keys[k]->id] && sp < (int)stack_cap)
-                                stack[sp++] = ext->keys[k]->id;
+                            if (op_node(g, ext->keys[k]) && !live[ext->keys[k]] && sp < (int)stack_cap)
+                                stack[sp++] = ext->keys[k];
                         }
                         for (uint8_t a = 0; a < ext->n_aggs; a++) {
-                            if (ext->agg_ins[a] && !live[ext->agg_ins[a]->id] && sp < (int)stack_cap)
-                                stack[sp++] = ext->agg_ins[a]->id;
+                            if (op_node(g, ext->agg_ins[a]) && !live[ext->agg_ins[a]] && sp < (int)stack_cap)
+                                stack[sp++] = ext->agg_ins[a];
                         }
                         break;
                     case OP_SORT:
                     case OP_SELECT:
                         for (uint8_t k = 0; k < ext->sort.n_cols; k++) {
-                            if (ext->sort.columns[k] && !live[ext->sort.columns[k]->id] && sp < (int)stack_cap)
-                                stack[sp++] = ext->sort.columns[k]->id;
+                            if (op_node(g, ext->sort.columns[k]) && !live[ext->sort.columns[k]] && sp < (int)stack_cap)
+                                stack[sp++] = ext->sort.columns[k];
                         }
                         break;
                     case OP_JOIN:
                     case OP_ANTIJOIN:
                         for (uint8_t k = 0; k < ext->join.n_join_keys; k++) {
-                            if (ext->join.left_keys[k] && !live[ext->join.left_keys[k]->id] && sp < (int)stack_cap)
-                                stack[sp++] = ext->join.left_keys[k]->id;
-                            if (ext->join.right_keys && ext->join.right_keys[k] &&
-                                !live[ext->join.right_keys[k]->id] && sp < (int)stack_cap)
-                                stack[sp++] = ext->join.right_keys[k]->id;
+                            if (op_node(g, ext->join.left_keys[k]) && !live[ext->join.left_keys[k]] && sp < (int)stack_cap)
+                                stack[sp++] = ext->join.left_keys[k];
+                            if (ext->join.right_keys && op_node(g, ext->join.right_keys[k]) &&
+                                !live[ext->join.right_keys[k]] && sp < (int)stack_cap)
+                                stack[sp++] = ext->join.right_keys[k];
                         }
                         break;
                     case OP_PIVOT:
                         for (uint8_t k = 0; k < ext->pivot.n_index; k++) {
-                            if (ext->pivot.index_cols[k] && !live[ext->pivot.index_cols[k]->id] && sp < (int)stack_cap)
-                                stack[sp++] = ext->pivot.index_cols[k]->id;
+                            if (op_node(g, ext->pivot.index_cols[k]) && !live[ext->pivot.index_cols[k]] && sp < (int)stack_cap)
+                                stack[sp++] = ext->pivot.index_cols[k];
                         }
-                        if (ext->pivot.pivot_col && !live[ext->pivot.pivot_col->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->pivot.pivot_col->id;
-                        if (ext->pivot.value_col && !live[ext->pivot.value_col->id] && sp < (int)stack_cap)
-                            stack[sp++] = ext->pivot.value_col->id;
+                        if (op_node(g, ext->pivot.pivot_col) && !live[ext->pivot.pivot_col] && sp < (int)stack_cap)
+                            stack[sp++] = ext->pivot.pivot_col;
+                        if (op_node(g, ext->pivot.value_col) && !live[ext->pivot.value_col] && sp < (int)stack_cap)
+                            stack[sp++] = ext->pivot.value_col;
                         break;
                     case OP_WINDOW_JOIN: {
                         ray_op_ext_t* wj_ext = find_ext(g, n->id);
                         if (wj_ext) {
-                            if (wj_ext->asof.time_key && !live[wj_ext->asof.time_key->id] && sp < (int)stack_cap)
-                                stack[sp++] = wj_ext->asof.time_key->id;
+                            if (op_node(g, wj_ext->asof.time_key) && !live[wj_ext->asof.time_key] && sp < (int)stack_cap)
+                                stack[sp++] = wj_ext->asof.time_key;
                             for (uint8_t k = 0; k < wj_ext->asof.n_eq_keys; k++) {
-                                if (wj_ext->asof.eq_keys[k] && !live[wj_ext->asof.eq_keys[k]->id] && sp < (int)stack_cap)
-                                    stack[sp++] = wj_ext->asof.eq_keys[k]->id;
+                                if (op_node(g, wj_ext->asof.eq_keys[k]) && !live[wj_ext->asof.eq_keys[k]] && sp < (int)stack_cap)
+                                    stack[sp++] = wj_ext->asof.eq_keys[k];
                             }
                         }
                         break;
                     }
                     case OP_WINDOW:
                         for (uint8_t k = 0; k < ext->window.n_part_keys; k++) {
-                            if (ext->window.part_keys[k] && !live[ext->window.part_keys[k]->id] && sp < (int)stack_cap)
-                                stack[sp++] = ext->window.part_keys[k]->id;
+                            if (op_node(g, ext->window.part_keys[k]) && !live[ext->window.part_keys[k]] && sp < (int)stack_cap)
+                                stack[sp++] = ext->window.part_keys[k];
                         }
                         for (uint8_t k = 0; k < ext->window.n_order_keys; k++) {
-                            if (ext->window.order_keys[k] && !live[ext->window.order_keys[k]->id] && sp < (int)stack_cap)
-                                stack[sp++] = ext->window.order_keys[k]->id;
+                            if (op_node(g, ext->window.order_keys[k]) && !live[ext->window.order_keys[k]] && sp < (int)stack_cap)
+                                stack[sp++] = ext->window.order_keys[k];
                         }
                         for (uint8_t f = 0; f < ext->window.n_funcs; f++) {
-                            if (ext->window.func_inputs[f] && !live[ext->window.func_inputs[f]->id] && sp < (int)stack_cap)
-                                stack[sp++] = ext->window.func_inputs[f]->id;
+                            if (op_node(g, ext->window.func_inputs[f]) && !live[ext->window.func_inputs[f]] && sp < (int)stack_cap)
+                                stack[sp++] = ext->window.func_inputs[f];
                         }
                         break;
                     default:
@@ -909,7 +924,7 @@ static ray_op_t* find_consumer(ray_graph_t* g, uint32_t node_id) {
         ray_op_t* n = &g->nodes[i];
         if (n->flags & OP_FLAG_DEAD) continue;
         for (int j = 0; j < n->arity && j < 2; j++) {
-            if (n->inputs[j] && n->inputs[j]->id == node_id)
+            if (n->in_id[j] == node_id)
                 return n;
         }
     }
@@ -921,8 +936,9 @@ static ray_op_t* find_upstream_scan(ray_graph_t* g, ray_op_t* node) {
     uint32_t limit = g ? g->node_count : 1024;
     for (uint32_t steps = 0; node && steps < limit; steps++) {
         if (node->opcode == OP_SCAN) return node;
-        if (node->arity > 0 && node->inputs[0])
-            node = node->inputs[0];
+        ray_op_t* in0 = op_child(g, node, 0);
+        if (node->arity > 0 && in0)
+            node = in0;
         else return NULL;
     }
     return NULL;
@@ -963,8 +979,9 @@ static void sip_pass(ray_graph_t* g, ray_op_t* root) {
 
         /* 2. Find the input scan to this expand (source side) */
         ray_op_t* src_scan = NULL;
-        if (expand->arity > 0 && expand->inputs[0])
-            src_scan = find_upstream_scan(g, expand->inputs[0]);
+        ray_op_t* expand_in0 = op_child(g, expand, 0);
+        if (expand->arity > 0 && expand_in0)
+            src_scan = find_upstream_scan(g, expand_in0);
 
         if (!src_scan) continue;
 
@@ -1005,9 +1022,9 @@ static void factorize_pass(ray_graph_t* g, ray_op_t* root) {
         if (!consumer || consumer->opcode != OP_GROUP) continue;
 
         ray_op_ext_t* grp_ext = find_ext(g, consumer->id);
-        if (!grp_ext || grp_ext->n_keys != 1 || !grp_ext->keys[0]) continue;
+        if (!grp_ext || grp_ext->n_keys != 1 || !op_node(g, grp_ext->keys[0])) continue;
 
-        ray_op_ext_t* key_ext = find_ext(g, grp_ext->keys[0]->id);
+        ray_op_ext_t* key_ext = find_ext(g, grp_ext->keys[0]);
         if (!key_ext || key_ext->base.opcode != OP_SCAN) continue;
 
         int64_t src_sym = ray_sym_intern("_src", 4);
@@ -1025,121 +1042,10 @@ static void factorize_pass(ray_graph_t* g, ray_op_t* root) {
  * -------------------------------------------------------------------------- */
 
 /* Allocate a new node in the graph (for use during optimization passes).
- * Same logic as graph_alloc_node in graph.c but local to opt.c. */
+ * Forwards to graph.c's graph_alloc_node — node ids are realloc-stable, so
+ * no pointer fixups are needed and there is no second copy of the logic. */
 ray_op_t* graph_alloc_node_opt(ray_graph_t* g) {
-    if (g->node_count >= g->node_cap) {
-        if (g->node_cap > UINT32_MAX / 2) return NULL;
-        uint32_t new_cap = g->node_cap * 2;
-        uintptr_t old_base = (uintptr_t)g->nodes;
-        ray_op_t* new_nodes = (ray_op_t*)ray_sys_realloc(g->nodes,
-                                                       new_cap * sizeof(ray_op_t));
-        if (!new_nodes) return NULL;
-        g->nodes = new_nodes;
-        g->node_cap = new_cap;
-        /* Fix up all input pointers after realloc */
-        ptrdiff_t delta = (ptrdiff_t)((uintptr_t)g->nodes - old_base);
-        if (delta != 0) {
-            for (uint32_t i = 0; i < g->node_count; i++) {
-                if (g->nodes[i].inputs[0])
-                    g->nodes[i].inputs[0] = (ray_op_t*)((char*)g->nodes[i].inputs[0] + delta);
-                if (g->nodes[i].inputs[1])
-                    g->nodes[i].inputs[1] = (ray_op_t*)((char*)g->nodes[i].inputs[1] + delta);
-            }
-            /* Fix ext node input pointers */
-            for (uint32_t i = 0; i < g->ext_count; i++) {
-                if (g->ext_nodes[i]) {
-                    if (g->ext_nodes[i]->base.inputs[0])
-                        g->ext_nodes[i]->base.inputs[0] =
-                            (ray_op_t*)((char*)g->ext_nodes[i]->base.inputs[0] + delta);
-                    if (g->ext_nodes[i]->base.inputs[1])
-                        g->ext_nodes[i]->base.inputs[1] =
-                            (ray_op_t*)((char*)g->ext_nodes[i]->base.inputs[1] + delta);
-                    /* Fix structural op column pointers */
-                    switch (g->ext_nodes[i]->base.opcode) {
-                        case OP_GROUP:
-                            for (uint8_t k = 0; k < g->ext_nodes[i]->n_keys; k++)
-                                if (g->ext_nodes[i]->keys[k])
-                                    g->ext_nodes[i]->keys[k] =
-                                        (ray_op_t*)((char*)g->ext_nodes[i]->keys[k] + delta);
-                            for (uint8_t a = 0; a < g->ext_nodes[i]->n_aggs; a++)
-                                if (g->ext_nodes[i]->agg_ins[a])
-                                    g->ext_nodes[i]->agg_ins[a] =
-                                        (ray_op_t*)((char*)g->ext_nodes[i]->agg_ins[a] + delta);
-                            break;
-                        case OP_SORT:
-                        case OP_SELECT:
-                            for (uint8_t k = 0; k < g->ext_nodes[i]->sort.n_cols; k++)
-                                if (g->ext_nodes[i]->sort.columns[k])
-                                    g->ext_nodes[i]->sort.columns[k] =
-                                        (ray_op_t*)((char*)g->ext_nodes[i]->sort.columns[k] + delta);
-                            break;
-                        case OP_JOIN:
-                            for (uint8_t k = 0; k < g->ext_nodes[i]->join.n_join_keys; k++) {
-                                if (g->ext_nodes[i]->join.left_keys[k])
-                                    g->ext_nodes[i]->join.left_keys[k] =
-                                        (ray_op_t*)((char*)g->ext_nodes[i]->join.left_keys[k] + delta);
-                                if (g->ext_nodes[i]->join.right_keys &&
-                                    g->ext_nodes[i]->join.right_keys[k])
-                                    g->ext_nodes[i]->join.right_keys[k] =
-                                        (ray_op_t*)((char*)g->ext_nodes[i]->join.right_keys[k] + delta);
-                            }
-                            break;
-                        case OP_WINDOW_JOIN:
-                            if (g->ext_nodes[i]->asof.time_key)
-                                g->ext_nodes[i]->asof.time_key = (ray_op_t*)((char*)g->ext_nodes[i]->asof.time_key + delta);
-                            for (uint8_t k = 0; k < g->ext_nodes[i]->asof.n_eq_keys; k++)
-                                if (g->ext_nodes[i]->asof.eq_keys[k])
-                                    g->ext_nodes[i]->asof.eq_keys[k] = (ray_op_t*)((char*)g->ext_nodes[i]->asof.eq_keys[k] + delta);
-                            break;
-                        case OP_ANTIJOIN:
-                            for (uint8_t k = 0; k < g->ext_nodes[i]->join.n_join_keys; k++) {
-                                if (g->ext_nodes[i]->join.left_keys[k])
-                                    g->ext_nodes[i]->join.left_keys[k] =
-                                        (ray_op_t*)((char*)g->ext_nodes[i]->join.left_keys[k] + delta);
-                                if (g->ext_nodes[i]->join.right_keys &&
-                                    g->ext_nodes[i]->join.right_keys[k])
-                                    g->ext_nodes[i]->join.right_keys[k] =
-                                        (ray_op_t*)((char*)g->ext_nodes[i]->join.right_keys[k] + delta);
-                            }
-                            break;
-                        case OP_PIVOT:
-                            for (uint8_t k = 0; k < g->ext_nodes[i]->pivot.n_index; k++)
-                                if (g->ext_nodes[i]->pivot.index_cols[k])
-                                    g->ext_nodes[i]->pivot.index_cols[k] =
-                                        (ray_op_t*)((char*)g->ext_nodes[i]->pivot.index_cols[k] + delta);
-                            if (g->ext_nodes[i]->pivot.pivot_col)
-                                g->ext_nodes[i]->pivot.pivot_col =
-                                    (ray_op_t*)((char*)g->ext_nodes[i]->pivot.pivot_col + delta);
-                            if (g->ext_nodes[i]->pivot.value_col)
-                                g->ext_nodes[i]->pivot.value_col =
-                                    (ray_op_t*)((char*)g->ext_nodes[i]->pivot.value_col + delta);
-                            break;
-                        case OP_WINDOW:
-                            for (uint8_t k = 0; k < g->ext_nodes[i]->window.n_part_keys; k++)
-                                if (g->ext_nodes[i]->window.part_keys[k])
-                                    g->ext_nodes[i]->window.part_keys[k] =
-                                        (ray_op_t*)((char*)g->ext_nodes[i]->window.part_keys[k] + delta);
-                            for (uint8_t k = 0; k < g->ext_nodes[i]->window.n_order_keys; k++)
-                                if (g->ext_nodes[i]->window.order_keys[k])
-                                    g->ext_nodes[i]->window.order_keys[k] =
-                                        (ray_op_t*)((char*)g->ext_nodes[i]->window.order_keys[k] + delta);
-                            for (uint8_t f = 0; f < g->ext_nodes[i]->window.n_funcs; f++)
-                                if (g->ext_nodes[i]->window.func_inputs[f])
-                                    g->ext_nodes[i]->window.func_inputs[f] =
-                                        (ray_op_t*)((char*)g->ext_nodes[i]->window.func_inputs[f] + delta);
-                            break;
-                        default:
-                            break;
-                    }
-                }
-            }
-        }
-    }
-    ray_op_t* n = &g->nodes[g->node_count];
-    memset(n, 0, sizeof(ray_op_t));
-    n->id = g->node_count;
-    g->node_count++;
-    return n;
+    return graph_alloc_node(g);
 }
 
 /* Count how many live nodes use node_id as an input.
@@ -1151,7 +1057,7 @@ static int count_node_consumers(ray_graph_t* g, uint32_t node_id) {
         ray_op_t* c = &g->nodes[j];
         if (c->flags & OP_FLAG_DEAD) continue;
         for (int k = 0; k < c->arity && k < 2; k++) {
-            if (c->inputs[k] && c->inputs[k]->id == node_id) {
+            if (c->in_id[k] == node_id) {
                 count++;
                 break;  /* count each consumer node once */
             }
@@ -1163,7 +1069,7 @@ static int count_node_consumers(ray_graph_t* g, uint32_t node_id) {
         if (c->flags & OP_FLAG_DEAD) continue;
         if (c->id < nc) continue;  /* already counted in nodes[] */
         for (int k = 0; k < c->arity && k < 2; k++) {
-            if (c->inputs[k] && c->inputs[k]->id == node_id) {
+            if (c->in_id[k] == node_id) {
                 count++;
                 break;
             }
@@ -1210,9 +1116,9 @@ static int collect_pred_scans(ray_graph_t* g, ray_op_t* pred,
             continue;
         }
         for (int i = 0; i < node->arity && i < 2; i++) {
-            if (node->inputs[i]) {
+            if (op_child(g, node, i)) {
                 if (sp >= 64) return -1;  /* stack overflow */
-                stack[sp++] = node->inputs[i]->id;
+                stack[sp++] = node->in_id[i];
             }
         }
         /* Walk ext-stored operands for multi-input ops */
@@ -1222,7 +1128,7 @@ static int collect_pred_scans(ray_graph_t* g, ray_op_t* pred,
                 case OP_IF:
                 case OP_SUBSTR:
                 case OP_REPLACE: {
-                    uint32_t third_id = (uint32_t)(uintptr_t)ext->literal;
+                    uint32_t third_id = ext->third_in;
                     if (third_id < nc && !visited[third_id]) {
                         if (sp >= 64) return -1;
                         stack[sp++] = third_id;
@@ -1274,8 +1180,8 @@ static bool is_reachable_from(ray_graph_t* g, ray_op_t* start, uint32_t target_i
         ray_op_t* node = &g->nodes[nid];
         if (node->flags & OP_FLAG_DEAD) continue;
         for (int i = 0; i < node->arity && i < 2; i++) {
-            if (node->inputs[i] && sp < 64)
-                stack[sp++] = node->inputs[i]->id;
+            if (op_child(g, node, i) && sp < 64)
+                stack[sp++] = node->in_id[i];
         }
         /* Walk ext-stored operands for multi-input ops */
         ray_op_ext_t* ext = find_ext(g, nid);
@@ -1284,7 +1190,7 @@ static bool is_reachable_from(ray_graph_t* g, ray_op_t* start, uint32_t target_i
                 case OP_IF:
                 case OP_SUBSTR:
                 case OP_REPLACE: {
-                    uint32_t third_id = (uint32_t)(uintptr_t)ext->literal;
+                    uint32_t third_id = ext->third_in;
                     if (third_id < nc && !visited[third_id] && sp < 64)
                         stack[sp++] = third_id;
                     break;
@@ -1310,7 +1216,7 @@ static bool is_reachable_from(ray_graph_t* g, ray_op_t* start, uint32_t target_i
 
 /* Redirect all consumers of old_id to point to new_target instead.
  * Skips nodes with IDs skip_a and skip_b (the swapped pair).
- * Updates both g->nodes[] and g->ext_nodes[].base.inputs[]. */
+ * Updates both g->nodes[] and g->ext_nodes[].base.in_id[]. */
 void redirect_consumers(ray_graph_t* g, uint32_t old_id,
                         ray_op_t* new_target,
                         uint32_t skip_a, uint32_t skip_b) {
@@ -1319,8 +1225,8 @@ void redirect_consumers(ray_graph_t* g, uint32_t old_id,
         ray_op_t* c = &g->nodes[j];
         if (c->flags & OP_FLAG_DEAD || j == skip_a || j == skip_b) continue;
         for (int k = 0; k < c->arity && k < 2; k++) {
-            if (c->inputs[k] && c->inputs[k]->id == old_id)
-                c->inputs[k] = new_target;
+            if (c->in_id[k] == old_id)
+                c->in_id[k] = new_target ? new_target->id : RAY_OP_NONE;
         }
     }
     /* Also update ext_node heap copies to keep them in sync */
@@ -1330,8 +1236,8 @@ void redirect_consumers(ray_graph_t* g, uint32_t old_id,
         if (c->flags & OP_FLAG_DEAD) continue;
         if (c->id == skip_a || c->id == skip_b) continue;
         for (int k = 0; k < c->arity && k < 2; k++) {
-            if (c->inputs[k] && c->inputs[k]->id == old_id)
-                c->inputs[k] = new_target;
+            if (c->in_id[k] == old_id)
+                c->in_id[k] = new_target ? new_target->id : RAY_OP_NONE;
         }
     }
 }
@@ -1349,8 +1255,8 @@ static ray_op_t* pass_predicate_pushdown(ray_graph_t* g, ray_op_t* root) {
             if (n->flags & OP_FLAG_DEAD) continue;
             if (n->opcode != OP_FILTER || n->arity != 2) continue;
 
-            ray_op_t* child = n->inputs[0];
-            ray_op_t* pred  = n->inputs[1];
+            ray_op_t* child = op_child(g, n, 0);
+            ray_op_t* pred  = op_child(g, n, 1);
             if (!child || !pred) continue;
 
             /* Push past SELECT/ALIAS (only if child is single-consumer,
@@ -1359,9 +1265,9 @@ static ray_op_t* pass_predicate_pushdown(ray_graph_t* g, ray_op_t* root) {
                 child->opcode == OP_ALIAS) {
                 if (count_node_consumers(g, child->id) > 1) continue;
                 /* Swap: FILTER(pred, SELECT(x)) -> SELECT(FILTER(pred, x)) */
-                ray_op_t* proj_input = child->inputs[0];
-                n->inputs[0] = proj_input;
-                child->inputs[0] = n;
+                ray_op_t* proj_input = op_child(g, child, 0);
+                n->in_id[0] = proj_input ? proj_input->id : RAY_OP_NONE;
+                child->in_id[0] = n->id;
                 redirect_consumers(g, n->id, child, child->id, n->id);
                 if (n->id == root->id) root = child;
                 changed = true;
@@ -1382,7 +1288,8 @@ static ray_op_t* pass_predicate_pushdown(ray_graph_t* g, ray_op_t* root) {
                 ray_op_ext_t* gext = find_ext(g, child->id);
                 if (!gext || gext->n_keys == 0) continue;
                 /* one pushed filter per GROUP (chained HAVING stays above) */
-                if (child->inputs[0] && child->inputs[0]->opcode == OP_FILTER)
+                ray_op_t* child_in0 = op_child(g, child, 0);
+                if (child_in0 && child_in0->opcode == OP_FILTER)
                     continue;
                 /* factorized-expand pipeline (key `_src`) reads the expand
                  * output, not g->table — never push into it */
@@ -1390,8 +1297,8 @@ static ray_op_t* pass_predicate_pushdown(ray_graph_t* g, ray_op_t* root) {
                     int64_t src_sym = ray_sym_intern("_src", 4);
                     bool is_fact = false;
                     for (uint8_t kk = 0; kk < gext->n_keys; kk++) {
-                        ray_op_ext_t* ke = gext->keys[kk]
-                            ? find_ext(g, gext->keys[kk]->id) : NULL;
+                        ray_op_ext_t* ke = op_node(g, gext->keys[kk])
+                            ? find_ext(g, gext->keys[kk]) : NULL;
                         if (ke && ke->base.opcode == OP_SCAN &&
                             ke->sym == src_sym) { is_fact = true; break; }
                     }
@@ -1406,9 +1313,9 @@ static ray_op_t* pass_predicate_pushdown(ray_graph_t* g, ray_op_t* root) {
                     if (!sext) { keys_only = false; break; }
                     bool matched = false;
                     for (uint8_t kk = 0; kk < gext->n_keys; kk++) {
-                        ray_op_t* kop = gext->keys[kk];
+                        ray_op_t* kop = op_node(g, gext->keys[kk]);
                         if (!kop || kop->opcode != OP_SCAN) continue;
-                        ray_op_ext_t* kext = find_ext(g, kop->id);
+                        ray_op_ext_t* kext = find_ext(g, gext->keys[kk]);
                         if (kext && kext->sym == sext->sym) { matched = true; break; }
                     }
                     if (!matched) keys_only = false;
@@ -1437,15 +1344,15 @@ static ray_op_t* pass_predicate_pushdown(ray_graph_t* g, ray_op_t* root) {
                 child = &g->nodes[child_id];
                 gext  = find_ext(g, child_id);
                 if (!gext) continue;
-                n->inputs[0] = tbl_node;
+                n->in_id[0] = tbl_node->id;
                 /* Mark the interposed filter so pass_filter_reorder leaves
                  * it alone: GROUP's arity is 0, so redirect_consumers would
                  * never re-point GROUP->inputs[0] at a split-off outer
                  * filter — an AND-split below the group silently drops a
                  * conjunct.  (OP_FILTER is dense-only; no ext copy.) */
                 n->flags |= OP_FLAG_PUSHED;
-                child->inputs[0] = n;        /* dense copy */
-                gext->base.inputs[0] = n;    /* ext copy in sync */
+                child->in_id[0] = n->id;        /* dense copy */
+                gext->base.in_id[0] = n->id;    /* ext copy in sync */
                 redirect_consumers(g, n_id, child, child_id, n_id);
                 if (n_id == root_id) root = child;
                 changed = true;
@@ -1461,7 +1368,7 @@ static ray_op_t* pass_predicate_pushdown(ray_graph_t* g, ray_op_t* root) {
 
                 /* All predicate scans must be reachable from the expand's
                  * source input (inputs[0]).  Walk the source subtree. */
-                ray_op_t* expand_src_tree = child->inputs[0];
+                ray_op_t* expand_src_tree = op_child(g, child, 0);
                 bool all_source = true;
                 for (int s = 0; s < n_scans; s++) {
                     if (!is_reachable_from(g, expand_src_tree, scan_ids[s])) {
@@ -1472,9 +1379,9 @@ static ray_op_t* pass_predicate_pushdown(ray_graph_t* g, ray_op_t* root) {
                 if (!all_source) continue;
 
                 /* Swap: FILTER(pred, EXPAND(src, rel)) -> EXPAND(FILTER(pred, src), rel) */
-                ray_op_t* expand_src = child->inputs[0];
-                n->inputs[0] = expand_src;
-                child->inputs[0] = n;
+                ray_op_t* expand_src = op_child(g, child, 0);
+                n->in_id[0] = expand_src ? expand_src->id : RAY_OP_NONE;
+                child->in_id[0] = n->id;
                 redirect_consumers(g, n->id, child, child->id, n->id);
                 if (n->id == root->id) root = child;
                 changed = true;
@@ -1488,22 +1395,23 @@ static ray_op_t* pass_predicate_pushdown(ray_graph_t* g, ray_op_t* root) {
 
 /* Score a predicate subtree: lower = cheaper = execute first. */
 static int filter_cost(ray_graph_t* g, ray_op_t* pred) {
-    (void)g;
     if (!pred) return 99;
     int cost = 0;
 
     /* Constant comparison: one input is OP_CONST */
     bool has_const = false;
     for (int i = 0; i < pred->arity && i < 2; i++) {
-        if (pred->inputs[i] && pred->inputs[i]->opcode == OP_CONST)
+        ray_op_t* in = op_child(g, pred, i);
+        if (in && in->opcode == OP_CONST)
             has_const = true;
     }
     if (!has_const) cost += 4;  /* col-col comparison */
 
     /* Type width cost */
     int8_t t = pred->out_type;
-    if (pred->arity >= 1 && pred->inputs[0])
-        t = pred->inputs[0]->out_type;
+    ray_op_t* pin0 = op_child(g, pred, 0);
+    if (pred->arity >= 1 && pin0)
+        t = pin0->out_type;
     switch (t) {
         case RAY_BOOL: case RAY_U8:  cost += 0; break;
         case RAY_I16:               cost += 1; break;
@@ -1529,12 +1437,12 @@ static ray_op_t* split_and_filter(ray_graph_t* g, ray_op_t* filter_node) {
     if (!filter_node || filter_node->opcode != OP_FILTER) return filter_node;
     if (filter_node->arity != 2) return filter_node;
 
-    ray_op_t* pred = filter_node->inputs[1];
+    ray_op_t* pred = op_child(g, filter_node, 1);
     if (!pred || pred->opcode != OP_AND || pred->arity != 2) return filter_node;
 
-    ray_op_t* pred_a = pred->inputs[0];
-    ray_op_t* pred_b = pred->inputs[1];
-    ray_op_t* input  = filter_node->inputs[0];
+    ray_op_t* pred_a = op_child(g, pred, 0);
+    ray_op_t* pred_b = op_child(g, pred, 1);
+    ray_op_t* input  = op_child(g, filter_node, 0);
     if (!pred_a || !pred_b || !input) return filter_node;
 
     /* Don't split a FILTER whose child is a GROUP.  Splitting an AND here
@@ -1560,12 +1468,12 @@ static ray_op_t* split_and_filter(ray_graph_t* g, ray_op_t* filter_node) {
     pred_b = &g->nodes[pred_b_id];
 
     /* Rewrite: filter_node becomes FILTER(pred_a, input) */
-    filter_node->inputs[1] = pred_a;
+    filter_node->in_id[1] = pred_a->id;
 
     outer->opcode = OP_FILTER;
     outer->arity = 2;
-    outer->inputs[0] = filter_node;
-    outer->inputs[1] = pred_b;
+    outer->in_id[0] = filter_node->id;
+    outer->in_id[1] = pred_b->id;
     outer->out_type = filter_node->out_type;
     outer->est_rows = filter_node->est_rows;
 
@@ -1578,13 +1486,13 @@ static ray_op_t* split_and_filter(ray_graph_t* g, ray_op_t* filter_node) {
  * chain.  (Pushed filters sit below GROUP with a const-table input, so
  * they can't normally appear inside an above-group chain — this is a
  * defensive stop.) */
-static int collect_filter_chain(ray_op_t* top, ray_op_t** chain, int max) {
+static int collect_filter_chain(ray_graph_t* g, ray_op_t* top, ray_op_t** chain, int max) {
     int n = 0;
     ray_op_t* cur = top;
     while (cur && cur->opcode == OP_FILTER &&
            !(cur->flags & OP_FLAG_PUSHED) && n < max) {
         chain[n++] = cur;
-        cur = cur->inputs[0];
+        cur = op_child(g, cur, 0);
     }
     return n;
 }
@@ -1613,8 +1521,9 @@ static ray_op_t* pass_filter_reorder(ray_graph_t* g, ray_op_t* root) {
              * dropped — and would also cost two rowsel passes instead
              * of one. */
             if (n->flags & OP_FLAG_PUSHED) continue;
-            if (n->arity != 2 || !n->inputs[1]) continue;
-            if (n->inputs[1]->opcode != OP_AND) continue;
+            ray_op_t* n_in1 = op_child(g, n, 1);
+            if (n->arity != 2 || !n_in1) continue;
+            if (n_in1->opcode != OP_AND) continue;
 
             /* Split AND and update consumers to point to new outer.
              * split_and_filter may realloc g->nodes, so re-fetch n afterwards. */
@@ -1655,7 +1564,7 @@ static ray_op_t* pass_filter_reorder(ray_graph_t* g, ray_op_t* root) {
 
         /* Collect the filter chain starting at this node */
         ray_op_t* chain[64];
-        int chain_len = collect_filter_chain(n, chain, 64);
+        int chain_len = collect_filter_chain(g, n, chain, 64);
         if (chain_len < 2) {
             for (int c = 0; c < chain_len; c++) visited[chain[c]->id] = true;
             continue;
@@ -1678,22 +1587,22 @@ static ray_op_t* pass_filter_reorder(ray_graph_t* g, ray_op_t* root) {
         /* Score each filter's predicate */
         int costs[64];
         for (int c = 0; c < chain_len; c++)
-            costs[c] = filter_cost(g, chain[c]->inputs[1]);
+            costs[c] = filter_cost(g, op_child(g, chain[c], 1));
 
         /* Insertion sort predicates by cost descending (stable: preserves
          * original order for equal costs). Expensive predicates go to
          * chain[0] (outer, runs last), cheap go to chain[N-1] (inner,
          * runs first). We swap predicates, not filter nodes. */
         for (int c = 1; c < chain_len; c++) {
-            ray_op_t* pred = chain[c]->inputs[1];
+            uint32_t pred_id = chain[c]->in_id[1];
             int cost = costs[c];
             int j = c - 1;
             while (j >= 0 && costs[j] < cost) {
-                chain[j + 1]->inputs[1] = chain[j]->inputs[1];
+                chain[j + 1]->in_id[1] = chain[j]->in_id[1];
                 costs[j + 1] = costs[j];
                 j--;
             }
-            chain[j + 1]->inputs[1] = pred;
+            chain[j + 1]->in_id[1] = pred_id;
             costs[j + 1] = cost;
         }
     }
@@ -1732,9 +1641,9 @@ static bool pass_projection_pushdown(ray_graph_t* g, ray_op_t* root) {
 
         /* Follow standard inputs */
         for (int i = 0; i < 2 && i < n->arity; i++) {
-            if (n->inputs[i] && !live[n->inputs[i]->id]) {
-                live[n->inputs[i]->id] = true;
-                if (qt < (int)nc) q[qt++] = n->inputs[i]->id;
+            if (op_child(g, n, i) && !live[n->in_id[i]]) {
+                live[n->in_id[i]] = true;
+                if (qt < (int)nc) q[qt++] = n->in_id[i];
             }
         }
 
@@ -1744,48 +1653,48 @@ static bool pass_projection_pushdown(ray_graph_t* g, ray_op_t* root) {
             switch (n->opcode) {
                 case OP_GROUP:
                     for (uint8_t k = 0; k < ext->n_keys; k++)
-                        if (ext->keys[k] && !live[ext->keys[k]->id]) {
-                            live[ext->keys[k]->id] = true;
-                            if (qt < (int)nc) q[qt++] = ext->keys[k]->id;
+                        if (op_node(g, ext->keys[k]) && !live[ext->keys[k]]) {
+                            live[ext->keys[k]] = true;
+                            if (qt < (int)nc) q[qt++] = ext->keys[k];
                         }
                     for (uint8_t a = 0; a < ext->n_aggs; a++)
-                        if (ext->agg_ins[a] && !live[ext->agg_ins[a]->id]) {
-                            live[ext->agg_ins[a]->id] = true;
-                            if (qt < (int)nc) q[qt++] = ext->agg_ins[a]->id;
+                        if (op_node(g, ext->agg_ins[a]) && !live[ext->agg_ins[a]]) {
+                            live[ext->agg_ins[a]] = true;
+                            if (qt < (int)nc) q[qt++] = ext->agg_ins[a];
                         }
                     break;
                 case OP_SORT:
                 case OP_SELECT:
                     for (uint8_t k = 0; k < ext->sort.n_cols; k++)
-                        if (ext->sort.columns[k] && !live[ext->sort.columns[k]->id]) {
-                            live[ext->sort.columns[k]->id] = true;
-                            if (qt < (int)nc) q[qt++] = ext->sort.columns[k]->id;
+                        if (op_node(g, ext->sort.columns[k]) && !live[ext->sort.columns[k]]) {
+                            live[ext->sort.columns[k]] = true;
+                            if (qt < (int)nc) q[qt++] = ext->sort.columns[k];
                         }
                     break;
                 case OP_JOIN:
                     for (uint8_t k = 0; k < ext->join.n_join_keys; k++) {
-                        if (ext->join.left_keys[k] && !live[ext->join.left_keys[k]->id]) {
-                            live[ext->join.left_keys[k]->id] = true;
-                            if (qt < (int)nc) q[qt++] = ext->join.left_keys[k]->id;
+                        if (op_node(g, ext->join.left_keys[k]) && !live[ext->join.left_keys[k]]) {
+                            live[ext->join.left_keys[k]] = true;
+                            if (qt < (int)nc) q[qt++] = ext->join.left_keys[k];
                         }
-                        if (ext->join.right_keys && ext->join.right_keys[k] &&
-                            !live[ext->join.right_keys[k]->id]) {
-                            live[ext->join.right_keys[k]->id] = true;
-                            if (qt < (int)nc) q[qt++] = ext->join.right_keys[k]->id;
+                        if (ext->join.right_keys && op_node(g, ext->join.right_keys[k]) &&
+                            !live[ext->join.right_keys[k]]) {
+                            live[ext->join.right_keys[k]] = true;
+                            if (qt < (int)nc) q[qt++] = ext->join.right_keys[k];
                         }
                     }
                     break;
                 case OP_WINDOW_JOIN: {
                     ray_op_ext_t* wj_ext = find_ext(g, n->id);
                     if (wj_ext) {
-                        if (wj_ext->asof.time_key && !live[wj_ext->asof.time_key->id]) {
-                            live[wj_ext->asof.time_key->id] = true;
-                            if (qt < (int)nc) q[qt++] = wj_ext->asof.time_key->id;
+                        if (op_node(g, wj_ext->asof.time_key) && !live[wj_ext->asof.time_key]) {
+                            live[wj_ext->asof.time_key] = true;
+                            if (qt < (int)nc) q[qt++] = wj_ext->asof.time_key;
                         }
                         for (uint8_t k = 0; k < wj_ext->asof.n_eq_keys; k++) {
-                            if (wj_ext->asof.eq_keys[k] && !live[wj_ext->asof.eq_keys[k]->id]) {
-                                live[wj_ext->asof.eq_keys[k]->id] = true;
-                                if (qt < (int)nc) q[qt++] = wj_ext->asof.eq_keys[k]->id;
+                            if (op_node(g, wj_ext->asof.eq_keys[k]) && !live[wj_ext->asof.eq_keys[k]]) {
+                                live[wj_ext->asof.eq_keys[k]] = true;
+                                if (qt < (int)nc) q[qt++] = wj_ext->asof.eq_keys[k];
                             }
                         }
                     }
@@ -1793,25 +1702,25 @@ static bool pass_projection_pushdown(ray_graph_t* g, ray_op_t* root) {
                 }
                 case OP_WINDOW:
                     for (uint8_t k = 0; k < ext->window.n_part_keys; k++)
-                        if (ext->window.part_keys[k] && !live[ext->window.part_keys[k]->id]) {
-                            live[ext->window.part_keys[k]->id] = true;
-                            if (qt < (int)nc) q[qt++] = ext->window.part_keys[k]->id;
+                        if (op_node(g, ext->window.part_keys[k]) && !live[ext->window.part_keys[k]]) {
+                            live[ext->window.part_keys[k]] = true;
+                            if (qt < (int)nc) q[qt++] = ext->window.part_keys[k];
                         }
                     for (uint8_t k = 0; k < ext->window.n_order_keys; k++)
-                        if (ext->window.order_keys[k] && !live[ext->window.order_keys[k]->id]) {
-                            live[ext->window.order_keys[k]->id] = true;
-                            if (qt < (int)nc) q[qt++] = ext->window.order_keys[k]->id;
+                        if (op_node(g, ext->window.order_keys[k]) && !live[ext->window.order_keys[k]]) {
+                            live[ext->window.order_keys[k]] = true;
+                            if (qt < (int)nc) q[qt++] = ext->window.order_keys[k];
                         }
                     for (uint8_t f = 0; f < ext->window.n_funcs; f++)
-                        if (ext->window.func_inputs[f] && !live[ext->window.func_inputs[f]->id]) {
-                            live[ext->window.func_inputs[f]->id] = true;
-                            if (qt < (int)nc) q[qt++] = ext->window.func_inputs[f]->id;
+                        if (op_node(g, ext->window.func_inputs[f]) && !live[ext->window.func_inputs[f]]) {
+                            live[ext->window.func_inputs[f]] = true;
+                            if (qt < (int)nc) q[qt++] = ext->window.func_inputs[f];
                         }
                     break;
                 case OP_IF:
                 case OP_SUBSTR:
                 case OP_REPLACE: {
-                    uint32_t third_id = (uint32_t)(uintptr_t)ext->literal;
+                    uint32_t third_id = ext->third_in;
                     if (third_id < nc && !live[third_id]) {
                         live[third_id] = true;
                         if (qt < (int)nc) q[qt++] = third_id;
@@ -1863,7 +1772,7 @@ static void pass_partition_pruning(ray_graph_t* g, ray_op_t* root) {
         if (n->flags & OP_FLAG_DEAD) continue;
         if (n->opcode != OP_FILTER || n->arity != 2) continue;
 
-        ray_op_t* pred = n->inputs[1];
+        ray_op_t* pred = op_child(g, n, 1);
         if (!pred || pred->arity != 2) continue;
 
         uint16_t cmp_op = pred->opcode;
@@ -1872,8 +1781,8 @@ static void pass_partition_pruning(ray_graph_t* g, ray_op_t* root) {
             cmp_op != OP_LE && cmp_op != OP_GE &&
             cmp_op != OP_IN && cmp_op != OP_NOT_IN) continue;
 
-        ray_op_t* lhs = pred->inputs[0];
-        ray_op_t* rhs = pred->inputs[1];
+        ray_op_t* lhs = op_child(g, pred, 0);
+        ray_op_t* rhs = op_child(g, pred, 1);
         if (!lhs || !rhs) continue;
 
         ray_op_t* scan_node = NULL;

--- a/src/ops/pivot.c
+++ b/src/ops/pivot.c
@@ -64,13 +64,13 @@ static inline int64_t sym_scalar_runtime_id(ray_t* v) {
  * ============================================================================ */
 
 ray_t* exec_if(ray_graph_t* g, ray_op_t* op) {
-    /* cond = inputs[0], then = inputs[1], else_id stored in ext->literal */
-    ray_t* cond_v = exec_node(g, op->inputs[0]);
-    ray_t* then_v = exec_node(g, op->inputs[1]);
+    /* cond = inputs[0], then = inputs[1], else_id stored in ext->third_in */
+    ray_t* cond_v = exec_node(g, op_child(g, op, 0));
+    ray_t* then_v = exec_node(g, op_child(g, op, 1));
 
     ray_op_ext_t* ext = find_ext(g, op->id);
-    uint32_t else_id = (uint32_t)(uintptr_t)ext->literal;
-    ray_t* else_v = exec_node(g, &g->nodes[else_id]);
+    uint32_t else_id = ext->third_in;
+    ray_t* else_v = exec_node(g, op_node(g, else_id));
 
     if (!cond_v || RAY_IS_ERR(cond_v)) {
         if (then_v && !RAY_IS_ERR(then_v)) ray_release(then_v);
@@ -277,18 +277,18 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     /* Resolve input columns */
     ray_t* idx_vecs[16];
     for (uint8_t i = 0; i < n_idx; i++) {
-        ray_op_ext_t* ie = find_ext(g, ext->pivot.index_cols[i]->id);
+        ray_op_ext_t* ie = find_ext(g, ext->pivot.index_cols[i]);
         idx_vecs[i] = (ie && ie->base.opcode == OP_SCAN)
                      ? ray_table_get_col(tbl, ie->sym) : NULL;
         if (!idx_vecs[i]) return ray_error("domain", "pivot: index column not found");
     }
 
-    ray_op_ext_t* pe = find_ext(g, ext->pivot.pivot_col->id);
+    ray_op_ext_t* pe = find_ext(g, ext->pivot.pivot_col);
     ray_t* pcol = (pe && pe->base.opcode == OP_SCAN)
                 ? ray_table_get_col(tbl, pe->sym) : NULL;
     if (!pcol) return ray_error("domain", "pivot: pivot column not found");
 
-    ray_op_ext_t* ve = find_ext(g, ext->pivot.value_col->id);
+    ray_op_ext_t* ve = find_ext(g, ext->pivot.value_col);
     ray_t* vcol = (ve && ve->base.opcode == OP_SCAN)
                 ? ray_table_get_col(tbl, ve->sym) : NULL;
     if (!vcol) return ray_error("domain", "pivot: value column not found");
@@ -589,7 +589,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
         if (new_col->type == RAY_SYM)
             ray_sym_vec_adopt_domain(new_col, idx_vecs[k]);
 
-        ray_op_ext_t* ie = find_ext(g, ext->pivot.index_cols[k]->id);
+        ray_op_ext_t* ie = find_ext(g, ext->pivot.index_cols[k]);
         result = ray_table_add_col(result, ie->sym, new_col);
         ray_release(new_col);
         if (RAY_IS_ERR(result)) goto pivot_cleanup;

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -3921,8 +3921,10 @@ ray_t* ray_try_count_select_expr(ray_t* expr, int* handled) {
     while (sp > 0) {
         ray_op_t* cur = stk[--sp];
         if (cur->opcode == OP_SCAN) { has_scan = 1; break; }
-        for (uint8_t a = 0; a < cur->arity && sp < 64; a++)
-            if (cur->inputs[a]) stk[sp++] = cur->inputs[a];
+        for (uint8_t a = 0; a < cur->arity && sp < 64; a++) {
+            ray_op_t* ch = op_child(g, cur, a);
+            if (ch) stk[sp++] = ch;
+        }
     }
     if (!has_scan) {
         ray_graph_free(g);
@@ -4796,8 +4798,10 @@ by_dict_done:
                                 reorder_safe = 0;
                                 break;
                             }
-                            for (uint8_t a = 0; a < cur->arity && sp < 64; a++)
-                                if (cur->inputs[a]) stk[sp++] = cur->inputs[a];
+                            for (uint8_t a = 0; a < cur->arity && sp < 64; a++) {
+                                ray_op_t* ch = op_child(g, cur, a);
+                                if (ch) stk[sp++] = ch;
+                            }
                         }
                         if (!has_scan) { all_ok = 0; break; }
                         compiled[i] = p;

--- a/src/ops/sort.c
+++ b/src/ops/sort.c
@@ -3351,7 +3351,7 @@ ray_t* exec_sort(ray_graph_t* g, ray_op_t* op, ray_t* tbl, int64_t limit) {
         ray_t* key_cols[16];
         int    all_scan = 1;
         for (uint8_t k = 0; k < n_sort; k++) {
-            ray_op_t* key_op = ext->sort.columns[k];
+            ray_op_t* key_op = op_node(g, ext->sort.columns[k]);
             ray_op_ext_t* key_ext = find_ext(g, key_op->id);
             if (key_ext && key_ext->base.opcode == OP_SCAN) {
                 key_cols[k] = ray_table_get_col(tbl, key_ext->sym);
@@ -3396,7 +3396,7 @@ ray_t* exec_sort(ray_graph_t* g, ray_op_t* op, ray_t* tbl, int64_t limit) {
     memset(sort_owned, 0, n_sort > 0 ? n_sort : 1);
 
     for (uint8_t k = 0; k < n_sort; k++) {
-        ray_op_t* key_op = ext->sort.columns[k];
+        ray_op_t* key_op = op_node(g, ext->sort.columns[k]);
         ray_op_ext_t* key_ext = find_ext(g, key_op->id);
         if (key_ext && key_ext->base.opcode == OP_SCAN) {
             sort_vecs[k] = ray_table_get_col(tbl, key_ext->sym);
@@ -3550,7 +3550,7 @@ sort_idx_ready:;
                         sk0_type == RAY_I16);
     int64_t sort_key_sym = -1;
     if (sorted_keys && n_sort == 1 && !RAY_IS_SYM(sk0_type) && !sk0_shifted) {
-        ray_op_ext_t* key_ext = find_ext(g, ext->sort.columns[0]->id);
+        ray_op_ext_t* key_ext = find_ext(g, ext->sort.columns[0]);
         if (key_ext && key_ext->base.opcode == OP_SCAN)
             sort_key_sym = key_ext->sym;
     }

--- a/src/ops/string.c
+++ b/src/ops/string.c
@@ -558,8 +558,8 @@ static ray_t* exec_like_input(ray_graph_t* g, ray_op_t* input_op) {
 }
 
 ray_t* exec_like(ray_graph_t* g, ray_op_t* op) {
-    ray_t* input = exec_like_input(g, op->inputs[0]);
-    ray_t* pat_v = exec_node(g, op->inputs[1]);
+    ray_t* input = exec_like_input(g, op_child(g, op, 0));
+    ray_t* pat_v = exec_node(g, op_child(g, op, 1));
     if (!input || RAY_IS_ERR(input)) { if (pat_v && !RAY_IS_ERR(pat_v)) ray_release(pat_v); return input; }
     if (!pat_v || RAY_IS_ERR(pat_v)) { ray_release(input); return pat_v; }
 
@@ -749,8 +749,8 @@ ray_t* exec_like(ray_graph_t* g, ray_op_t* op) {
 /* Case-insensitive LIKE — same syntax as `like`, ASCII-fold both sides. */
 
 ray_t* exec_ilike(ray_graph_t* g, ray_op_t* op) {
-    ray_t* input = exec_node(g, op->inputs[0]);
-    ray_t* pat_v = exec_node(g, op->inputs[1]);
+    ray_t* input = exec_node(g, op_child(g, op, 0));
+    ray_t* pat_v = exec_node(g, op_child(g, op, 1));
     if (!input || RAY_IS_ERR(input)) { if (pat_v && !RAY_IS_ERR(pat_v)) ray_release(pat_v); return input; }
     if (!pat_v || RAY_IS_ERR(pat_v)) { ray_release(input); return pat_v; }
 
@@ -838,7 +838,7 @@ ray_t* exec_ilike(ray_graph_t* g, ray_op_t* op) {
 
 /* UPPER / LOWER / TRIM — unary SYM/STR → SYM/STR */
 ray_t* exec_string_unary(ray_graph_t* g, ray_op_t* op) {
-    ray_t* input = exec_node(g, op->inputs[0]);
+    ray_t* input = exec_node(g, op_child(g, op, 0));
     if (!input || RAY_IS_ERR(input)) return input;
 
     int64_t len = input->len;
@@ -920,7 +920,7 @@ ray_t* exec_string_unary(ray_graph_t* g, ray_op_t* op) {
 
 /* LENGTH — SYM → I64 */
 ray_t* exec_strlen(ray_graph_t* g, ray_op_t* op) {
-    ray_t* input = exec_node(g, op->inputs[0]);
+    ray_t* input = exec_node(g, op_child(g, op, 0));
     if (!input || RAY_IS_ERR(input)) return input;
 
     int64_t len = input->len;
@@ -958,15 +958,14 @@ ray_t* exec_strlen(ray_graph_t* g, ray_op_t* op) {
 
 /* SUBSTR(str, start, len) — 1-based start */
 ray_t* exec_substr(ray_graph_t* g, ray_op_t* op) {
-    ray_t* input = exec_node(g, op->inputs[0]);
-    ray_t* start_v = exec_node(g, op->inputs[1]);
+    ray_t* input = exec_node(g, op_child(g, op, 0));
+    ray_t* start_v = exec_node(g, op_child(g, op, 1));
     if (!input || RAY_IS_ERR(input)) { if (start_v && !RAY_IS_ERR(start_v)) ray_release(start_v); return input; }
     if (!start_v || RAY_IS_ERR(start_v)) { ray_release(input); return start_v; }
 
-    /* Get len arg from ext node's literal field */
+    /* Get len arg from ext node's third input id */
     ray_op_ext_t* ext = find_ext(g, op->id);
-    uint32_t len_id = (uint32_t)(uintptr_t)ext->literal;
-    ray_t* len_v = exec_node(g, &g->nodes[len_id]);
+    ray_t* len_v = exec_node(g, op_node(g, ext->third_in));
     if (!len_v || RAY_IS_ERR(len_v)) { ray_release(input); ray_release(start_v); return len_v; }
 
     int64_t nrows = input->len;
@@ -1065,14 +1064,13 @@ ray_t* exec_substr(ray_graph_t* g, ray_op_t* op) {
 
 /* REPLACE(str, from, to) */
 ray_t* exec_replace(ray_graph_t* g, ray_op_t* op) {
-    ray_t* input = exec_node(g, op->inputs[0]);
-    ray_t* from_v = exec_node(g, op->inputs[1]);
+    ray_t* input = exec_node(g, op_child(g, op, 0));
+    ray_t* from_v = exec_node(g, op_child(g, op, 1));
     if (!input || RAY_IS_ERR(input)) { if (from_v && !RAY_IS_ERR(from_v)) ray_release(from_v); return input; }
     if (!from_v || RAY_IS_ERR(from_v)) { ray_release(input); return from_v; }
 
     ray_op_ext_t* ext = find_ext(g, op->id);
-    uint32_t to_id = (uint32_t)(uintptr_t)ext->literal;
-    ray_t* to_v = exec_node(g, &g->nodes[to_id]);
+    ray_t* to_v = exec_node(g, op_node(g, ext->third_in));
     if (!to_v || RAY_IS_ERR(to_v)) { ray_release(input); ray_release(from_v); return to_v; }
 
     /* from_v and to_v should be string constants (SYM atoms) */
@@ -1185,8 +1183,8 @@ ray_t* exec_concat(ray_graph_t* g, ray_op_t* op) {
         if (!args) return ray_error("oom", NULL);
     }
 
-    args[0] = exec_node(g, op->inputs[0]);
-    args[1] = exec_node(g, op->inputs[1]);
+    args[0] = exec_node(g, op_child(g, op, 0));
+    args[1] = exec_node(g, op_child(g, op, 1));
     uint32_t* trail = (uint32_t*)((char*)(ext + 1));
     for (int i = 2; i < n_args; i++) {
         args[i] = exec_node(g, &g->nodes[trail[i - 2]]);

--- a/src/ops/temporal.c
+++ b/src/ops/temporal.c
@@ -336,7 +336,7 @@ ray_t* ray_temporal_truncate(ray_t* input, int kind) {
  * ============================================================================ */
 
 ray_t* exec_extract(ray_graph_t* g, ray_op_t* op) {
-    ray_t* input = exec_node(g, op->inputs[0]);
+    ray_t* input = exec_node(g, op_child(g, op, 0));
     if (!input || RAY_IS_ERR(input)) return input;
 
     ray_op_ext_t* ext = find_ext(g, op->id);
@@ -490,7 +490,7 @@ static int64_t days_from_civil(int64_t y, int64_t m, int64_t d) {
 }
 
 ray_t* exec_date_trunc(ray_graph_t* g, ray_op_t* op) {
-    ray_t* input = exec_node(g, op->inputs[0]);
+    ray_t* input = exec_node(g, op_child(g, op, 0));
     if (!input || RAY_IS_ERR(input)) return input;
 
     ray_op_ext_t* ext = find_ext(g, op->id);

--- a/src/ops/window.c
+++ b/src/ops/window.c
@@ -695,7 +695,7 @@ ray_t* exec_window(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     memset(sort_descs, 0, sizeof(sort_descs));
 
     for (uint8_t k = 0; k < n_part; k++) {
-        sort_vecs[k] = win_resolve_vec(g, ext->window.part_keys[k], tbl,
+        sort_vecs[k] = win_resolve_vec(g, op_node(g, ext->window.part_keys[k]), tbl,
                                         &sort_owned[k]);
         sort_descs[k] = 0;  /* partition keys always ASC */
         if (!sort_vecs[k] || RAY_IS_ERR(sort_vecs[k])) {
@@ -707,7 +707,7 @@ ray_t* exec_window(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
         }
     }
     for (uint8_t k = 0; k < n_order; k++) {
-        sort_vecs[n_part + k] = win_resolve_vec(g, ext->window.order_keys[k],
+        sort_vecs[n_part + k] = win_resolve_vec(g, op_node(g, ext->window.order_keys[k]),
                                                  tbl, &sort_owned[n_part + k]);
         sort_descs[n_part + k] = ext->window.order_descs[k];
         if (!sort_vecs[n_part + k] || RAY_IS_ERR(sort_vecs[n_part + k])) {
@@ -727,7 +727,7 @@ ray_t* exec_window(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     memset(func_owned, 0, sizeof(func_owned));
     memset(result_vecs, 0, sizeof(result_vecs));
     for (uint8_t f = 0; f < n_funcs; f++) {
-        ray_op_t* fi = ext->window.func_inputs[f];
+        ray_op_t* fi = op_node(g, ext->window.func_inputs[f]);
         if (fi) {
             func_vecs[f] = win_resolve_vec(g, fi, tbl, &func_owned[f]);
             if (!func_vecs[f] || RAY_IS_ERR(func_vecs[f])) {

--- a/test/test_group_pushdown.c
+++ b/test/test_group_pushdown.c
@@ -66,18 +66,16 @@ static ray_op_t* build_having_plan(ray_graph_t* g, gp_pred_builder_t pb,
 
 /* Plan-shape probe: pushed = root is GROUP with an OP_FILTER inputs[0]. */
 static bool plan_pushed(ray_graph_t* g, ray_op_t* root) {
-    (void)g;
     return root && root->opcode == OP_GROUP &&
-           root->inputs[0] && root->inputs[0]->opcode == OP_FILTER;
+           op_child(g, root, 0) && op_child(g, root, 0)->opcode == OP_FILTER;
 }
 
 /* Un-split HAVING shape: root is FILTER whose direct child is GROUP and whose
  * predicate is still an intact AND (the split would have made inputs[0] a FILTER). */
 static bool plan_having_unsplit(ray_graph_t* g, ray_op_t* root) {
-    (void)g;
     return root && root->opcode == OP_FILTER &&
-           root->inputs[0] && root->inputs[0]->opcode == OP_GROUP &&
-           root->inputs[1] && root->inputs[1]->opcode == OP_AND;
+           op_child(g, root, 0) && op_child(g, root, 0)->opcode == OP_GROUP &&
+           op_child(g, root, 1) && op_child(g, root, 1)->opcode == OP_AND;
 }
 
 /* Pred on the AGG OUTPUT column — HAVING proper; must never push.
@@ -151,7 +149,7 @@ static test_result_t test_and_split_non_group_still_splits(void) {
 
     /* Split still happens: root is the outer FILTER, its input another FILTER. */
     TEST_ASSERT(root && root->opcode == OP_FILTER, "root is FILTER");
-    TEST_ASSERT(root->inputs[0] && root->inputs[0]->opcode == OP_FILTER,
+    TEST_ASSERT(op_child(g, root, 0) && op_child(g, root, 0)->opcode == OP_FILTER,
         "non-GROUP AND-filter must still split into a chain");
 
     ray_graph_free(g); ray_release(tbl);
@@ -180,12 +178,12 @@ static test_result_t test_exec_group_with_pushed_filter(void) {
 
     /* Wire filt as GROUP's inputs[0] (Task-3 optimizer shape).
      * grp points into g->nodes[] — that's the live node exec_node sees. */
-    grp->inputs[0] = filt;
+    grp->in_id[0] = filt->id;
     ray_op_ext_t* gext = find_ext(g, grp->id);
     TEST_ASSERT(gext != NULL, "group ext");
-    gext->base.inputs[0] = filt;   /* keep ext copy in sync */
+    gext->base.in_id[0] = filt->id;   /* keep ext copy in sync */
     /* Dual-slot sync check */
-    TEST_ASSERT(grp->inputs[0] == gext->base.inputs[0], "dense/ext inputs in sync");
+    TEST_ASSERT(grp->in_id[0] == gext->base.in_id[0], "dense/ext inputs in sync");
 
     ray_t* r = ray_execute(g, grp);
     TEST_ASSERT_FALSE(RAY_IS_ERR(r));
@@ -215,7 +213,7 @@ static test_result_t test_having_on_key_pushed(void) {
     /* Dual-slot sync check after optimizer rewrite */
     ray_op_ext_t* gext = find_ext(g, root->id);
     TEST_ASSERT(gext != NULL, "group ext after push");
-    TEST_ASSERT(root->inputs[0] == gext->base.inputs[0], "dense/ext inputs in sync after push");
+    TEST_ASSERT(root->in_id[0] == gext->base.in_id[0], "dense/ext inputs in sync after push");
 
     ray_t* r = ray_execute(g, root);
     TEST_ASSERT_FALSE(RAY_IS_ERR(r));
@@ -661,17 +659,17 @@ static test_result_t test_diff_and_of_keys(void) {
             "AND-of-keys pred must push below GROUP (pass-6)");
 
         /* Plan-shape: root->inputs[0] is the pushed OP_FILTER, flagged. */
-        ray_op_t* f0 = root->inputs[0];
+        ray_op_t* f0 = op_child(g, root, 0);
         TEST_ASSERT(f0 != NULL && f0->opcode == OP_FILTER,
             "GROUP inputs[0] must be OP_FILTER");
         TEST_ASSERT(f0->flags & OP_FLAG_PUSHED,
             "pushed filter must carry OP_FLAG_PUSHED");
 
         /* The pred must still be the un-split AND … */
-        TEST_ASSERT(f0->inputs[1] != NULL && f0->inputs[1]->opcode == OP_AND,
+        TEST_ASSERT(op_child(g, f0, 1) != NULL && op_child(g, f0, 1)->opcode == OP_AND,
             "pushed filter pred must remain the un-split AND");
         /* … and the data input the const-table: chain depth 1, no split. */
-        TEST_ASSERT(f0->inputs[0] != NULL && f0->inputs[0]->opcode != OP_FILTER,
+        TEST_ASSERT(op_child(g, f0, 0) != NULL && op_child(g, f0, 0)->opcode != OP_FILTER,
             "pushed filter input must be the const-table (chain depth 1)");
 
         ray_op_t* skeys[1] = {ray_scan(g, "k")};

--- a/test/test_opt.c
+++ b/test/test_opt.c
@@ -26,6 +26,7 @@
 #include <rayforce.h>
 #include "mem/heap.h"
 #include "ops/ops.h"
+#include "ops/internal.h"
 #include "store/csr.h"
 #include <string.h>
 
@@ -185,12 +186,12 @@ static test_result_t test_filter_reorder_dag(void) {
      *   chain[0] (outer) gets the higher cost pred
      *   chain[1] (inner) gets the lower cost pred */
     TEST_ASSERT_EQ_I(opt->opcode, OP_FILTER);
-    ray_op_t* inner = opt->inputs[0];
+    ray_op_t* inner = op_child(g, opt, 0);
     TEST_ASSERT_EQ_I(inner->opcode, OP_FILTER);
 
     /* Inner pred should be eq (cheaper), outer pred should be gt (more expensive) */
-    TEST_ASSERT_EQ_I(inner->inputs[1]->id, eq_pred_id);
-    TEST_ASSERT_EQ_I(opt->inputs[1]->id, gt_pred_id);
+    TEST_ASSERT_EQ_I(inner->in_id[1], eq_pred_id);
+    TEST_ASSERT_EQ_I(opt->in_id[1], gt_pred_id);
 
     ray_graph_free(g);
     ray_release(tbl);
@@ -231,14 +232,14 @@ static test_result_t test_pushdown_past_select(void) {
     /* Verify DAG structure: filter should have been pushed below select */
     ray_op_t* sel_after = &g->nodes[sel_id];
     TEST_ASSERT_EQ_I(sel_after->opcode, OP_SELECT);
-    TEST_ASSERT_EQ_I(sel_after->inputs[0]->opcode, OP_FILTER);
+    TEST_ASSERT_EQ_I(op_child(g, sel_after, 0)->opcode, OP_FILTER);
 
     /* Verify the optimized root is the select node (filter was pushed below) */
     TEST_ASSERT_EQ_U(opt_root->id, sel_id);
 
     /* Execute COUNT from the pushed-down filter to validate correctness.
      * The filter (now below select) should still produce the right row count. */
-    ray_op_t* cnt = ray_count(g, sel_after->inputs[0]);
+    ray_op_t* cnt = ray_count(g, op_child(g, sel_after, 0));
     ray_t* result = ray_execute(g, cnt);
     TEST_ASSERT_FALSE(RAY_IS_ERR(result));
     TEST_ASSERT_EQ_I(result->i64, 4);
@@ -871,8 +872,8 @@ static test_result_t test_opt_pushdown_past_expand(void) {
     TEST_ASSERT_EQ_U(opt->id, expand_id);
     TEST_ASSERT_EQ_I(opt->opcode, OP_EXPAND);
     /* EXPAND.inputs[0] should now be a FILTER node (the pushed filter). */
-    TEST_ASSERT_NOT_NULL(opt->inputs[0]);
-    TEST_ASSERT_EQ_I(opt->inputs[0]->opcode, OP_FILTER);
+    TEST_ASSERT_NOT_NULL(op_child(g, opt, 0));
+    TEST_ASSERT_EQ_I(op_child(g, opt, 0)->opcode, OP_FILTER);
 
     ray_graph_free(g);
     ray_rel_free(rel);
@@ -954,7 +955,7 @@ static test_result_t test_opt_pushdown_expand_blocked(void) {
     /* Pushdown blocked: filter remains the root, expand stays below. */
     TEST_ASSERT_EQ_U(opt->id, filt_id);
     TEST_ASSERT_EQ_I(opt->opcode, OP_FILTER);
-    TEST_ASSERT_EQ_U(opt->inputs[0]->id, expand_id);
+    TEST_ASSERT_EQ_U(opt->in_id[0], expand_id);
 
     ray_graph_free(g);
     ray_rel_free(rel);
@@ -1066,16 +1067,16 @@ static test_result_t test_opt_realloc_during_split(void) {
     /* Walk from new root: must be FILTER -> FILTER -> SCAN(v1) chain,
      * with predicates pointing at eq and gt (post-fix-up). */
     TEST_ASSERT_EQ_I(opt->opcode, OP_FILTER);
-    TEST_ASSERT_NOT_NULL(opt->inputs[0]);
-    TEST_ASSERT_EQ_I(opt->inputs[0]->opcode, OP_FILTER);
+    TEST_ASSERT_NOT_NULL(op_child(g, opt, 0));
+    TEST_ASSERT_EQ_I(op_child(g, opt, 0)->opcode, OP_FILTER);
 
     /* After AND-split + reorder, the inner predicate is the cheaper
      * (eq on i64) and outer predicate is gt on f64 — but here we just
      * need the predicates to point to valid live nodes (no use-after-
      * realloc).  Both pred nodes' IDs must still resolve to live ops. */
-    ray_op_t* outer_pred = opt->inputs[1];
-    ray_op_t* inner = opt->inputs[0];
-    ray_op_t* inner_pred = inner->inputs[1];
+    ray_op_t* outer_pred = op_child(g, opt, 1);
+    ray_op_t* inner = op_child(g, opt, 0);
+    ray_op_t* inner_pred = op_child(g, inner, 1);
     TEST_ASSERT_NOT_NULL(outer_pred);
     TEST_ASSERT_NOT_NULL(inner_pred);
     TEST_ASSERT_TRUE(outer_pred->id == eq_id || outer_pred->id == gt_id);
@@ -1087,7 +1088,7 @@ static test_result_t test_opt_realloc_during_split(void) {
 
     /* And the filter chain bottoms out at SCAN(v1) — verifying the
      * input-pointer fix-up walked the whole chain correctly. */
-    ray_op_t* scan_node = inner->inputs[0];
+    ray_op_t* scan_node = op_child(g, inner, 0);
     TEST_ASSERT_NOT_NULL(scan_node);
     TEST_ASSERT_EQ_I(scan_node->opcode, OP_SCAN);
 
@@ -1834,8 +1835,8 @@ static test_result_t test_factorize_expand_group_src(void) {
     TEST_ASSERT_NOT_NULL(grp);
 
     /* Attach group as consumer of expand */
-    grp->inputs[0] = expand;
-    g->nodes[grp->id].inputs[0] = expand;
+    grp->in_id[0] = expand->id;
+    g->nodes[grp->id].in_id[0] = expand->id;
 
     ray_op_t* opt = ray_optimize(g, grp);
     TEST_ASSERT_NOT_NULL(opt);
@@ -1923,8 +1924,8 @@ static test_result_t test_idiom_first_last_asc_scan_no_nulls(void) {
     ray_op_t* opt = ray_optimize(g, root);
     TEST_ASSERT_NOT_NULL(opt);
     TEST_ASSERT_EQ_I(opt->opcode, OP_ADD);
-    TEST_ASSERT_EQ_I(opt->inputs[0]->opcode, OP_MIN);
-    TEST_ASSERT_EQ_I(opt->inputs[1]->opcode, OP_MAX);
+    TEST_ASSERT_EQ_I(op_child(g, opt, 0)->opcode, OP_MIN);
+    TEST_ASSERT_EQ_I(op_child(g, opt, 1)->opcode, OP_MAX);
 
     ray_graph_free(g);
     ray_release(tbl);
@@ -1953,8 +1954,8 @@ static test_result_t test_idiom_first_asc_scan_with_nulls_stays_safe(void) {
     ray_op_t* opt = ray_optimize(g, root);
     TEST_ASSERT_NOT_NULL(opt);
     TEST_ASSERT_EQ_I(opt->opcode, OP_ADD);
-    TEST_ASSERT_EQ_I(opt->inputs[0]->opcode, OP_FIRST);
-    TEST_ASSERT_EQ_I(opt->inputs[0]->inputs[0]->opcode, OP_ASC);
+    TEST_ASSERT_EQ_I(op_child(g, opt, 0)->opcode, OP_FIRST);
+    TEST_ASSERT_EQ_I(op_child(g, op_child(g, opt, 0), 0)->opcode, OP_ASC);
 
     ray_graph_free(g);
     ray_release(tbl);
@@ -2318,8 +2319,8 @@ static test_result_t test_opt_pushdown_expand_if_pred(void) {
     /* After pushdown, root should be EXPAND with FILTER as its source input */
     TEST_ASSERT_EQ_U(opt->id, expand_id);
     TEST_ASSERT_EQ_I(opt->opcode, OP_EXPAND);
-    TEST_ASSERT_NOT_NULL(opt->inputs[0]);
-    TEST_ASSERT_EQ_I(opt->inputs[0]->opcode, OP_FILTER);
+    TEST_ASSERT_NOT_NULL(op_child(g, opt, 0));
+    TEST_ASSERT_EQ_I(op_child(g, opt, 0)->opcode, OP_FILTER);
 
     ray_graph_free(g);
     ray_rel_free(rel);
@@ -2449,8 +2450,8 @@ static test_result_t test_factorize_expand_group_non_src(void) {
     ray_op_t* agg_ins[] = { val_scan };
     ray_op_t* grp = ray_group(g, keys, 1, agg_ops, agg_ins, 1);
     TEST_ASSERT_NOT_NULL(grp);
-    grp->inputs[0] = expand;
-    g->nodes[grp->id].inputs[0] = expand;
+    grp->in_id[0] = expand->id;
+    g->nodes[grp->id].in_id[0] = expand->id;
 
     ray_op_t* opt = ray_optimize(g, grp);
     TEST_ASSERT_NOT_NULL(opt);


### PR DESCRIPTION
Replace raw ray_op_t* input pointers with realloc-stable uint32 node ids, eliminating the manual pointer-fixup machinery and the type-punning of 3-ary third inputs.

- ray_op_t.inputs[2] (ptr) -> in_id[2] (uint32_t); RAY_OP_NONE sentinel (node id 0 is valid, so zero cannot mean "none").
- ext-union edge members (keys/agg_ins/agg_ins2/sort.columns/join keys/ asof time+eq keys/window keys+func_inputs/pivot cols) -> uint32 ids.
- new ray_op_ext.third_in replaces (ray_t*)(uintptr_t) punning of literal for OP_IF else / OP_SUBSTR len / OP_REPLACE to.
- op_node(g,id) / op_child(g,op,i) accessors centralize id->ptr resolution (reads go through them, preserving NULL/deref semantics; id-0 truthiness hazard avoided everywhere).
- delete graph_fix_ptr/graph_fixup_ptrs/graph_fixup_ext_ptrs and the duplicate fixup in graph_alloc_node_opt (now forwards to graph_alloc_node); drop the re-resolve-after-realloc dances.
- EXT_TRAIL layout math kept at sizeof(ray_op_t*) (ids over-allocated in 8B slots) so writer/reader offsets stay identical.

make test: 3487/3489 pass (2 pre-existing skips), 0 fail, 0 ASan/UBSan.