### PR TITLE
v2.1.8

### DIFF
--- a/docs/docs/storage/index.md
+++ b/docs/docs/storage/index.md
@@ -6,6 +6,8 @@ Columnar file I/O, splayed tables, date-partitioned storage, symbol table persis
 
 Rayforce's native binary format stores a single vector per file. Each file contains a 32-byte header followed by the raw element data and an optional null bitmap. The format is designed for direct memory mapping — no deserialization needed.
 
+The header carries a single-byte format generation. The current generation is `0`, and data written by any prior engine that produced the same layout (also generation `0`) loads unchanged — no migration required. A file whose generation the reader does not recognize is refused with a `version` error rather than mis-read; a future breaking layout change bumps the generation so old files are rejected for migration instead of silently misinterpreted.
+
 ### File Structure
 
 ```c

--- a/src/store/col.h
+++ b/src/store/col.h
@@ -29,7 +29,7 @@
 
 struct ray_sym_domain_s;
 
-/* On-disk column format version, carried in the 32-byte header's `order`
+/* On-disk column format generation, carried in the 32-byte header's `order`
  * byte (offset 17).  The on-disk header IS the in-memory ray_t allocator
  * layout (payload at offset 32); there is NO separate envelope.
  *
@@ -37,28 +37,38 @@ struct ray_sym_domain_s;
  * on-disk-free (written 0 and recomputed on load).  aux(0-15) is RESERVED
  * for postponed on-disk index persistence (min/max zone map) and must not
  * be squatted; rc(20-23) carries the SYM saved dictionary count;
- * type/attrs/len are live data.  So the version lives in `order`.
+ * type/attrs/len are live data.  So the generation lives in `order`.
  *
- * A SINGLE byte = MAJOR version.  Compatibility is gated by major only:
+ * A SINGLE byte = MAJOR generation.  Compatibility is gated by major only:
  * minor/additive changes stay backward-compatible, so one byte (0-255
  * generations) suffices.  There is NO magic — the type allowlist +
  * len-vs-filesize + SYM rc saved-count already validate file integrity;
  * this byte only gates the format generation.
  *
- * FRESH SWAP, NO LEGACY: a file whose `order` byte != the reader's major is
- * rejected with a "version" error (RAY_ERR_VERSION). */
-#define RAY_COL_FORMAT_MAJOR    ((uint8_t)1)
+ * The CURRENT generation is 0, and this is deliberate.  `order` is
+ * on-disk-free and was written 0 by every engine that produced today's
+ * splayed layout, so declaring the shipped format generation 0 means all
+ * existing on-disk data is read as-is — no migration, no orphaned databases.
+ * (An earlier build briefly stamped 1, which rejected every pre-existing file
+ * with a "version" error: see ray_col_check_format.  Generation 0 reclaims
+ * that data.)  Generation 1 is intentionally SKIPPED because those stray
+ * order==1 files carry the identical generation-0 layout; the next genuine
+ * breaking layout change bumps MAJOR straight to 2, at which point
+ * generation-0 files are correctly rejected and must be migrated rather than
+ * silently mis-decoded. */
+#define RAY_COL_FORMAT_MAJOR    ((uint8_t)0)
 
-/* Stamp the format major version into a 32-byte on-disk header's `order`
- * byte.  Does NOT touch aux (reserved for postponed index persistence).
- * Replaces the prior `header.order = 0` at every write site. */
+/* Stamp the format generation into a 32-byte on-disk header's `order` byte.
+ * Does NOT touch aux (reserved for postponed index persistence).  Writes the
+ * current generation; the runtime `order` is recomputed on load. */
 static inline void ray_col_stamp_format(ray_t* header) {
     header->order = RAY_COL_FORMAT_MAJOR;
 }
 
-/* Validate the format major version in a mapped/built column header's
- * `order` byte (offset 17).  Returns RAY_OK iff it matches the reader's
- * major, else RAY_ERR_VERSION. */
+/* Validate the format generation in a mapped/built column header's `order`
+ * byte (offset 17).  Returns RAY_OK iff it matches the reader's generation,
+ * else RAY_ERR_VERSION.  Strict equality: with the current generation at 0,
+ * legacy/pre-stamp files (order==0) load and any other generation is refused. */
 static inline ray_err_t ray_col_check_format(const ray_t* header) {
     return header->order == RAY_COL_FORMAT_MAJOR ? RAY_OK : RAY_ERR_VERSION;
 }

--- a/test/rfl/store/col_format_generation.rfl
+++ b/test/rfl/store/col_format_generation.rfl
@@ -1,0 +1,28 @@
+;; On-disk column format generation (the header `order` byte, offset 17).
+;;
+;; Regression: an engine build briefly stamped the generation to 1 and demanded
+;; 1 back, which rejected every pre-existing splayed database — written by
+;; earlier engines that left the byte 0 — with a `version` error surfaced as
+;; "cannot read .d schema".  The shipped layout is generation 0, so generation
+;; 0 (legacy/unstamped) data MUST load, and the version gate must still refuse
+;; an unrecognized generation.
+(.sys.exec "rm -rf /tmp/rfl_colgen_*")
+
+(set T-Gen (table [a b] (list [1 2 3] [10.0 20.0 30.0])))
+
+;; ─── generation-0 (legacy/pre-stamp) data loads ───
+;; Force every column file + .d to order==0, mimicking data written before any
+;; version byte existed.  This fails loudly if the generation is ever bumped
+;; back off 0 (writer would stamp non-zero, reader would reject the forced 0s).
+(.db.splayed.set "/tmp/rfl_colgen_legacy/" T-Gen)
+(.sys.exec "for f in /tmp/rfl_colgen_legacy/.d /tmp/rfl_colgen_legacy/a /tmp/rfl_colgen_legacy/b; do printf '\\000' | dd of=$f bs=1 seek=17 count=1 conv=notrunc 2>/dev/null; done") -- 0
+(count (.db.splayed.get "/tmp/rfl_colgen_legacy/")) -- 3
+(at (.db.splayed.get "/tmp/rfl_colgen_legacy/") 'a) -- (at T-Gen 'a)
+(at (.db.splayed.get "/tmp/rfl_colgen_legacy/") 'b) -- (at T-Gen 'b)
+
+;; ─── the version gate still rejects an unknown generation ───
+;; Stamp the .d header's order byte to 0x07 and confirm the load is refused
+;; (proves the check did not regress into accepting everything).
+(.db.splayed.set "/tmp/rfl_colgen_bad/" T-Gen)
+(.sys.exec "printf '\\007' | dd of=/tmp/rfl_colgen_bad/.d bs=1 seek=17 count=1 conv=notrunc 2>/dev/null") -- 0
+(.db.splayed.get "/tmp/rfl_colgen_bad/") !- version

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -4150,9 +4150,9 @@ static test_result_t test_col_str_pool_roundtrip(void) {
 }
 
 /* ---- test_col_format_version_roundtrip ---------------------------------- */
-/* FRESH-SWAP format: a saved column carries the format MAJOR version in the
- * 32-byte header's `order` byte (offset 17), with aux (bytes 0-15) ZERO on
- * disk (no magic — aux is reserved for postponed index persistence).  It
+/* A saved column carries the format generation in the 32-byte header's
+ * `order` byte (offset 17), with aux (bytes 0-15) ZERO on disk (no magic —
+ * aux is reserved for postponed index persistence).  It
  * round-trips through both ray_col_load (deep copy) and ray_col_mmap
  * (zero-copy) with value + attrs intact, and the on-disk version byte must
  * NOT leak into the in-memory runtime aux. */
@@ -4202,14 +4202,18 @@ static test_result_t test_col_format_version_roundtrip(void) {
 }
 
 /* ---- test_col_format_bad_version ---------------------------------------- */
-/* A file whose `order` byte (offset 17) does not match the reader's major
- * version must be rejected with a "version" error by both load + mmap. */
+/* The current format generation is 0 (RAY_COL_FORMAT_MAJOR).  Generation 0 is
+ * the shipped/legacy layout, so a zeroed order byte (offset 17) — pre-stamp
+ * data written by earlier engines — MUST load (regression: an earlier build
+ * demanded 1 and orphaned every pre-existing database with a "version" error).
+ * A file whose `order` byte is an UNRECOGNIZED generation is still rejected
+ * with a "version" error by both load + mmap. */
 static test_result_t test_col_format_bad_version(void) {
     int64_t raw[] = {1, 2, 3};
     ray_t* vec = ray_vec_from_raw(RAY_I64, raw, 3);
     TEST_ASSERT_FALSE(RAY_IS_ERR(vec));
 
-    /* (a) zeroed version byte => "version". */
+    /* (a) generation 0 (legacy/unstamped order byte) => loads, value intact. */
     TEST_ASSERT_EQ_I(ray_col_save(vec, TMP_COL_PATH), RAY_OK);
     {
         FILE* f = fopen(TMP_COL_PATH, "r+b");
@@ -4220,15 +4224,16 @@ static test_result_t test_col_format_bad_version(void) {
         fclose(f);
     }
     ray_t* r1 = ray_col_load(TMP_COL_PATH);
-    TEST_ASSERT_TRUE(RAY_IS_ERR(r1));
-    TEST_ASSERT_STR_EQ(ray_err_code(r1), "version");
+    TEST_ASSERT_FALSE(RAY_IS_ERR(r1));
+    TEST_ASSERT_EQ_I(r1->len, 3);
+    TEST_ASSERT_EQ_I(((int64_t*)ray_data(r1))[2], 3);
     ray_release(r1);
     ray_t* r2 = ray_col_mmap(TMP_COL_PATH);
-    TEST_ASSERT_TRUE(RAY_IS_ERR(r2));
-    TEST_ASSERT_STR_EQ(ray_err_code(r2), "version");
+    TEST_ASSERT_FALSE(RAY_IS_ERR(r2));
+    TEST_ASSERT_EQ_I(r2->len, 3);
     ray_release(r2);
 
-    /* (b) version bumped past the reader's major => "version". */
+    /* (b) an unrecognized generation => "version" (both load + mmap). */
     TEST_ASSERT_EQ_I(ray_col_save(vec, TMP_COL_PATH), RAY_OK);
     {
         FILE* f = fopen(TMP_COL_PATH, "r+b");
@@ -4238,10 +4243,14 @@ static test_result_t test_col_format_bad_version(void) {
         TEST_ASSERT_EQ_U(fwrite(&bad_ver, 1, 1, f), 1);
         fclose(f);
     }
-    ray_t* r3 = ray_col_mmap(TMP_COL_PATH);
+    ray_t* r3 = ray_col_load(TMP_COL_PATH);
     TEST_ASSERT_TRUE(RAY_IS_ERR(r3));
     TEST_ASSERT_STR_EQ(ray_err_code(r3), "version");
     ray_release(r3);
+    ray_t* r4 = ray_col_mmap(TMP_COL_PATH);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(r4));
+    TEST_ASSERT_STR_EQ(ray_err_code(r4), "version");
+    ray_release(r4);
 
     ray_release(vec);
     unlink(TMP_COL_PATH);


### PR DESCRIPTION
…tion to 0

The column format generation lives in the on-disk header's `order` byte (offset 17), which is on-disk-free and was written 0 by every engine that produced today's splayed layout. A prior change stamped it 1 and demanded 1 back, which rejected every pre-existing database on load with a `version` error surfaced as "cannot read .d schema".

Declare the shipped generation 0 so existing on-disk data — byte-identical apart from that one header byte (symfile, SYM file-position encoding, .d schema and column data all unchanged) — loads as-is, with no migration. The check stays strict (==): generation 1 is skipped because those stray order==1 files carry the identical gen-0 layout, and the next genuine breaking layout change bumps MAJOR straight to 2 so old files are rejected for migration rather than silently mis-decoded.

- src/store/col.h: RAY_COL_FORMAT_MAJOR 1 -> 0; rationale rewritten.
- test/test_store.c: gen-0 (legacy/unstamped) order byte now loads; an unrecognized generation is still rejected on both load + mmap.
- test/rfl/store/col_format_generation.rfl: regression — forced gen-0 data loads (fails if the generation is ever re-bumped); the version gate still refuses an unknown generation.
- docs/docs/storage/index.md: document the one-byte format generation.