### PR TITLE
Parse hyphenated quoted symbols

### DIFF
--- a/src/lang/parse.c
+++ b/src/lang/parse.c
@@ -460,7 +460,8 @@ static ray_t* parse_symbol(ray_parser_t *p) {
     }
 
     /* Regular symbol */
-    while (PA(*p->pos) == PA_ALPHA || PA(*p->pos) == PA_DIGIT || *p->pos == '_' || *p->pos == '.')
+    while (PA(*p->pos) == PA_ALPHA || PA(*p->pos) == PA_DIGIT
+           || *p->pos == '_' || *p->pos == '.' || *p->pos == '-')
         p->pos++;
     size_t len = (size_t)(p->pos - start);
     int64_t id = (len == 0) ? 0 : ray_sym_intern(start, len);  /* empty symbol — sym 0 */

--- a/test/rfl/cmp/gt.rfl
+++ b/test/rfl/cmp/gt.rfl
@@ -55,7 +55,6 @@
 (> ['b 'b 'b] ['a 'b 'c]) -- [true false false]
 
 ;; mixed inline (≤ 12 bytes) and pooled (> 12 bytes) — exercises SSO.
-;; Note: hyphens in symbols would be parsed as ops, so use underscore.
 ;; 's' > 'l' so 'short > 'longer_…
 (> 'short 'longer_than_twelve_bytes_symbol) -- true
 (> 'longer_than_twelve_bytes_symbol 'short) -- false

--- a/test/rfl/lang/parse_branch_cov.rfl
+++ b/test/rfl/lang/parse_branch_cov.rfl
@@ -225,6 +225,9 @@
 ;; dotted / underscored symbol chars (parse_symbol loop :456)
 (as 'STR 'a.b.c) -- "a.b.c"
 (as 'STR 'a_b) -- "a_b"
+;; hyphenated quoted symbol chars match the documented symbol syntax
+(as 'STR 'a-b) -- "a-b"
+(== 'a-b 'a-b) -- true
 ;; empty symbol before a closing bracket / brace / paren
 ;; (parse_symbol terminator guard :408-409)
 (count (list ')) -- 1


### PR DESCRIPTION
## Summary
- Allow `-` in tick-quoted symbol literals.
- Cover hyphenated quoted symbols in parser branch coverage.
- Remove a stale test comment saying hyphenated symbols parse as operators.

## Why
The language docs describe quoted symbols as supporting alphanumeric names plus hyphens, and bare names/keyword literals already accept hyphenated forms. Before this change, `'a-b` parsed as `'a` followed by unresolved `-b`, so documented symbols failed to parse as a single literal.

## Validation
- `make test TEST_CORES=2`