### PR TITLE
fix(query): fold (quote X) in DAG predicates so it matches the 'X form

### DIFF
--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -1032,6 +1032,32 @@ ray_op_t* compile_expr_dag(ray_graph_t* g, ray_t* expr) {
         const char* fname = fn_name_str ? ray_str_ptr(fn_name_str) : NULL;
         size_t fname_len = fn_name_str ? ray_str_len(fn_name_str) : 0;
 
+        /* (quote X) — the explicit quote special form.  The reader lowers the
+         * `'X` shorthand to an ATTR_QUOTED atom (folded by the literal branches
+         * above), but the call form `(quote X)` reaches here as a 2-element
+         * list and previously fell through to the unknown-builtin path
+         * (→ NULL → "WHERE predicate not supported by DAG compiler"), so an
+         * inline `(quote x)` worked in a projection (eval fallback) but errored
+         * in a WHERE predicate.  Fold it to the literal datum X.
+         *
+         * Deliberately NOT applying the in-query column-shadow rule here: by
+         * design an inline `(quote col)` call node STAYS the literal symbol,
+         * whereas the tick atom `'col` resolves to the column (the AST-shape
+         * boundary pinned by test/rfl/query/literal_col_ref.rfl — Part 2
+         * unwraps a literal -RAY_SYM atom, not a (quote …) call node).  So a
+         * quoted symbol always folds to a const atom; vector / atom data folds
+         * to a const node; non-foldable quoted data (e.g. a quoted list)
+         * returns NULL. */
+        if (fname_len == 5 && memcmp(fname, "quote", 5) == 0) {
+            if (n != 2) return NULL;
+            ray_t* q = elems[1];
+            if (!q) return NULL;
+            if (q->type == -RAY_SYM) return ray_const_atom(g, q);
+            if (ray_is_vec(q))       return ray_const_vec(g, q);
+            if (ray_is_atom(q))      return ray_const_atom(g, q);
+            return NULL;
+        }
+
         if (fname_len == 4 && memcmp(fname, "xbar", 4) == 0) {
             if (n != 3) return NULL;
             ray_op_t* col = compile_expr_dag(g, elems[1]);

--- a/test/rfl/query/literal_col_ref.rfl
+++ b/test/rfl/query/literal_col_ref.rfl
@@ -66,3 +66,20 @@
 ;; an operand — that atom then resolves, which is why the idiom works.
 (== 'price (quote price)) -- true
 (at (select {o: (quote price) from: Tlit}) 'o) -- ['price 'price 'price]
+
+;; --- regression (fix: (quote X) in a WHERE/DAG predicate).  Before the fix
+;; the (quote X) CALL form reaching compile_expr_dag returned NULL, so an
+;; inline (quote x) worked in a projection (eval fallback) but ERRORED in a
+;; WHERE predicate ("WHERE predicate not supported by DAG compiler").  It now
+;; folds to the literal symbol — WITHOUT the in-query column-shadow rule, so it
+;; stays the literal even when it names a column (the AST-shape boundary above).
+;; T2 has SYM col `s` (['a 'b 'c 'a]) and BOOL col `b`.
+;;   (quote b): literal 'b  -> (== s 'b-literal) matches the 'b row     -> 1
+;;   'b (tick): resolves to col b -> (== s b) sym-vs-bool               -> 0
+(count (select {from: T2 where: (== s (quote b))})) -- 1
+(count (select {from: T2 where: (== s 'b)})) -- 0
+;; a symbol naming NO column: (quote a) and 'a agree (both literal)     -> 2
+(count (select {from: T2 where: (== s (quote a))})) -- 2
+(count (select {from: T2 where: (== s 'a)})) -- 2
+;; and-chained predicate operand also folds (no longer "not supported")
+(count (select {from: T2 where: (and (== s (quote a)) (== s 'a))})) -- 2


### PR DESCRIPTION
## Problem
`(quote X)` inside a `where:` predicate (or any DAG-compiled predicate) fails with `domain — WHERE predicate not supported by DAG compiler`, while the value-equivalent tick literal `'X` works. The same `(quote X)` works in a select **projection**, so the behaviour is asymmetric.

```lisp
(set t (table [s v] (list ['a 'b] [1 2])))
(select {from: t where: (== s 'a)})          ; ok
(select {from: t where: (== s (quote a))})   ; error: domain — WHERE predicate not supported
```

## Cause
The reader lowers `'X` to an `ATTR_QUOTED` `-RAY_SYM` **atom**, which `compile_expr_dag` (`src/ops/query.c`) folds to a const. But `(quote X)` stays a **call node**; it reaches the LIST branch, matches no opcode, and returns `NULL`. The count-select fast path and the materialised select path turn that `NULL` into the "not supported" error. Projections take the full-eval path, hence the asymmetry.

## Fix
Fold `(quote X)` to the literal datum in `compile_expr_dag`: quoted symbol/atom → const atom, quoted vector → const vec, anything else (e.g. `(quote (+ 1 2))`) → `NULL` as before.

Deliberately **not** applying the in-query column-shadow rule to `(quote col)`: by design the tick atom `'col` resolves to a column while the `(quote col)` call node stays the literal symbol — the AST-shape boundary pinned by `test/rfl/query/literal_col_ref.rfl`. The dynamic-query idiom is unaffected (it evaluates `(quote col)` to the `'col` atom before it becomes an operand).

## Tests
Adds regression assertions to `literal_col_ref.rfl`: `(quote X)` as a WHERE operand, the `(quote col)` vs `'col` distinction, and an `and`-chained predicate. Full suite on `dev`: **3514/3514 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)