### PR TITLE
fix(join): carry adaptive-width SYM keys from splayed sources in asof/window-join

### DIFF
--- a/src/ops/join.c
+++ b/src/ops/join.c
@@ -2213,9 +2213,14 @@ ray_t* exec_window_join(ray_graph_t* g, ray_op_t* op,
         int64_t col_name = ray_table_col_name(left_table, c);
         ray_t* src_col = ray_table_get_col_idx(left_table, c);
         int8_t ctype = src_col->type;
-        ray_t* dst_col = ray_vec_new(ctype, out_n);
-
-        uint8_t esz = ray_type_sizes[ctype];
+        /* SYM is adaptive-width (W8/W16/W32/W64): a splayed/loaded source is
+         * typically W32 while ray_vec_new(RAY_SYM,…) yields a W64 dst.  Copy at
+         * the SOURCE element size into a dst of the SAME width — otherwise the
+         * ids are read at the wrong stride and decode to the empty symbol. */
+        uint8_t esz = (ctype == RAY_SYM) ? col_esz(src_col) : ray_type_sizes[ctype];
+        ray_t* dst_col = (ctype == RAY_SYM)
+            ? ray_sym_vec_new((uint8_t)(src_col->attrs & RAY_SYM_W_MASK), out_n)
+            : ray_vec_new(ctype, out_n);
         char* src = (char*)ray_data(src_col);
         char* dst = (char*)ray_data(dst_col);
         for (int64_t wi = 0; wi < out_n; wi++)
@@ -2241,9 +2246,11 @@ ray_t* exec_window_join(ray_graph_t* g, ray_op_t* op,
         int64_t col_name = ray_table_col_name(right_table, cidx);
         ray_t* src_col = ray_table_get_col_idx(right_table, cidx);
         int8_t ctype = src_col->type;
-        ray_t* dst_col = ray_vec_new(ctype, out_n);
-
-        uint8_t esz = ray_type_sizes[ctype];
+        /* SYM adaptive-width: match the source width (see left-gather note). */
+        uint8_t esz = (ctype == RAY_SYM) ? col_esz(src_col) : ray_type_sizes[ctype];
+        ray_t* dst_col = (ctype == RAY_SYM)
+            ? ray_sym_vec_new((uint8_t)(src_col->attrs & RAY_SYM_W_MASK), out_n)
+            : ray_vec_new(ctype, out_n);
         char* src = (char*)ray_data(src_col);
         char* dst = (char*)ray_data(dst_col);
         for (int64_t wi = 0; wi < out_n; wi++) {

--- a/test/rfl/integration/joins.rfl
+++ b/test/rfl/integration/joins.rfl
@@ -290,3 +290,17 @@
 (sum (at (inner-join [id] LJsmall RJbig) 'val)) -- 36
 ;; 200 back-to-back radix joins — a single dropped row anywhere shows as < 1600.
 (sum (map (fn [_] (count (inner-join [id] LJsmall RJbig))) (til 200))) -- 1600
+
+;; ── regression: asof / window-join must carry an adaptive-width SYM equality
+;; key from a splayed (loaded) source.  Splayed SYM columns are W32; the output
+;; gather in exec_window_join used a fixed W64 (ray_type_sizes[RAY_SYM]) stride,
+;; reading ids at the wrong offset and emitting the empty symbol.  Round-trip a
+;; table through splayed storage (→ W32 FILE-domain sym) then join it.
+(.sys.exec "rm -rf /tmp/rfl_asof_symw")
+(set Asw (table [sym time bid] (list [AAPL AAPL MSFT] [100 200 150] [1 2 3])))
+(.db.splayed.set "/tmp/rfl_asof_symw/t" Asw "/tmp/rfl_asof_symw/sym")
+(set Asl (.db.splayed.get "/tmp/rfl_asof_symw/t" "/tmp/rfl_asof_symw/sym"))
+;; asof-join: the left SYM key survives (was [' ' '] before the fix)
+(at (asof-join [sym time] (select {from: Asl sym: sym time: time bid: bid}) (select {from: Asl sym: sym time: time b2: bid})) 'sym) -- [AAPL AAPL MSFT]
+;; window-join: same executor (OP_WINDOW_JOIN), same key-gather path
+(at (window-join [sym time] (map-left + [-50 50] (at Asl 'time)) (select {from: Asl sym: sym time: time}) (select {from: Asl sym: sym time: time bid: bid}) {mb: (min bid)}) 'sym) -- [AAPL AAPL MSFT]


### PR DESCRIPTION
## Problem
`asof-join` (and `window-join`, same executor) drops the SYM equality key — it comes out as the **empty symbol** — when the input tables are loaded from splayed / partitioned storage. The join itself matches correctly (numeric/other columns are right); only SYM columns are wrong.

```lisp
(set t (table [sym time bid] (list [AAPL AAPL MSFT] [100 200 150] [1 2 3])))
(.db.splayed.set "/tmp/d/t" t "/tmp/d/sym")
(set a (.db.splayed.get "/tmp/d/t" "/tmp/d/sym"))
(at (asof-join [sym time]
      (select {from: a sym: sym time: time bid: bid})
      (select {from: a sym: sym time: time b2: bid})) 'sym)
;; before:  [' ' ']         after:  [AAPL AAPL MSFT]
```
Fresh in-memory (runtime-domain) sym columns are unaffected, which is why it only shows up on loaded data.

## Cause
`exec_window_join` (backs both `asof-join` and `window-join`) gathers result columns with a fixed element size: `esz = ray_type_sizes[ctype]`, which is **8** for `RAY_SYM` (the W64 stride). But SYM columns are **adaptive-width** (W8/W16/W32/W64). A splayed/loaded SYM column is typically **W32** (4-byte ids). Reading a W32 source at an 8-byte stride yields garbled ids that decode to the empty symbol. Fresh runtime sym columns are W64, so they happened to work.

## Fix
For SYM columns, gather at the **source** element size (`col_esz(src_col)`) into a destination of the **same width** (`ray_sym_vec_new(src width, …)`), in both the left and right gather loops. Non-SYM columns keep the fixed `ray_type_sizes` stride. `ray_sym_vec_adopt_domain` then carries the source domain over ids that are now read at the correct offset.

This covers `window-join` too — it shares `exec_window_join` (both build `OP_WINDOW_JOIN` via `ray_asof_join`). Verified empirically; a `min`/`max`-aggregating window-join over splayed data now returns the correct key.

## Tests
Adds a regression to `test/rfl/integration/joins.rfl`: round-trip a table through splayed storage (→ W32 FILE-domain sym) and assert `asof-join` / `window-join` preserve the SYM equality key. Full suite on `dev`: **3514/3514 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)