### PR TITLE
select/group: retire the fixed 16-slot arrays (unbounded slots, cut 1)

### DIFF
--- a/src/ops/agg_engine.c
+++ b/src/ops/agg_engine.c
@@ -29,10 +29,6 @@ bool agg_v2_can_handle(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     if (!ext) return false;
     if (ext->n_keys < 1 || ext->n_keys > 16) return false;  /* 1b: 1..16 keys */
     if (ext->n_aggs == 0) return false;        /* need >=1 aggregate  */
-    /* Defensive mirror of the compile-side RAY_GROUP_MAX_SLOTS cap: the
-     * engine fills [16] per-agg arrays, so bail to the legacy path rather
-     * than rely solely on the upstream invariant. */
-    if (ext->n_aggs > 16) return false;
     if (!tbl) return false;
     /* A pushed WHERE filter (g->selection set) is now handled by exec_group_v2's
      * compact-table prologue: it gathers the selected rows of the keys/agg-inputs
@@ -450,6 +446,87 @@ static inline void agg_sel_gather_vals(void* dst, const void* src, uint8_t esz,
     }
 }
 
+/* Per-dispatch descriptor tables, sized from ext->n_keys / ext->n_aggs.
+ * One carve; 8-byte arrays first, then narrower.  Replaces the fixed
+ * [16] blocks that used to cap the engine at 16 keys/aggs. */
+typedef struct {
+    ray_t*        hdr;
+    const void**  key_data;
+    const void**  val_data;  const void** val2_data;
+    int64_t*      agg_syms;
+    int8_t*       val_types; int8_t*  val2_types;
+    bool*         val_hasnull; bool*  val2_hasnull;
+    uint8_t*      val_esz;   uint8_t* val2_esz;
+} agg_desc_t;
+
+static bool agg_desc_init(agg_desc_t* d, ray_graph_t* g, ray_op_ext_t* ext,
+                          ray_t* tbl, ray_t** key_cols) {
+    uint8_t nk = ext->n_keys, na = ext->n_aggs;
+    size_t n8 = (size_t)nk + 3u * na;              /* key_data,val_data,val2_data,agg_syms */
+    size_t n1 = 6u * na;                           /* types/hasnull/esz pairs */
+    d->key_data = (const void**)scratch_alloc(&d->hdr, n8 * 8 + n1);
+    if (!d->key_data) return false;
+    d->val_data   = d->key_data + nk;
+    d->val2_data  = d->val_data + na;
+    d->agg_syms   = (int64_t*)(d->val2_data + na);
+    d->val_types  = (int8_t*)(d->agg_syms + na);
+    d->val2_types = d->val_types + na;
+    d->val_hasnull  = (bool*)(d->val2_types + na);
+    d->val2_hasnull = d->val_hasnull + na;
+    d->val_esz  = (uint8_t*)(d->val2_hasnull + na);
+    d->val2_esz = d->val_esz + na;
+    for (uint8_t k = 0; k < nk; k++) d->key_data[k] = ray_data(key_cols[k]);
+    for (uint8_t a = 0; a < na; a++) {
+        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
+        d->agg_syms[a] = ie->sym;
+        ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
+        d->val_data[a]    = vc ? ray_data(vc) : NULL;
+        d->val_types[a]   = vc ? vc->type : RAY_I64;
+        d->val_hasnull[a] = vc ? ((vc->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
+        d->val_esz[a]     = vc ? col_esz(vc) : 0;
+        /* Binary agg (pearson): resolve the y-side column from agg_ins2[a]. */
+        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE)
+            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a])->sym) : NULL;
+        d->val2_data[a]    = vc2 ? ray_data(vc2) : NULL;
+        d->val2_types[a]   = vc2 ? vc2->type : RAY_I64;
+        d->val2_hasnull[a] = vc2 ? ((vc2->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
+        d->val2_esz[a]     = vc2 ? col_esz(vc2) : 0;
+    }
+    return true;
+}
+
+static void agg_desc_free(agg_desc_t* d) { scratch_free(d->hdr); d->hdr = NULL; }
+
+/* Per-dispatch AoS layout tables (vtable ptr + state offset per agg), carved
+ * from one buffer sized na*(sizeof(void*)+sizeof(size_t)).  Replaces the fixed
+ * [16] vts/off blocks. */
+typedef struct {
+    ray_t*               hdr;
+    const agg_vtable_t** vts;
+    size_t*              off;
+    size_t               block;
+} agg_vo_t;
+
+static bool agg_vo_init(agg_vo_t* vo, ray_graph_t* g, ray_op_ext_t* ext, ray_t* tbl) {
+    uint8_t na = ext->n_aggs;
+    vo->vts = (const agg_vtable_t**)scratch_alloc(&vo->hdr,
+                (size_t)na * (sizeof(void*) + sizeof(size_t)));
+    if (!vo->vts) return false;
+    vo->off = (size_t*)(vo->vts + na);
+    vo->block = 0;
+    for (uint8_t a = 0; a < na; a++) {
+        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
+        ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
+        int8_t in_type = vc ? vc->type : RAY_I64;
+        vo->vts[a] = agg_resolve(ext->agg_ops[a], in_type);
+        vo->off[a] = vo->block;
+        vo->block += vo->vts[a]->state_size;
+    }
+    return true;
+}
+
+static void agg_vo_free(agg_vo_t* vo) { scratch_free(vo->hdr); vo->hdr = NULL; }
+
 /* Per-agg value descriptors, shared by every strategy's parallel ctx.  Gathered
  * into a struct so the sel-mode chunk accumulator can be written once. */
 typedef struct {
@@ -465,13 +542,27 @@ typedef struct {
  * per agg (sized AGG_SEL_CHUNK * esz), plus the y-side for binary aggs.  Lazily
  * allocated the first time a worker touches a non-COUNT agg. */
 typedef struct {
-    char* gv[16];
-    char* gy[16];
+    char** gv;      /* [n_aggs], carved */
+    char** gy;
+    ray_t* hdr;
+    uint8_t n_aggs;
     int   oom;
 } agg_sel_scratch_t;
 
+/* Carve 2*n_aggs zeroed value-buffer pointers (gv[n_aggs] followed by gy[n_aggs]).
+ * Returns false on OOM (leaves sc safe for agg_sel_scratch_free). */
+static bool agg_sel_scratch_init(agg_sel_scratch_t* sc, uint8_t n_aggs) {
+    sc->hdr = NULL; sc->gv = NULL; sc->gy = NULL; sc->n_aggs = 0; sc->oom = 0;
+    sc->gv = (char**)scratch_calloc(&sc->hdr, (size_t)2u * n_aggs * sizeof(char*));
+    if (!sc->gv) return false;
+    sc->gy = sc->gv + n_aggs;
+    sc->n_aggs = n_aggs;
+    return true;
+}
+
 static void agg_sel_scratch_free(agg_sel_scratch_t* sc) {
-    for (int a = 0; a < 16; a++) { ray_free_raw(sc->gv[a]); ray_free_raw(sc->gy[a]); sc->gv[a] = NULL; sc->gy[a] = NULL; }
+    for (uint8_t a = 0; a < sc->n_aggs; a++) { ray_free_raw(sc->gv[a]); ray_free_raw(sc->gy[a]); }
+    scratch_free(sc->hdr); sc->hdr = NULL; sc->gv = NULL; sc->gy = NULL; sc->n_aggs = 0;
 }
 
 /* Accumulate one decoded chunk (rows[], gid[] indexed [0,n)) into `states` for
@@ -536,9 +627,13 @@ static bool agg_dense_plan_sel(ray_t** key_cols, uint8_t n_keys, int64_t n_sel,
     }
 
     /* One pass over the selected rows updating every key's min/max together. */
-    int64_t mins[16], maxs[16];
+    ray_t* pre_hdr;
+    void* pre = scratch_alloc(&pre_hdr, 3u * (size_t)n_keys * 8);   /* mins,maxs,key_data */
+    if (!pre) return false;
+    int64_t* mins = (int64_t*)pre;
+    int64_t* maxs = mins + n_keys;
+    const void** key_data = (const void**)(maxs + n_keys);
     for (uint8_t k = 0; k < n_keys; k++) { mins[k] = INT64_MAX; maxs[k] = INT64_MIN; }
-    const void* key_data[16];
     for (uint8_t k = 0; k < n_keys; k++) key_data[k] = ray_data(key_cols[k]);
 
     int64_t rows[AGG_SEL_CHUNK];
@@ -558,10 +653,11 @@ static bool agg_dense_plan_sel(ray_t** key_cols, uint8_t n_keys, int64_t n_sel,
         }
     }
     for (uint8_t k = 0; k < n_keys; k++) {
-        if (maxs[k] < mins[k]) return false;
+        if (maxs[k] < mins[k]) { scratch_free(pre_hdr); return false; }
         out->mins[k]   = mins[k];
         out->ranges[k] = maxs[k] - mins[k] + 1;
     }
+    scratch_free(pre_hdr);
 
     int64_t total = 1;
     for (uint8_t k = 0; k < n_keys; k++) {
@@ -752,30 +848,9 @@ static ray_t* exec_group_v2_parallel(
     ray_pool_t* pool = ray_pool_get();
     uint32_t nw = ray_pool_total_workers(pool);
 
-    /* key data bases (read-only across workers) */
-    const void* key_data[16];
-    for (uint8_t k = 0; k < n_keys; k++) key_data[k] = ray_data(key_cols[k]);
-
-    /* per-agg value column bases / types (resolve once) */
-    const void* val_data[16]; int8_t val_types[16]; bool val_hasnull[16]; uint8_t val_esz[16];
-    const void* val2_data[16]; int8_t val2_types[16]; bool val2_hasnull[16]; uint8_t val2_esz[16];
-    int64_t agg_syms[16];
-    for (uint8_t a = 0; a < n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
-        agg_syms[a] = ie->sym;
-        ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
-        val_data[a]    = vc ? ray_data(vc) : NULL;
-        val_types[a]   = vc ? vc->type : RAY_I64;
-        val_hasnull[a] = vc ? ((vc->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
-        val_esz[a]     = vc ? col_esz(vc) : 0;
-        /* Binary agg (pearson): resolve the y-side column from agg_ins2[a]. */
-        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE)
-            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a])->sym) : NULL;
-        val2_data[a]    = vc2 ? ray_data(vc2) : NULL;
-        val2_types[a]   = vc2 ? vc2->type : RAY_I64;
-        val2_hasnull[a] = vc2 ? ((vc2->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
-        val2_esz[a]     = vc2 ? col_esz(vc2) : 0;
-    }
+    /* key data bases + per-agg value column bases/types (resolve once). */
+    agg_desc_t d;
+    if (!agg_desc_init(&d, g, ext, tbl, key_cols)) return ray_error("oom", NULL);
 
     /* per-worker ht sized to next_pow2(2*nrows): over-allocates (each worker
      * sees only its morsels) but memory isn't gated in 1c — simple & correct. */
@@ -784,7 +859,7 @@ static ray_t* exec_group_v2_parallel(
     int64_t cap = nrows > 0 ? nrows : 1;   /* a worker can't exceed nrows groups */
 
     agg_local_t* locals = ray_calloc_raw((size_t)((size_t)nw) * (sizeof(agg_local_t)));
-    if (!locals) return ray_error("oom", NULL);
+    if (!locals) { agg_desc_free(&d); return ray_error("oom", NULL); }
 
     int alloc_oom = 0;
     for (uint32_t w = 0; w < nw; w++)
@@ -792,16 +867,17 @@ static ray_t* exec_group_v2_parallel(
     if (alloc_oom) {
         for (uint32_t w = 0; w < nw; w++) agg_local_destroy(&locals[w]);
         ray_free_raw(locals);
+        agg_desc_free(&d);
         return ray_error("oom", NULL);
     }
 
     agg_par_ctx_t ctx = {
-        .key_cols = key_cols, .key_data = key_data, .n_keys = n_keys,
+        .key_cols = key_cols, .key_data = d.key_data, .n_keys = n_keys,
         .vts = vts, .off = off, .block = block, .n_aggs = n_aggs,
-        .val_data = val_data, .val_types = val_types,
-        .val_hasnull = val_hasnull, .val_esz = val_esz,
-        .val2_data = val2_data, .val2_types = val2_types,
-        .val2_hasnull = val2_hasnull, .val2_esz = val2_esz, .locals = locals,
+        .val_data = d.val_data, .val_types = d.val_types,
+        .val_hasnull = d.val_hasnull, .val_esz = d.val_esz,
+        .val2_data = d.val2_data, .val2_types = d.val2_types,
+        .val2_hasnull = d.val2_hasnull, .val2_esz = d.val2_esz, .locals = locals,
     };
     ray_pool_dispatch(pool, agg_phaseA_fn, &ctx, nrows);
 
@@ -811,6 +887,7 @@ static ray_t* exec_group_v2_parallel(
             for (uint32_t i = 0; i < nw; i++)
                 agg_table_destroy(&locals[i], vts, off, block, n_aggs);
             ray_free_raw(locals);
+            agg_desc_free(&d);
             return ray_error("oom", NULL);
         }
 
@@ -821,6 +898,7 @@ static ray_t* exec_group_v2_parallel(
         for (uint32_t i = 0; i < nw; i++)
             agg_table_destroy(&locals[i], vts, off, block, n_aggs);
         ray_free_raw(locals);
+        agg_desc_free(&d);
         return ray_error("oom", NULL);
     }
 
@@ -828,7 +906,7 @@ static ray_t* exec_group_v2_parallel(
         agg_local_t* loc = &locals[w];
         for (int64_t lg = 0; lg < loc->ng; lg++) {
             int64_t fr = loc->first_row[lg];
-            uint64_t h = agg_tuple_hash(key_cols, key_data, n_keys, fr);
+            uint64_t h = agg_tuple_hash(key_cols, d.key_data, n_keys, fr);
             uint64_t slot = h & gt.htmask;
             int64_t gg;
             for (;;) {
@@ -842,7 +920,7 @@ static ray_t* exec_group_v2_parallel(
                     gt.ng++;
                     break;
                 }
-                if (agg_tuple_eq(key_cols, key_data, n_keys, fr, gt.first_row[gp])) {
+                if (agg_tuple_eq(key_cols, d.key_data, n_keys, fr, gt.first_row[gp])) {
                     gg = gp;
                     if (fr < gt.first_row[gg]) gt.first_row[gg] = fr;  /* MIN */
                     break;
@@ -878,6 +956,7 @@ static ray_t* exec_group_v2_parallel(
     ray_t* result = ray_table_new(n_keys + n_aggs);
     if (!result || RAY_IS_ERR(result)) {
         agg_table_destroy(&gt, vts, off, block, n_aggs);
+        agg_desc_free(&d);
         return result ? result : ray_error("oom", NULL);
     }
 
@@ -885,6 +964,7 @@ static ray_t* exec_group_v2_parallel(
         ray_t* kc = agg_gather_key_col(key_cols[k], gt.first_row, ng);
         if (!kc || RAY_IS_ERR(kc)) {
             agg_table_destroy(&gt, vts, off, block, n_aggs);
+            agg_desc_free(&d);
             ray_release(result); return kc ? kc : ray_error("oom", NULL);
         }
         result = ray_table_add_col(result, key_syms[k], kc);
@@ -896,6 +976,7 @@ static ray_t* exec_group_v2_parallel(
         ray_t* out = is_list ? ray_list_new(ng) : ray_vec_new(vts[a]->out_type, ng);
         if (!out || RAY_IS_ERR(out)) {
             agg_table_destroy(&gt, vts, off, block, n_aggs);
+            agg_desc_free(&d);
             ray_release(result); return out ? out : ray_error("oom", NULL);
         }
         out->len = ng;
@@ -910,12 +991,13 @@ static ray_t* exec_group_v2_parallel(
                 ray_release(cell);
             }
         }
-        int64_t agg_name = agg_result_col_name(agg_syms[a], ext->agg_ops[a]);
+        int64_t agg_name = agg_result_col_name(d.agg_syms[a], ext->agg_ops[a]);
         result = ray_table_add_col(result, agg_name, out);
         ray_release(out);
     }
 
     agg_table_destroy(&gt, vts, off, block, n_aggs);
+    agg_desc_free(&d);
     return result;
 }
 
@@ -1018,7 +1100,8 @@ static void agg_dense_phaseA_fn(void* vctx, uint32_t wid, int64_t start, int64_t
     if (c->sel) {
         int64_t rows[AGG_SEL_CHUNK];
         uint32_t gid[AGG_SEL_CHUNK];
-        agg_sel_scratch_t sc = {0};
+        agg_sel_scratch_t sc;
+        if (!agg_sel_scratch_init(&sc, c->n_aggs)) { loc->oom = 1; return; }
         agg_sel_cursor_t cur;
         agg_sel_cursor_init(&cur, c->sel, c->sel_prefix, start, end);
         int64_t cn;
@@ -1121,40 +1204,21 @@ static ray_t* exec_group_v2_parallel_dense(
     uint32_t nw = ray_pool_total_workers(pool);
 
     /* Re-derive the AoS layout (same order as exec_group_v2). */
-    const agg_vtable_t* vts[16]; size_t off[16]; size_t block = 0;
-    for (uint8_t a = 0; a < n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
-        ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
-        int8_t in_type = vc ? vc->type : RAY_I64;
-        vts[a] = agg_resolve(ext->agg_ops[a], in_type);
-        off[a] = block;
-        block += vts[a]->state_size;
-    }
+    agg_vo_t vo;
+    if (!agg_vo_init(&vo, g, ext, tbl)) return ray_error("oom", NULL);
+    const agg_vtable_t** vts = vo.vts; size_t* off = vo.off; size_t block = vo.block;
 
-    const void* key_data[16];
-    for (uint8_t k = 0; k < n_keys; k++) key_data[k] = ray_data(key_cols[k]);
-
-    const void* val_data[16]; int8_t val_types[16]; bool val_hasnull[16]; uint8_t val_esz[16];
-    const void* val2_data[16]; int8_t val2_types[16]; bool val2_hasnull[16]; uint8_t val2_esz[16];
-    int64_t agg_syms[16];
-    for (uint8_t a = 0; a < n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
-        agg_syms[a] = ie->sym;
-        ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
-        val_data[a]    = vc ? ray_data(vc) : NULL;
-        val_types[a]   = vc ? vc->type : RAY_I64;
-        val_hasnull[a] = vc ? ((vc->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
-        val_esz[a]     = vc ? col_esz(vc) : 0;
-        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE)
-            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a])->sym) : NULL;
-        val2_data[a]    = vc2 ? ray_data(vc2) : NULL;
-        val2_types[a]   = vc2 ? vc2->type : RAY_I64;
-        val2_hasnull[a] = vc2 ? ((vc2->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
-        val2_esz[a]     = vc2 ? col_esz(vc2) : 0;
-    }
+    agg_desc_t d;
+    if (!agg_desc_init(&d, g, ext, tbl, key_cols)) { agg_vo_free(&vo); return ray_error("oom", NULL); }
+    const void** key_data = d.key_data;
+    const void** val_data = d.val_data; const int8_t* val_types = d.val_types;
+    const bool* val_hasnull = d.val_hasnull; const uint8_t* val_esz = d.val_esz;
+    const void** val2_data = d.val2_data; const int8_t* val2_types = d.val2_types;
+    const bool* val2_hasnull = d.val2_hasnull; const uint8_t* val2_esz = d.val2_esz;
+    const int64_t* agg_syms = d.agg_syms;
 
     agg_dense_local_t* locals = ray_calloc_raw((size_t)((size_t)nw) * (sizeof(agg_dense_local_t)));
-    if (!locals) return ray_error("oom", NULL);
+    if (!locals) { agg_vo_free(&vo); agg_desc_free(&d); return ray_error("oom", NULL); }
     uint32_t n_init = 0;   /* slabs whose slots were fully init'd (destroy-safe) */
     int alloc_oom = 0;
     for (uint32_t w = 0; w < nw; w++) {
@@ -1169,6 +1233,7 @@ static ray_t* exec_group_v2_parallel_dense(
             agg_dense_slab_destroy_states(locals[w].states, total_slots, vts, off, block, n_aggs);
         for (uint32_t w = 0; w < nw; w++) agg_dense_local_destroy(&locals[w]);
         ray_free_raw(locals);
+        agg_vo_free(&vo); agg_desc_free(&d);
         return ray_error("oom", NULL);
     }
 
@@ -1193,6 +1258,7 @@ static ray_t* exec_group_v2_parallel_dense(
                 agg_dense_slab_destroy_states(locals[i].states, total_slots, vts, off, block, n_aggs);
             for (uint32_t i = 0; i < nw; i++) agg_dense_local_destroy(&locals[i]);
             ray_free_raw(locals);
+            agg_vo_free(&vo); agg_desc_free(&d);
             return ray_error("oom", NULL);
         }
 
@@ -1205,6 +1271,7 @@ static ray_t* exec_group_v2_parallel_dense(
             agg_dense_slab_destroy_states(locals[i].states, total_slots, vts, off, block, n_aggs);
         for (uint32_t i = 0; i < nw; i++) agg_dense_local_destroy(&locals[i]);
         ray_free_raw(locals);
+        agg_vo_free(&vo); agg_desc_free(&d);
         return ray_error("oom", NULL);
     }
     for (int64_t s = 0; s < total_slots; s++) {
@@ -1243,6 +1310,7 @@ static ray_t* exec_group_v2_parallel_dense(
         ray_free_raw(occupied_slot); ray_free_raw(first_row_ordered);
         agg_dense_slab_destroy_states(gstates, total_slots, vts, off, block, n_aggs);
         ray_free_raw(gstates); ray_free_raw(gfirst);
+        agg_vo_free(&vo); agg_desc_free(&d);
         return ray_error("oom", NULL);
     }
     { int64_t i = 0;
@@ -1254,6 +1322,7 @@ static ray_t* exec_group_v2_parallel_dense(
     if (!result || RAY_IS_ERR(result)) {
         agg_dense_slab_destroy_states(gstates, total_slots, vts, off, block, n_aggs);
         ray_free_raw(occupied_slot); ray_free_raw(first_row_ordered); ray_free_raw(gstates); ray_free_raw(gfirst);
+        agg_vo_free(&vo); agg_desc_free(&d);
         return result ? result : ray_error("oom", NULL);
     }
 
@@ -1262,6 +1331,7 @@ static ray_t* exec_group_v2_parallel_dense(
         if (!kc || RAY_IS_ERR(kc)) {
             agg_dense_slab_destroy_states(gstates, total_slots, vts, off, block, n_aggs);
             ray_free_raw(occupied_slot); ray_free_raw(first_row_ordered); ray_free_raw(gstates); ray_free_raw(gfirst);
+            agg_vo_free(&vo); agg_desc_free(&d);
             ray_release(result); return kc ? kc : ray_error("oom", NULL);
         }
         result = ray_table_add_col(result, key_syms[k], kc);
@@ -1276,6 +1346,7 @@ static ray_t* exec_group_v2_parallel_dense(
         if (!out || RAY_IS_ERR(out)) {
             agg_dense_slab_destroy_states(gstates, total_slots, vts, off, block, n_aggs);
             ray_free_raw(occupied_slot); ray_free_raw(first_row_ordered); ray_free_raw(gstates); ray_free_raw(gfirst);
+            agg_vo_free(&vo); agg_desc_free(&d);
             ray_release(result); return out ? out : ray_error("oom", NULL);
         }
         out->len = ng;
@@ -1299,6 +1370,7 @@ static ray_t* exec_group_v2_parallel_dense(
      * state exactly once before freeing the slab. */
     agg_dense_slab_destroy_states(gstates, total_slots, vts, off, block, n_aggs);
     ray_free_raw(occupied_slot); ray_free_raw(first_row_ordered); ray_free_raw(gstates); ray_free_raw(gfirst);
+    agg_vo_free(&vo); agg_desc_free(&d);
     return result;
 }
 
@@ -1555,7 +1627,8 @@ static void agg_sh_phaseA_fn(void* vctx, uint32_t wid, int64_t start, int64_t en
     if (c->sel) {
         int64_t rows[AGG_SEL_CHUNK];
         uint32_t sgid[AGG_SEL_CHUNK];
-        agg_sel_scratch_t sc = {0};
+        agg_sel_scratch_t sc;
+        if (!agg_sel_scratch_init(&sc, c->n_aggs)) { sh->oom = 1; return; }
         agg_sel_cursor_t cur;
         agg_sel_cursor_init(&cur, c->sel, c->sel_prefix, start, end);
         int64_t cn;
@@ -1626,27 +1699,14 @@ static ray_t* exec_group_v2_parallel_smallhash(
     ray_pool_t* pool = ray_pool_get();
     uint32_t nw = ray_pool_total_workers(pool);
 
-    const void* key_data[16];
-    for (uint8_t k = 0; k < n_keys; k++) key_data[k] = ray_data(key_cols[k]);
-
-    const void* val_data[16]; int8_t val_types[16]; bool val_hasnull[16]; uint8_t val_esz[16];
-    const void* val2_data[16]; int8_t val2_types[16]; bool val2_hasnull[16]; uint8_t val2_esz[16];
-    int64_t agg_syms[16];
-    for (uint8_t a = 0; a < n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
-        agg_syms[a] = ie->sym;
-        ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
-        val_data[a]    = vc ? ray_data(vc) : NULL;
-        val_types[a]   = vc ? vc->type : RAY_I64;
-        val_hasnull[a] = vc ? ((vc->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
-        val_esz[a]     = vc ? col_esz(vc) : 0;
-        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE)
-            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a])->sym) : NULL;
-        val2_data[a]    = vc2 ? ray_data(vc2) : NULL;
-        val2_types[a]   = vc2 ? vc2->type : RAY_I64;
-        val2_hasnull[a] = vc2 ? ((vc2->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
-        val2_esz[a]     = vc2 ? col_esz(vc2) : 0;
-    }
+    agg_desc_t d;
+    if (!agg_desc_init(&d, g, ext, tbl, key_cols)) return ray_error("oom", NULL);
+    const void** key_data = d.key_data;
+    const void** val_data = d.val_data; const int8_t* val_types = d.val_types;
+    const bool* val_hasnull = d.val_hasnull; const uint8_t* val_esz = d.val_esz;
+    const void** val2_data = d.val2_data; const int8_t* val2_types = d.val2_types;
+    const bool* val2_hasnull = d.val2_hasnull; const uint8_t* val2_esz = d.val2_esz;
+    const int64_t* agg_syms = d.agg_syms;
 
     /* Per-worker hash sized to ~4× the estimated cardinality (floor 256) — the
      * cap, not N.  Grows by rehash if a worker sees more distinct keys than the
@@ -1656,13 +1716,14 @@ static ray_t* exec_group_v2_parallel_smallhash(
     if (nrows > 0 && cap0 > nrows) cap0 = nrows;
 
     agg_sh_t* locals = ray_calloc_raw((size_t)((size_t)nw) * (sizeof(agg_sh_t)));
-    if (!locals) return ray_error("oom", NULL);
+    if (!locals) { agg_desc_free(&d); return ray_error("oom", NULL); }
     int alloc_oom = 0;
     for (uint32_t w = 0; w < nw; w++)
         if (agg_sh_init(&locals[w], cap0, block) != 0) { alloc_oom = 1; break; }
     if (alloc_oom) {
         for (uint32_t w = 0; w < nw; w++) agg_sh_destroy(&locals[w]);
         ray_free_raw(locals);
+        agg_desc_free(&d);
         return ray_error("oom", NULL);
     }
 
@@ -1687,6 +1748,7 @@ static ray_t* exec_group_v2_parallel_smallhash(
     if (atomic_load_explicit(&ctx.overflow, memory_order_relaxed)) {
         for (uint32_t w = 0; w < nw; w++) agg_sh_destroy(&locals[w]);
         ray_free_raw(locals);
+        agg_desc_free(&d);
         return exec_group_v2_parallel_radix(g, op, tbl, nrows, key_cols, key_syms,
                                             vts, off, block, sel, sel_prefix, n_sel);
     }
@@ -1695,6 +1757,7 @@ static ray_t* exec_group_v2_parallel_smallhash(
         if (locals[w].oom) {
             for (uint32_t i = 0; i < nw; i++) agg_sh_destroy(&locals[i]);
             ray_free_raw(locals);
+            agg_desc_free(&d);
             return ray_error("oom", NULL);
         }
 
@@ -1707,6 +1770,7 @@ static ray_t* exec_group_v2_parallel_smallhash(
         agg_sh_destroy(&gt);
         for (uint32_t i = 0; i < nw; i++) agg_sh_destroy(&locals[i]);
         ray_free_raw(locals);
+        agg_desc_free(&d);
         return ray_error("oom", NULL);
     }
     for (uint32_t w = 0; w < nw; w++) {
@@ -1719,6 +1783,7 @@ static ray_t* exec_group_v2_parallel_smallhash(
                 agg_sh_destroy(&gt);
                 for (uint32_t i = 0; i < nw; i++) agg_sh_destroy(&locals[i]);
                 ray_free_raw(locals);
+                agg_desc_free(&d);
                 return ray_error("oom", NULL);
             }
             for (uint8_t a = 0; a < n_aggs; a++)
@@ -1735,13 +1800,13 @@ static ray_t* exec_group_v2_parallel_smallhash(
      * trivially cheap for the few groups this path handles. */
     ray_t* result = ray_table_new(n_keys + n_aggs);
     if (!result || RAY_IS_ERR(result)) {
-        agg_sh_destroy(&gt);
+        agg_sh_destroy(&gt); agg_desc_free(&d);
         return result ? result : ray_error("oom", NULL);
     }
     for (uint8_t k = 0; k < n_keys; k++) {
         ray_t* kc = agg_gather_key_col(key_cols[k], gt.first_row, ng);
         if (!kc || RAY_IS_ERR(kc)) {
-            agg_sh_destroy(&gt); ray_release(result);
+            agg_sh_destroy(&gt); agg_desc_free(&d); ray_release(result);
             return kc ? kc : ray_error("oom", NULL);
         }
         result = ray_table_add_col(result, key_syms[k], kc);
@@ -1750,7 +1815,7 @@ static ray_t* exec_group_v2_parallel_smallhash(
     for (uint8_t a = 0; a < n_aggs; a++) {
         ray_t* out = ray_vec_new(vts[a]->out_type, ng);   /* streaming → never LIST */
         if (!out || RAY_IS_ERR(out)) {
-            agg_sh_destroy(&gt); ray_release(result);
+            agg_sh_destroy(&gt); agg_desc_free(&d); ray_release(result);
             return out ? out : ray_error("oom", NULL);
         }
         out->len = ng;
@@ -1765,6 +1830,7 @@ static ray_t* exec_group_v2_parallel_smallhash(
         ray_release(out);
     }
     agg_sh_destroy(&gt);   /* streaming-only: no per-group destroy lifecycle */
+    agg_desc_free(&d);
     return result;
 }
 
@@ -1904,8 +1970,8 @@ typedef struct {
      *   [val2_off[a] ..]        agg a's 2nd input (pearson) at native esz
      *   [row_off ..]            int64 source row index (for first_row) */
     size_t              rec;        /* total record size, 8-aligned */
-    size_t              val_off[16];
-    size_t              val2_off[16];
+    const size_t*       val_off;    /* [n_aggs], carved by the caller */
+    const size_t*       val2_off;   /* [n_aggs], carved by the caller */
     size_t              row_off;
     /* When false, NO admitted aggregate consults the original row (first_row is
      * dead): the record omits its 8-byte row index and Phase-2/3 skip it.  Set
@@ -2011,8 +2077,16 @@ static void agg_radix_group_fn(void* vctx, uint32_t wid, int64_t start, int64_t 
         }
         for (int64_t i = 0; i < htcap; i++) ht[i] = -1;
 
-        /* Per-agg dense value buffers, gathered contiguously from the records. */
-        char* gv[16] = {0}; char* gy[16] = {0};
+        /* Per-agg dense value buffers, gathered contiguously from the records.
+         * gv/gy are per-partition scratch (this worker only) — carved here, not
+         * the shared descriptor, so per-invocation allocation is correct. */
+        char** gv = ray_calloc_raw((size_t)(n_aggs ? n_aggs : 1) * sizeof(char*));
+        char** gy = ray_calloc_raw((size_t)(n_aggs ? n_aggs : 1) * sizeof(char*));
+        if (!gv || !gy) {
+            ray_free_raw(gv); ray_free_raw(gy);
+            ray_free_raw(ht); ray_free_raw(ht_salt); ray_free_raw(first_row); ray_free_raw(states); ray_free_raw(keyp); ray_free_raw(gid); ray_free_raw(gkeys);
+            pr->oom = 1; return;
+        }
         for (uint8_t a = 0; a < n_aggs; a++) {
             if (c->val_data[a]) {
                 uint8_t ez = c->val_esz[a];
@@ -2094,12 +2168,14 @@ static void agg_radix_group_fn(void* vctx, uint32_t wid, int64_t start, int64_t 
         }
 
         for (uint8_t a = 0; a < n_aggs; a++) { ray_free_raw(gv[a]); ray_free_raw(gy[a]); }
+        ray_free_raw(gv); ray_free_raw(gy);
         ray_free_raw(gid);
         pr->states = states; pr->first_row = first_row; pr->keys = gkeys; pr->ng = ng;
         continue;
     oom:
         ray_free_raw(ht); ray_free_raw(ht_salt); ray_free_raw(first_row); ray_free_raw(states); ray_free_raw(keyp); ray_free_raw(gid); ray_free_raw(gkeys);
         for (uint8_t a = 0; a < n_aggs; a++) { ray_free_raw(gv[a]); ray_free_raw(gy[a]); }
+        ray_free_raw(gv); ray_free_raw(gy);
         pr->oom = 1; return;
     }
 }
@@ -2180,27 +2256,14 @@ static ray_t* exec_group_v2_parallel_radix(
     ray_pool_t* pool = ray_pool_get();
     uint32_t nw = ray_pool_total_workers(pool);
 
-    const void* key_data[16];
-    for (uint8_t k = 0; k < n_keys; k++) key_data[k] = ray_data(key_cols[k]);
-
-    const void* val_data[16]; int8_t val_types[16]; bool val_hasnull[16]; uint8_t val_esz[16];
-    const void* val2_data[16]; int8_t val2_types[16]; bool val2_hasnull[16]; uint8_t val2_esz[16];
-    int64_t agg_syms[16];
-    for (uint8_t a = 0; a < n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
-        agg_syms[a] = ie->sym;
-        ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
-        val_data[a]    = vc ? ray_data(vc) : NULL;
-        val_types[a]   = vc ? vc->type : RAY_I64;
-        val_hasnull[a] = vc ? ((vc->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
-        val_esz[a]     = vc ? col_esz(vc) : 0;
-        ray_t* vc2 = (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE)
-            ? ray_table_get_col(tbl, find_ext(g, ext->agg_ins2[a])->sym) : NULL;
-        val2_data[a]    = vc2 ? ray_data(vc2) : NULL;
-        val2_types[a]   = vc2 ? vc2->type : RAY_I64;
-        val2_hasnull[a] = vc2 ? ((vc2->attrs & RAY_ATTR_HAS_NULLS) != 0) : false;
-        val2_esz[a]     = vc2 ? col_esz(vc2) : 0;
-    }
+    agg_desc_t d;
+    if (!agg_desc_init(&d, g, ext, tbl, key_cols)) return ray_error("oom", NULL);
+    const void** key_data = d.key_data;
+    const void** val_data = d.val_data; const int8_t* val_types = d.val_types;
+    const bool* val_hasnull = d.val_hasnull; const uint8_t* val_esz = d.val_esz;
+    const void** val2_data = d.val2_data; const int8_t* val2_types = d.val2_types;
+    const bool* val2_hasnull = d.val2_hasnull; const uint8_t* val2_esz = d.val2_esz;
+    const int64_t* agg_syms = d.agg_syms;
 
     /* Row-dependent aggregates (FIRST/LAST) consult the representative original
      * row; every other admitted agg (COUNT/SUM/AVG/MIN/MAX/VAR/STDDEV/PEARSON/
@@ -2216,8 +2279,12 @@ static ray_t* exec_group_v2_parallel_radix(
     for (uint8_t a = 0; a < n_aggs; a++)
         if (ext->agg_ops[a] == OP_FIRST || ext->agg_ops[a] == OP_LAST) { needs_row = true; break; }
 
-    /* Per-row payload record layout: [packed keys][agg values][row_idx?]. */
-    size_t val_off[16] = {0}, val2_off[16] = {0};
+    /* Per-row payload record layout: [packed keys][agg values][row_idx?].
+     * val_off/val2_off are per-dispatch (filled once here, read by workers). */
+    ray_t* off_hdr;
+    size_t* val_off = (size_t*)scratch_calloc(&off_hdr, 2u * (size_t)n_aggs * sizeof(size_t));
+    if (!val_off) { agg_desc_free(&d); return ray_error("oom", NULL); }
+    size_t* val2_off = val_off + n_aggs;
     size_t rec_cur = (size_t)n_keys * 8;
     for (uint8_t a = 0; a < n_aggs; a++) {
         if (val_data[a])  { val_off[a]  = rec_cur; rec_cur += val_esz[a]; }
@@ -2229,7 +2296,11 @@ static ray_t* exec_group_v2_parallel_radix(
     size_t nbuf = (size_t)nw * AGG_RADIX_P;
     agg_pay_buf_t*    bufs  = ray_calloc_raw((size_t)(nbuf) * (sizeof(agg_pay_buf_t)));
     agg_radix_part_t* parts = ray_calloc_raw((size_t)(AGG_RADIX_P) * (sizeof(agg_radix_part_t)));
-    if (!bufs || !parts) { ray_free_raw(bufs); ray_free_raw(parts); return ray_error("oom", NULL); }
+    if (!bufs || !parts) {
+        ray_free_raw(bufs); ray_free_raw(parts);
+        scratch_free(off_hdr); agg_desc_free(&d);
+        return ray_error("oom", NULL);
+    }
 
     agg_radix_ctx_t ctx = {
         .key_cols = key_cols, .key_data = key_data, .n_keys = n_keys,
@@ -2239,9 +2310,8 @@ static ray_t* exec_group_v2_parallel_radix(
         .nw = nw, .bufs = bufs, .parts = parts, .phase1_oom = 0,
         .rec = rec, .row_off = row_off, .needs_row = needs_row,
         .sel = sel, .sel_prefix = sel_prefix,
+        .val_off = val_off, .val2_off = val2_off,
     };
-    memcpy(ctx.val_off, val_off, sizeof(val_off));
-    memcpy(ctx.val2_off, val2_off, sizeof(val2_off));
 
     /* Phase 1: scatter.  Sel mode dispatches over selected-row space [0,n_sel);
      * each worker decodes its slice of selected rows to ORIGINAL indices. */
@@ -2255,10 +2325,14 @@ static ray_t* exec_group_v2_parallel_radix(
         for (uint32_t p = 0; p < AGG_RADIX_P; p++)
             if (parts[p].oom) { oom = 1; break; }
 
+    /* Phases 1+2 done (both dispatches joined); val_off/val2_off no longer read. */
+    scratch_free(off_hdr);
+
     if (oom) {
         agg_radix_parts_destroy(parts, AGG_RADIX_P, vts, off, block, n_aggs);
         for (size_t i = 0; i < nbuf; i++) ray_free_raw(bufs[i].buf);
         ray_free_raw(bufs); ray_free_raw(parts);
+        agg_desc_free(&d);
         return ray_error("oom", NULL);
     }
 
@@ -2279,6 +2353,7 @@ static ray_t* exec_group_v2_parallel_radix(
         agg_radix_parts_destroy(parts, AGG_RADIX_P, vts, off, block, n_aggs);
         for (size_t i = 0; i < nbuf; i++) ray_free_raw(bufs[i].buf);
         ray_free_raw(bufs); ray_free_raw(parts);
+        agg_desc_free(&d);
         return ray_error("oom", NULL);
     }
     { int64_t i = 0;
@@ -2296,6 +2371,7 @@ static ray_t* exec_group_v2_parallel_radix(
         agg_radix_parts_destroy(parts, AGG_RADIX_P, vts, off, block, n_aggs);
         for (size_t i = 0; i < nbuf; i++) ray_free_raw(bufs[i].buf);
         ray_free_raw(bufs); ray_free_raw(parts);
+        agg_desc_free(&d);
         return result ? result : ray_error("oom", NULL);
     }
 
@@ -2310,6 +2386,7 @@ static ray_t* exec_group_v2_parallel_radix(
             agg_radix_parts_destroy(parts, AGG_RADIX_P, vts, off, block, n_aggs);
             for (size_t i = 0; i < nbuf; i++) ray_free_raw(bufs[i].buf);
             ray_free_raw(bufs); ray_free_raw(parts);
+            agg_desc_free(&d);
             ray_release(result); return kc ? kc : ray_error("oom", NULL);
         }
         result = ray_table_add_col(result, key_syms[k], kc);
@@ -2320,8 +2397,17 @@ static ray_t* exec_group_v2_parallel_radix(
      * pass can write disjoint slices into all scalar columns at once.  LIST
      * (top/bot) columns are finalized serially below — outs[a] stays NULL for
      * them so the parallel worker skips them. */
-    ray_t* outs[16] = {0};
-    int64_t kparams[16] = {0};
+    ray_t* outs_hdr;
+    ray_t** outs = (ray_t**)scratch_calloc(&outs_hdr, (size_t)n_aggs * (sizeof(ray_t*) + sizeof(int64_t)));
+    if (!outs) {
+        ray_free_raw(pairs);
+        agg_radix_parts_destroy(parts, AGG_RADIX_P, vts, off, block, n_aggs);
+        for (size_t i = 0; i < nbuf; i++) ray_free_raw(bufs[i].buf);
+        ray_free_raw(bufs); ray_free_raw(parts);
+        agg_desc_free(&d);
+        ray_release(result); return ray_error("oom", NULL);
+    }
+    int64_t* kparams = (int64_t*)(outs + n_aggs);
     for (uint8_t a = 0; a < n_aggs; a++) {
         /* Buffered top_n/bot_n produce a LIST cell per group (a native vector);
          * median and all streaming aggs produce a scalar out_type cell. */
@@ -2333,6 +2419,7 @@ static ray_t* exec_group_v2_parallel_radix(
             agg_radix_parts_destroy(parts, AGG_RADIX_P, vts, off, block, n_aggs);
             for (size_t i = 0; i < nbuf; i++) ray_free_raw(bufs[i].buf);
             ray_free_raw(bufs); ray_free_raw(parts);
+            scratch_free(outs_hdr); agg_desc_free(&d);
             ray_release(result); return out ? out : ray_error("oom", NULL);
         }
         out->len = ng;
@@ -2346,9 +2433,11 @@ static ray_t* exec_group_v2_parallel_radix(
     bool par_fin = (pool && ng >= RAY_PARALLEL_THRESHOLD);
     if (par_fin) {
         uint8_t* saw_null = ray_calloc_raw((size_t)((size_t)nw * (n_aggs ? n_aggs : 1)) * (1));
-        if (!saw_null) { par_fin = false; }
+        ray_t* scalar_hdr = NULL;
+        ray_t** scalar_outs = saw_null
+            ? (ray_t**)scratch_alloc(&scalar_hdr, (size_t)n_aggs * sizeof(ray_t*)) : NULL;
+        if (!saw_null || !scalar_outs) { par_fin = false; ray_free_raw(saw_null); scratch_free(scalar_hdr); }
         else {
-            ray_t* scalar_outs[16];
             for (uint8_t a = 0; a < n_aggs; a++)
                 scalar_outs[a] = (vts[a]->out_type == RAY_LIST) ? NULL : outs[a];
             agg_radix_fin_ctx_t fc = {
@@ -2367,6 +2456,7 @@ static ray_t* exec_group_v2_parallel_radix(
                     }
             }
             ray_free_raw(saw_null);
+            scratch_free(scalar_hdr);
         }
     }
 
@@ -2401,6 +2491,7 @@ static ray_t* exec_group_v2_parallel_radix(
     agg_radix_parts_destroy(parts, AGG_RADIX_P, vts, off, block, n_aggs);
     for (size_t i = 0; i < nbuf; i++) ray_free_raw(bufs[i].buf);
     ray_free_raw(bufs); ray_free_raw(parts);
+    scratch_free(outs_hdr); agg_desc_free(&d);
     return result;
 }
 
@@ -2438,15 +2529,9 @@ static ray_t* exec_group_v2_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
     }
 
     /* Precompute AoS state layout for the admitted aggregates. */
-    const agg_vtable_t* vts[16]; size_t off[16]; size_t block = 0;
-    for (uint8_t a = 0; a < ext->n_aggs; a++) {
-        ray_op_ext_t* ie = find_ext(g, ext->agg_ins[a]);
-        ray_t* vc = (ext->agg_ops[a] != OP_COUNT) ? ray_table_get_col(tbl, ie->sym) : NULL;
-        int8_t in_type = vc ? vc->type : RAY_I64;
-        vts[a] = agg_resolve(ext->agg_ops[a], in_type);
-        off[a] = block;
-        block += vts[a]->state_size;
-    }
+    agg_vo_t vo;
+    if (!agg_vo_init(&vo, g, ext, tbl)) return ray_error("oom", NULL);
+    const agg_vtable_t** vts = vo.vts; size_t* off = vo.off; size_t block = vo.block;
 
     /* Dense plan (low-card int/SYM keys + streaming aggs → direct index, no
      * hash).  Computed up front so both the parallel and serial dispatch can use
@@ -2463,6 +2548,7 @@ static ray_t* exec_group_v2_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
      * recurse with sel=NULL so the unmodified strategy runs over it. */
     #define AGG_RUN_COMPACT_FALLBACK()                                          \
         do {                                                                    \
+            agg_vo_free(&vo);   /* not needed by the compact recursion */       \
             ray_t* idxb = ray_rowsel_to_indices(sel);                           \
             if (!idxb) return ray_error("oom", NULL);                           \
             ray_t* compact = agg_build_compact(g, op, tbl, (int64_t*)ray_data(idxb), n_sel); \
@@ -2520,9 +2606,11 @@ static ray_t* exec_group_v2_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
         for (uint8_t a = 0; a < ext->n_aggs && all_streaming; a++)
             if (vts[a]->kind != ACC_STREAMING) all_streaming = false;
 
-        if (dense_par_ok)
-            return exec_group_v2_parallel_dense(g, op, tbl, key_cols, key_syms, ext, nrows, pool, &dp,
-                                                sel, sel_prefix, n_sel);
+        if (dense_par_ok) {
+            ray_t* r = exec_group_v2_parallel_dense(g, op, tbl, key_cols, key_syms, ext, nrows, pool, &dp,
+                                                    sel, sel_prefix, n_sel);
+            agg_vo_free(&vo); return r;
+        }
         if (keys_intsym) {
             /* Dense-FAIL int/SYM streaming shapes: probe cardinality on a bounded
              * sample.  LOW card → small-hash (O(groups) working set, no scatter
@@ -2558,17 +2646,25 @@ static ray_t* exec_group_v2_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
                 int64_t est = sel
                     ? agg_estimate_card_sel(key_cols, key_data, ext->n_keys, sel, sel_prefix, n_sel, 65536, T_ROUTE)
                     : agg_estimate_card(key_cols, key_data, ext->n_keys, nrows, 65536, T_ROUTE);
-                if (est <= T_ROUTE)
-                    return exec_group_v2_parallel_smallhash(g, op, tbl, nrows,
+                if (est <= T_ROUTE) {
+                    ray_t* r = exec_group_v2_parallel_smallhash(g, op, tbl, nrows,
                             key_cols, key_syms, vts, off, block, est, sel, sel_prefix, n_sel);
+                    agg_vo_free(&vo); return r;
+                }
             }
-            return exec_group_v2_parallel_radix(g, op, tbl, nrows, key_cols, key_syms, vts, off, block,
-                                                sel, sel_prefix, n_sel);
+            { ray_t* r = exec_group_v2_parallel_radix(g, op, tbl, nrows, key_cols, key_syms, vts, off, block,
+                                                      sel, sel_prefix, n_sel);
+              agg_vo_free(&vo); return r; }
         }
         /* Hash fallback (F64 / STR keys): not a chunked strategy — compact. */
         if (sel) AGG_RUN_COMPACT_FALLBACK();
-        return exec_group_v2_parallel(g, op, tbl, nrows, key_cols, key_syms, vts, off, block);
+        { ray_t* r = exec_group_v2_parallel(g, op, tbl, nrows, key_cols, key_syms, vts, off, block);
+          agg_vo_free(&vo); return r; }
     }
+
+    /* Serial path does not consult the vts/off tables (per-agg vt is re-resolved
+     * below), so release the layout carve before it runs. */
+    agg_vo_free(&vo);
 
     /* Serial path: keep the compact fallback when a filter is active (selected
      * count is below the parallel threshold here → small; not a perf blocker). */

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -8768,6 +8768,7 @@ ht_path:;
               if (agg_owned2[a] && agg_vecs2[a]) ray_release(agg_vecs2[a]); }
         for (uint8_t k = 0; k < n_keys; k++)
             if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
+        if (match_idx_block) ray_release(match_idx_block);
         return ray_error("nyi", NULL);
     }
     /* The HT row-layout reads agg_vecs directly — convert any fused-product
@@ -8779,6 +8780,7 @@ ht_path:;
               if (agg_owned2[a] && agg_vecs2[a]) ray_release(agg_vecs2[a]); }
         for (uint8_t k = 0; k < n_keys; k++)
             if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
+        if (match_idx_block) ray_release(match_idx_block);
         return ray_error("oom", NULL);
     }
 

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -5450,13 +5450,29 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
     int can_partition = g->selection ? 0 : 1;
     int has_avg = 0;
     int has_stddev = 0;
-    int64_t key_syms[8];
+    /* Exact-size scratch carves — n_keys/n_aggs are uint8_t (up to 255 on the
+     * unbounded-slots branch) and this dispatch runs BEFORE the n_keys/n_aggs
+     * > 8 nyi guard, so fixed key_syms[8]/agg_syms[8] stack arrays overflowed
+     * for a parted GROUP BY with 9+ keys or agg inputs.  Sized min 1 to avoid
+     * a zero-byte allocation; both stay live through the
+     * exec_group_per_partition call below (they are passed to it), then freed
+     * before the concat fallback (which re-derives its columns via find_ext,
+     * not these arrays). */
+    int64_t key_max = n_keys > 0 ? (int64_t)n_keys : 1;
+    ray_t* key_syms_hdr = NULL;
+    int64_t* key_syms = (int64_t*)scratch_alloc(&key_syms_hdr,
+            (size_t)key_max * sizeof(int64_t));
+    if (!key_syms) return ray_error("oom", NULL);
     for (uint8_t k = 0; k < n_keys && can_partition; k++) {
         ray_op_ext_t* ke = find_ext(g, ext->keys[k]);
         if (!ke || ke->base.opcode != OP_SCAN) { can_partition = 0; break; }
         key_syms[k] = ke->sym;
     }
-    int64_t agg_syms[8];
+    int64_t agg_max = n_aggs > 0 ? (int64_t)n_aggs : 1;
+    ray_t* agg_syms_hdr = NULL;
+    int64_t* agg_syms = (int64_t*)scratch_alloc(&agg_syms_hdr,
+            (size_t)agg_max * sizeof(int64_t));
+    if (!agg_syms) { scratch_free(key_syms_hdr); return ray_error("oom", NULL); }
     for (uint8_t a = 0; a < n_aggs && can_partition; a++) {
         uint16_t aop = ext->agg_ops[a];
         /* Holistic aggs (OP_MEDIAN / OP_TOP_N / OP_BOT_N) can't be
@@ -5550,9 +5566,17 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
         ray_t* result = exec_group_per_partition(parted_tbl, ext, n_parts,
                                                  key_syms, agg_syms, has_avg,
                                                  has_stddev, group_limit);
-        if (result) return result;
+        if (result) {
+            scratch_free(key_syms_hdr);
+            scratch_free(agg_syms_hdr);
+            return result;
+        }
         /* NULL = per-partition failed, fall through to concat */
     }
+    /* key_syms/agg_syms are unused past this point (the concat fallback
+     * re-derives its columns via find_ext) — free before falling through. */
+    scratch_free(key_syms_hdr);
+    scratch_free(agg_syms_hdr);
 
     /* ---- Concat fallback ---- */
     /* ---- Concat-only-needed-columns fallback ----

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -7086,9 +7086,10 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
          * agg_linear[0].enabled implies null-free.) */
         typedef void (*scalar_fn_t)(void*, uint32_t, int64_t, int64_t);
         scalar_fn_t sc_fn = scalar_accum_fn;
-        bool agg0_has_nulls = sc_int_null_has[0] ||
-            (agg_vecs[0] && agg_vecs[0]->type == RAY_F64 &&
-             (agg_vecs[0]->attrs & RAY_ATTR_HAS_NULLS));
+        bool agg0_has_nulls = n_aggs > 0 &&
+            (sc_int_null_has[0] ||
+             (agg_vecs[0] && agg_vecs[0]->type == RAY_F64 &&
+              (agg_vecs[0]->attrs & RAY_ATTR_HAS_NULLS)));
         if (n_aggs == 1 && !match_idx && !rowsel && agg_ptrs[0] != NULL && !agg0_has_nulls) {
             uint16_t op0 = ext->agg_ops[0];
             int8_t   t0  = agg_types[0];

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -4656,8 +4656,11 @@ typedef struct {
     /* per-worker accumulators (1 slot each) */
     da_accum_t*    accums;
     uint32_t       n_accums;
-    /* Per-agg integer-null sentinel + mask (mirrors da_ctx_t). */
-    uint32_t       agg_int_null_mask;
+    /* Per-agg integer-null sentinel + has-nulls flag.  A per-element array
+     * (not a bitmask, unlike da_ctx_t's agg_int_null_mask) because this
+     * path's n_aggs is VLA-sized with no fixed cap — a 32/64-bit mask would
+     * silently alias past that many aggregates. */
+    const bool*    agg_int_null_has;
     int64_t*       agg_int_null_sentinel;
 } scalar_ctx_t;
 
@@ -4749,7 +4752,7 @@ static inline void scalar_accum_row(scalar_ctx_t* c, da_accum_t* acc, int64_t r)
         uint16_t op = c->agg_ops[a];
         bool is_f = (c->agg_types[a] == RAY_F64);
         /* NULL_I* sentinel = null. */
-        bool int_null = !is_f && (c->agg_int_null_mask & (1u << a)) &&
+        bool int_null = !is_f && c->agg_int_null_has[a] &&
                         iv == c->agg_int_null_sentinel[a];
         bool is_null = is_f ? !(fv == fv) : int_null;
         if (op == OP_SUM || op == OP_AVG || op == OP_STDDEV || op == OP_STDDEV_POP || op == OP_VAR || op == OP_VAR_POP) {
@@ -6637,7 +6640,17 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
         }
     }
 
-    if (n_keys > 8 || n_aggs > 8) return ray_error("nyi", NULL);
+    /* The ght `[8]` fast layout (key_data[8]/key_pool[8], and the per-agg
+     * agg_is_binary/agg_is_holistic/agg_is_wide bitmasks) structurally caps
+     * n_keys and n_aggs at 8 there — kept until a future cut (see the
+     * unbounded-slots design doc: "group-HT [8] fast layout ... until cut
+     * 4").  The scalar-reduction fast path below (n_keys == 0) is a
+     * separate, VLA-sized accumulator with no such limit, so let n_aggs > 8
+     * through when there are no group keys; the guard just before
+     * ght_compute_layout (`ht_path:`) still rejects the rare fallback
+     * (accumulator OOM / oversized scan) that would actually need the
+     * capped HT layout. */
+    if (n_keys > 8 || (n_keys > 0 && n_aggs > 8)) return ray_error("nyi", NULL);
 
     /* Extract selection (rowsel) for pushdown.  Prefer streaming the
      * morsel-local rowsel directly; flattening to int64 indices is kept
@@ -6911,7 +6924,10 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
         void* agg_ptrs[vla_aggs];
         int8_t agg_types[vla_aggs];
         int64_t sc_int_null_sentinel[vla_aggs];
-        uint32_t sc_int_null_mask = 0;
+        /* Per-element flag, not a bitmask: this path's n_aggs is VLA-sized
+         * with no fixed cap, so a fixed-width bitmask would silently alias
+         * once n_aggs exceeded its bit width. */
+        bool sc_int_null_has[vla_aggs];
         bool sc_any_nullable = false;
         for (uint8_t a = 0; a < n_aggs; a++) {
             if (agg_prod[a].enabled) {
@@ -6919,22 +6935,22 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
                 agg_ptrs[a]  = NULL;
                 agg_types[a] = RAY_F64;
                 sc_int_null_sentinel[a] = 0;
+                sc_int_null_has[a] = false;
                 continue;
             }
             if (agg_vecs[a]) {
                 agg_ptrs[a]  = ray_data(agg_vecs[a]);
                 agg_types[a] = agg_vecs[a]->type;
                 sc_int_null_sentinel[a] = agg_int_null_sentinel_for(agg_vecs[a]->type);
-                /* Only set the int-null mask bit for storage types whose
-                 * sentinel is meaningful.  BOOL/U8/SYM use 0 as their default
+                /* Only flag int-null for storage types whose sentinel is
+                 * meaningful.  BOOL/U8/SYM use 0 as their default
                  * "sentinel" which collides with legitimate values
                  * (FALSE / zero byte / SYM id 0); gating those would silently
                  * drop real rows from SUM/MIN/MAX.  F64 has its own NaN path. */
                 int8_t t = agg_vecs[a]->type;
                 bool is_sentinel_typed = (t == RAY_I16 || t == RAY_I32 || t == RAY_I64 ||
                                           t == RAY_DATE || t == RAY_TIME || t == RAY_TIMESTAMP);
-                if (is_sentinel_typed && (agg_vecs[a]->attrs & RAY_ATTR_HAS_NULLS))
-                    sc_int_null_mask |= (1u << a);
+                sc_int_null_has[a] = is_sentinel_typed && (agg_vecs[a]->attrs & RAY_ATTR_HAS_NULLS);
                 if ((agg_vecs[a]->attrs & RAY_ATTR_HAS_NULLS) &&
                     (agg_vecs[a]->type == RAY_F64 || is_sentinel_typed))
                     sc_any_nullable = true;
@@ -6942,6 +6958,7 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
                 agg_ptrs[a]  = NULL;
                 agg_types[a] = 0;
                 sc_int_null_sentinel[a] = 0;
+                sc_int_null_has[a] = false;
             }
         }
 
@@ -7022,7 +7039,7 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
             .rowsel     = rowsel,
             .accums     = sc_acc,
             .n_accums   = sc_n,
-            .agg_int_null_mask = sc_int_null_mask,
+            .agg_int_null_has = sc_int_null_has,
             .agg_int_null_sentinel = sc_int_null_sentinel,
         };
 
@@ -7038,7 +7055,7 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
          * agg_linear[0].enabled implies null-free.) */
         typedef void (*scalar_fn_t)(void*, uint32_t, int64_t, int64_t);
         scalar_fn_t sc_fn = scalar_accum_fn;
-        bool agg0_has_nulls = (sc_int_null_mask & 1u) != 0 ||
+        bool agg0_has_nulls = sc_int_null_has[0] ||
             (agg_vecs[0] && agg_vecs[0]->type == RAY_F64 &&
              (agg_vecs[0]->attrs & RAY_ATTR_HAS_NULLS));
         if (n_aggs == 1 && !match_idx && !rowsel && agg_ptrs[0] != NULL && !agg0_has_nulls) {
@@ -8707,6 +8724,21 @@ dyn_dense_done:
     }
 
 ht_path:;
+    /* n_keys == 0 with n_aggs > 8 is let through the top-of-function guard
+     * on the assumption the scalar fast path (VLA-sized) will serve it —
+     * that path returns before reaching here in the common case.  The rare
+     * fallback into this HT row-layout (accumulator OOM / oversized scan)
+     * still can't serve n_aggs > 8: agg_is_binary/agg_is_holistic/agg_is_wide
+     * are single-byte bitmasks in ght_layout_t.  n_keys > 0 with n_aggs > 8
+     * already returned at the top of the function and never reaches here. */
+    if (n_aggs > 8) {
+        for (uint8_t a = 0; a < n_aggs; a++)
+            { if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
+              if (agg_owned2[a] && agg_vecs2[a]) ray_release(agg_vecs2[a]); }
+        for (uint8_t k = 0; k < n_keys; k++)
+            if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
+        return ray_error("nyi", NULL);
+    }
     /* The HT row-layout reads agg_vecs directly — convert any fused-product
      * slots into ordinary materialized inputs first. */
     if (!group_materialize_prod_slots(agg_prod, agg_vecs, agg_owned,

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -5559,12 +5559,16 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
      * Used when query has AVG or expression keys/aggs.
      * Only concatenates the columns actually referenced by the GROUP BY. */
     {
-        /* Collect needed column sym IDs (keys + agg inputs).  Keys and agg
-         * inputs are each capped at RAY_GROUP_MAX_SLOTS by the compile path,
-         * but their deduplicated UNION can reach the sum of both caps —
-         * size for that, not for one cap (a bare [16] here overflowed the
-         * stack with >16 distinct key+agg columns). */
-        int64_t needed[2 * RAY_GROUP_MAX_SLOTS];
+        /* Collect needed column sym IDs (keys + agg inputs).  The
+         * deduplicated UNION of key and agg-input columns can reach the sum
+         * of both counts, so size the scratch to that union bound exactly
+         * (min 1 to avoid a zero-size allocation). */
+        int64_t needed_max = (int64_t)n_keys + (int64_t)n_aggs;
+        if (needed_max < 1) needed_max = 1;
+        ray_t* needed_hdr = NULL;
+        int64_t* needed = (int64_t*)scratch_alloc(&needed_hdr,
+                (size_t)needed_max * sizeof(int64_t));
+        if (!needed) return ray_error("oom", NULL);
         int n_needed = 0;
         for (uint8_t k = 0; k < n_keys; k++) {
             ray_op_ext_t* ke = find_ext(g, ext->keys[k]);
@@ -5592,7 +5596,7 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
 
         /* Build flat table with only needed columns (or all if n_needed==0) */
         ray_t* flat_tbl = ray_table_new(n_needed > 0 ? (int64_t)n_needed : ncols);
-        if (!flat_tbl || RAY_IS_ERR(flat_tbl)) return flat_tbl;
+        if (!flat_tbl || RAY_IS_ERR(flat_tbl)) { scratch_free(needed_hdr); return flat_tbl; }
 
         int64_t cols_to_iter = n_needed > 0 ? (int64_t)n_needed : ncols;
         for (int64_t ci = 0; ci < cols_to_iter; ci++) {
@@ -5634,6 +5638,7 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
                 flat = typed_vec_new(base_type, base_attrs, total_rows);
                 if (!flat || RAY_IS_ERR(flat)) {
                     ray_release(flat_tbl);
+                    scratch_free(needed_hdr);
                     return ray_error("oom", NULL);
                 }
                 /* segment cells are copied id-preserving — all partitions
@@ -5658,6 +5663,7 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
             }
             if (!flat || RAY_IS_ERR(flat)) {
                 ray_release(flat_tbl);
+                scratch_free(needed_hdr);
                 return ray_error("oom", NULL);
             }
 
@@ -5670,6 +5676,7 @@ static ray_t* exec_group_parted(ray_graph_t* g, ray_op_t* op, ray_t* parted_tbl,
         ray_t* result = exec_group(g, op, flat_tbl, 0);
         g->table = saved;
         ray_release(flat_tbl);
+        scratch_free(needed_hdr);
         return result;
     }
 }

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -117,15 +117,6 @@ static inline void* scratch_calloc(ray_t** hdr_out, size_t nbytes) {
     return p;
 }
 
-/* Fixed slot capacity for the select/group-by compile and exec paths: group
- * keys, aggregate outputs, non-aggregate outputs, and sort keys each collect
- * into stack arrays of this size.  Exceeding it is rejected with a clear
- * error rather than silently dropping the surplus (which produced wrong
- * results).  Exec-side consumers (group.c, agg_engine.c) may rely on
- * compiled GROUP nodes respecting this bound but must still guard their own
- * fixed arrays against it. */
-#define RAY_GROUP_MAX_SLOTS 16
-
 /* Allocate uninitialized scratch buffer. */
 static inline void* scratch_alloc(ray_t** hdr_out, size_t nbytes) {
     ray_t* h = ray_alloc(nbytes);

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -6434,7 +6434,6 @@ by_dict_done:
                         ray_t* rowbuf_hdr = NULL;
                         int64_t* rv = (int64_t*)scratch_alloc(&rowbuf_hdr,
                             (size_t)nk * (sizeof(int64_t) + 1));
-                        uint8_t* rn = (uint8_t*)(rv + nk);
                         if (!rv) {
                             ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
                             scratch_free(keyrd_hdr); scratch_free(cntnames_hdr); scratch_free(keycols_hdr);
@@ -6442,6 +6441,7 @@ by_dict_done:
                             ray_release(tbl);
                             scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                         }
+                        uint8_t* rn = (uint8_t*)(rv + nk);
 
                         int64_t found = 0;
                         for (int64_t r = 0; r < nrows; r++) {

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -5650,7 +5650,7 @@ by_dict_done:
     ray_op_t** agg_ins2       = agg_ins + aggs_max;
     int64_t*   agg_k          = (int64_t*)(agg_ins2 + aggs_max);
     uint16_t*  agg_ops        = (uint16_t*)(agg_k + aggs_max);
-    uint8_t n_nonaggs = 0;
+    int64_t n_nonaggs = 0;  /* bounded by n_out_max (nonagg_names/_exprs size) */
     int     n_hidden_aggs = 0;
     int     n_compound = 0;
     int     n_aggs_real = 0;           /* DAG agg slots before hidden ones */
@@ -7882,11 +7882,6 @@ by_dict_done:
                         if (compound_pos[ci] == i) { pre_compound = true; break; }
                     if (pre_compound) continue;
                 }
-                if (n_nonaggs >= RAY_GROUP_MAX_SLOTS) {
-                    for (int ci = 0; ci < n_compound; ci++) ray_release(compound_rw[ci]);
-                    ray_graph_free(g); ray_release(tbl);
-                    scratch_free(sel_slots_hdr); return ray_error("range", "select by: too many non-aggregate columns (max %d)", RAY_GROUP_MAX_SLOTS);
-                }
                 nonagg_names[n_nonaggs] = kid;
                 nonagg_exprs[n_nonaggs] = val_expr;
                 n_nonaggs++;
@@ -9186,12 +9181,12 @@ by_dict_done:
                 /* Pre-check ALL nonaggs first so we don't half-apply on
                  * an unhandled atom type and then have to roll back. */
                 int all_broadcastable = 1;
-                for (uint8_t ni = 0; ni < n_nonaggs && all_broadcastable; ni++) {
+                for (int64_t ni = 0; ni < n_nonaggs && all_broadcastable; ni++) {
                     if (!can_atom_broadcast(nonagg_exprs[ni]))
                         all_broadcastable = 0;
                 }
                 if (all_broadcastable) {
-                    for (uint8_t ni = 0; ni < n_nonaggs; ni++) {
+                    for (int64_t ni = 0; ni < n_nonaggs; ni++) {
                         ray_t* col = atom_broadcast_vec(nonagg_exprs[ni], n_groups);
                         if (!col) {
                             /* can_atom_broadcast vetted these — anything
@@ -9667,7 +9662,7 @@ by_dict_done:
                  * group counts — falls into count_distinct_per_group_buf
                  * which requires idx_buf+offsets+grp_cnt. */
                 int needs_slice_idx = 0;
-                for (uint8_t ni = 0; ni < n_nonaggs && !needs_slice_idx; ni++) {
+                for (int64_t ni = 0; ni < n_nonaggs && !needs_slice_idx; ni++) {
                     ray_t* cd_inner = match_count_distinct(nonagg_exprs[ni]);
                     int simple_cd_global = (cd_inner &&
                                             cd_inner->type == -RAY_SYM &&
@@ -9783,7 +9778,7 @@ by_dict_done:
                 }
 
                 ray_t* scatter_err = NULL;
-                for (uint8_t ni = 0; ni < n_nonaggs && !scatter_err; ni++) {
+                for (int64_t ni = 0; ni < n_nonaggs && !scatter_err; ni++) {
                     /* Per-group count(distinct) — dispatch directly to
                      * exec_count_distinct on each group's slice using
                      * the same idx_buf+offsets+grp_cnt layout the
@@ -10025,7 +10020,7 @@ by_dict_done:
                 /* Empty group set: add empty LIST columns so the
                  * output schema still includes the user-declared
                  * non-agg columns. */
-                for (uint8_t ni = 0; ni < n_nonaggs; ni++) {
+                for (int64_t ni = 0; ni < n_nonaggs; ni++) {
                     ray_t* empty_list = ray_list_new(0);
                     if (!empty_list || RAY_IS_ERR(empty_list)) {
                         ray_release(result); ray_release(tbl);

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -8421,12 +8421,26 @@ by_dict_done:
                 ray_release(fres);
             }
 
-            uint16_t  s_agg_ops[16];
-            ray_op_t* s_agg_ins[16];
-            ray_op_t* s_agg_ins2[16];
-            uint8_t   s_n_aggs = 0;
-            int       s_has_binary = 0;
-            for (int64_t i = 0; i + 1 < dict_n && s_n_aggs < 16; i += 2) {
+            /* Exact-size scratch carve: bound by select_output_count (every
+             * output here is an aggregate, so outputs == aggs).  The former
+             * fixed [16] arrays silently stopped compiling past the 16th
+             * output (loop guard `s_n_aggs < 16`) — the remaining outputs
+             * were never wired into the group node. */
+            int64_t s_max = select_output_count(dict_elems, dict_n);
+            if (s_max < 1) s_max = 1;
+            ray_t* sagg_hdr = NULL;
+            ray_op_t** s_agg_ins = (ray_op_t**)scratch_alloc(&sagg_hdr,
+                    (size_t)s_max * (2 * sizeof(ray_op_t*) + sizeof(uint16_t)));
+            if (!s_agg_ins) {
+                if (g->selection) { ray_release(g->selection); g->selection = NULL; }
+                ray_graph_free(g); ray_release(tbl);
+                scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
+            }
+            ray_op_t** s_agg_ins2 = s_agg_ins + s_max;
+            uint16_t*  s_agg_ops  = (uint16_t*)(s_agg_ins2 + s_max);
+            int64_t    s_n_aggs = 0;
+            int        s_has_binary = 0;
+            for (int64_t i = 0; i + 1 < dict_n; i += 2) {
                 int64_t kid = dict_elems[i]->i64;
                 if (kid == from_id || kid == where_id || kid == by_id ||
                     kid == take_id || kid == asc_id || kid == desc_id || kid == nearest_id) continue;
@@ -8442,6 +8456,7 @@ by_dict_done:
                         g->selection = NULL;
                     }
                     ray_graph_free(g); ray_release(tbl);
+                    scratch_free(sagg_hdr);
                     scratch_free(sel_slots_hdr); return ray_error("domain", "select: failed to compile aggregation argument");
                 }
                 /* Canonical aggregand type-admission (same table as the scalar
@@ -8453,29 +8468,42 @@ by_dict_done:
                     int8_t in_t = s_agg_ins[s_n_aggs]->out_type;            /* capture BEFORE free */
                     if (g->selection) { ray_release(g->selection); g->selection = NULL; }
                     ray_graph_free(g); ray_release(tbl);
+                    scratch_free(sagg_hdr);
                     scratch_free(sel_slots_hdr); return ray_error("type", "select: aggregation does not admit input type %s", ray_type_name(in_t));
                 }
                 if (op == OP_PEARSON_CORR) {
                     if (ray_len(val_expr) < 3) {
                         if (g->selection) { ray_release(g->selection); g->selection = NULL; }
                         ray_graph_free(g); ray_release(tbl);
+                        scratch_free(sagg_hdr);
                         scratch_free(sel_slots_hdr); return ray_error("arity", "select: cor aggregation requires two column arguments");
                     }
                     s_agg_ins2[s_n_aggs] = compile_expr_dag(g, agg_elems[2]);
                     if (!s_agg_ins2[s_n_aggs]) {
                         if (g->selection) { ray_release(g->selection); g->selection = NULL; }
                         ray_graph_free(g); ray_release(tbl);
+                        scratch_free(sagg_hdr);
                         scratch_free(sel_slots_hdr); return ray_error("domain", "select: failed to compile cor second argument");
                     }
                     s_has_binary = 1;
                 }
                 s_n_aggs++;
             }
+            /* The op-graph builders carry the agg count in uint8_t; guard the
+             * representational limit before narrowing at the call (same shape
+             * as the by: path's group-column guard). */
+            if (s_n_aggs > UINT8_MAX) {
+                if (g->selection) { ray_release(g->selection); g->selection = NULL; }
+                ray_graph_free(g); ray_release(tbl);
+                scratch_free(sagg_hdr);
+                scratch_free(sel_slots_hdr); return ray_error("range", "select: too many aggregate outputs for the op graph (max %d)", UINT8_MAX);
+            }
             if (s_has_binary)
                 root = ray_group2(g, NULL, 0, s_agg_ops, s_agg_ins,
-                                   s_agg_ins2, s_n_aggs);
+                                   s_agg_ins2, (uint8_t)s_n_aggs);
             else
-                root = ray_group(g, NULL, 0, s_agg_ops, s_agg_ins, s_n_aggs);
+                root = ray_group(g, NULL, 0, s_agg_ops, s_agg_ins, (uint8_t)s_n_aggs);
+            scratch_free(sagg_hdr);
         } else {
             /* Projection only (no group by) — select specific columns */
             ray_op_t* col_ops[16];

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -6096,15 +6096,25 @@ by_dict_done:
                 int64_t nk = ray_len(by_expr);
                 int64_t* key_syms = (int64_t*)ray_data(by_expr);
                 int64_t nrows = ray_table_nrows(eval_tbl);
-                ray_t* key_cols[16];
-                if (nk <= 0 || nk > 16) {
+                if (nk <= 0) {
                     if (eval_tbl != tbl) ray_release(eval_tbl);
                     ray_release(tbl);
-                    scratch_free(sel_slots_hdr); return ray_error("domain", "eval-level multi-key groupby requires 1..16 keys");
+                    scratch_free(sel_slots_hdr); return ray_error("domain", "eval-level multi-key groupby requires at least one key");
+                }
+                /* Pure-eval grouping carries no graph-representation limit —
+                 * carve the key-column pointers to the exact key count.  This
+                 * scratch lives until every return path in this block. */
+                ray_t* keycols_hdr = NULL;
+                ray_t** key_cols = (ray_t**)scratch_alloc(&keycols_hdr, (size_t)nk * sizeof(ray_t*));
+                if (!key_cols) {
+                    if (eval_tbl != tbl) ray_release(eval_tbl);
+                    ray_release(tbl);
+                    scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                 }
                 for (int64_t k = 0; k < nk; k++) {
                     key_cols[k] = ray_table_get_col(eval_tbl, key_syms[k]);
                     if (!key_cols[k]) {
+                        scratch_free(keycols_hdr);
                         if (eval_tbl != tbl) ray_release(eval_tbl);
                         ray_release(tbl);
                         scratch_free(sel_slots_hdr); return ray_error("domain", "group key column not found");
@@ -6148,6 +6158,10 @@ by_dict_done:
                         default: distinct_only = false; break;
                     }
                 }
+                /* agg_select_distinct addresses keys through a uint8_t count —
+                 * beyond 255 keys the fast path cannot represent the shape, so
+                 * fall through to the composite (unbounded) path below. */
+                if (nk > UINT8_MAX) distinct_only = false;
                 if (distinct_only) {
                     /* Consume the projection hint (if a consumer published one) —
                      * carry only its referenced non-key columns.  Consume-once. */
@@ -6159,6 +6173,7 @@ by_dict_done:
                     }
                     ray_t* dres = agg_select_distinct(eval_tbl, key_cols, key_syms,
                                                       (uint8_t)nk, nrows, keep, keep_n);
+                    scratch_free(keycols_hdr);
                     if (eval_tbl != tbl) ray_release(eval_tbl);
                     ray_release(tbl);
                     scratch_free(sel_slots_hdr); return dres;
@@ -6169,26 +6184,42 @@ by_dict_done:
                     dict_elems, dict_n, asc_id, desc_id, take_id,
                     nrows, &pre_take_groups);
                 if (has_pre_take && pre_take_groups <= 1024) {
-                    query_key_reader_t key_readers[16];
+                    /* Per-key reader and per-output name buffers carved to the
+                     * exact key / output counts (no fixed slot cap).  Both live
+                     * until this pre-take block returns or falls through to the
+                     * composite path below. */
+                    ray_t* keyrd_hdr = NULL;
+                    query_key_reader_t* key_readers = (query_key_reader_t*)scratch_alloc(
+                        &keyrd_hdr, (size_t)nk * sizeof(query_key_reader_t));
+                    int64_t cnt_out_max = select_output_count(dict_elems, dict_n);
+                    ray_t* cntnames_hdr = NULL;
+                    int64_t* count_names = (int64_t*)scratch_alloc(
+                        &cntnames_hdr, (size_t)(cnt_out_max > 0 ? cnt_out_max : 1) * sizeof(int64_t));
+                    if (!key_readers || !count_names) {
+                        scratch_free(keyrd_hdr); scratch_free(cntnames_hdr);
+                        scratch_free(keycols_hdr);
+                        if (eval_tbl != tbl) ray_release(eval_tbl);
+                        ray_release(tbl);
+                        scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
+                    }
                     for (int64_t k = 0; k < nk; k++) {
                         if (!query_key_reader_init(&key_readers[k], key_cols[k])) {
+                            scratch_free(keyrd_hdr); scratch_free(cntnames_hdr);
+                            scratch_free(keycols_hdr);
                             if (eval_tbl != tbl) ray_release(eval_tbl);
                             ray_release(tbl);
                             scratch_free(sel_slots_hdr); return ray_error("type", "unsupported group key");
                         }
                     }
                     int n_count_out = 0;
-                    int64_t count_names[RAY_GROUP_MAX_SLOTS];
                     bool count_only = true;
                     for (int64_t i = 0; i + 1 < dict_n; i += 2) {
                         int64_t kid = dict_elems[i]->i64;
                         if (kid == from_id || kid == where_id || kid == by_id ||
                             kid == take_id || kid == asc_id || kid == desc_id) continue;
                         ray_t* val_expr_item = dict_elems[i + 1];
-                        if (!is_plain_count_expr(val_expr_item) ||
-                            n_count_out >= RAY_GROUP_MAX_SLOTS) {
-                            /* Not a count expr, or too many outputs for this
-                             * fast path's fixed slots — use the general path
+                        if (!is_plain_count_expr(val_expr_item)) {
+                            /* Not a plain count expr — use the general path
                              * (never silently drop outputs). */
                             count_only = false;
                             break;
@@ -6204,6 +6235,7 @@ by_dict_done:
                             if (vals_hdr) ray_free(vals_hdr);
                             if (null_hdr) ray_free(null_hdr);
                             if (cnt_hdr) ray_free(cnt_hdr);
+                            scratch_free(keyrd_hdr); scratch_free(cntnames_hdr); scratch_free(keycols_hdr);
                             if (eval_tbl != tbl) ray_release(eval_tbl);
                             ray_release(tbl);
                             scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
@@ -6214,13 +6246,26 @@ by_dict_done:
                         memset(key_null, 0, (size_t)cap * (size_t)nk);
                         memset(counts, 0, (size_t)cap * sizeof(int64_t));
 
+                        /* Per-row key value / null scratch, carved once to the
+                         * exact key count and reused across the row loop. */
+                        ray_t* rowbuf_hdr = NULL;
+                        int64_t* rv = (int64_t*)scratch_alloc(&rowbuf_hdr,
+                            (size_t)nk * (sizeof(int64_t) + 1));
+                        uint8_t* rn = (uint8_t*)(rv + nk);
+                        if (!rv) {
+                            ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
+                            scratch_free(keyrd_hdr); scratch_free(cntnames_hdr); scratch_free(keycols_hdr);
+                            if (eval_tbl != tbl) ray_release(eval_tbl);
+                            ray_release(tbl);
+                            scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
+                        }
+
                         int64_t found = 0;
                         for (int64_t r = 0; r < nrows; r++) {
-                            int64_t rv[16];
-                            uint8_t rn[16];
                             for (int64_t k = 0; k < nk; k++) {
                                 if (!query_key_reader_read(&key_readers[k], r, &rv[k], &rn[k])) {
                                     ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
+                                    scratch_free(rowbuf_hdr); scratch_free(keyrd_hdr); scratch_free(cntnames_hdr); scratch_free(keycols_hdr);
                                     if (eval_tbl != tbl) ray_release(eval_tbl);
                                     ray_release(tbl);
                                     scratch_free(sel_slots_hdr); return ray_error("type", "unsupported group key");
@@ -6254,6 +6299,7 @@ by_dict_done:
                         ray_t* result = ray_table_new(nk + n_count_out);
                         if (!result || RAY_IS_ERR(result)) {
                             ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
+                            scratch_free(rowbuf_hdr); scratch_free(keyrd_hdr); scratch_free(cntnames_hdr); scratch_free(keycols_hdr);
                             if (eval_tbl != tbl) ray_release(eval_tbl);
                             ray_release(tbl);
                             scratch_free(sel_slots_hdr); return result ? result : ray_error("oom", NULL);
@@ -6273,6 +6319,7 @@ by_dict_done:
                             if (!key_vec || RAY_IS_ERR(key_vec)) {
                                 ray_release(result);
                                 ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
+                                scratch_free(rowbuf_hdr); scratch_free(keyrd_hdr); scratch_free(cntnames_hdr); scratch_free(keycols_hdr);
                                 if (eval_tbl != tbl) ray_release(eval_tbl);
                                 ray_release(tbl);
                                 scratch_free(sel_slots_hdr); return key_vec ? key_vec : ray_error("oom", NULL);
@@ -6316,6 +6363,7 @@ by_dict_done:
                             ray_release(key_vec);
                             if (RAY_IS_ERR(result)) {
                                 ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
+                                scratch_free(rowbuf_hdr); scratch_free(keyrd_hdr); scratch_free(cntnames_hdr); scratch_free(keycols_hdr);
                                 if (eval_tbl != tbl) ray_release(eval_tbl);
                                 ray_release(tbl);
                                 scratch_free(sel_slots_hdr); return result;
@@ -6326,6 +6374,7 @@ by_dict_done:
                             if (!cv || RAY_IS_ERR(cv)) {
                                 ray_release(result);
                                 ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
+                                scratch_free(rowbuf_hdr); scratch_free(keyrd_hdr); scratch_free(cntnames_hdr); scratch_free(keycols_hdr);
                                 if (eval_tbl != tbl) ray_release(eval_tbl);
                                 ray_release(tbl);
                                 scratch_free(sel_slots_hdr); return cv ? cv : ray_error("oom", NULL);
@@ -6336,20 +6385,26 @@ by_dict_done:
                             ray_release(cv);
                             if (RAY_IS_ERR(result)) {
                                 ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
+                                scratch_free(rowbuf_hdr); scratch_free(keyrd_hdr); scratch_free(cntnames_hdr); scratch_free(keycols_hdr);
                                 if (eval_tbl != tbl) ray_release(eval_tbl);
                                 ray_release(tbl);
                                 scratch_free(sel_slots_hdr); return result;
                             }
                         }
                         ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
+                        scratch_free(rowbuf_hdr); scratch_free(keyrd_hdr); scratch_free(cntnames_hdr); scratch_free(keycols_hdr);
                         if (eval_tbl != tbl) ray_release(eval_tbl);
                         ray_release(tbl);
                         scratch_free(sel_slots_hdr); return result;
                     }
+                    /* Not a count-only shape — release the pre-take scratch and
+                     * fall through to the composite grouping path. */
+                    scratch_free(keyrd_hdr); scratch_free(cntnames_hdr);
                 }
 
                 ray_t* composite_keys = ray_list_new(nrows);
                 if (!composite_keys || RAY_IS_ERR(composite_keys)) {
+                    scratch_free(keycols_hdr);
                     if (eval_tbl != tbl) ray_release(eval_tbl);
                     ray_release(tbl);
                     scratch_free(sel_slots_hdr); return composite_keys ? composite_keys : ray_error("oom", NULL);
@@ -6358,6 +6413,7 @@ by_dict_done:
                     ray_t* row_key = ray_list_new(nk);
                     if (!row_key || RAY_IS_ERR(row_key)) {
                         ray_release(composite_keys);
+                        scratch_free(keycols_hdr);
                         if (eval_tbl != tbl) ray_release(eval_tbl);
                         ray_release(tbl);
                         scratch_free(sel_slots_hdr); return row_key ? row_key : ray_error("oom", NULL);
@@ -6368,6 +6424,7 @@ by_dict_done:
                         if (!cell || RAY_IS_ERR(cell)) {
                             ray_release(row_key);
                             ray_release(composite_keys);
+                            scratch_free(keycols_hdr);
                             if (eval_tbl != tbl) ray_release(eval_tbl);
                             ray_release(tbl);
                             scratch_free(sel_slots_hdr); return cell ? cell : ray_error("domain", "select by: failed to read composite group key cell");
@@ -6376,6 +6433,7 @@ by_dict_done:
                         if (alloc) ray_release(cell);
                         if (!row_key || RAY_IS_ERR(row_key)) {
                             ray_release(composite_keys);
+                            scratch_free(keycols_hdr);
                             if (eval_tbl != tbl) ray_release(eval_tbl);
                             ray_release(tbl);
                             scratch_free(sel_slots_hdr); return row_key ? row_key : ray_error("oom", NULL);
@@ -6384,6 +6442,7 @@ by_dict_done:
                     composite_keys = ray_list_append(composite_keys, row_key);
                     ray_release(row_key);
                     if (!composite_keys || RAY_IS_ERR(composite_keys)) {
+                        scratch_free(keycols_hdr);
                         if (eval_tbl != tbl) ray_release(eval_tbl);
                         ray_release(tbl);
                         scratch_free(sel_slots_hdr); return composite_keys ? composite_keys : ray_error("oom", NULL);
@@ -6393,6 +6452,7 @@ by_dict_done:
                 ray_t* groups_dict = ray_group_fn(composite_keys);
                 ray_release(composite_keys);
                 if (!groups_dict || RAY_IS_ERR(groups_dict)) {
+                    scratch_free(keycols_hdr);
                     if (eval_tbl != tbl) ray_release(eval_tbl);
                     ray_release(tbl);
                     scratch_free(sel_slots_hdr); return groups_dict ? groups_dict : ray_error("domain", "select by: failed to compute composite groups");
@@ -6400,6 +6460,7 @@ by_dict_done:
                 ray_t* groups = groups_to_pair_list(groups_dict);
                 ray_release(groups_dict);
                 if (!groups || RAY_IS_ERR(groups)) {
+                    scratch_free(keycols_hdr);
                     if (eval_tbl != tbl) ray_release(eval_tbl);
                     ray_release(tbl);
                     scratch_free(sel_slots_hdr); return groups ? groups : ray_error("domain", "select by: failed to build groups pair list");
@@ -6411,19 +6472,24 @@ by_dict_done:
                     n_groups, &out_groups);
 
                 int n_agg_out = 0;
-                int64_t agg_names[RAY_GROUP_MAX_SLOTS];
-                ray_t* agg_results[RAY_GROUP_MAX_SLOTS] = {0};
+                /* Per-output collectors carved to the exact output count (no
+                 * fixed slot cap); results slots zeroed so unassigned entries
+                 * are NULL for the error-path release loops. */
+                int64_t agg_nout_max = select_output_count(dict_elems, dict_n);
+                if (agg_nout_max < 1) agg_nout_max = 1;
+                ray_t* aggnames_hdr = NULL;
+                int64_t* agg_names = (int64_t*)scratch_alloc(&aggnames_hdr, (size_t)agg_nout_max * sizeof(int64_t));
+                ray_t* aggres_hdr = NULL;
+                ray_t** agg_results = (ray_t**)scratch_calloc(&aggres_hdr, (size_t)agg_nout_max * sizeof(ray_t*));
+                if (!agg_names || !agg_results) {
+                    scratch_free(aggnames_hdr); scratch_free(aggres_hdr); scratch_free(keycols_hdr);
+                    ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
+                    scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
+                }
                 for (int64_t i = 0; i + 1 < dict_n; i += 2) {
                     int64_t kid = dict_elems[i]->i64;
                     if (kid == from_id || kid == where_id || kid == by_id ||
                         kid == take_id || kid == asc_id || kid == desc_id) continue;
-                    if (n_agg_out >= RAY_GROUP_MAX_SLOTS) {
-                        /* Terminal eval-group path: reject loudly instead of
-                         * silently dropping outputs past the slot cap. */
-                        for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
-                        ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                        scratch_free(sel_slots_hdr); return ray_error("range", "select: too many output columns (max %d)", RAY_GROUP_MAX_SLOTS);
-                    }
                     ray_t* val_expr_item = dict_elems[i + 1];
 
                     /* Per-group count(distinct) — bypass full ray_eval per
@@ -6436,6 +6502,7 @@ by_dict_done:
                             cd_inner, eval_tbl, groups, out_groups);
                         if (!per_group || RAY_IS_ERR(per_group)) {
                             for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
+                            scratch_free(aggnames_hdr); scratch_free(aggres_hdr); scratch_free(keycols_hdr);
                             ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
                             scratch_free(sel_slots_hdr); return per_group ? per_group : ray_error("domain", "select by: count-distinct aggregation failed");
                         }
@@ -6463,6 +6530,7 @@ by_dict_done:
                                 src_col_val = ray_lazy_materialize(src_col_val);
                             if (!src_col_val || RAY_IS_ERR(src_col_val)) {
                                 for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
+                                scratch_free(aggnames_hdr); scratch_free(aggres_hdr); scratch_free(keycols_hdr);
                                 ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
                                 scratch_free(sel_slots_hdr); return src_col_val ? src_col_val : ray_error("domain", "select by: failed to evaluate aggregation source column");
                             }
@@ -6545,6 +6613,7 @@ by_dict_done:
                         ray_t* per_group = nonagg_eval_per_group(val_expr_item, eval_tbl, groups, n_groups);
                         if (!per_group || RAY_IS_ERR(per_group)) {
                             for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
+                            scratch_free(aggnames_hdr); scratch_free(aggres_hdr); scratch_free(keycols_hdr);
                             ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
                             scratch_free(sel_slots_hdr); return per_group ? per_group : ray_error("domain", "select by: per-group projection evaluation failed");
                         }
@@ -6557,6 +6626,7 @@ by_dict_done:
                 ray_t* result = ray_table_new(nk + n_agg_out);
                 if (!result || RAY_IS_ERR(result)) {
                     for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
+                    scratch_free(aggnames_hdr); scratch_free(aggres_hdr); scratch_free(keycols_hdr);
                     ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
                     scratch_free(sel_slots_hdr); return result ? result : ray_error("oom", NULL);
                 }
@@ -6593,6 +6663,7 @@ by_dict_done:
                     }
                     if (!key_vec || RAY_IS_ERR(key_vec)) {
                         for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
+                        scratch_free(aggnames_hdr); scratch_free(aggres_hdr); scratch_free(keycols_hdr);
                         ray_release(result); ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
                         scratch_free(sel_slots_hdr); return key_vec ? key_vec : ray_error("oom", NULL);
                     }
@@ -6600,6 +6671,7 @@ by_dict_done:
                     ray_release(key_vec);
                     if (RAY_IS_ERR(result)) {
                         for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
+                        scratch_free(aggnames_hdr); scratch_free(aggres_hdr); scratch_free(keycols_hdr);
                         ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
                         scratch_free(sel_slots_hdr); return result;
                     }
@@ -6608,9 +6680,12 @@ by_dict_done:
                     if (agg_results[ai]) {
                         result = ray_table_add_col(result, agg_names[ai], agg_results[ai]);
                         ray_release(agg_results[ai]);
-                        if (RAY_IS_ERR(result)) { ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return result; }
+                        if (RAY_IS_ERR(result)) { scratch_free(aggnames_hdr); scratch_free(aggres_hdr); scratch_free(keycols_hdr); ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return result; }
                     }
                 }
+                /* Aggregate results consumed and key columns emitted — release
+                 * their exact-size collectors before the tail paths. */
+                scratch_free(aggnames_hdr); scratch_free(aggres_hdr); scratch_free(keycols_hdr);
 
                 /* No-agg-no-nonagg form (`select {by:[k1 k2]}`): carry the
                  * first-of-group value of every non-key column, matching the
@@ -6928,20 +7003,24 @@ by_dict_done:
                 scratch_free(sel_slots_hdr); return empty;
             }
 
-            /* Collect aggregation results */
+            /* Collect aggregation results.  Per-output collectors carved to the
+             * exact output count (no fixed slot cap); result slots zeroed so
+             * unassigned entries are NULL for the error-path release loops. */
             int n_agg_out = 0;
-            int64_t agg_names[RAY_GROUP_MAX_SLOTS];
-            ray_t* agg_results[RAY_GROUP_MAX_SLOTS] = {0};
+            int64_t agg_nout_max = select_output_count(dict_elems, dict_n);
+            if (agg_nout_max < 1) agg_nout_max = 1;
+            ray_t* aggnames_hdr = NULL;
+            int64_t* agg_names = (int64_t*)scratch_alloc(&aggnames_hdr, (size_t)agg_nout_max * sizeof(int64_t));
+            ray_t* aggres_hdr = NULL;
+            ray_t** agg_results = (ray_t**)scratch_calloc(&aggres_hdr, (size_t)agg_nout_max * sizeof(ray_t*));
+            if (!agg_names || !agg_results) {
+                scratch_free(aggnames_hdr); scratch_free(aggres_hdr);
+                ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
+                scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
+            }
             for (int64_t i = 0; i + 1 < dict_n; i += 2) {
                 int64_t kid = dict_elems[i]->i64;
                 if (kid == from_id || kid == where_id || kid == by_id || kid == take_id || kid == asc_id || kid == desc_id) continue;
-                if (n_agg_out >= RAY_GROUP_MAX_SLOTS) {
-                    /* Terminal eval-group path: reject loudly instead of
-                     * silently dropping outputs past the slot cap. */
-                    for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
-                    ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                    scratch_free(sel_slots_hdr); return ray_error("range", "select: too many output columns (max %d)", RAY_GROUP_MAX_SLOTS);
-                }
                 ray_t* val_expr_item = dict_elems[i + 1];
 
                 /* Per-group count(distinct) — bypass full ray_eval per
@@ -6953,6 +7032,7 @@ by_dict_done:
                             cd_inner, eval_tbl, groups, n_groups);
                         if (!per_group || RAY_IS_ERR(per_group)) {
                             for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
+                            scratch_free(aggnames_hdr); scratch_free(aggres_hdr);
                             ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
                             scratch_free(sel_slots_hdr); return per_group ? per_group : ray_error("domain", "select by: count-distinct aggregation failed");
                         }
@@ -6989,6 +7069,7 @@ by_dict_done:
                             src_col_val = ray_lazy_materialize(src_col_val);
                         if (RAY_IS_ERR(src_col_val)) {
                             for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
+                            scratch_free(aggnames_hdr); scratch_free(aggres_hdr);
                             ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return src_col_val;
                         }
                     }
@@ -7074,6 +7155,7 @@ by_dict_done:
                             val_expr_item, eval_tbl, groups, n_groups);
                         if (RAY_IS_ERR(per_group)) {
                             for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
+                            scratch_free(aggnames_hdr); scratch_free(aggres_hdr);
                             ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
                             scratch_free(sel_slots_hdr); return per_group;
                         }
@@ -7088,6 +7170,7 @@ by_dict_done:
                      * (non-agg produces list-of-vectors). */
                     if (ray_env_push_scope() != RAY_OK) {
                         for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
+                        scratch_free(aggnames_hdr); scratch_free(aggres_hdr);
                         ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
                         scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                     }
@@ -7097,6 +7180,7 @@ by_dict_done:
                     ray_env_pop_scope();
                     if (RAY_IS_ERR(full_val)) {
                         for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
+                        scratch_free(aggnames_hdr); scratch_free(aggres_hdr);
                         ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return full_val;
                     }
 
@@ -7106,6 +7190,7 @@ by_dict_done:
                     if (!list_col || RAY_IS_ERR(list_col)) {
                         ray_release(full_val);
                         for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
+                        scratch_free(aggnames_hdr); scratch_free(aggres_hdr);
                         ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
                         scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                     }
@@ -7143,6 +7228,7 @@ by_dict_done:
                             val_expr_item, eval_tbl, groups, n_groups);
                         if (RAY_IS_ERR(per_group)) {
                             for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
+                            scratch_free(aggnames_hdr); scratch_free(aggres_hdr);
                             ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
                             scratch_free(sel_slots_hdr); return per_group;
                         }
@@ -7177,7 +7263,7 @@ by_dict_done:
 
             /* Build result table: key column + aggregation columns */
             ray_t* result = ray_table_new(1 + n_agg_out);
-            if (RAY_IS_ERR(result)) { ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return result; }
+            if (RAY_IS_ERR(result)) { for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); } scratch_free(aggnames_hdr); scratch_free(aggres_hdr); ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return result; }
 
             /* Key column: build a typed vector matching the source column type */
             ray_t** grp_items = (ray_t**)ray_data(groups);
@@ -7210,6 +7296,7 @@ by_dict_done:
                 }
                 if (!key_vec || RAY_IS_ERR(key_vec)) {
                     for (int i = 0; i < n_agg_out; i++) { if (agg_results[i]) ray_release(agg_results[i]); }
+                    scratch_free(aggnames_hdr); scratch_free(aggres_hdr);
                     ray_release(result); ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
                     scratch_free(sel_slots_hdr); return key_vec ? key_vec : ray_error("oom", NULL);
                 }
@@ -7222,6 +7309,8 @@ by_dict_done:
                     result = ray_table_add_col(result, agg_names[i], agg_results[i]);
                 if (agg_results[i]) ray_release(agg_results[i]);
             }
+            /* Aggregate results consumed — release their exact-size collectors. */
+            scratch_free(aggnames_hdr); scratch_free(aggres_hdr);
 
             /* No explicit aggs: gather first-of-group for all non-key columns */
             if (n_agg_out == 0 && n_groups > 0) {

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -572,9 +572,25 @@ static ray_t* apply_sort_take(ray_t* result, ray_t** dict_elems, int64_t dict_n,
 
     /* Sort */
     if (has_sort) {
-        ray_op_t* sort_keys[16];
-        uint8_t   sort_descs[16];
-        uint8_t   n_sort = 0;
+        /* Exact-size scratch carve: bound = total names across the dict's
+         * asc:/desc: entries (a -RAY_SYM atom counts 1, a RAY_SYM vector
+         * counts its length).  The former fixed [16] arrays silently
+         * capped multi-key sorts past the 16th key. */
+        int64_t n_sort_max = 0;
+        for (int64_t i = 0; i + 1 < dict_n; i += 2) {
+            int64_t kid = dict_elems[i]->i64;
+            if (kid != asc_id && kid != desc_id) continue;
+            ray_t* val = dict_elems[i + 1];
+            if (val->type == -RAY_SYM) n_sort_max += 1;
+            else if (ray_is_vec(val) && val->type == RAY_SYM) n_sort_max += ray_len(val);
+        }
+        if (n_sort_max < 1) n_sort_max = 1;
+        ray_t* sortk_hdr = NULL;
+        ray_op_t** sort_keys = (ray_op_t**)scratch_alloc(&sortk_hdr,
+                (size_t)n_sort_max * (sizeof(ray_op_t*) + 1));
+        if (!sort_keys) { ray_graph_free(g); ray_release(result); return ray_error("oom", NULL); }
+        uint8_t* sort_descs = (uint8_t*)(sort_keys + n_sort_max);
+        int64_t n_sort = 0;
         for (int64_t i = 0; i + 1 < dict_n; i += 2) {
             int64_t kid = dict_elems[i]->i64;
             uint8_t is_desc = 0;
@@ -583,14 +599,12 @@ static ray_t* apply_sort_take(ray_t* result, ray_t** dict_elems, int64_t dict_n,
             else continue;
             ray_t* val = dict_elems[i + 1];
             if (val->type == -RAY_SYM) {
-                if (n_sort >= RAY_GROUP_MAX_SLOTS) { ray_graph_free(g); ray_release(result); return ray_error("range", "select: too many sort keys (max %d)", RAY_GROUP_MAX_SLOTS); }
                 ray_t* s = ray_sym_str(val->i64);
                 sort_keys[n_sort] = ray_scan(g, ray_str_ptr(s));
                 sort_descs[n_sort] = is_desc;
                 n_sort++;
             } else if (ray_is_vec(val) && val->type == RAY_SYM) {
                 for (int64_t c = 0; c < val->len; c++) {
-                    if (n_sort >= RAY_GROUP_MAX_SLOTS) { ray_graph_free(g); ray_release(result); return ray_error("range", "select: too many sort keys (max %d)", RAY_GROUP_MAX_SLOTS); }
                     /* cell-data: resolve through the vec's domain */
                     ray_t* s = ray_sym_vec_cell(val, c);
                     sort_keys[n_sort] = ray_scan(g, ray_str_ptr(s));
@@ -599,8 +613,14 @@ static ray_t* apply_sort_take(ray_t* result, ray_t** dict_elems, int64_t dict_n,
                 }
             }
         }
+        if (n_sort > UINT8_MAX) {
+            scratch_free(sortk_hdr);
+            ray_graph_free(g); ray_release(result);
+            return ray_error("range", "select: too many sort keys for the op graph (max %d)", UINT8_MAX);
+        }
         if (n_sort > 0)
-            root = ray_sort_op(g, root, sort_keys, sort_descs, NULL, n_sort);
+            root = ray_sort_op(g, root, sort_keys, sort_descs, NULL, (uint8_t)n_sort);
+        scratch_free(sortk_hdr);
     }
 
     /* Take: avoid the DAG ray_head/ray_tail op — it can't handle
@@ -4895,6 +4915,7 @@ ray_t* ray_select(ray_t** args, int64_t n) {
              * a single scalar column, take is an atom K, and every
              * output column is a -RAY_SYM source-column reference (no
              * agg, no expression). */
+            /* fast-path budget: >16 declines to the general sort (not a correctness cap) */
             int64_t sort_key_syms[16];
             uint8_t sort_descs[16];
             uint8_t n_sort_keys = 0;
@@ -8644,9 +8665,25 @@ by_dict_done:
      * Values are unevaluated — a SYM atom is a column name, a SYM vector
      * is multiple column names.  No ray_eval needed. */
     if (has_sort && !by_expr) {
-        ray_op_t* sort_keys[16];
-        uint8_t   sort_descs[16];
-        uint8_t   n_sort = 0;
+        /* Exact-size scratch carve: bound = total names across the dict's
+         * asc:/desc: entries (a -RAY_SYM atom counts 1, a RAY_SYM vector
+         * counts its length).  The former fixed [16] arrays silently
+         * capped multi-key sorts past the 16th key. */
+        int64_t n_sort_max = 0;
+        for (int64_t i = 0; i + 1 < dict_n; i += 2) {
+            int64_t kid = dict_elems[i]->i64;
+            if (kid != asc_id && kid != desc_id) continue;
+            ray_t* val = dict_elems[i + 1];
+            if (val->type == -RAY_SYM) n_sort_max += 1;
+            else if (ray_is_vec(val) && val->type == RAY_SYM) n_sort_max += ray_len(val);
+        }
+        if (n_sort_max < 1) n_sort_max = 1;
+        ray_t* sortk_hdr = NULL;
+        ray_op_t** sort_keys = (ray_op_t**)scratch_alloc(&sortk_hdr,
+                (size_t)n_sort_max * (sizeof(ray_op_t*) + 1));
+        if (!sort_keys) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("oom", NULL); }
+        uint8_t* sort_descs = (uint8_t*)(sort_keys + n_sort_max);
+        int64_t n_sort = 0;
         for (int64_t i = 0; i + 1 < dict_n; i += 2) {
             int64_t kid = dict_elems[i]->i64;
             uint8_t is_desc = 0;
@@ -8656,7 +8693,6 @@ by_dict_done:
             ray_t* val = dict_elems[i + 1];
             if (val->type == -RAY_SYM) {
                 /* Single column name */
-                if (n_sort >= RAY_GROUP_MAX_SLOTS) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("range", "select: too many sort keys (max %d)", RAY_GROUP_MAX_SLOTS); }
                 ray_t* s = ray_sym_str(val->i64);
                 sort_keys[n_sort] = ray_scan(g, ray_str_ptr(s));
                 sort_descs[n_sort] = is_desc;
@@ -8664,19 +8700,25 @@ by_dict_done:
             } else if (ray_is_vec(val) && val->type == RAY_SYM) {
                 /* Multiple column names — cell-data via the vec's domain */
                 for (int64_t c = 0; c < val->len; c++) {
-                    if (n_sort >= RAY_GROUP_MAX_SLOTS) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("range", "select: too many sort keys (max %d)", RAY_GROUP_MAX_SLOTS); }
                     ray_t* s = ray_sym_vec_cell(val, c);
                     sort_keys[n_sort] = ray_scan(g, ray_str_ptr(s));
                     sort_descs[n_sort] = is_desc;
                     n_sort++;
                 }
             } else {
+                scratch_free(sortk_hdr);
                 ray_graph_free(g); ray_release(tbl);
                 scratch_free(sel_slots_hdr); return ray_error("domain", "select: asc/desc value must be a column name or symbol list, got %s", ray_type_name(val->type));
             }
         }
+        if (n_sort > UINT8_MAX) {
+            scratch_free(sortk_hdr);
+            ray_graph_free(g); ray_release(tbl);
+            scratch_free(sel_slots_hdr); return ray_error("range", "select: too many sort keys for the op graph (max %d)", UINT8_MAX);
+        }
         if (n_sort > 0)
-            root = ray_sort_op(g, root, sort_keys, sort_descs, NULL, n_sort);
+            root = ray_sort_op(g, root, sort_keys, sort_descs, NULL, (uint8_t)n_sort);
+        scratch_free(sortk_hdr);
     }
 
     /* Take: add to DAG only when no group-by and no nearest (rerank

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -2227,7 +2227,7 @@ static ray_t* match_count_distinct(ray_t* expr) {
  * per-output collection arrays in the select compile path (the former
  * fixed-16 slot arrays).  dict_n is the element count of the flattened
  * [k0 v0 k1 v1 ...] view, so outputs <= dict_n/2 <= DICT_VIEW_MAX. */
-static int64_t __attribute__((unused)) select_output_count(ray_t** dict_elems, int64_t dict_n) {
+static int64_t select_output_count(ray_t** dict_elems, int64_t dict_n) {
     int64_t from_id    = ray_sym_intern("from",    4);
     int64_t where_id   = ray_sym_intern("where",   5);
     int64_t by_id      = ray_sym_intern("by",      2);
@@ -2249,7 +2249,7 @@ static int64_t __attribute__((unused)) select_output_count(ray_t** dict_elems, i
 /* Upper bound on the aggregate subcalls a compound output decomposes
  * into (try_decompose_agg_arith extracts each is_group_dag_agg_expr
  * node as one hidden slot).  Pure structural walk — cheap, compile-time. */
-static int64_t __attribute__((unused)) count_agg_subexprs(ray_t* expr) {
+static int64_t count_agg_subexprs(ray_t* expr) {
     if (!expr) return 0;
     if (is_group_dag_agg_expr(expr)) return 1;
     if (expr->type != RAY_LIST) return 0;
@@ -5429,19 +5429,58 @@ by_dict_done:
 
     ray_op_t* root = ray_const_table(g, tbl);
 
-    /* Non-agg expression tracking for post-DAG scatter (used in GROUP BY) */
-    int64_t nonagg_names[16];
-    ray_t*  nonagg_exprs[16];
+    /* Non-agg expression tracking for post-DAG scatter (used in GROUP BY).
+     * Arith-of-aggs decomposition (see try_decompose_agg_arith): hidden agg
+     * subexpressions ride the DAG group pass as extra slots; each compound
+     * output keeps its rewritten wrapper for one post-group eval over the
+     * n_groups-row result.  All per-output collector arrays are carved from
+     * one exact-size scratch block (bounds computed once from the dict view),
+     * living until the function's result return — freed beside every
+     * ray_graph_free(g) exit that follows. */
+    int64_t n_out_max = select_output_count(dict_elems, dict_n);
+    int64_t hidden_max = 0;
+    for (int64_t i = 0; i + 1 < dict_n; i += 2) {
+        int64_t kid = dict_elems[i]->i64;
+        if (kid == from_id || kid == where_id || kid == by_id ||
+            kid == take_id || kid == asc_id || kid == desc_id ||
+            kid == nearest_id) continue;
+        hidden_max += count_agg_subexprs(dict_elems[i + 1]);
+    }
+    if (n_out_max < 1) n_out_max = 1;          /* zero-size alloc guard */
+    if (hidden_max < 1) hidden_max = 1;
+    /* Group keys and aggregate slots also collect into this same block: the
+     * key count is bounded by the by-clause and the agg count by outputs plus
+     * hidden decomposed slots.  All bounds are known here, so one exact-size
+     * carve serves every per-output/per-key collector and is freed on every
+     * exit that follows (no separate per-scope headers to leak). */
+    int64_t nk_max = (by_expr && ray_is_vec(by_expr) && by_expr->type == RAY_SYM)
+                         ? ray_len(by_expr) : 1;
+    if (nk_max < 1) nk_max = 1;
+    int64_t aggs_max = n_out_max + hidden_max;
+    /* One block for all collector arrays (8-byte elems first, uint16 tail). */
+    ray_t* sel_slots_hdr = NULL;
+    int64_t* nonagg_names = (int64_t*)scratch_alloc(&sel_slots_hdr,
+        (size_t)n_out_max * (3 * sizeof(int64_t) + 2 * sizeof(ray_t*)) +
+        (size_t)hidden_max * (sizeof(ray_t*) + sizeof(int64_t)) +
+        (size_t)nk_max * sizeof(ray_op_t*) +
+        (size_t)aggs_max * (2 * sizeof(ray_op_t*) + sizeof(int64_t) + sizeof(uint16_t)));
+    if (!nonagg_names) {
+        if (by_sym_vec_owned) ray_release(by_sym_vec_owned);
+        ray_graph_free(g); ray_release(tbl); return ray_error("oom", NULL);
+    }
+    ray_t**  nonagg_exprs     = (ray_t**)(nonagg_names + n_out_max);
+    int64_t* compound_names   = (int64_t*)(nonagg_exprs + n_out_max);
+    int64_t* compound_pos     = (int64_t*)(compound_names + n_out_max);
+    ray_t**  compound_rw      = (ray_t**)(compound_pos + n_out_max);
+    ray_t**  hidden_agg_exprs = (ray_t**)(compound_rw + n_out_max);
+    int64_t* hidden_agg_names = (int64_t*)(hidden_agg_exprs + hidden_max);
+    ray_op_t** key_ops        = (ray_op_t**)(hidden_agg_names + hidden_max);
+    ray_op_t** agg_ins        = key_ops + nk_max;
+    ray_op_t** agg_ins2       = agg_ins + aggs_max;
+    int64_t*   agg_k          = (int64_t*)(agg_ins2 + aggs_max);
+    uint16_t*  agg_ops        = (uint16_t*)(agg_k + aggs_max);
     uint8_t n_nonaggs = 0;
-    /* Arith-of-aggs decomposition (see try_decompose_agg_arith): hidden
-     * agg subexpressions ride the DAG group pass as extra slots; each
-     * compound output keeps its rewritten wrapper for one post-group eval
-     * over the n_groups-row result. */
-    ray_t*  hidden_agg_exprs[16];      /* borrowed agg subcalls */
-    int64_t hidden_agg_names[16];      /* __haN symbols */
     int     n_hidden_aggs = 0;
-    int64_t compound_names[16];        /* user output name (dict kid) */
-    ray_t*  compound_rw[16];           /* owned rewritten wrappers */
     int     n_compound = 0;
     int     n_aggs_real = 0;           /* DAG agg slots before hidden ones */
     int synth_count_col = 0;  /* 1 if we synthesized OP_COUNT for group boundaries */
@@ -5606,7 +5645,7 @@ by_dict_done:
             ray_op_t* pred = compile_expr_dag(g, where_expr);
             if (!pred) {
                 ray_graph_free(g); ray_release(tbl);
-                return ray_error("domain",
+                scratch_free(sel_slots_hdr); return ray_error("domain",
                     "WHERE predicate not supported by DAG compiler — "
                     "most common causes: arity mismatch "
                     "(e.g. `(in v)` instead of `(in col v)`), "
@@ -5634,7 +5673,7 @@ by_dict_done:
     if (nearest_expr) {
         if (nearest_expr->type != RAY_LIST || ray_len(nearest_expr) < 3) {
             ray_graph_free(g); ray_release(tbl);
-            return ray_error("domain",
+            scratch_free(sel_slots_hdr); return ray_error("domain",
                 "nearest: expected (ann <handle> <query> [ef]) or (knn <col> <query> [metric])");
         }
         int64_t nlen = ray_len(nearest_expr);
@@ -5642,7 +5681,7 @@ by_dict_done:
         ray_t* head = nlist[0];
         if (head->type != -RAY_SYM) {
             ray_graph_free(g); ray_release(tbl);
-            return ray_error("domain",
+            scratch_free(sel_slots_hdr); return ray_error("domain",
                 "nearest: first element must be the symbol `ann` or `knn`");
         }
         int64_t ann_sym_id = ray_sym_intern("ann", 3);
@@ -5654,19 +5693,19 @@ by_dict_done:
             ray_t* tv = ray_eval(take_expr);
             if (!tv || RAY_IS_ERR(tv)) {
                 ray_graph_free(g); ray_release(tbl);
-                return tv ? tv : ray_error("domain", "nearest: failed to evaluate `take:`");
+                scratch_free(sel_slots_hdr); return tv ? tv : ray_error("domain", "nearest: failed to evaluate `take:`");
             }
             if (tv->type == -RAY_I64)      k_req = tv->i64;
             else if (tv->type == -RAY_I32) k_req = tv->i32;
             else {
                 ray_release(tv);
                 ray_graph_free(g); ray_release(tbl);
-                return ray_error("type", "nearest: take must be an integer atom");
+                scratch_free(sel_slots_hdr); return ray_error("type", "nearest: take must be an integer atom");
             }
             ray_release(tv);
             if (k_req <= 0) {
                 ray_graph_free(g); ray_release(tbl);
-                return ray_error("domain", "nearest: take must be positive");
+                scratch_free(sel_slots_hdr); return ray_error("domain", "nearest: take must be positive");
             }
         }
 
@@ -5674,20 +5713,20 @@ by_dict_done:
         ray_t* qvec = ray_eval(nlist[2]);
         if (!qvec || RAY_IS_ERR(qvec)) {
             ray_graph_free(g); ray_release(tbl);
-            return qvec ? qvec : ray_error("domain", "nearest: failed to evaluate query vector");
+            scratch_free(sel_slots_hdr); return qvec ? qvec : ray_error("domain", "nearest: failed to evaluate query vector");
         }
         if (!ray_is_vec(qvec) ||
             (qvec->type != RAY_F32 && qvec->type != RAY_F64 &&
              qvec->type != RAY_I32 && qvec->type != RAY_I64)) {
             ray_release(qvec);
             ray_graph_free(g); ray_release(tbl);
-            return ray_error("type", "nearest: query must be a numeric vector");
+            scratch_free(sel_slots_hdr); return ray_error("type", "nearest: query must be a numeric vector");
         }
         int32_t dim = (int32_t)qvec->len;
         if (dim <= 0) {
             ray_release(qvec);
             ray_graph_free(g); ray_release(tbl);
-            return ray_error("length", "nearest: query vector is empty");
+            scratch_free(sel_slots_hdr); return ray_error("length", "nearest: query vector is empty");
         }
 
         /* Copy query into a fresh float[] that the DAG op borrows; freed
@@ -5696,7 +5735,7 @@ by_dict_done:
         if (!nearest_query_owned) {
             ray_release(qvec);
             ray_graph_free(g); ray_release(tbl);
-            return ray_error("oom", NULL);
+            scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
         }
         switch (qvec->type) {
             case RAY_F32:
@@ -5725,12 +5764,12 @@ by_dict_done:
             if (!hobj || RAY_IS_ERR(hobj)) {
                 ray_sys_free(nearest_query_owned);
                 ray_graph_free(g); ray_release(tbl);
-                return hobj ? hobj : ray_error("domain", "nearest (ann): failed to evaluate HNSW handle");
+                scratch_free(sel_slots_hdr); return hobj ? hobj : ray_error("domain", "nearest (ann): failed to evaluate HNSW handle");
             }
             if (hobj->type != -RAY_I64 || !(hobj->attrs & RAY_ATTR_HNSW)) {
                 ray_release(hobj); ray_sys_free(nearest_query_owned);
                 ray_graph_free(g); ray_release(tbl);
-                return ray_error("type",
+                scratch_free(sel_slots_hdr); return ray_error("type",
                     "nearest (ann): first arg must be an HNSW handle (from hnsw-build)");
             }
             ray_hnsw_t* idx = (ray_hnsw_t*)(uintptr_t)hobj->i64;
@@ -5738,13 +5777,13 @@ by_dict_done:
                 /* Defensive: attr set but pointer cleared — treat as invalid. */
                 ray_release(hobj); ray_sys_free(nearest_query_owned);
                 ray_graph_free(g); ray_release(tbl);
-                return ray_error("type",
+                scratch_free(sel_slots_hdr); return ray_error("type",
                     "nearest (ann): HNSW handle has been freed");
             }
             if (idx->dim != dim) {
                 ray_release(hobj); ray_sys_free(nearest_query_owned);
                 ray_graph_free(g); ray_release(tbl);
-                return ray_error("length",
+                scratch_free(sel_slots_hdr); return ray_error("length",
                     "nearest (ann): query dim does not match index dim");
             }
             int32_t ef = HNSW_DEFAULT_EF_S;
@@ -5753,7 +5792,7 @@ by_dict_done:
                 if (!ev || RAY_IS_ERR(ev)) {
                     ray_release(hobj); ray_sys_free(nearest_query_owned);
                     ray_graph_free(g); ray_release(tbl);
-                    return ev ? ev : ray_error("domain",
+                    scratch_free(sel_slots_hdr); return ev ? ev : ray_error("domain",
                         "nearest (ann): ef expression failed to evaluate");
                 }
                 if (ev->type == -RAY_I64)      ef = (int32_t)ev->i64;
@@ -5762,7 +5801,7 @@ by_dict_done:
                     ray_release(ev); ray_release(hobj);
                     ray_sys_free(nearest_query_owned);
                     ray_graph_free(g); ray_release(tbl);
-                    return ray_error("type",
+                    scratch_free(sel_slots_hdr); return ray_error("type",
                         "nearest (ann): ef must be an integer atom");
                 }
                 ray_release(ev);
@@ -5778,7 +5817,7 @@ by_dict_done:
             if (col_expr->type != -RAY_SYM) {
                 ray_sys_free(nearest_query_owned);
                 ray_graph_free(g); ray_release(tbl);
-                return ray_error("type",
+                scratch_free(sel_slots_hdr); return ray_error("type",
                     "nearest (knn): first arg must be an unquoted column name");
             }
             int64_t col_sym = col_expr->i64;
@@ -5793,7 +5832,7 @@ by_dict_done:
                     else {
                         ray_sys_free(nearest_query_owned);
                         ray_graph_free(g); ray_release(tbl);
-                        return ray_error("domain",
+                        scratch_free(sel_slots_hdr); return ray_error("domain",
                             "nearest (knn): metric must be 'cosine, 'l2, or 'ip");
                     }
                 }
@@ -5802,14 +5841,14 @@ by_dict_done:
         } else {
             ray_sys_free(nearest_query_owned);
             ray_graph_free(g); ray_release(tbl);
-            return ray_error("domain",
+            scratch_free(sel_slots_hdr); return ray_error("domain",
                 "nearest: expected `ann` or `knn` as the first element");
         }
         if (!root) {
             if (nearest_handle_owned) ray_release(nearest_handle_owned);
             ray_sys_free(nearest_query_owned);
             ray_graph_free(g); ray_release(tbl);
-            return ray_error("oom", NULL);
+            scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
         }
 
         /* When the user didn't specify output columns, project only the
@@ -5827,7 +5866,7 @@ by_dict_done:
                 if (nearest_handle_owned) ray_release(nearest_handle_owned);
                 ray_sys_free(nearest_query_owned);
                 ray_graph_free(g); ray_release(tbl);
-                return ray_error("limit",
+                scratch_free(sel_slots_hdr); return ray_error("limit",
                     "nearest: implicit projection exceeds 255 source columns — "
                     "specify output columns explicitly");
             }
@@ -5838,7 +5877,7 @@ by_dict_done:
                     if (nearest_handle_owned) ray_release(nearest_handle_owned);
                     ray_sys_free(nearest_query_owned);
                     ray_graph_free(g); ray_release(tbl);
-                    return ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                 }
                 int nc = 0;
                 bool scan_err = false;
@@ -5855,7 +5894,7 @@ by_dict_done:
                     if (nearest_handle_owned) ray_release(nearest_handle_owned);
                     ray_sys_free(nearest_query_owned);
                     ray_graph_free(g); ray_release(tbl);
-                    return ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                 }
                 root = ray_select_op(g, root, col_ops, (uint8_t)nc);
                 ray_sys_free(col_ops);
@@ -5863,7 +5902,7 @@ by_dict_done:
                     if (nearest_handle_owned) ray_release(nearest_handle_owned);
                     ray_sys_free(nearest_query_owned);
                     ray_graph_free(g); ray_release(tbl);
-                    return ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                 }
             }
         }
@@ -6046,9 +6085,9 @@ by_dict_done:
                 if (fvm) { fvm->filt_keep = sv_fk; fvm->filt_keep_n = sv_fn;
                            fvm->filt_depth = sv_fd; }
                 ray_graph_free(g); g = NULL;
-                if (!fres || RAY_IS_ERR(fres)) { ray_release(tbl); return fres ? fres : ray_error("domain", "select: `where:` filter produced no result"); }
+                if (!fres || RAY_IS_ERR(fres)) { ray_release(tbl); scratch_free(sel_slots_hdr); return fres ? fres : ray_error("domain", "select: `where:` filter produced no result"); }
                 if (ray_is_lazy(fres)) fres = ray_lazy_materialize(fres);
-                if (!fres || RAY_IS_ERR(fres)) { ray_release(tbl); return fres ? fres : ray_error("domain", "select: failed to materialize filtered result"); }
+                if (!fres || RAY_IS_ERR(fres)) { ray_release(tbl); scratch_free(sel_slots_hdr); return fres ? fres : ray_error("domain", "select: failed to materialize filtered result"); }
                 eval_tbl = fres;
             } else {
                 ray_graph_free(g); g = NULL;
@@ -6061,14 +6100,14 @@ by_dict_done:
                 if (nk <= 0 || nk > 16) {
                     if (eval_tbl != tbl) ray_release(eval_tbl);
                     ray_release(tbl);
-                    return ray_error("domain", "eval-level multi-key groupby requires 1..16 keys");
+                    scratch_free(sel_slots_hdr); return ray_error("domain", "eval-level multi-key groupby requires 1..16 keys");
                 }
                 for (int64_t k = 0; k < nk; k++) {
                     key_cols[k] = ray_table_get_col(eval_tbl, key_syms[k]);
                     if (!key_cols[k]) {
                         if (eval_tbl != tbl) ray_release(eval_tbl);
                         ray_release(tbl);
-                        return ray_error("domain", "group key column not found");
+                        scratch_free(sel_slots_hdr); return ray_error("domain", "group key column not found");
                     }
                 }
 
@@ -6122,7 +6161,7 @@ by_dict_done:
                                                       (uint8_t)nk, nrows, keep, keep_n);
                     if (eval_tbl != tbl) ray_release(eval_tbl);
                     ray_release(tbl);
-                    return dres;
+                    scratch_free(sel_slots_hdr); return dres;
                 }
 
                 int64_t pre_take_groups = nrows;
@@ -6135,7 +6174,7 @@ by_dict_done:
                         if (!query_key_reader_init(&key_readers[k], key_cols[k])) {
                             if (eval_tbl != tbl) ray_release(eval_tbl);
                             ray_release(tbl);
-                            return ray_error("type", "unsupported group key");
+                            scratch_free(sel_slots_hdr); return ray_error("type", "unsupported group key");
                         }
                     }
                     int n_count_out = 0;
@@ -6167,7 +6206,7 @@ by_dict_done:
                             if (cnt_hdr) ray_free(cnt_hdr);
                             if (eval_tbl != tbl) ray_release(eval_tbl);
                             ray_release(tbl);
-                            return ray_error("oom", NULL);
+                            scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                         }
                         int64_t* key_vals = (int64_t*)ray_data(vals_hdr);
                         uint8_t* key_null = (uint8_t*)ray_data(null_hdr);
@@ -6184,7 +6223,7 @@ by_dict_done:
                                     ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
                                     if (eval_tbl != tbl) ray_release(eval_tbl);
                                     ray_release(tbl);
-                                    return ray_error("type", "unsupported group key");
+                                    scratch_free(sel_slots_hdr); return ray_error("type", "unsupported group key");
                                 }
                             }
 
@@ -6217,7 +6256,7 @@ by_dict_done:
                             ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
                             if (eval_tbl != tbl) ray_release(eval_tbl);
                             ray_release(tbl);
-                            return result ? result : ray_error("oom", NULL);
+                            scratch_free(sel_slots_hdr); return result ? result : ray_error("oom", NULL);
                         }
                         for (int64_t k = 0; k < nk; k++) {
                             ray_t* src = key_cols[k];
@@ -6236,7 +6275,7 @@ by_dict_done:
                                 ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
                                 if (eval_tbl != tbl) ray_release(eval_tbl);
                                 ray_release(tbl);
-                                return key_vec ? key_vec : ray_error("oom", NULL);
+                                scratch_free(sel_slots_hdr); return key_vec ? key_vec : ray_error("oom", NULL);
                             }
                             /* key_vals holds RAW cell ids read from ONE
                              * source column — the output resolves over
@@ -6279,7 +6318,7 @@ by_dict_done:
                                 ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
                                 if (eval_tbl != tbl) ray_release(eval_tbl);
                                 ray_release(tbl);
-                                return result;
+                                scratch_free(sel_slots_hdr); return result;
                             }
                         }
                         for (int ai = 0; ai < n_count_out; ai++) {
@@ -6289,7 +6328,7 @@ by_dict_done:
                                 ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
                                 if (eval_tbl != tbl) ray_release(eval_tbl);
                                 ray_release(tbl);
-                                return cv ? cv : ray_error("oom", NULL);
+                                scratch_free(sel_slots_hdr); return cv ? cv : ray_error("oom", NULL);
                             }
                             cv->len = found;
                             memcpy(ray_data(cv), counts, (size_t)found * sizeof(int64_t));
@@ -6299,13 +6338,13 @@ by_dict_done:
                                 ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
                                 if (eval_tbl != tbl) ray_release(eval_tbl);
                                 ray_release(tbl);
-                                return result;
+                                scratch_free(sel_slots_hdr); return result;
                             }
                         }
                         ray_free(vals_hdr); ray_free(null_hdr); ray_free(cnt_hdr);
                         if (eval_tbl != tbl) ray_release(eval_tbl);
                         ray_release(tbl);
-                        return result;
+                        scratch_free(sel_slots_hdr); return result;
                     }
                 }
 
@@ -6313,7 +6352,7 @@ by_dict_done:
                 if (!composite_keys || RAY_IS_ERR(composite_keys)) {
                     if (eval_tbl != tbl) ray_release(eval_tbl);
                     ray_release(tbl);
-                    return composite_keys ? composite_keys : ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return composite_keys ? composite_keys : ray_error("oom", NULL);
                 }
                 for (int64_t r = 0; r < nrows; r++) {
                     ray_t* row_key = ray_list_new(nk);
@@ -6321,7 +6360,7 @@ by_dict_done:
                         ray_release(composite_keys);
                         if (eval_tbl != tbl) ray_release(eval_tbl);
                         ray_release(tbl);
-                        return row_key ? row_key : ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return row_key ? row_key : ray_error("oom", NULL);
                     }
                     for (int64_t k = 0; k < nk; k++) {
                         int alloc = 0;
@@ -6331,7 +6370,7 @@ by_dict_done:
                             ray_release(composite_keys);
                             if (eval_tbl != tbl) ray_release(eval_tbl);
                             ray_release(tbl);
-                            return cell ? cell : ray_error("domain", "select by: failed to read composite group key cell");
+                            scratch_free(sel_slots_hdr); return cell ? cell : ray_error("domain", "select by: failed to read composite group key cell");
                         }
                         row_key = ray_list_append(row_key, cell);
                         if (alloc) ray_release(cell);
@@ -6339,7 +6378,7 @@ by_dict_done:
                             ray_release(composite_keys);
                             if (eval_tbl != tbl) ray_release(eval_tbl);
                             ray_release(tbl);
-                            return row_key ? row_key : ray_error("oom", NULL);
+                            scratch_free(sel_slots_hdr); return row_key ? row_key : ray_error("oom", NULL);
                         }
                     }
                     composite_keys = ray_list_append(composite_keys, row_key);
@@ -6347,7 +6386,7 @@ by_dict_done:
                     if (!composite_keys || RAY_IS_ERR(composite_keys)) {
                         if (eval_tbl != tbl) ray_release(eval_tbl);
                         ray_release(tbl);
-                        return composite_keys ? composite_keys : ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return composite_keys ? composite_keys : ray_error("oom", NULL);
                     }
                 }
 
@@ -6356,14 +6395,14 @@ by_dict_done:
                 if (!groups_dict || RAY_IS_ERR(groups_dict)) {
                     if (eval_tbl != tbl) ray_release(eval_tbl);
                     ray_release(tbl);
-                    return groups_dict ? groups_dict : ray_error("domain", "select by: failed to compute composite groups");
+                    scratch_free(sel_slots_hdr); return groups_dict ? groups_dict : ray_error("domain", "select by: failed to compute composite groups");
                 }
                 ray_t* groups = groups_to_pair_list(groups_dict);
                 ray_release(groups_dict);
                 if (!groups || RAY_IS_ERR(groups)) {
                     if (eval_tbl != tbl) ray_release(eval_tbl);
                     ray_release(tbl);
-                    return groups ? groups : ray_error("domain", "select by: failed to build groups pair list");
+                    scratch_free(sel_slots_hdr); return groups ? groups : ray_error("domain", "select by: failed to build groups pair list");
                 }
                 int64_t n_groups = ray_len(groups) / 2;
                 int64_t out_groups = n_groups;
@@ -6383,7 +6422,7 @@ by_dict_done:
                          * silently dropping outputs past the slot cap. */
                         for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
                         ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                        return ray_error("range", "select: too many output columns (max %d)", RAY_GROUP_MAX_SLOTS);
+                        scratch_free(sel_slots_hdr); return ray_error("range", "select: too many output columns (max %d)", RAY_GROUP_MAX_SLOTS);
                     }
                     ray_t* val_expr_item = dict_elems[i + 1];
 
@@ -6398,7 +6437,7 @@ by_dict_done:
                         if (!per_group || RAY_IS_ERR(per_group)) {
                             for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
                             ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                            return per_group ? per_group : ray_error("domain", "select by: count-distinct aggregation failed");
+                            scratch_free(sel_slots_hdr); return per_group ? per_group : ray_error("domain", "select by: count-distinct aggregation failed");
                         }
                         agg_names[n_agg_out] = kid;
                         agg_results[n_agg_out] = per_group;
@@ -6425,7 +6464,7 @@ by_dict_done:
                             if (!src_col_val || RAY_IS_ERR(src_col_val)) {
                                 for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
                                 ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                                return src_col_val ? src_col_val : ray_error("domain", "select by: failed to evaluate aggregation source column");
+                                scratch_free(sel_slots_hdr); return src_col_val ? src_col_val : ray_error("domain", "select by: failed to evaluate aggregation source column");
                             }
                         }
 
@@ -6507,7 +6546,7 @@ by_dict_done:
                         if (!per_group || RAY_IS_ERR(per_group)) {
                             for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
                             ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                            return per_group ? per_group : ray_error("domain", "select by: per-group projection evaluation failed");
+                            scratch_free(sel_slots_hdr); return per_group ? per_group : ray_error("domain", "select by: per-group projection evaluation failed");
                         }
                         agg_names[n_agg_out] = kid;
                         agg_results[n_agg_out] = per_group;
@@ -6519,7 +6558,7 @@ by_dict_done:
                 if (!result || RAY_IS_ERR(result)) {
                     for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
                     ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                    return result ? result : ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return result ? result : ray_error("oom", NULL);
                 }
                 ray_t** grp_items = (ray_t**)ray_data(groups);
                 for (int64_t k = 0; k < nk; k++) {
@@ -6555,21 +6594,21 @@ by_dict_done:
                     if (!key_vec || RAY_IS_ERR(key_vec)) {
                         for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
                         ray_release(result); ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                        return key_vec ? key_vec : ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return key_vec ? key_vec : ray_error("oom", NULL);
                     }
                     result = ray_table_add_col(result, key_syms[k], key_vec);
                     ray_release(key_vec);
                     if (RAY_IS_ERR(result)) {
                         for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
                         ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                        return result;
+                        scratch_free(sel_slots_hdr); return result;
                     }
                 }
                 for (int ai = 0; ai < n_agg_out; ai++) {
                     if (agg_results[ai]) {
                         result = ray_table_add_col(result, agg_names[ai], agg_results[ai]);
                         ray_release(agg_results[ai]);
-                        if (RAY_IS_ERR(result)) { ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); return result; }
+                        if (RAY_IS_ERR(result)) { ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return result; }
                     }
                 }
 
@@ -6583,7 +6622,7 @@ by_dict_done:
                     ray_t* fi_hdr = ray_alloc((size_t)out_groups * sizeof(int64_t));
                     if (!fi_hdr) {
                         ray_release(result); ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                        return ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                     }
                     int64_t* fi = (int64_t*)ray_data(fi_hdr);
                     for (int64_t gi = 0; gi < out_groups; gi++) {
@@ -6634,7 +6673,7 @@ by_dict_done:
                         if (!dst || RAY_IS_ERR(dst)) {
                             if (dst) ray_release(dst);
                             ray_free(fi_hdr); ray_release(result); ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                            return ray_error("oom", NULL);
+                            scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                         }
                         result = ray_table_add_col(result, cn, dst);
                         ray_release(dst);
@@ -6642,7 +6681,7 @@ by_dict_done:
                     ray_free(fi_hdr);
                     if (RAY_IS_ERR(result)) {
                         ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                        return result;
+                        scratch_free(sel_slots_hdr); return result;
                     }
                 }
 
@@ -6650,11 +6689,11 @@ by_dict_done:
                 if (eval_tbl != tbl) ray_release(eval_tbl);
                 ray_release(tbl);
                 if (take_preapplied) {
-                    return result;
+                    scratch_free(sel_slots_hdr); return result;
                 }
                 result = apply_sort_take(result, dict_elems, dict_n,
                                          asc_id, desc_id, take_id);
-                return result;
+                scratch_free(sel_slots_hdr); return result;
             }
 
 	            /* eval_group path supports only simple scalar / [col] by-forms;
@@ -6662,7 +6701,7 @@ by_dict_done:
 	            if (by_key_sym < 0) {
 	                if (eval_tbl != tbl) ray_release(eval_tbl);
 	                ray_release(tbl);
-	                return ray_error("nyi", "eval-level groupby requires scalar key");
+	                scratch_free(sel_slots_hdr); return ray_error("nyi", "eval-level groupby requires scalar key");
 	            }
             ray_t* key_col = ray_table_get_col(eval_tbl, by_key_sym);
 
@@ -6682,14 +6721,14 @@ by_dict_done:
                 while ((uint64_t)cap < (uint64_t)n * 2 && cap < (1u << 28)) cap <<= 1;
                 uint32_t mask = cap - 1;
                 ray_t* ht_hdr = ray_alloc((size_t)cap * sizeof(uint32_t));
-                if (!ht_hdr) { if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); return ray_error("oom", NULL); }
+                if (!ht_hdr) { if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("oom", NULL); }
                 uint32_t* ht = (uint32_t*)ray_data(ht_hdr);
                 memset(ht, 0xFF, (size_t)cap * sizeof(uint32_t));
 
                 int64_t fi_cap = n < 1024 ? 1024 : (n < (1 << 20) ? n : (1 << 20));
                 if (fi_cap < 256) fi_cap = 256;
                 ray_t* fi_hdr = ray_alloc((size_t)fi_cap * sizeof(int64_t));
-                if (!fi_hdr) { ray_free(ht_hdr); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); return ray_error("oom", NULL); }
+                if (!fi_hdr) { ray_free(ht_hdr); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("oom", NULL); }
                 int64_t* fi = (int64_t*)ray_data(fi_hdr);
                 int64_t ngroups = 0;
 
@@ -6700,7 +6739,7 @@ by_dict_done:
                             ray_free(ht_hdr);
                             if (eval_tbl != tbl) ray_release(eval_tbl);
                             ray_release(tbl);
-                            return ray_error("cancel", "interrupted");
+                            scratch_free(sel_slots_hdr); return ray_error("cancel", "interrupted");
                         }
                         ray_progress_update("select", "by: first-of-group",
                                             (uint64_t)i, (uint64_t)n);
@@ -6718,7 +6757,7 @@ by_dict_done:
                         if (ngroups >= fi_cap) {
                             int64_t new_cap = fi_cap * 2;
                             ray_t* new_hdr = ray_alloc((size_t)new_cap * sizeof(int64_t));
-                            if (!new_hdr) { ray_free(fi_hdr); ray_free(ht_hdr); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); return ray_error("oom", NULL); }
+                            if (!new_hdr) { ray_free(fi_hdr); ray_free(ht_hdr); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("oom", NULL); }
                             memcpy(ray_data(new_hdr), fi, (size_t)ngroups * sizeof(int64_t));
                             ray_free(fi_hdr);
                             fi_hdr = new_hdr;
@@ -6843,20 +6882,20 @@ by_dict_done:
                 ray_release(tbl);
                 if (first_err) {
                     if (res) ray_release(res);
-                    return first_err;
+                    scratch_free(sel_slots_hdr); return first_err;
                 }
                 res = apply_sort_take(res, dict_elems, dict_n,
                                       asc_id, desc_id, take_id);
-                return res;
+                scratch_free(sel_slots_hdr); return res;
             }
 
             ray_t* groups_dict = ray_group_fn(key_col);
-            if (RAY_IS_ERR(groups_dict)) { if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); return groups_dict; }
+            if (RAY_IS_ERR(groups_dict)) { if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return groups_dict; }
             /* Flatten the dict into the legacy [k0,v0,…] interleaved LIST
              * representation that the rest of this branch was written for. */
             ray_t* groups = groups_to_pair_list(groups_dict);
             ray_release(groups_dict);
-            if (RAY_IS_ERR(groups)) { if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); return groups; }
+            if (RAY_IS_ERR(groups)) { if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return groups; }
 
             int64_t gn = ray_len(groups);
             int64_t n_groups = gn / 2;
@@ -6886,7 +6925,7 @@ by_dict_done:
                 }
                 if (eval_tbl != tbl) ray_release(eval_tbl);
                 ray_release(tbl);
-                return empty;
+                scratch_free(sel_slots_hdr); return empty;
             }
 
             /* Collect aggregation results */
@@ -6901,7 +6940,7 @@ by_dict_done:
                      * silently dropping outputs past the slot cap. */
                     for (int ai = 0; ai < n_agg_out; ai++) if (agg_results[ai]) ray_release(agg_results[ai]);
                     ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                    return ray_error("range", "select: too many output columns (max %d)", RAY_GROUP_MAX_SLOTS);
+                    scratch_free(sel_slots_hdr); return ray_error("range", "select: too many output columns (max %d)", RAY_GROUP_MAX_SLOTS);
                 }
                 ray_t* val_expr_item = dict_elems[i + 1];
 
@@ -6915,7 +6954,7 @@ by_dict_done:
                         if (!per_group || RAY_IS_ERR(per_group)) {
                             for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
                             ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                            return per_group ? per_group : ray_error("domain", "select by: count-distinct aggregation failed");
+                            scratch_free(sel_slots_hdr); return per_group ? per_group : ray_error("domain", "select by: count-distinct aggregation failed");
                         }
                         agg_names[n_agg_out] = kid;
                         agg_results[n_agg_out] = per_group;
@@ -6950,7 +6989,7 @@ by_dict_done:
                             src_col_val = ray_lazy_materialize(src_col_val);
                         if (RAY_IS_ERR(src_col_val)) {
                             for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
-                            ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); return src_col_val;
+                            ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return src_col_val;
                         }
                     }
 
@@ -7036,7 +7075,7 @@ by_dict_done:
                         if (RAY_IS_ERR(per_group)) {
                             for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
                             ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                            return per_group;
+                            scratch_free(sel_slots_hdr); return per_group;
                         }
                         agg_names[n_agg_out] = kid;
                         agg_results[n_agg_out] = per_group;
@@ -7050,7 +7089,7 @@ by_dict_done:
                     if (ray_env_push_scope() != RAY_OK) {
                         for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
                         ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                        return ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                     }
                     ray_t* _aqt = bind_all_columns(eval_tbl);
                     ray_t* full_val = ray_eval(val_expr_item);
@@ -7058,7 +7097,7 @@ by_dict_done:
                     ray_env_pop_scope();
                     if (RAY_IS_ERR(full_val)) {
                         for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
-                        ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); return full_val;
+                        ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return full_val;
                     }
 
                     /* Build LIST column: pre-allocate, then gather per group.
@@ -7068,7 +7107,7 @@ by_dict_done:
                         ray_release(full_val);
                         for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
                         ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                        return ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                     }
                     list_col->type = RAY_LIST;
                     /* Track filled length incrementally — see the DAG
@@ -7105,7 +7144,7 @@ by_dict_done:
                         if (RAY_IS_ERR(per_group)) {
                             for (int ai = 0; ai < n_agg_out; ai++) { if (agg_results[ai]) ray_release(agg_results[ai]); }
                             ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                            return per_group;
+                            scratch_free(sel_slots_hdr); return per_group;
                         }
                         /* core produces typed vec or list as appropriate */
                         agg_names[n_agg_out] = kid;
@@ -7138,7 +7177,7 @@ by_dict_done:
 
             /* Build result table: key column + aggregation columns */
             ray_t* result = ray_table_new(1 + n_agg_out);
-            if (RAY_IS_ERR(result)) { ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); return result; }
+            if (RAY_IS_ERR(result)) { ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return result; }
 
             /* Key column: build a typed vector matching the source column type */
             ray_t** grp_items = (ray_t**)ray_data(groups);
@@ -7172,7 +7211,7 @@ by_dict_done:
                 if (!key_vec || RAY_IS_ERR(key_vec)) {
                     for (int i = 0; i < n_agg_out; i++) { if (agg_results[i]) ray_release(agg_results[i]); }
                     ray_release(result); ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl);
-                    return key_vec ? key_vec : ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return key_vec ? key_vec : ray_error("oom", NULL);
                 }
                 result = ray_table_add_col(result, by_key_sym, key_vec);
                 ray_release(key_vec);
@@ -7193,7 +7232,7 @@ by_dict_done:
                 int64_t* fi = (n_groups <= 256) ? fi_stack : NULL;
                 if (!fi) {
                     fi_hdr = ray_alloc((size_t)n_groups * sizeof(int64_t));
-                    if (!fi_hdr) { ray_release(result); ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); return ray_error("oom", NULL); }
+                    if (!fi_hdr) { ray_release(result); ray_release(groups); if (eval_tbl != tbl) ray_release(eval_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("oom", NULL); }
                     fi = (int64_t*)ray_data(fi_hdr);
                 }
                 for (int64_t gi = 0; gi < n_groups; gi++) {
@@ -7271,7 +7310,7 @@ by_dict_done:
             ray_release(tbl);
             result = apply_sort_take(result, dict_elems, dict_n,
                                      asc_id, desc_id, take_id);
-            return result;
+            scratch_free(sel_slots_hdr); return result;
         }
 
         /* Pre-scan: any non-aggregation expressions that need a flat
@@ -7310,9 +7349,7 @@ by_dict_done:
         int n_grp_agg_outputs = 0;   /* dag-aggs + decomposed compounds */
         int has_cd_output = 0;
         int sg_shapes_ok = 1;        /* every agg slot kernel-shaped */
-        int64_t compound_pos[16];
         {
-            int mirror_aggs = 0;
             for (int64_t i = 0; i + 1 < dict_n; i += 2) {
                 int64_t kid = dict_elems[i]->i64;
                 if (kid == from_id || kid == where_id || kid == by_id ||
@@ -7321,12 +7358,9 @@ by_dict_done:
                 if (is_single_group_key_projection(by_expr, expr))
                     continue;
                 if (is_group_dag_agg_expr(expr)) {
-                    /* Mirror the compile loop's slot budget; a query with
-                     * more than RAY_GROUP_MAX_SLOTS aggregates is rejected
-                     * there with a clear error (not silently dropped), so
-                     * this cap only bounds the mirror count.  Not a flat
+                    /* dag-aggs claim output slots in order.  Not a flat
                      * forcer. */
-                    if (mirror_aggs < RAY_GROUP_MAX_SLOTS) { mirror_aggs++; n_grp_agg_outputs++; }
+                    n_grp_agg_outputs++;
                     if (!sg_agg_expr_ok(expr)) sg_shapes_ok = 0;
                     continue;
                 }
@@ -7334,12 +7368,11 @@ by_dict_done:
                 int is_simple_cd = cd_inner && cd_inner->type == -RAY_SYM &&
                                    !(cd_inner->attrs & ATTR_QUOTED);
                 if (is_simple_cd) { has_cd_output = 1; continue; }
-                if (n_compound < 16) {
-                    int cap = 16 - mirror_aggs - n_hidden_aggs;
+                if (n_compound < n_out_max) {
                     int h_before = n_hidden_aggs;
                     ray_t* rw = try_decompose_agg_arith(
                         expr, tbl, hidden_agg_exprs, hidden_agg_names,
-                        &n_hidden_aggs, n_hidden_aggs + (cap > 0 ? cap : 0));
+                        &n_hidden_aggs, (int)hidden_max);
                     if (rw) {
                         for (int hi = h_before; hi < n_hidden_aggs; hi++)
                             if (!sg_agg_expr_ok(hidden_agg_exprs[hi]))
@@ -7364,7 +7397,7 @@ by_dict_done:
             ray_t* flat_tbl = ray_table_new(ray_table_ncols(tbl));
             if (!flat_tbl || RAY_IS_ERR(flat_tbl)) {
                 ray_graph_free(g); ray_release(tbl);
-                return flat_tbl ? flat_tbl : ray_error("oom", NULL);
+                scratch_free(sel_slots_hdr); return flat_tbl ? flat_tbl : ray_error("oom", NULL);
             }
             int64_t ncols = ray_table_ncols(tbl);
             for (int64_t c = 0; c < ncols; c++) {
@@ -7373,26 +7406,26 @@ by_dict_done:
                 ray_t* flat_col = query_materialize_parted_col(col);
                 if (!flat_col || RAY_IS_ERR(flat_col)) {
                     ray_release(flat_tbl); ray_graph_free(g); ray_release(tbl);
-                    return flat_col ? flat_col : ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return flat_col ? flat_col : ray_error("oom", NULL);
                 }
                 flat_tbl = ray_table_add_col(flat_tbl, name, flat_col);
                 ray_release(flat_col);
                 if (!flat_tbl || RAY_IS_ERR(flat_tbl)) {
                     ray_graph_free(g); ray_release(tbl);
-                    return flat_tbl ? flat_tbl : ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return flat_tbl ? flat_tbl : ray_error("oom", NULL);
                 }
             }
             ray_graph_free(g);
             ray_release(tbl);
             tbl = flat_tbl;
             g = ray_graph_new(tbl);
-            if (!g) { ray_release(tbl); return ray_error("oom", NULL); }
+            if (!g) { ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("oom", NULL); }
             root = ray_const_table(g, tbl);
             if (where_expr) {
                 ray_op_t* pred = compile_expr_dag(g, where_expr);
                 if (!pred) {
                     ray_graph_free(g); ray_release(tbl);
-                    return ray_error("domain", "select: failed to compile `where:` predicate");
+                    scratch_free(sel_slots_hdr); return ray_error("domain", "select: failed to compile `where:` predicate");
                 }
                 root = ray_filter(g, root, pred);
             }
@@ -7460,7 +7493,7 @@ by_dict_done:
                         g->selection = NULL;
                     }
                     ray_graph_free(g); ray_release(tbl);
-                    return fres ? fres : ray_error("domain", "select: `where:` filter produced no result");
+                    scratch_free(sel_slots_hdr); return fres ? fres : ray_error("domain", "select: `where:` filter produced no result");
                 }
                 /* OP_CONST/OP_FILTER both retain, so the returned
                  * table has an extra refcount we must release.
@@ -7479,42 +7512,36 @@ by_dict_done:
                 root = ray_optimize(g, root);
                 ray_t* fres = ray_execute(g, root);
                 ray_graph_free(g); g = NULL;
-                if (!fres || RAY_IS_ERR(fres)) { ray_release(tbl); return fres ? fres : ray_error("domain", "select: `where:` filter produced no result"); }
+                if (!fres || RAY_IS_ERR(fres)) { ray_release(tbl); scratch_free(sel_slots_hdr); return fres ? fres : ray_error("domain", "select: `where:` filter produced no result"); }
                 if (ray_is_lazy(fres)) fres = ray_lazy_materialize(fres);
-                if (!fres || RAY_IS_ERR(fres)) { ray_release(tbl); return fres ? fres : ray_error("domain", "select: failed to materialize filtered result"); }
+                if (!fres || RAY_IS_ERR(fres)) { ray_release(tbl); scratch_free(sel_slots_hdr); return fres ? fres : ray_error("domain", "select: failed to materialize filtered result"); }
                 ray_release(tbl);
                 tbl = fres;
                 g = ray_graph_new(tbl);
-                if (!g) { ray_release(tbl); return ray_error("oom", NULL); }
+                if (!g) { ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("oom", NULL); }
                 root = ray_const_table(g, tbl);
             }
         where_done: ;
         }
 
-        /* Compile group key(s) */
-        ray_op_t* key_ops[16];
-        uint8_t n_keys = 0;
+        /* Compile group key(s) — key_ops carved with the top-level collectors */
+        int64_t n_keys = 0;
 
         if (by_expr->type == RAY_SYM) {
             /* Multiple keys as SYM vector: [col1 col2 ...] —
              * cell-data resolved through the vec's domain. */
             int64_t nk = ray_len(by_expr);
-            if (nk > RAY_GROUP_MAX_SLOTS) {
-                for (int ci = 0; ci < n_compound; ci++) ray_release(compound_rw[ci]);
-                ray_graph_free(g); ray_release(tbl);
-                return ray_error("range", "select by: too many group keys (max %d)", RAY_GROUP_MAX_SLOTS);
-            }
-            for (int64_t i = 0; i < nk && n_keys < 16; i++) {
+            for (int64_t i = 0; i < nk && n_keys < nk_max; i++) {
                 ray_t* name_str = ray_sym_vec_cell(by_expr, i);
-                if (!name_str) { ray_graph_free(g); ray_release(tbl); return ray_error("domain", "select by: unknown group key symbol"); }
+                if (!name_str) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("domain", "select by: unknown group key symbol"); }
                 key_ops[n_keys] = ray_scan(g, ray_str_ptr(name_str));
-                if (!key_ops[n_keys]) { ray_graph_free(g); ray_release(tbl); return ray_error("domain", "select by: group key column not found"); }
+                if (!key_ops[n_keys]) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("domain", "select by: group key column not found"); }
                 n_keys++;
             }
         } else {
             /* Single key expression */
             key_ops[0] = compile_expr_dag(g, by_expr);
-            if (!key_ops[0]) { ray_graph_free(g); ray_release(tbl); return ray_error("domain", "select by: failed to compile group key expression"); }
+            if (!key_ops[0]) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("domain", "select by: failed to compile group key expression"); }
             n_keys = 1;
         }
 
@@ -7524,12 +7551,9 @@ by_dict_done:
          * non-NULL for binary aggs (currently OP_PEARSON_CORR).  The
          * has_binary_agg flag selects ray_group2 below.  agg_k[] carries
          * a scalar literal alongside the column for holistic aggs that
-         * take K (top/bot); zero in unrelated slots. */
-        uint16_t agg_ops[16];
-        ray_op_t* agg_ins[16];
-        ray_op_t* agg_ins2[16];
-        int64_t agg_k[16];
-        uint8_t n_aggs = 0;
+         * take K (top/bot); zero in unrelated slots.  agg_ops/agg_ins/
+         * agg_ins2/agg_k are carved with the top-level collectors. */
+        int64_t n_aggs = 0;
         int has_binary_agg = 0;
         int has_agg_k = 0;
 
@@ -7539,11 +7563,6 @@ by_dict_done:
 
             ray_t* val_expr = dict_elems[i + 1];
             if (is_group_dag_agg_expr(val_expr)) {
-                if (n_aggs >= RAY_GROUP_MAX_SLOTS) {
-                    for (int ci = 0; ci < n_compound; ci++) ray_release(compound_rw[ci]);
-                    ray_graph_free(g); ray_release(tbl);
-                    return ray_error("range", "select by: too many aggregate columns (max %d)", RAY_GROUP_MAX_SLOTS);
-                }
                 ray_t** agg_elems = (ray_t**)ray_data(val_expr);
                 uint16_t op = resolve_agg_opcode(agg_elems[0]->i64);
                 ray_t* agg_arg = agg_elems[1];
@@ -7561,31 +7580,31 @@ by_dict_done:
                 agg_ops[n_aggs] = op;
                 /* Compile the aggregation input (the column reference) */
                 agg_ins[n_aggs] = compile_expr_dag(g, agg_arg);
-                if (!agg_ins[n_aggs]) { ray_graph_free(g); ray_release(tbl); return ray_error("domain", "select by: failed to compile aggregation argument"); }
+                if (!agg_ins[n_aggs]) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("domain", "select by: failed to compile aggregation argument"); }
                 /* Canonical aggregand type-admission (matches the scalar
                  * builtins): reject non-numeric / absolute-temporal inputs so a
                  * by-group sum/avg/var never silently folds symbol ids etc. */
                 if (agg_ins[n_aggs]->out_type > 0 &&
                     !agg_type_admitted(op, agg_ins[n_aggs]->out_type)) {
                     int8_t in_t = agg_ins[n_aggs]->out_type;            /* capture BEFORE free */
-                    ray_graph_free(g); ray_release(tbl); return ray_error("type", "select by: aggregation does not admit input type %s", ray_type_name(in_t));
+                    ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("type", "select by: aggregation does not admit input type %s", ray_type_name(in_t));
                 }
                 agg_ins2[n_aggs] = NULL;
                 agg_k[n_aggs] = 0;
                 if (op == OP_PEARSON_CORR) {
-                    if (ray_len(val_expr) < 3) { ray_graph_free(g); ray_release(tbl); return ray_error("arity", "select by: cor aggregation requires two column arguments"); }
+                    if (ray_len(val_expr) < 3) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("arity", "select by: cor aggregation requires two column arguments"); }
                     agg_ins2[n_aggs] = compile_expr_dag(g, agg_elems[2]);
-                    if (!agg_ins2[n_aggs]) { ray_graph_free(g); ray_release(tbl); return ray_error("domain", "select by: failed to compile cor second argument"); }
+                    if (!agg_ins2[n_aggs]) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("domain", "select by: failed to compile cor second argument"); }
                     has_binary_agg = 1;
                 } else if (op == OP_TOP_N || op == OP_BOT_N) {
-                    if (ray_len(val_expr) < 3) { ray_graph_free(g); ray_release(tbl); return ray_error("arity", "select by: top/bot aggregation requires a K argument"); }
+                    if (ray_len(val_expr) < 3) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("arity", "select by: top/bot aggregation requires a K argument"); }
                     ray_t* k_expr = agg_elems[2];
                     int64_t k_val;
                     if (k_expr->type == -RAY_I64)       k_val = k_expr->i64;
                     else if (k_expr->type == -RAY_I32)  k_val = (int64_t)(int32_t)k_expr->i64;
-                    else { ray_graph_free(g); ray_release(tbl); return ray_error("type", "top/bot K must be integer literal"); }
-                    if (k_val < 1) { ray_graph_free(g); ray_release(tbl); return ray_error("range", "top/bot K must be >= 1"); }
-                    if (k_val > 1024) { ray_graph_free(g); ray_release(tbl); return ray_error("range", "top/bot K capped at 1024"); }
+                    else { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("type", "top/bot K must be integer literal"); }
+                    if (k_val < 1) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("range", "top/bot K must be >= 1"); }
+                    if (k_val > 1024) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("range", "top/bot K capped at 1024"); }
                     agg_k[n_aggs] = k_val;
                     has_agg_k = 1;
                 }
@@ -7606,7 +7625,7 @@ by_dict_done:
                 if (n_nonaggs >= RAY_GROUP_MAX_SLOTS) {
                     for (int ci = 0; ci < n_compound; ci++) ray_release(compound_rw[ci]);
                     ray_graph_free(g); ray_release(tbl);
-                    return ray_error("range", "select by: too many non-aggregate columns (max %d)", RAY_GROUP_MAX_SLOTS);
+                    scratch_free(sel_slots_hdr); return ray_error("range", "select by: too many non-aggregate columns (max %d)", RAY_GROUP_MAX_SLOTS);
                 }
                 nonagg_names[n_nonaggs] = kid;
                 nonagg_exprs[n_nonaggs] = val_expr;
@@ -7618,11 +7637,6 @@ by_dict_done:
         /* Compile the hidden decomposed agg slots (unary DAG aggs by
          * construction — see agg_arith_rewrite). */
         for (int hi = 0; hi < n_hidden_aggs; hi++) {
-            if (n_aggs >= RAY_GROUP_MAX_SLOTS) {
-                for (int ci = 0; ci < n_compound; ci++) ray_release(compound_rw[ci]);
-                ray_graph_free(g); ray_release(tbl);
-                return ray_error("range", "select by: too many aggregate columns (max %d)", RAY_GROUP_MAX_SLOTS);
-            }
             ray_t** he = (ray_t**)ray_data(hidden_agg_exprs[hi]);
             uint16_t hop = resolve_agg_opcode(he[0]->i64);
             agg_ops[n_aggs] = hop;
@@ -7631,7 +7645,7 @@ by_dict_done:
                 for (int ci = 0; ci < n_compound; ci++)
                     ray_release(compound_rw[ci]);
                 ray_graph_free(g); ray_release(tbl);
-                return ray_error("domain", "select by: failed to compile aggregation argument");
+                scratch_free(sel_slots_hdr); return ray_error("domain", "select by: failed to compile aggregation argument");
             }
             if (agg_ins[n_aggs]->out_type > 0 &&
                 !agg_type_admitted(hop, agg_ins[n_aggs]->out_type)) {
@@ -7639,13 +7653,21 @@ by_dict_done:
                 for (int ci = 0; ci < n_compound; ci++)
                     ray_release(compound_rw[ci]);
                 ray_graph_free(g); ray_release(tbl);
-                return ray_error("type", "select by: aggregation does not admit input type %s", ray_type_name(in_t));
+                scratch_free(sel_slots_hdr); return ray_error("type", "select by: aggregation does not admit input type %s", ray_type_name(in_t));
             }
             agg_ins2[n_aggs] = NULL;
             agg_k[n_aggs] = 0;
             n_aggs++;
         }
 
+        /* The op-graph builders carry key/agg counts in uint8_t; guard the
+         * representational limit before narrowing at the call. */
+        if (n_aggs > UINT8_MAX || n_keys > UINT8_MAX) {
+            for (int ci = 0; ci < n_compound; ci++) ray_release(compound_rw[ci]);
+            scratch_free(sel_slots_hdr);
+            ray_graph_free(g); ray_release(tbl);
+            return ray_error("range", "select by: too many group columns for the op graph (max %d)", UINT8_MAX);
+        }
         if (n_aggs > 0 || n_nonaggs > 0) {
             if (n_aggs > 0) {
                 if (has_agg_k) {
@@ -7653,20 +7675,20 @@ by_dict_done:
                      * these and produces LIST output (differential-validated
                      * to match the old OP_TOP_N LIST shape).  Build a plain
                      * OP_GROUP node via ray_group3 so agg_k is preserved. */
-                    root = ray_group3(g, key_ops, n_keys, agg_ops,
+                    root = ray_group3(g, key_ops, (uint8_t)n_keys, agg_ops,
                                        agg_ins, has_binary_agg ? agg_ins2 : NULL,
-                                       agg_k, n_aggs);
+                                       agg_k, (uint8_t)n_aggs);
                 } else if (has_binary_agg) {
                     /* pearson carries a 2nd input column (y) per agg.  v2
                      * admits these and computes signed r.  Build a plain
                      * OP_GROUP node via ray_group2 so agg_ins2 is preserved. */
-                    root = ray_group2(g, key_ops, n_keys, agg_ops,
-                                       agg_ins, agg_ins2, n_aggs);
+                    root = ray_group2(g, key_ops, (uint8_t)n_keys, agg_ops,
+                                       agg_ins, agg_ins2, (uint8_t)n_aggs);
                 } else {
                     /* Plain unary aggs (incl. max+min, median+stddev,
                      * sum+count) — v2 handles all of these.  Build a plain
                      * OP_GROUP node. */
-                    root = ray_group(g, key_ops, n_keys, agg_ops, agg_ins, n_aggs);
+                    root = ray_group(g, key_ops, (uint8_t)n_keys, agg_ops, agg_ins, (uint8_t)n_aggs);
                 }
             } else {
                 /* No aggs but non-agg expressions exist — still need group
@@ -7674,7 +7696,7 @@ by_dict_done:
                  * The count column will be dropped after execution. */
                 uint16_t cnt_op = OP_COUNT;
                 ray_op_t* cnt_in = key_ops[0];
-                root = ray_group(g, key_ops, n_keys, &cnt_op, &cnt_in, 1);
+                root = ray_group(g, key_ops, (uint8_t)n_keys, &cnt_op, &cnt_in, 1);
                 synth_count_col = 1;
             }
         } else {
@@ -7686,23 +7708,17 @@ by_dict_done:
                 root = ray_optimize(g, root);
                 ray_t* fres = ray_execute(g, root);
                 ray_graph_free(g); g = NULL;
-                if (!fres || RAY_IS_ERR(fres)) { ray_release(tbl); return fres ? fres : ray_error("domain", "select: `where:` filter produced no result"); }
+                if (!fres || RAY_IS_ERR(fres)) { ray_release(tbl); scratch_free(sel_slots_hdr); return fres ? fres : ray_error("domain", "select: `where:` filter produced no result"); }
                 if (ray_is_lazy(fres)) fres = ray_lazy_materialize(fres);
-                if (!fres || RAY_IS_ERR(fres)) { ray_release(tbl); return fres ? fres : ray_error("domain", "select: failed to materialize filtered result"); }
+                if (!fres || RAY_IS_ERR(fres)) { ray_release(tbl); scratch_free(sel_slots_hdr); return fres ? fres : ray_error("domain", "select: failed to materialize filtered result"); }
                 filtered_tbl = fres;
                 /* Rebuild graph on filtered table for GROUP+COUNT */
                 g = ray_graph_new(filtered_tbl);
-                if (!g) { if (filtered_tbl != tbl) ray_release(filtered_tbl); ray_release(tbl); return ray_error("oom", NULL); }
+                if (!g) { if (filtered_tbl != tbl) ray_release(filtered_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("oom", NULL); }
                 n_keys = 0;
                 if (by_expr->type == RAY_SYM) {
                     int64_t nk = ray_len(by_expr);
-                    if (nk > RAY_GROUP_MAX_SLOTS) {
-                        ray_graph_free(g);
-                        if (filtered_tbl != tbl) ray_release(filtered_tbl);
-                        ray_release(tbl);
-                        return ray_error("range", "select by: too many group keys (max %d)", RAY_GROUP_MAX_SLOTS);
-                    }
-                    for (int64_t i = 0; i < nk && n_keys < 16; i++) {
+                    for (int64_t i = 0; i < nk && n_keys < nk_max; i++) {
                         /* cell-data via the vec's domain */
                         ray_t* ns = ray_sym_vec_cell(by_expr, i);
                         if (ns) key_ops[n_keys++] = ray_scan(g, ray_str_ptr(ns));
@@ -7713,13 +7729,19 @@ by_dict_done:
                 }
             }
 
+            if (n_keys > UINT8_MAX) {
+                ray_graph_free(g);
+                if (filtered_tbl != tbl) ray_release(filtered_tbl);
+                ray_release(tbl);
+                scratch_free(sel_slots_hdr); return ray_error("range", "select by: too many group columns for the op graph (max %d)", UINT8_MAX);
+            }
             uint16_t cnt_op = OP_COUNT;
             ray_op_t* cnt_in = key_ops[0];
-            root = ray_group(g, key_ops, n_keys, &cnt_op, &cnt_in, 1);
+            root = ray_group(g, key_ops, (uint8_t)n_keys, &cnt_op, &cnt_in, 1);
             root = ray_optimize(g, root);
             ray_t* grouped = ray_execute(g, root);
             ray_graph_free(g); g = NULL;
-            if (!grouped || RAY_IS_ERR(grouped)) { if (filtered_tbl != tbl) ray_release(filtered_tbl); ray_release(tbl); return grouped; }
+            if (!grouped || RAY_IS_ERR(grouped)) { if (filtered_tbl != tbl) ray_release(filtered_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return grouped; }
             if (ray_is_lazy(grouped)) grouped = ray_lazy_materialize(grouped);
 
             int64_t n_groups = ray_table_nrows(grouped);
@@ -7832,7 +7854,7 @@ by_dict_done:
                 }
                 if (filtered_tbl != tbl) ray_release(filtered_tbl);
                 ray_release(tbl);
-                return empty;
+                scratch_free(sel_slots_hdr); return empty;
             }
 
             /* Build first_idx: scan filtered key column once, record first
@@ -7852,14 +7874,14 @@ by_dict_done:
                 if (!computed_key || RAY_IS_ERR(computed_key)) {
                     if (filtered_tbl != tbl) ray_release(filtered_tbl);
                     ray_release(tbl);
-                    return computed_key ? computed_key : ray_error("domain", "select by: failed to evaluate group key expression");
+                    scratch_free(sel_slots_hdr); return computed_key ? computed_key : ray_error("domain", "select by: failed to evaluate group key expression");
                 }
                 ray_t* groups2_dict = ray_group_fn(computed_key);
                 if (!groups2_dict || RAY_IS_ERR(groups2_dict)) {
                     ray_release(computed_key);
                     if (filtered_tbl != tbl) ray_release(filtered_tbl);
                     ray_release(tbl);
-                    return groups2_dict ? groups2_dict : ray_error("domain", "select by: failed to compute groups");
+                    scratch_free(sel_slots_hdr); return groups2_dict ? groups2_dict : ray_error("domain", "select by: failed to compute groups");
                 }
                 ray_t* groups2 = groups_to_pair_list(groups2_dict);
                 ray_release(groups2_dict);
@@ -7867,10 +7889,10 @@ by_dict_done:
                     ray_release(computed_key);
                     if (filtered_tbl != tbl) ray_release(filtered_tbl);
                     ray_release(tbl);
-                    return groups2;
+                    scratch_free(sel_slots_hdr); return groups2;
                 }
                 int64_t ng2 = ray_len(groups2) / 2;
-                if (ng2 == 0) { ray_release(groups2); ray_release(computed_key); if (filtered_tbl != tbl) ray_release(filtered_tbl); ray_release(tbl); return ray_table_new(0); }
+                if (ng2 == 0) { ray_release(groups2); ray_release(computed_key); if (filtered_tbl != tbl) ray_release(filtered_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_table_new(0); }
                 ray_t** gi2 = (ray_t**)ray_data(groups2);
 
                 /* fi2 must sweep EVERY group, not just the first 256 —
@@ -7887,7 +7909,7 @@ by_dict_done:
                         ray_release(groups2); ray_release(computed_key);
                         if (filtered_tbl != tbl) ray_release(filtered_tbl);
                         ray_release(tbl);
-                        return ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                     }
                     fi2 = (int64_t*)ray_data(fi2_hdr);
                 }
@@ -7987,7 +8009,7 @@ by_dict_done:
                 ray_release(groups2); ray_release(computed_key);
                 if (filtered_tbl != tbl) ray_release(filtered_tbl);
                 ray_release(tbl);
-                return res2;
+                scratch_free(sel_slots_hdr); return res2;
             }
 
             ray_t* orig_key_col = ray_table_get_col(filtered_tbl, key_sym);
@@ -8004,7 +8026,7 @@ by_dict_done:
             int64_t* gk_vals = gk_stack;
             if (n_groups > 256) {
                 gk_heap_hdr = ray_alloc((size_t)n_groups * sizeof(int64_t));
-                if (!gk_heap_hdr) { ray_release(grouped); if (filtered_tbl != tbl) ray_release(filtered_tbl); ray_release(tbl); return ray_error("oom", NULL); }
+                if (!gk_heap_hdr) { ray_release(grouped); if (filtered_tbl != tbl) ray_release(filtered_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("oom", NULL); }
                 gk_vals = (int64_t*)ray_data(gk_heap_hdr);
             }
 
@@ -8035,7 +8057,7 @@ by_dict_done:
                     ray_release(grouped);
                     if (filtered_tbl != tbl) ray_release(filtered_tbl);
                     ray_release(tbl);
-                    return ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                 }
                 gk_null = (uint8_t*)ray_data(gk_null_hdr);
             }
@@ -8069,7 +8091,7 @@ by_dict_done:
             int64_t* first_idx = first_idx_stack;
             if (n_groups > 256) {
                 fi_heap_hdr = ray_alloc((size_t)n_groups * sizeof(int64_t));
-                if (!fi_heap_hdr) { if (gk_heap_hdr) ray_free(gk_heap_hdr); if (filtered_tbl != tbl) ray_release(filtered_tbl); ray_release(tbl); return ray_error("oom", NULL); }
+                if (!fi_heap_hdr) { if (gk_heap_hdr) ray_free(gk_heap_hdr); if (filtered_tbl != tbl) ray_release(filtered_tbl); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("oom", NULL); }
                 first_idx = (int64_t*)ray_data(fi_heap_hdr);
             }
 
@@ -8091,7 +8113,7 @@ by_dict_done:
                     if (fi_heap_hdr) ray_free(fi_heap_hdr);
                     if (filtered_tbl != tbl) ray_release(filtered_tbl);
                     ray_release(tbl);
-                    return ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                 }
                 uint32_t* fi_ht = (uint32_t*)ray_data(fi_ht_hdr);
                 memset(fi_ht, 0xFF, (size_t)fi_cap * sizeof(uint32_t));
@@ -8167,24 +8189,24 @@ by_dict_done:
             /* Build result table: key column first, then others */
             int64_t ncols = ray_table_ncols(filtered_tbl);
             ray_t* result = ray_table_new(ncols);
-            if (RAY_IS_ERR(result)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); return result; }
+            if (RAY_IS_ERR(result)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); scratch_free(sel_slots_hdr); return result; }
 
             /* Add key column first */
             ray_t* key_vec_src = ray_table_get_col(filtered_tbl, key_sym);
             if (key_vec_src->type == RAY_STR) {
                 ray_t* key_vec_dst = ray_vec_new(RAY_STR, n_groups);
-                if (!key_vec_dst || RAY_IS_ERR(key_vec_dst)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); return key_vec_dst ? key_vec_dst : ray_error("oom", NULL); }
+                if (!key_vec_dst || RAY_IS_ERR(key_vec_dst)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); scratch_free(sel_slots_hdr); return key_vec_dst ? key_vec_dst : ray_error("oom", NULL); }
                 for (int64_t gi = 0; gi < n_groups; gi++) {
                     size_t slen = 0;
                     const char* sp = ray_str_vec_get(key_vec_src, first_idx[gi], &slen);
                     key_vec_dst = ray_str_vec_append(key_vec_dst, sp ? sp : "", sp ? slen : 0);
-                    if (RAY_IS_ERR(key_vec_dst)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); return key_vec_dst; }
+                    if (RAY_IS_ERR(key_vec_dst)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); scratch_free(sel_slots_hdr); return key_vec_dst; }
                 }
                 result = ray_table_add_col(result, key_sym, key_vec_dst);
                 ray_release(key_vec_dst);
             } else {
                 ray_t* key_vec_dst = ray_vec_new(key_vec_src->type, n_groups);
-                if (RAY_IS_ERR(key_vec_dst)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); return key_vec_dst; }
+                if (RAY_IS_ERR(key_vec_dst)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); scratch_free(sel_slots_hdr); return key_vec_dst; }
                 /* Set len BEFORE the store loop: store_typed_elem routes
                  * null atoms through ray_vec_set_null, which range-checks
                  * idx against vec->len and silently returns RAY_ERR_RANGE
@@ -8213,19 +8235,19 @@ by_dict_done:
                 if (ct == RAY_STR) {
                     /* String column: build STR vector */
                     ray_t* dst = ray_vec_new(RAY_STR, n_groups);
-                    if (!dst || RAY_IS_ERR(dst)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); return dst ? dst : ray_error("oom", NULL); }
+                    if (!dst || RAY_IS_ERR(dst)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); scratch_free(sel_slots_hdr); return dst ? dst : ray_error("oom", NULL); }
                     for (int64_t gi = 0; gi < n_groups; gi++) {
                         size_t slen = 0;
                         const char* sp = ray_str_vec_get(src_col, first_idx[gi], &slen);
                         dst = ray_str_vec_append(dst, sp ? sp : "", sp ? slen : 0);
-                        if (RAY_IS_ERR(dst)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); return dst; }
+                        if (RAY_IS_ERR(dst)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); scratch_free(sel_slots_hdr); return dst; }
                     }
                     result = ray_table_add_col(result, col_name, dst);
                     ray_release(dst);
                 } else if (ct == RAY_LIST) {
                     /* List column: pick items */
                     ray_t* dst = ray_alloc(n_groups * sizeof(ray_t*));
-                    if (!dst) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); return ray_error("oom", NULL); }
+                    if (!dst) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); scratch_free(sel_slots_hdr); return ray_error("oom", NULL); }
                     dst->type = RAY_LIST;
                     dst->len = n_groups;
                     ray_t** dout = (ray_t**)ray_data(dst);
@@ -8242,7 +8264,7 @@ by_dict_done:
                      * propagate through store_typed_elem → ray_vec_set_null
                      * (same reason as the key column above). */
                     ray_t* dst = ray_vec_new(ct, n_groups);
-                    if (RAY_IS_ERR(dst)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); return dst; }
+                    if (RAY_IS_ERR(dst)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); ray_release(result); scratch_free(sel_slots_hdr); return dst; }
                     dst->len = n_groups;
                     for (int64_t gi = 0; gi < n_groups; gi++) {
                         int alloc = 0;
@@ -8253,7 +8275,7 @@ by_dict_done:
                     result = ray_table_add_col(result, col_name, dst);
                     ray_release(dst);
                 }
-                if (RAY_IS_ERR(result)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); return result; }
+                if (RAY_IS_ERR(result)) { if (fi_heap_hdr) ray_free(fi_heap_hdr); ray_release(tbl); scratch_free(sel_slots_hdr); return result; }
             }
 
             if (fi_heap_hdr) ray_free(fi_heap_hdr);
@@ -8261,7 +8283,7 @@ by_dict_done:
             ray_release(tbl);
             result = apply_sort_take(result, dict_elems, dict_n,
                                      asc_id, desc_id, take_id);
-            return result;
+            scratch_free(sel_slots_hdr); return result;
         }
     } else if (n_out > 0) {
         /* No `by:` but explicit output expressions.
@@ -8305,7 +8327,7 @@ by_dict_done:
                         g->selection = NULL;
                     }
                     ray_graph_free(g); ray_release(tbl);
-                    return fres ? fres : ray_error("domain", "select: `where:` filter produced no result");
+                    scratch_free(sel_slots_hdr); return fres ? fres : ray_error("domain", "select: `where:` filter produced no result");
                 }
                 ray_release(fres);
             }
@@ -8331,7 +8353,7 @@ by_dict_done:
                         g->selection = NULL;
                     }
                     ray_graph_free(g); ray_release(tbl);
-                    return ray_error("domain", "select: failed to compile aggregation argument");
+                    scratch_free(sel_slots_hdr); return ray_error("domain", "select: failed to compile aggregation argument");
                 }
                 /* Canonical aggregand type-admission (same table as the scalar
                  * builtins): reject non-numeric (SYM/STR/GUID) and, for sum,
@@ -8342,19 +8364,19 @@ by_dict_done:
                     int8_t in_t = s_agg_ins[s_n_aggs]->out_type;            /* capture BEFORE free */
                     if (g->selection) { ray_release(g->selection); g->selection = NULL; }
                     ray_graph_free(g); ray_release(tbl);
-                    return ray_error("type", "select: aggregation does not admit input type %s", ray_type_name(in_t));
+                    scratch_free(sel_slots_hdr); return ray_error("type", "select: aggregation does not admit input type %s", ray_type_name(in_t));
                 }
                 if (op == OP_PEARSON_CORR) {
                     if (ray_len(val_expr) < 3) {
                         if (g->selection) { ray_release(g->selection); g->selection = NULL; }
                         ray_graph_free(g); ray_release(tbl);
-                        return ray_error("arity", "select: cor aggregation requires two column arguments");
+                        scratch_free(sel_slots_hdr); return ray_error("arity", "select: cor aggregation requires two column arguments");
                     }
                     s_agg_ins2[s_n_aggs] = compile_expr_dag(g, agg_elems[2]);
                     if (!s_agg_ins2[s_n_aggs]) {
                         if (g->selection) { ray_release(g->selection); g->selection = NULL; }
                         ray_graph_free(g); ray_release(tbl);
-                        return ray_error("domain", "select: failed to compile cor second argument");
+                        scratch_free(sel_slots_hdr); return ray_error("domain", "select: failed to compile cor second argument");
                     }
                     s_has_binary = 1;
                 }
@@ -8404,7 +8426,7 @@ by_dict_done:
                         if (nearest_handle_owned) ray_release(nearest_handle_owned);
                         if (nearest_query_owned)  ray_sys_free(nearest_query_owned);
                         ray_release(tbl);
-                        return fres ? fres : ray_error("domain", "select: `where:` filter produced no result");
+                        scratch_free(sel_slots_hdr); return fres ? fres : ray_error("domain", "select: `where:` filter produced no result");
                     }
                     ray_release(tbl);
                     tbl = fres;
@@ -8413,7 +8435,7 @@ by_dict_done:
                         if (nearest_handle_owned) ray_release(nearest_handle_owned);
                         if (nearest_query_owned)  ray_sys_free(nearest_query_owned);
                         ray_release(tbl);
-                        return ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                     }
                 }
                 ray_t* result = ray_table_new(0);
@@ -8421,7 +8443,7 @@ by_dict_done:
                     if (nearest_handle_owned) ray_release(nearest_handle_owned);
                     if (nearest_query_owned)  ray_sys_free(nearest_query_owned);
                     ray_graph_free(g); ray_release(tbl);
-                    return result ? result : ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return result ? result : ray_error("oom", NULL);
                 }
                 int64_t nrows = ray_table_nrows(tbl);
                 int64_t out_len = -1;   /* length of the first materialized column */
@@ -8442,7 +8464,7 @@ by_dict_done:
                         if (nearest_handle_owned) ray_release(nearest_handle_owned);
                         if (nearest_query_owned)  ray_sys_free(nearest_query_owned);
                         ray_graph_free(g); ray_release(tbl);
-                        return err;
+                        scratch_free(sel_slots_hdr); return err;
                     }
                     /* All output columns must agree in length — a length-changing
                      * projection (e.g. distinct) beside a full-length column would
@@ -8456,7 +8478,7 @@ by_dict_done:
                         if (nearest_handle_owned) ray_release(nearest_handle_owned);
                         if (nearest_query_owned)  ray_sys_free(nearest_query_owned);
                         ray_graph_free(g); ray_release(tbl);
-                        return ray_error("length", "select: output column length %lld does not match %lld", (long long)col_len, (long long)out_len);
+                        scratch_free(sel_slots_hdr); return ray_error("length", "select: output column length %lld does not match %lld", (long long)col_len, (long long)out_len);
                     }
                     result = ray_table_add_col(result, kid, col);
                     ray_release(col);
@@ -8464,7 +8486,7 @@ by_dict_done:
                         if (nearest_handle_owned) ray_release(nearest_handle_owned);
                         if (nearest_query_owned)  ray_sys_free(nearest_query_owned);
                         ray_graph_free(g); ray_release(tbl);
-                        return result;
+                        scratch_free(sel_slots_hdr); return result;
                     }
                 }
                 if (nearest_handle_owned) ray_release(nearest_handle_owned);
@@ -8472,7 +8494,7 @@ by_dict_done:
                 ray_graph_free(g); ray_release(tbl);
                 result = apply_sort_take(result, dict_elems, dict_n,
                                          asc_id, desc_id, take_id);
-                return result;
+                scratch_free(sel_slots_hdr); return result;
             } else {
                 root = ray_select_op(g, root, col_ops, nc);
             }
@@ -8497,7 +8519,7 @@ by_dict_done:
             ray_t* val = dict_elems[i + 1];
             if (val->type == -RAY_SYM) {
                 /* Single column name */
-                if (n_sort >= RAY_GROUP_MAX_SLOTS) { ray_graph_free(g); ray_release(tbl); return ray_error("range", "select: too many sort keys (max %d)", RAY_GROUP_MAX_SLOTS); }
+                if (n_sort >= RAY_GROUP_MAX_SLOTS) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("range", "select: too many sort keys (max %d)", RAY_GROUP_MAX_SLOTS); }
                 ray_t* s = ray_sym_str(val->i64);
                 sort_keys[n_sort] = ray_scan(g, ray_str_ptr(s));
                 sort_descs[n_sort] = is_desc;
@@ -8505,7 +8527,7 @@ by_dict_done:
             } else if (ray_is_vec(val) && val->type == RAY_SYM) {
                 /* Multiple column names — cell-data via the vec's domain */
                 for (int64_t c = 0; c < val->len; c++) {
-                    if (n_sort >= RAY_GROUP_MAX_SLOTS) { ray_graph_free(g); ray_release(tbl); return ray_error("range", "select: too many sort keys (max %d)", RAY_GROUP_MAX_SLOTS); }
+                    if (n_sort >= RAY_GROUP_MAX_SLOTS) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return ray_error("range", "select: too many sort keys (max %d)", RAY_GROUP_MAX_SLOTS); }
                     ray_t* s = ray_sym_vec_cell(val, c);
                     sort_keys[n_sort] = ray_scan(g, ray_str_ptr(s));
                     sort_descs[n_sort] = is_desc;
@@ -8513,7 +8535,7 @@ by_dict_done:
                 }
             } else {
                 ray_graph_free(g); ray_release(tbl);
-                return ray_error("domain", "select: asc/desc value must be a column name or symbol list, got %s", ray_type_name(val->type));
+                scratch_free(sel_slots_hdr); return ray_error("domain", "select: asc/desc value must be a column name or symbol list, got %s", ray_type_name(val->type));
             }
         }
         if (n_sort > 0)
@@ -8525,7 +8547,7 @@ by_dict_done:
     ray_t* take_range = NULL;
     if (take_expr && !by_expr && !nearest_expr) {
         ray_t* tv = ray_eval(take_expr);
-        if (!tv || RAY_IS_ERR(tv)) { ray_graph_free(g); ray_release(tbl); return tv ? tv : ray_error("domain", "select: failed to evaluate `take:`"); }
+        if (!tv || RAY_IS_ERR(tv)) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); return tv ? tv : ray_error("domain", "select: failed to evaluate `take:`"); }
         if (ray_is_atom(tv) && (tv->type == -RAY_I64 || tv->type == -RAY_I32)) {
             int64_t n_take = (tv->type == -RAY_I64) ? tv->i64 : tv->i32;
             ray_release(tv);
@@ -8539,7 +8561,7 @@ by_dict_done:
             int8_t tv_t = tv->type;            /* capture BEFORE free */
             ray_release(tv);
             ray_graph_free(g); ray_release(tbl);
-            return ray_error("domain", "select: `take:` must be an integer atom or a 2-element integer range, got %s", ray_type_name(tv_t));
+            scratch_free(sel_slots_hdr); return ray_error("domain", "select: `take:` must be an integer atom or a 2-element integer range, got %s", ray_type_name(tv_t));
         }
     }
 
@@ -8698,20 +8720,23 @@ by_dict_done:
              * in dict-iteration order of the agg entries. */
             if (by_expr) {
                 /* Rename only the agg columns (positions after keys).
-                 * Non-agg LIST columns were named at scatter time.  The agg
-                 * count is bounded by RAY_GROUP_MAX_SLOTS (a query exceeding
-                 * it errored during compilation), so a fixed buffer is safe. */
-                int64_t agg_user_names[RAY_GROUP_MAX_SLOTS];
-                int n_agg_user = 0;
-                for (int64_t i = 0; i + 1 < dict_n; i += 2) {
-                    int64_t kid = dict_elems[i]->i64;
-                    if (kid == from_id || kid == where_id || kid == by_id ||
-                        kid == take_id || kid == asc_id || kid == desc_id) continue;
-                    if (!is_group_dag_agg_expr(dict_elems[i + 1])) continue;
-                    if (n_agg_user < RAY_GROUP_MAX_SLOTS) agg_user_names[n_agg_user++] = kid;
+                 * Non-agg LIST columns were named at scatter time. */
+                ray_t* aun_hdr = NULL;
+                int64_t* agg_user_names = (int64_t*)scratch_alloc(&aun_hdr,
+                        (size_t)n_out_max * sizeof(int64_t));
+                int64_t n_agg_user = 0;
+                if (agg_user_names) {
+                    for (int64_t i = 0; i + 1 < dict_n; i += 2) {
+                        int64_t kid = dict_elems[i]->i64;
+                        if (kid == from_id || kid == where_id || kid == by_id ||
+                            kid == take_id || kid == asc_id || kid == desc_id) continue;
+                        if (!is_group_dag_agg_expr(dict_elems[i + 1])) continue;
+                        if (n_agg_user < n_out_max) agg_user_names[n_agg_user++] = kid;
+                    }
+                    for (int64_t j = 0; j < n_agg_user && n_key_cols + j < ncols; j++)
+                        ray_table_set_col_name(result, n_key_cols + j, agg_user_names[j]);
                 }
-                for (int j = 0; j < n_agg_user && n_key_cols + j < ncols; j++)
-                    ray_table_set_col_name(result, n_key_cols + j, agg_user_names[j]);
+                scratch_free(aun_hdr);
             } else {
                 /* Projection-only: columns are in dict order.  Rename each
                  * output column directly — a projection may have any number
@@ -8742,7 +8767,15 @@ by_dict_done:
                 nk2 = (int)ray_len(by_expr);
             int64_t hbase = (int64_t)nk2 + n_aggs_real;
             int64_t rnc = ray_table_ncols(result);
-            ray_t* comp_cols[16] = {0};
+            ray_t* cc_hdr = NULL;
+            ray_t** comp_cols = (ray_t**)scratch_calloc(&cc_hdr,
+                    (size_t)(n_compound > 0 ? n_compound : 1) * sizeof(ray_t*));
+            if (!comp_cols) {
+                for (int ci = 0; ci < n_compound; ci++)
+                    { ray_release(compound_rw[ci]); compound_rw[ci] = NULL; }
+                ray_release(result); ray_release(tbl);
+                scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
+            }
             ray_t* cerr = NULL;
             bool layout_ok = hbase + n_hidden_aggs <= rnc;
             if (layout_ok) {
@@ -8768,9 +8801,10 @@ by_dict_done:
             if (cerr) {
                 for (int ci = 0; ci < n_compound; ci++)
                     if (comp_cols[ci]) ray_release(comp_cols[ci]);
+                scratch_free(cc_hdr);
                 ray_release(result);
                 ray_release(tbl);
-                return cerr;
+                scratch_free(sel_slots_hdr); return cerr;
             }
             if (layout_ok) {
                 ray_t* nt = ray_table_new(rnc - n_hidden_aggs + n_compound);
@@ -8791,6 +8825,7 @@ by_dict_done:
             }
             for (int ci = 0; ci < n_compound; ci++)
                 if (comp_cols[ci]) ray_release(comp_cols[ci]);
+            scratch_free(cc_hdr);
             n_compound = 0;
         }
     }
@@ -8833,13 +8868,13 @@ by_dict_done:
                             /* can_atom_broadcast vetted these — anything
                              * after that is an OOM in atom_broadcast_vec. */
                             ray_release(result); ray_release(tbl);
-                            return ray_error("oom", NULL);
+                            scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                         }
                         result = ray_table_add_col(result, nonagg_names[ni], col);
                         ray_release(col);
                         if (RAY_IS_ERR(result)) {
                             ray_release(tbl);
-                            return result;
+                            scratch_free(sel_slots_hdr); return result;
                         }
                     }
                     goto nonagg_done;
@@ -8855,7 +8890,7 @@ by_dict_done:
 
             if (ks < 0) {
                 ray_release(result); ray_release(tbl);
-                return ray_error("domain", "select by: could not resolve scalar group key symbol");
+                scratch_free(sel_slots_hdr); return ray_error("domain", "select by: could not resolve scalar group key symbol");
             }
 
             ray_t* orig_key = ray_table_get_col(tbl, ks);
@@ -8864,7 +8899,7 @@ by_dict_done:
 
             if (!orig_key || !grp_key) {
                 ray_release(result); ray_release(tbl);
-                return ray_error("domain", "select by: group key column not found");
+                scratch_free(sel_slots_hdr); return ray_error("domain", "select by: group key column not found");
             }
 
             if (n_groups > 0 && nrows > 0) {
@@ -8874,7 +8909,7 @@ by_dict_done:
                     scan_key = query_materialize_parted_col(scan_key);
                     if (!scan_key || RAY_IS_ERR(scan_key)) {
                         ray_release(result); ray_release(tbl);
-                        return scan_key ? scan_key : ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return scan_key ? scan_key : ray_error("oom", NULL);
                     }
                     scan_key_owned = 1;
                 }
@@ -8940,7 +8975,7 @@ by_dict_done:
                 if (!key_supported) {
                     RELEASE_SCAN_KEY();
                     ray_release(result); ray_release(tbl);
-                    return ray_error("nyi", "non-agg scatter: unsupported group key type");
+                    scratch_free(sel_slots_hdr); return ray_error("nyi", "non-agg scatter: unsupported group key type");
                 }
 
                 /* The DAG group result key column must have a base
@@ -8950,7 +8985,7 @@ by_dict_done:
                 if (okt != gkt) {
                     RELEASE_SCAN_KEY();
                     ray_release(result); ray_release(tbl);
-                    return ray_error("type", "group key type mismatch");
+                    scratch_free(sel_slots_hdr); return ray_error("type", "group key type mismatch");
                 }
 
                 /* Allocations — any failure errors out rather than
@@ -8968,7 +9003,7 @@ by_dict_done:
                     if (pos_hdr) ray_free(pos_hdr);
                     RELEASE_SCAN_KEY();
                     ray_release(result); ray_release(tbl);
-                    return ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                 }
                 int64_t* gk      = (int64_t*)ray_data(gk_hdr);
                 int64_t* row_gid = (int64_t*)ray_data(rg_hdr);
@@ -9049,7 +9084,7 @@ by_dict_done:
                         ray_free(off_hdr); ray_free(pos_hdr);
                         RELEASE_SCAN_KEY();
                         ray_release(result); ray_release(tbl);
-                        return ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                     }
                     cap = c;
                     uint64_t mask = cap - 1;
@@ -9062,7 +9097,7 @@ by_dict_done:
                         ray_free(off_hdr); ray_free(pos_hdr);
                         RELEASE_SCAN_KEY();
                         ray_release(result); ray_release(tbl);
-                        return ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                     }
                     for (int64_t gi = 0; gi < n_groups; gi++) {
                         uint64_t h = ray_str_t_hash(&gdesc[gi], gpool);
@@ -9118,7 +9153,7 @@ by_dict_done:
                         ray_free(off_hdr); ray_free(pos_hdr);
                         RELEASE_SCAN_KEY();
                         ray_release(result); ray_release(tbl);
-                        return ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                     }
                     cap = c;
                     uint64_t mask = cap - 1;
@@ -9135,7 +9170,7 @@ by_dict_done:
                         ray_free(off_hdr); ray_free(pos_hdr);
                         RELEASE_SCAN_KEY();
                         ray_release(result); ray_release(tbl);
-                        return ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                     }
 
                     /* If n_groups exceeds the int32 sentinel range we'd
@@ -9153,7 +9188,7 @@ by_dict_done:
                             ray_free(off_hdr); ray_free(pos_hdr);
                             RELEASE_SCAN_KEY();
                             ray_release(result); ray_release(tbl);
-                            return ray_error("oom", NULL);
+                            scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                         }
                     }
 
@@ -9375,7 +9410,7 @@ by_dict_done:
                                 ray_free(pos_hdr);
                                 RELEASE_SCAN_KEY();
                                 ray_release(result); ray_release(tbl);
-                                return ray_error("oom", NULL);
+                                scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                             }
                             idx_buf = (int64_t*)ray_data(idx_hdr);
                             pctx.idx_buf = idx_buf;
@@ -9401,7 +9436,7 @@ by_dict_done:
                             ray_free(off_hdr); ray_free(pos_hdr);
                             RELEASE_SCAN_KEY();
                             ray_release(result); ray_release(tbl);
-                            return ray_error("oom", NULL);
+                            scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                         }
                         idx_buf = (int64_t*)ray_data(idx_hdr);
 
@@ -9654,7 +9689,7 @@ by_dict_done:
                 if (scatter_err) {
                     if (result) ray_release(result);
                     ray_release(tbl);
-                    return scatter_err;
+                    scratch_free(sel_slots_hdr); return scatter_err;
                 }
                 #undef RELEASE_SCAN_KEY
             } else {
@@ -9665,11 +9700,11 @@ by_dict_done:
                     ray_t* empty_list = ray_list_new(0);
                     if (!empty_list || RAY_IS_ERR(empty_list)) {
                         ray_release(result); ray_release(tbl);
-                        return empty_list ? empty_list : ray_error("oom", NULL);
+                        scratch_free(sel_slots_hdr); return empty_list ? empty_list : ray_error("oom", NULL);
                     }
                     result = ray_table_add_col(result, nonagg_names[ni], empty_list);
                     ray_release(empty_list);
-                    if (RAY_IS_ERR(result)) { ray_release(tbl); return result; }
+                    if (RAY_IS_ERR(result)) { ray_release(tbl); scratch_free(sel_slots_hdr); return result; }
                 }
             }
         nonagg_done: ;  /* R8 fast-path target; nothing else to do here */
@@ -9682,14 +9717,14 @@ by_dict_done:
             result = ray_lazy_materialize(result);
         if (result && RAY_IS_ERR(result)) {
             ray_release(tbl);
-            return result;
+            scratch_free(sel_slots_hdr); return result;
         }
         if (result && result->type == RAY_TABLE) {
             ray_t* base_col = ray_table_get_col(result, dep_key_base_sym);
             if (!base_col || !key_type_i64_projectable(base_col->type)) {
                 ray_release(result);
                 ray_release(tbl);
-                return ray_error("domain", "dependent group key base missing");
+                scratch_free(sel_slots_hdr); return ray_error("domain", "dependent group key base missing");
             }
             int64_t n_groups = ray_table_nrows(result);
             for (uint8_t dk = 0; dk < n_dep_keys; dk++) {
@@ -9697,7 +9732,7 @@ by_dict_done:
                 if (!col || RAY_IS_ERR(col)) {
                     ray_release(result);
                     ray_release(tbl);
-                    return col ? col : ray_error("oom", NULL);
+                    scratch_free(sel_slots_hdr); return col ? col : ray_error("oom", NULL);
                 }
                 col->len = n_groups;
                 int64_t* out = (int64_t*)ray_data(col);
@@ -9708,7 +9743,7 @@ by_dict_done:
                 ray_release(col);
                 if (RAY_IS_ERR(result)) {
                     ray_release(tbl);
-                    return result;
+                    scratch_free(sel_slots_hdr); return result;
                 }
             }
         }
@@ -9725,7 +9760,7 @@ by_dict_done:
     if (by_sym_vec_owned) ray_release(by_sym_vec_owned);
     if (saved_selection) ray_release(saved_selection);
 
-    return result;
+    scratch_free(sel_slots_hdr); return result;
 }
 
 /* (xbar col bucket) — time/value bucketing: floor(col/bucket)*bucket */

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -4056,9 +4056,16 @@ ray_t* ray_window_fn(ray_t** args, int64_t n) {
         return ray_error("domain", "window: `funcs:` has too many entries");
     }
     int n_funcs = (int)(fv_n / 2);
-    if (n_funcs == 0 || n_funcs > 32) {
+    if (n_funcs == 0) {
         ray_release(tbl);
-        return ray_error("domain", "window: `funcs:` must have 1-32 entries, got %d", n_funcs);
+        return ray_error("domain", "window: `funcs:` must have at least 1 entry, got %d", n_funcs);
+    }
+    /* ray_window_op's n_funcs parameter is uint8_t — DICT_VIEW_MAX (256) sits
+     * one past UINT8_MAX, so this is a real representational limit, not the
+     * old fixed-array cap. */
+    if (n_funcs > UINT8_MAX) {
+        ray_release(tbl);
+        return ray_error("range", "window: too many `funcs:` entries for the op graph (max %d)", UINT8_MAX);
     }
 
     /* ── frame: ── */
@@ -4087,53 +4094,94 @@ ray_t* ray_window_fn(ray_t** args, int64_t n) {
     if (!g) { ray_release(tbl); return ray_error("oom", NULL); }
     ray_op_t* tbl_node = ray_const_table(g, tbl);
 
-    /* part: – SYM vector or atom naming partition columns */
-    ray_op_t* part_ops[16];
-    uint8_t   n_part = 0;
-    {
-        ray_t* pe = dict_get(dict, "part");
-        if (pe) {
-            if (pe->type == -RAY_SYM && !(pe->attrs & ATTR_QUOTED)) {
-                ray_t* s = ray_sym_str(pe->i64);
+    /* part: – SYM vector or atom naming partition columns. Exact-size scratch
+     * carve replaces the fixed part_ops[16] stack array; bound is 1 for an
+     * atom column ref, else the SYM vector's length. */
+    ray_t* pe = dict_get(dict, "part");
+    int64_t n_part_max = (pe && pe->type == RAY_SYM) ? pe->len : 1;
+    if (n_part_max < 1) n_part_max = 1;
+    ray_t* part_hdr = NULL;
+    ray_op_t** part_ops = (ray_op_t**)scratch_alloc(&part_hdr, (size_t)n_part_max * sizeof(ray_op_t*));
+    if (!part_ops) { ray_graph_free(g); ray_release(tbl); return ray_error("oom", NULL); }
+    int64_t n_part = 0;
+    if (pe) {
+        if (pe->type == -RAY_SYM && !(pe->attrs & ATTR_QUOTED)) {
+            ray_t* s = ray_sym_str(pe->i64);
+            if (s) part_ops[n_part++] = ray_scan(g, ray_str_ptr(s));
+        } else if (pe->type == RAY_SYM) {
+            for (int64_t i = 0; i < pe->len; i++) {
+                int64_t sid = sym_cell_runtime_id(pe, i);
+                ray_t*  s   = ray_sym_str(sid);
                 if (s) part_ops[n_part++] = ray_scan(g, ray_str_ptr(s));
-            } else if (pe->type == RAY_SYM) {
-                if (pe->len > RAY_GROUP_MAX_SLOTS) { ray_graph_free(g); ray_release(tbl); return ray_error("range", "window: too many partition columns (max %d)", RAY_GROUP_MAX_SLOTS); }
-                for (int64_t i = 0; i < pe->len; i++) {
-                    int64_t sid = sym_cell_runtime_id(pe, i);
-                    ray_t*  s   = ray_sym_str(sid);
-                    if (s) part_ops[n_part++] = ray_scan(g, ray_str_ptr(s));
-                }
             }
         }
     }
+    /* ray_window_op takes n_part as uint8_t (and graph.c's own part_ids[256]
+     * scratch caps there too) — this is the real representational limit. */
+    if (n_part > UINT8_MAX) {
+        scratch_free(part_hdr); ray_graph_free(g); ray_release(tbl);
+        return ray_error("range", "window: too many partition columns for the op graph (max %d)", UINT8_MAX);
+    }
 
-    /* order: – SYM vector or atom naming sort columns (all ascending) */
-    ray_op_t* order_ops[16];
-    uint8_t   order_descs[16];
-    uint8_t   n_order = 0;
-    memset(order_descs, 0, sizeof(order_descs));
-    {
-        ray_t* oe = dict_get(dict, "order");
-        if (oe) {
-            if (oe->type == -RAY_SYM && !(oe->attrs & ATTR_QUOTED)) {
-                ray_t* s = ray_sym_str(oe->i64);
+    /* order: – SYM vector or atom naming sort columns (all ascending).
+     * One carve holds both order_ops (pointers) and order_descs (bytes,
+     * trailing), sized the same way as part_ops. */
+    ray_t* oe = dict_get(dict, "order");
+    int64_t n_order_max = (oe && oe->type == RAY_SYM) ? oe->len : 1;
+    if (n_order_max < 1) n_order_max = 1;
+    ray_t* order_hdr = NULL;
+    ray_op_t** order_ops = (ray_op_t**)scratch_alloc(&order_hdr,
+            (size_t)n_order_max * (sizeof(ray_op_t*) + 1));
+    if (!order_ops) {
+        scratch_free(part_hdr); ray_graph_free(g); ray_release(tbl);
+        return ray_error("oom", NULL);
+    }
+    uint8_t* order_descs = (uint8_t*)(order_ops + n_order_max);
+    memset(order_descs, 0, (size_t)n_order_max);
+    int64_t n_order = 0;
+    if (oe) {
+        if (oe->type == -RAY_SYM && !(oe->attrs & ATTR_QUOTED)) {
+            ray_t* s = ray_sym_str(oe->i64);
+            if (s) order_ops[n_order++] = ray_scan(g, ray_str_ptr(s));
+        } else if (oe->type == RAY_SYM) {
+            for (int64_t i = 0; i < oe->len; i++) {
+                int64_t sid = sym_cell_runtime_id(oe, i);
+                ray_t*  s   = ray_sym_str(sid);
                 if (s) order_ops[n_order++] = ray_scan(g, ray_str_ptr(s));
-            } else if (oe->type == RAY_SYM) {
-                if (oe->len > RAY_GROUP_MAX_SLOTS) { ray_graph_free(g); ray_release(tbl); return ray_error("range", "window: too many order columns (max %d)", RAY_GROUP_MAX_SLOTS); }
-                for (int64_t i = 0; i < oe->len; i++) {
-                    int64_t sid = sym_cell_runtime_id(oe, i);
-                    ray_t*  s   = ray_sym_str(sid);
-                    if (s) order_ops[n_order++] = ray_scan(g, ray_str_ptr(s));
-                }
             }
         }
     }
+    if (n_order > UINT8_MAX) {
+        scratch_free(order_hdr); scratch_free(part_hdr); ray_graph_free(g); ray_release(tbl);
+        return ray_error("range", "window: too many order columns for the op graph (max %d)", UINT8_MAX);
+    }
 
-    /* Parse each funcs: entry: key = output name atom, value = (fn input_col) list */
-    uint8_t    func_kinds[32];
-    ray_op_t*  func_inputs[32];
-    int64_t    func_params[32];
-    int64_t    out_name_ids[32];
+    /* Parse each funcs: entry: key = output name atom, value = (fn input_col)
+     * list. One carve holds func_inputs (pointers) + func_params (int64_t) +
+     * func_kinds (bytes, trailing) sized to n_funcs — all three are only
+     * needed through the ray_window_op call below, so they're freed right
+     * after it. out_name_ids gets its own carve: it's read again after
+     * ray_execute() to rename the output columns, so it must outlive the
+     * other three (freed at the very end of the function instead). */
+    ray_t* funcs_hdr = NULL;
+    size_t func_ptr_sz = (size_t)n_funcs * sizeof(ray_op_t*);
+    size_t func_i64_sz = (size_t)n_funcs * sizeof(int64_t);
+    void*  func_scratch = scratch_alloc(&funcs_hdr, func_ptr_sz + func_i64_sz + (size_t)n_funcs);
+    if (!func_scratch) {
+        scratch_free(order_hdr); scratch_free(part_hdr); ray_graph_free(g); ray_release(tbl);
+        return ray_error("oom", NULL);
+    }
+    ray_op_t** func_inputs  = (ray_op_t**)func_scratch;
+    int64_t*   func_params  = (int64_t*)((char*)func_scratch + func_ptr_sz);
+    uint8_t*   func_kinds   = (uint8_t*)((char*)func_scratch + func_ptr_sz + func_i64_sz);
+
+    ray_t* outname_hdr = NULL;
+    int64_t* out_name_ids = (int64_t*)scratch_alloc(&outname_hdr, (size_t)n_funcs * sizeof(int64_t));
+    if (!out_name_ids) {
+        scratch_free(funcs_hdr); scratch_free(order_hdr); scratch_free(part_hdr);
+        ray_graph_free(g); ray_release(tbl);
+        return ray_error("oom", NULL);
+    }
 
     for (int fi = 0; fi < n_funcs; fi++) {
         ray_t* key_atom = fv[fi * 2];
@@ -4143,6 +4191,7 @@ ray_t* ray_window_fn(ray_t** args, int64_t n) {
 
         /* val_expr must be a list: (fn_name input_col [param]) */
         if (!val_expr || val_expr->type != RAY_LIST || ray_len(val_expr) < 2) {
+            scratch_free(outname_hdr); scratch_free(funcs_hdr); scratch_free(order_hdr); scratch_free(part_hdr);
             ray_graph_free(g); ray_release(tbl);
             return ray_error("domain",
                 "window: `funcs:` value must be a function call like (min v), got wrong shape at entry %d",
@@ -4154,17 +4203,24 @@ ray_t* ray_window_fn(ray_t** args, int64_t n) {
 
         /* Function name → RAY_WIN_* kind */
         if (!fn_expr || fn_expr->type != -RAY_SYM) {
+            scratch_free(outname_hdr); scratch_free(funcs_hdr); scratch_free(order_hdr); scratch_free(part_hdr);
             ray_graph_free(g); ray_release(tbl);
             return ray_error("domain", "window: function name must be a symbol");
         }
         ray_t* fn_s = ray_sym_str(fn_expr->i64);
-        if (!fn_s) { ray_graph_free(g); ray_release(tbl); return ray_error("domain", "window: unknown function"); }
+        if (!fn_s) {
+            scratch_free(outname_hdr); scratch_free(funcs_hdr); scratch_free(order_hdr); scratch_free(part_hdr);
+            ray_graph_free(g); ray_release(tbl);
+            return ray_error("domain", "window: unknown function");
+        }
         uint8_t kind = win_kind_from_name(ray_str_ptr(fn_s), ray_str_len(fn_s));
         if (kind == 255) {
+            scratch_free(outname_hdr); scratch_free(funcs_hdr); scratch_free(order_hdr); scratch_free(part_hdr);
             ray_graph_free(g); ray_release(tbl);
             return ray_error("domain", "window: unsupported window function '%s'", ray_str_ptr(fn_s));
         }
         if ((kind == RAY_WIN_FIRST_VALUE || kind == RAY_WIN_LAST_VALUE) && n_order == 0) {
+            scratch_free(outname_hdr); scratch_free(funcs_hdr); scratch_free(order_hdr); scratch_free(part_hdr);
             ray_graph_free(g); ray_release(tbl);
             return ray_error("domain", "window: first/last require order:");
         }
@@ -4173,32 +4229,41 @@ ray_t* ray_window_fn(ray_t** args, int64_t n) {
 
         /* Input column name */
         if (!col_expr || col_expr->type != -RAY_SYM) {
+            scratch_free(outname_hdr); scratch_free(funcs_hdr); scratch_free(order_hdr); scratch_free(part_hdr);
             ray_graph_free(g); ray_release(tbl);
             return ray_error("domain", "window: function input must be a column name symbol");
         }
         ray_t* col_s = ray_sym_str(col_expr->i64);
-        if (!col_s) { ray_graph_free(g); ray_release(tbl); return ray_error("domain", "window: unknown input column"); }
+        if (!col_s) {
+            scratch_free(outname_hdr); scratch_free(funcs_hdr); scratch_free(order_hdr); scratch_free(part_hdr);
+            ray_graph_free(g); ray_release(tbl);
+            return ray_error("domain", "window: unknown input column");
+        }
         func_inputs[fi] = ray_scan(g, ray_str_ptr(col_s));
     }
 
     /* ── Assemble and execute ── */
     ray_op_t* win_op = ray_window_op(g, tbl_node,
-                                     n_part  ? part_ops  : NULL, n_part,
+                                     n_part  ? part_ops  : NULL, (uint8_t)n_part,
                                      n_order ? order_ops : NULL,
-                                     n_order ? order_descs : NULL, n_order,
+                                     n_order ? order_descs : NULL, (uint8_t)n_order,
                                      func_kinds, func_inputs, func_params,
                                      (uint8_t)n_funcs,
                                      RAY_FRAME_ROWS,
                                      RAY_BOUND_UNBOUNDED_PRECEDING, frame_end,
                                      0, 0);
-    if (!win_op) { ray_graph_free(g); ray_release(tbl); return ray_error("oom", NULL); }
+    scratch_free(funcs_hdr); scratch_free(order_hdr); scratch_free(part_hdr);
+    if (!win_op) {
+        scratch_free(outname_hdr); ray_graph_free(g); ray_release(tbl);
+        return ray_error("oom", NULL);
+    }
 
     win_op = ray_optimize(g, win_op);
     ray_t* result = ray_execute(g, win_op);
     ray_graph_free(g);
     ray_release(tbl);
 
-    if (!result || RAY_IS_ERR(result)) return result;
+    if (!result || RAY_IS_ERR(result)) { scratch_free(outname_hdr); return result; }
 
     /* Rename _w0/_w1/… to the user-specified output names */
     int64_t base_ncols = ray_table_ncols(result) - n_funcs;
@@ -4206,6 +4271,7 @@ ray_t* ray_window_fn(ray_t** args, int64_t n) {
         if (out_name_ids[fi] >= 0)
             ray_table_set_col_name(result, base_ncols + fi, out_name_ids[fi]);
     }
+    scratch_free(outname_hdr);
 
     return result;
 }

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -2374,13 +2374,21 @@ typedef ray_t* (*idx_feeder_fn)(int64_t gi, void* state);
 static ray_t* nonagg_eval_per_group_core(ray_t* expr, ray_t* tbl,
                                          idx_feeder_fn feeder, void* fstate,
                                          int64_t n_groups) {
-    int64_t col_syms[16];
-    int n_cols = collect_col_refs(expr, tbl, col_syms, 16, 0);
-    ray_t* cols[16];
+    /* Exact-size carve: collect_col_refs dedups against real table columns,
+     * so ray_table_ncols(tbl) is a hard upper bound — no silent truncation
+     * past the former [16] cap. */
+    int64_t ncols_max = ray_table_ncols(tbl);
+    if (ncols_max < 1) ncols_max = 1;
+    ray_t* refs_hdr = NULL;
+    int64_t* col_syms = (int64_t*)scratch_alloc(&refs_hdr,
+            (size_t)ncols_max * (sizeof(int64_t) + sizeof(ray_t*)));
+    if (!col_syms) return ray_error("oom", NULL);
+    int n_cols = collect_col_refs(expr, tbl, col_syms, (int)ncols_max, 0);
+    ray_t** cols = (ray_t**)(col_syms + ncols_max);
     for (int i = 0; i < n_cols; i++)
         cols[i] = ray_table_get_col(tbl, col_syms[i]);
 
-    if (ray_env_push_scope() != RAY_OK) return ray_error("oom", NULL);
+    if (ray_env_push_scope() != RAY_OK) { scratch_free(refs_hdr); return ray_error("oom", NULL); }
 
     /* B3 Part 2: publish `tbl` as the active query table so a literal
      * column-name symbol inside `expr` resolves to its column during the
@@ -2400,6 +2408,7 @@ static ray_t* nonagg_eval_per_group_core(ray_t* expr, ray_t* tbl,
             g_active_query_table = _aqt;
             ray_env_pop_scope();
             if (result) ray_release(result);
+            scratch_free(refs_hdr);
             return ray_error("oom", NULL);
         }
         for (int i = 0; i < n_cols; i++) {
@@ -2408,6 +2417,7 @@ static ray_t* nonagg_eval_per_group_core(ray_t* expr, ray_t* tbl,
                 g_active_query_table = _aqt;
                 ray_env_pop_scope();
                 if (result) ray_release(result);
+                scratch_free(refs_hdr);
                 return err;
             }
         }
@@ -2416,6 +2426,7 @@ static ray_t* nonagg_eval_per_group_core(ray_t* expr, ray_t* tbl,
             g_active_query_table = _aqt;
             ray_env_pop_scope();
             if (result) ray_release(result);
+            scratch_free(refs_hdr);
             return cell ? cell : ray_error("domain", "select by: per-group expression evaluation failed");
         }
         /* Materialise lazy cells before storing.  Per-group projection
@@ -2431,6 +2442,7 @@ static ray_t* nonagg_eval_per_group_core(ray_t* expr, ray_t* tbl,
                 g_active_query_table = _aqt;
                 ray_env_pop_scope();
                 if (result) ray_release(result);
+                scratch_free(refs_hdr);
                 return cell ? cell : ray_error("domain", "select by: failed to materialize per-group cell");
             }
         }
@@ -2444,6 +2456,7 @@ static ray_t* nonagg_eval_per_group_core(ray_t* expr, ray_t* tbl,
                 if (!result || RAY_IS_ERR(result)) {
                     g_active_query_table = _aqt;
                     ray_env_pop_scope(); ray_release(cell);
+                    scratch_free(refs_hdr);
                     return result ? result : ray_error("oom", NULL);
                 }
                 result->len = n_groups;
@@ -2461,6 +2474,7 @@ static ray_t* nonagg_eval_per_group_core(ray_t* expr, ray_t* tbl,
                 if (!result) {
                     g_active_query_table = _aqt;
                     ray_env_pop_scope(); ray_release(cell);
+                    scratch_free(refs_hdr);
                     return ray_error("oom", NULL);
                 }
                 result->type = RAY_LIST;
@@ -2481,6 +2495,7 @@ static ray_t* nonagg_eval_per_group_core(ray_t* expr, ray_t* tbl,
                 if (RAY_IS_ERR(list_col)) {
                     g_active_query_table = _aqt;
                     ray_env_pop_scope(); ray_release(cell);
+                    scratch_free(refs_hdr);
                     return list_col;
                 }
                 result = list_col;
@@ -2496,6 +2511,7 @@ static ray_t* nonagg_eval_per_group_core(ray_t* expr, ray_t* tbl,
 
     g_active_query_table = _aqt;
     ray_env_pop_scope();
+    scratch_free(refs_hdr);
     return result;
 }
 
@@ -2552,13 +2568,21 @@ static ray_t* nonagg_eval_per_group_buf(ray_t* expr, ray_t* tbl,
 }
 
 static ray_t* eval_expr_per_row(ray_t* expr, ray_t* tbl, int64_t nrows) {
-    int64_t col_syms[16];
-    int n_cols = collect_col_refs(expr, tbl, col_syms, 16, 0);
-    ray_t* cols[16];
+    /* Exact-size carve, mirrors nonagg_eval_per_group_core: ncols(tbl) is
+     * a hard upper bound for collect_col_refs's deduplicated table-column
+     * output — no silent truncation past the former [16] cap. */
+    int64_t ncols_max = ray_table_ncols(tbl);
+    if (ncols_max < 1) ncols_max = 1;
+    ray_t* refs_hdr = NULL;
+    int64_t* col_syms = (int64_t*)scratch_alloc(&refs_hdr,
+            (size_t)ncols_max * (sizeof(int64_t) + sizeof(ray_t*)));
+    if (!col_syms) return ray_error("oom", NULL);
+    int n_cols = collect_col_refs(expr, tbl, col_syms, (int)ncols_max, 0);
+    ray_t** cols = (ray_t**)(col_syms + ncols_max);
     for (int i = 0; i < n_cols; i++)
         cols[i] = ray_table_get_col(tbl, col_syms[i]);
 
-    if (ray_env_push_scope() != RAY_OK) return ray_error("oom", NULL);
+    if (ray_env_push_scope() != RAY_OK) { scratch_free(refs_hdr); return ray_error("oom", NULL); }
 
     /* B3 Part 2: publish `tbl` as the active query table so a literal
      * column-name symbol inside `expr` resolves to its column during the
@@ -2580,6 +2604,7 @@ static ray_t* eval_expr_per_row(ray_t* expr, ray_t* tbl, int64_t nrows) {
                 g_active_query_table = _aqt;
                 ray_env_pop_scope();
                 if (result) ray_release(result);
+                scratch_free(refs_hdr);
                 return arg ? arg : ray_error("domain", "select: failed to read column cell for per-row eval");
             }
             ray_env_set_local(col_syms[i], arg);
@@ -2591,6 +2616,7 @@ static ray_t* eval_expr_per_row(ray_t* expr, ray_t* tbl, int64_t nrows) {
             g_active_query_table = _aqt;
             ray_env_pop_scope();
             if (result) ray_release(result);
+            scratch_free(refs_hdr);
             return cell ? cell : ray_error("domain", "select: per-row expression evaluation failed");
         }
 
@@ -2603,6 +2629,7 @@ static ray_t* eval_expr_per_row(ray_t* expr, ray_t* tbl, int64_t nrows) {
                     g_active_query_table = _aqt;
                     ray_env_pop_scope();
                     ray_release(cell);
+                    scratch_free(refs_hdr);
                     return result ? result : ray_error("oom", NULL);
                 }
                 result->len = nrows;
@@ -2622,6 +2649,7 @@ static ray_t* eval_expr_per_row(ray_t* expr, ray_t* tbl, int64_t nrows) {
                     g_active_query_table = _aqt;
                     ray_env_pop_scope();
                     ray_release(cell);
+                    scratch_free(refs_hdr);
                     return ray_error("oom", NULL);
                 }
                 result->type = RAY_LIST;
@@ -2641,6 +2669,7 @@ static ray_t* eval_expr_per_row(ray_t* expr, ray_t* tbl, int64_t nrows) {
                     g_active_query_table = _aqt;
                     ray_env_pop_scope();
                     ray_release(cell);
+                    scratch_free(refs_hdr);
                     return list_col;
                 }
                 result = list_col;
@@ -2656,6 +2685,7 @@ static ray_t* eval_expr_per_row(ray_t* expr, ray_t* tbl, int64_t nrows) {
 
     g_active_query_table = _aqt;
     ray_env_pop_scope();
+    scratch_free(refs_hdr);
     if (!result) {
         result = ray_alloc(0);
         if (!result) return ray_error("oom", NULL);
@@ -3259,7 +3289,12 @@ static ray_t* try_count_distinct_v2_rewrite(
     if (!X_name) { ray_graph_free(g_in); return NULL; }
     ray_op_t* X_scan = ray_scan(g_in, ray_str_ptr(X_name));
     if (!X_scan) { ray_graph_free(g_in); return NULL; }
-    ray_op_t* keys_in[16];
+    /* Exact-size carve: the inner group's key list is K_scans[0..n_K) plus
+     * the distinct-target X_scan — n_K+1 is the exact count, not a cap. */
+    ray_t* ki_hdr = NULL;
+    ray_op_t** keys_in = (ray_op_t**)scratch_alloc(&ki_hdr,
+            (size_t)(n_K + 1) * sizeof(ray_op_t*));
+    if (!keys_in) { ray_graph_free(g_in); return ray_error("oom", NULL); }
     for (int j = 0; j < n_K; j++) keys_in[j] = K_scans[j];
     keys_in[n_K] = X_scan;
     uint16_t  agg_ops_in[1] = { OP_COUNT };
@@ -3271,21 +3306,23 @@ static ray_t* try_count_distinct_v2_rewrite(
      * OP_FILTERED_GROUP fused node; results are identical. */
     if (where_expr) {
         ray_op_t* pred = compile_expr_dag(g_in, where_expr);
-        if (!pred) { ray_graph_free(g_in); return NULL; }
+        if (!pred) { scratch_free(ki_hdr); ray_graph_free(g_in); return NULL; }
         ray_op_t* froot = ray_filter(g_in, ray_const_table(g_in, tbl), pred);
-        if (!froot) { ray_graph_free(g_in); return NULL; }
+        if (!froot) { scratch_free(ki_hdr); ray_graph_free(g_in); return NULL; }
         froot = ray_optimize(g_in, froot);
         ray_t* fres = exec_node(g_in, froot);
         if (!fres || RAY_IS_ERR(fres)) {
             if (g_in->selection) { ray_release(g_in->selection); g_in->selection = NULL; }
+            scratch_free(ki_hdr);
             ray_graph_free(g_in);
             return (fres && RAY_IS_ERR(fres)) ? fres : NULL;
         }
     }
     ray_op_t* inner = ray_group(g_in, keys_in, n_K + 1,
                                 agg_ops_in, agg_ins_in, 1);
-    if (!inner) { ray_graph_free(g_in); return NULL; }
+    if (!inner) { scratch_free(ki_hdr); ray_graph_free(g_in); return NULL; }
     ray_t* dedup = ray_execute(g_in, inner);
+    scratch_free(ki_hdr);
     ray_graph_free(g_in);
     if (!dedup) return NULL;
     if (RAY_IS_ERR(dedup)) return dedup;
@@ -5109,9 +5146,17 @@ ray_t* ray_select(ray_t** args, int64_t n) {
      * ray_select_fn sees a standard multi-key group-by. */
     ray_t* by_sym_vec_owned = NULL;
     int64_t dep_key_base_sym = -1;
+    /* dep_key_names/biases stay fixed-size: they hold at most nk entries,
+     * and nk is already hard-bound to <=16 by the "1..16 keys" domain check
+     * below (a genuine exec-kernel key-count limit shared with
+     * agg_engine.c's own composite-key grouping, not a query.c collector
+     * artifact) — sizing from nk here would buy nothing since nk can never
+     * exceed 16, while this pair must survive across the rest of this
+     * (very long) function, so heap-carving them would need a matching
+     * scratch_free at every one of its many return sites for no benefit. */
     int64_t dep_key_names[16];
     int64_t dep_key_biases[16];
-    uint8_t n_dep_keys = 0;
+    int64_t n_dep_keys = 0;
 
     /* B3 Part 2: a LITERAL scalar by-key symbol (`by: 'g`) resolves like a
      * name-ref — the same column-only, query-only rule the projection/where
@@ -5185,10 +5230,23 @@ ray_t* ray_select(ray_t** args, int64_t n) {
             dep_candidate = base_col && key_type_i64_projectable(base_col->type) &&
                             !(base_col->attrs & RAY_ATTR_HAS_NULLS);
         }
-        int64_t local_dep_names[16];
-        int64_t local_dep_biases[16];
-        uint8_t local_n_dep = 0;
+        /* Exact-size carve: at most nk dependent-key entries can ever be
+         * collected (one per by-dict pair) — nk is already bound to ≤16 by
+         * the "1..16 keys" gate above (a genuine exec-kernel key-count
+         * limit, not a query.c collector cap), so this scratch buffer is
+         * tiny and short-lived (consumed entirely within this block). */
+        ray_t* local_dep_hdr = NULL;
+        int64_t* local_dep_names = NULL;
+        int64_t* local_dep_biases = NULL;
+        int64_t local_n_dep = 0;
         if (dep_candidate && base_sym >= 0) {
+            local_dep_names = (int64_t*)scratch_alloc(&local_dep_hdr,
+                    (size_t)nk * 2 * sizeof(int64_t));
+            if (!local_dep_names) {
+                ray_release(tbl);
+                return ray_error("oom", NULL);
+            }
+            local_dep_biases = local_dep_names + nk;
             for (int64_t i = 0; i < nk && dep_candidate; i++) {
                 ray_t* k = d_elems[i * 2];
                 ray_t* v = d_elems[i * 2 + 1];
@@ -5220,6 +5278,7 @@ ray_t* ray_select(ray_t** args, int64_t n) {
         if (dep_candidate && base_sym >= 0 && local_n_dep > 0) {
             by_sym_vec_owned = ray_vec_new(RAY_SYM, 1);
             if (!by_sym_vec_owned || RAY_IS_ERR(by_sym_vec_owned)) {
+                scratch_free(local_dep_hdr);
                 ray_release(tbl);
                 return ray_error("oom", NULL);
             }
@@ -5228,12 +5287,14 @@ ray_t* ray_select(ray_t** args, int64_t n) {
             by_expr = by_sym_vec_owned;
             dep_key_base_sym = base_key_name;
             n_dep_keys = local_n_dep;
-            for (uint8_t i = 0; i < n_dep_keys; i++) {
+            for (int64_t i = 0; i < n_dep_keys; i++) {
                 dep_key_names[i] = local_dep_names[i];
                 dep_key_biases[i] = local_dep_biases[i];
             }
+            scratch_free(local_dep_hdr);
             goto by_dict_done;
         }
+        scratch_free(local_dep_hdr);
 
         bool has_computed_by_val = false;
         for (int64_t i = 0; i < nk; i++) {
@@ -5313,11 +5374,19 @@ ray_t* ray_select(ray_t** args, int64_t n) {
          * what was meant to be a cheap prefilter (single-col filter
          * is O(passing × esz), full filter is ~50× that). */
         if (where_expr && (prefilter_computed_by || prefilter_multi_key_where)) {
-            int64_t keep_syms[256];
+            /* Exact-size carve: collect_col_refs_set dedups against real
+             * table columns, so ray_table_ncols(tbl) is a hard upper bound —
+             * no silent cap on wide tables past the former [256]. */
+            int64_t ncols_max = ray_table_ncols(tbl);
+            if (ncols_max < 1) ncols_max = 1;
+            ray_t* keep_hdr = NULL;
+            int64_t* keep_syms = (int64_t*)scratch_alloc(&keep_hdr,
+                    (size_t)ncols_max * sizeof(int64_t));
+            if (!keep_syms) { ray_release(tbl); return ray_error("oom", NULL); }
             int n_keep = 0;
             n_keep = collect_col_refs_set(where_expr, tbl,
-                                          keep_syms, 256, n_keep);
-            for (int64_t i = 0; i + 1 < dict_n && n_keep < 256; i += 2) {
+                                          keep_syms, (int)ncols_max, n_keep);
+            for (int64_t i = 0; i + 1 < dict_n && n_keep < ncols_max; i += 2) {
                 int64_t kid = dict_elems[i]->i64;
                 if (kid == from_id || kid == where_id || kid == take_id ||
                     kid == nearest_id) continue;
@@ -5328,10 +5397,9 @@ ray_t* ray_select(ray_t** args, int64_t n) {
                  * other entries are output cols — agg or non-agg
                  * expressions whose refs we also need post-filter. */
                 n_keep = collect_col_refs_set(dict_elems[i + 1], tbl,
-                                              keep_syms, 256, n_keep);
+                                              keep_syms, (int)ncols_max, n_keep);
             }
-            int can_project = (n_keep > 0 && n_keep < 256 &&
-                               n_keep < ray_table_ncols(tbl));
+            int can_project = (n_keep > 0 && n_keep < ncols_max);
             ray_t* narrow_tbl = NULL;
             if (can_project) {
                 narrow_tbl = project_table_cols(tbl, keep_syms, n_keep);
@@ -5341,6 +5409,7 @@ ray_t* ray_select(ray_t** args, int64_t n) {
                     can_project = 0;
                 }
             }
+            scratch_free(keep_hdr);
             ray_t* prefilter_input = can_project ? narrow_tbl : tbl;
             ray_graph_t* fg = ray_graph_new(prefilter_input);
             if (!fg) {
@@ -5440,9 +5509,22 @@ ray_t* ray_select(ray_t** args, int64_t n) {
                 sv_data[i] = k->i64;
                 continue;
             }
-            int64_t ref_syms[16];
-            ray_t* materialized_refs[16];
-            int n_refs = collect_col_refs(v, tbl, ref_syms, 16, 0);
+            /* Exact-size carve: collect_col_refs dedups against real table
+             * columns, so ray_table_ncols(tbl) is a hard upper bound — no
+             * silent truncation past the former [16] cap.  Scoped to this
+             * loop iteration only (tbl may gain a column each pass via
+             * ray_table_add_col below), freed before every exit. */
+            int64_t ncols_max = ray_table_ncols(tbl);
+            if (ncols_max < 1) ncols_max = 1;
+            ray_t* refs_hdr = NULL;
+            int64_t* ref_syms = (int64_t*)scratch_alloc(&refs_hdr,
+                    (size_t)ncols_max * (sizeof(int64_t) + sizeof(ray_t*)));
+            if (!ref_syms) {
+                fail_err = ray_error("oom", NULL);
+                failed = true; break;
+            }
+            ray_t** materialized_refs = (ray_t**)(ref_syms + ncols_max);
+            int n_refs = collect_col_refs(v, tbl, ref_syms, (int)ncols_max, 0);
             for (int ri = 0; ri < n_refs; ri++) materialized_refs[ri] = NULL;
             for (int ri = 0; ri < n_refs; ri++) {
                 ray_t* ref_col = ray_table_get_col(tbl, ref_syms[ri]);
@@ -5465,6 +5547,7 @@ ray_t* ray_select(ray_t** args, int64_t n) {
                         ray_release(materialized_refs[ri]);
                     }
                 }
+                scratch_free(refs_hdr);
                 break;
             }
             ray_t* col_vec = ray_eval(v);
@@ -5475,6 +5558,7 @@ ray_t* ray_select(ray_t** args, int64_t n) {
                     ray_release(materialized_refs[ri]);
                 }
             }
+            scratch_free(refs_hdr);
             if (!col_vec || RAY_IS_ERR(col_vec)) {
                 fail_err = col_vec ? col_vec : ray_error("domain", "by-dict val eval");
                 failed = true; break;
@@ -9972,7 +10056,7 @@ by_dict_done:
                 scratch_free(sel_slots_hdr); return ray_error("domain", "dependent group key base missing");
             }
             int64_t n_groups = ray_table_nrows(result);
-            for (uint8_t dk = 0; dk < n_dep_keys; dk++) {
+            for (int64_t dk = 0; dk < n_dep_keys; dk++) {
                 ray_t* col = ray_vec_new(RAY_I64, n_groups);
                 if (!col || RAY_IS_ERR(col)) {
                     ray_release(result);

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -2246,7 +2246,9 @@ static ray_t* match_count_distinct(ray_t* expr) {
  * whose key is not a clause keyword.  This is the natural bound for all
  * per-output collection arrays in the select compile path (the former
  * fixed-16 slot arrays).  dict_n is the element count of the flattened
- * [k0 v0 k1 v1 ...] view, so outputs <= dict_n/2 <= DICT_VIEW_MAX. */
+ * [k0 v0 k1 v1 ...] view, so outputs <= dict_n/2 <= DICT_VIEW_MAX.
+ * Contract: callers must pass a non-overflowed dict view (dict_n >= 0);
+ * an overflowed view (dict_n == -1) yields 0, which callers clamp to 1. */
 static int64_t select_output_count(ray_t** dict_elems, int64_t dict_n) {
     int64_t from_id    = ray_sym_intern("from",    4);
     int64_t where_id   = ray_sym_intern("where",   5);
@@ -6350,6 +6352,16 @@ by_dict_done:
                     scratch_free(sel_slots_hdr); return dres;
                 }
 
+                /* NOTE: this multi-key count-only pre-take block is currently
+                 * unreachable for any shape that returns a correct result. Since
+                 * the routing change above, every all-count-agg >1-key by:
+                 * answers through the parallel DAG/v2 path instead (see
+                 * test/rfl/query/width_matrix.rfl's ROUTING NOTE on the `rmk`
+                 * cell). The only remaining trigger into this block is a
+                 * RAY_LIST-typed by-key column, which hits a pre-existing
+                 * vec_new(LIST) bug building the key output column. Left in
+                 * place — not correctness-load-bearing — pending a follow-up
+                 * that either fixes the LIST-key case or deletes this block. */
                 int64_t pre_take_groups = nrows;
                 bool has_pre_take = unsorted_positive_take_limit(
                     dict_elems, dict_n, asc_id, desc_id, take_id,
@@ -7601,10 +7613,14 @@ by_dict_done:
          * WHERE materialize path (and, on parted sources, a full column
          * flatten) that its rewritten form no longer needs.  Decompose
          * here, before the routing decisions, and let the compile loop
-         * consume the precomputed rewrites via compound_pos.  The mirror
-         * counter replicates the compile loop's slot accounting exactly:
-         * dag-aggs claim slots in output order and hidden slots share
-         * the 16-slot cap. */
+         * consume the precomputed rewrites via compound_pos.  This pass
+         * also classifies every output for routing: dag-aggs and
+         * decomposed compounds are tallied into n_grp_agg_outputs, a bare
+         * count(distinct sym) sets has_cd_output, and sg_shapes_ok tracks
+         * whether every agg slot seen so far is kernel-shaped.  Everything
+         * else marks has_nonagg_needing_flat.  All per-output arrays are
+         * sized to n_out_max (select_output_count), not a fixed slot
+         * cap. */
         int has_nonagg_needing_flat = 0;
         int n_grp_agg_outputs = 0;   /* dag-aggs + decomposed compounds */
         int has_cd_output = 0;

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -8505,21 +8505,25 @@ by_dict_done:
                 root = ray_group(g, NULL, 0, s_agg_ops, s_agg_ins, (uint8_t)s_n_aggs);
             scratch_free(sagg_hdr);
         } else {
-            /* Projection only (no group by) — select specific columns */
-            ray_op_t* col_ops[16];
-            uint8_t nc = 0;
+            /* Projection only (no group by) — select specific columns.
+             * Exact-size scratch carve bound by select_output_count — the
+             * former fixed col_ops[16] silently routed >16 outputs to the
+             * eval fallback via the width check below; now only the other
+             * use_eval_fallback trigger (a failed compile) applies. */
+            int64_t nc_max = select_output_count(dict_elems, dict_n);
+            if (nc_max < 1) nc_max = 1;
+            ray_t* colops_hdr = NULL;
+            ray_op_t** col_ops = (ray_op_t**)scratch_alloc(&colops_hdr,
+                    (size_t)nc_max * sizeof(ray_op_t*));
+            if (!col_ops) {
+                ray_graph_free(g); ray_release(tbl);
+                scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
+            }
+            int64_t nc = 0;
             int use_eval_fallback = 0;
             for (int64_t i = 0; i + 1 < dict_n; i += 2) {
                 int64_t kid = dict_elems[i]->i64;
                 if (kid == from_id || kid == where_id || kid == by_id || kid == take_id || kid == asc_id || kid == desc_id || kid == nearest_id) continue;
-                if (nc >= RAY_GROUP_MAX_SLOTS) {
-                    /* More projection columns than the DAG fast path's fixed
-                     * col_ops[] holds — take the eval fallback, which builds
-                     * the result column-by-column with no fixed cap, rather
-                     * than silently dropping the surplus columns. */
-                    use_eval_fallback = 1;
-                    break;
-                }
                 col_ops[nc] = compile_expr_dag(g, dict_elems[i + 1]);
                 if (!col_ops[nc]) {
                     use_eval_fallback = 1;
@@ -8543,6 +8547,7 @@ by_dict_done:
                         if (nearest_handle_owned) ray_release(nearest_handle_owned);
                         if (nearest_query_owned)  ray_sys_free(nearest_query_owned);
                         ray_release(tbl);
+                        scratch_free(colops_hdr);
                         scratch_free(sel_slots_hdr); return fres ? fres : ray_error("domain", "select: `where:` filter produced no result");
                     }
                     ray_release(tbl);
@@ -8552,6 +8557,7 @@ by_dict_done:
                         if (nearest_handle_owned) ray_release(nearest_handle_owned);
                         if (nearest_query_owned)  ray_sys_free(nearest_query_owned);
                         ray_release(tbl);
+                        scratch_free(colops_hdr);
                         scratch_free(sel_slots_hdr); return ray_error("oom", NULL);
                     }
                 }
@@ -8560,6 +8566,7 @@ by_dict_done:
                     if (nearest_handle_owned) ray_release(nearest_handle_owned);
                     if (nearest_query_owned)  ray_sys_free(nearest_query_owned);
                     ray_graph_free(g); ray_release(tbl);
+                    scratch_free(colops_hdr);
                     scratch_free(sel_slots_hdr); return result ? result : ray_error("oom", NULL);
                 }
                 int64_t nrows = ray_table_nrows(tbl);
@@ -8581,6 +8588,7 @@ by_dict_done:
                         if (nearest_handle_owned) ray_release(nearest_handle_owned);
                         if (nearest_query_owned)  ray_sys_free(nearest_query_owned);
                         ray_graph_free(g); ray_release(tbl);
+                        scratch_free(colops_hdr);
                         scratch_free(sel_slots_hdr); return err;
                     }
                     /* All output columns must agree in length — a length-changing
@@ -8595,6 +8603,7 @@ by_dict_done:
                         if (nearest_handle_owned) ray_release(nearest_handle_owned);
                         if (nearest_query_owned)  ray_sys_free(nearest_query_owned);
                         ray_graph_free(g); ray_release(tbl);
+                        scratch_free(colops_hdr);
                         scratch_free(sel_slots_hdr); return ray_error("length", "select: output column length %lld does not match %lld", (long long)col_len, (long long)out_len);
                     }
                     result = ray_table_add_col(result, kid, col);
@@ -8603,6 +8612,7 @@ by_dict_done:
                         if (nearest_handle_owned) ray_release(nearest_handle_owned);
                         if (nearest_query_owned)  ray_sys_free(nearest_query_owned);
                         ray_graph_free(g); ray_release(tbl);
+                        scratch_free(colops_hdr);
                         scratch_free(sel_slots_hdr); return result;
                     }
                 }
@@ -8611,9 +8621,19 @@ by_dict_done:
                 ray_graph_free(g); ray_release(tbl);
                 result = apply_sort_take(result, dict_elems, dict_n,
                                          asc_id, desc_id, take_id);
+                scratch_free(colops_hdr);
                 scratch_free(sel_slots_hdr); return result;
             } else {
-                root = ray_select_op(g, root, col_ops, nc);
+                /* The op-graph builder carries the column count in uint8_t;
+                 * guard the representational limit before narrowing at the
+                 * call (same shape as the by: path's aggregate-count guard). */
+                if (nc > UINT8_MAX) {
+                    scratch_free(colops_hdr);
+                    ray_graph_free(g); ray_release(tbl);
+                    scratch_free(sel_slots_hdr); return ray_error("range", "select: too many projection columns for the op graph (max %d)", UINT8_MAX);
+                }
+                root = ray_select_op(g, root, col_ops, (uint8_t)nc);
+                scratch_free(colops_hdr);
             }
         }
     }

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -146,6 +146,18 @@ static void dict_pair_view(ray_t* d, ray_t* key_atoms, ray_t** out_elems, int64_
  * `ray_release(tbl); return ray_error("domain", "clause too big");`. */
 #define DICT_VIEW_OVERFLOW(name) ((name##_n) < 0)
 
+/* File-scope keyword id globals for select clauses.  Cached symbol ids for
+ * the reserved select keywords: from, where, by, take, asc, desc, nearest.
+ * These are populated by ray_select before use in compile-time helper
+ * functions like select_output_count and count_agg_subexprs. */
+static int64_t from_id = 0;
+static int64_t where_id = 0;
+static int64_t by_id = 0;
+static int64_t take_id = 0;
+static int64_t asc_id = 0;
+static int64_t desc_id = 0;
+static int64_t nearest_id = 0;
+
 /* Convert a RAY_DICT (keys, vals) into a transient interleaved
  * [k0_atom, v0, k1_atom, v1, …] RAY_LIST.  Used by select's group-by
  * aggregation paths which were written for the old in-place pair-array
@@ -2220,6 +2232,36 @@ static ray_t* match_count_distinct(ray_t* expr) {
     if (!dnm || ray_str_len(dnm) != 8 ||
         memcmp(ray_str_ptr(dnm), "distinct", 8) != 0) return NULL;
     return in_elems[1];
+}
+
+/* Count the OUTPUT entries of a select dict view: every key/value pair
+ * whose key is not a clause keyword.  This is the natural bound for all
+ * per-output collection arrays in the select compile path (the former
+ * fixed-16 slot arrays).  dict_n is the element count of the flattened
+ * [k0 v0 k1 v1 ...] view, so outputs <= dict_n/2 <= DICT_VIEW_MAX. */
+static int64_t __attribute__((unused)) select_output_count(ray_t** dict_elems, int64_t dict_n) {
+    int64_t n = 0;
+    for (int64_t i = 0; i + 1 < dict_n; i += 2) {
+        int64_t kid = dict_elems[i]->i64;
+        if (kid == from_id || kid == where_id || kid == by_id ||
+            kid == take_id || kid == asc_id || kid == desc_id ||
+            kid == nearest_id) continue;
+        n++;
+    }
+    return n;
+}
+
+/* Upper bound on the aggregate subcalls a compound output decomposes
+ * into (try_decompose_agg_arith extracts each is_group_dag_agg_expr
+ * node as one hidden slot).  Pure structural walk — cheap, compile-time. */
+static int64_t __attribute__((unused)) count_agg_subexprs(ray_t* expr) {
+    if (!expr) return 0;
+    if (is_group_dag_agg_expr(expr)) return 1;
+    if (expr->type != RAY_LIST) return 0;
+    ray_t** e = (ray_t**)ray_data(expr);
+    int64_t n = ray_len(expr), c = 0;
+    for (int64_t i = 0; i < n; i++) c += count_agg_subexprs(e[i]);
+    return c;
 }
 
 /* Walk expr once, gather unique column-ref symbol ids that resolve to

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -146,18 +146,6 @@ static void dict_pair_view(ray_t* d, ray_t* key_atoms, ray_t** out_elems, int64_
  * `ray_release(tbl); return ray_error("domain", "clause too big");`. */
 #define DICT_VIEW_OVERFLOW(name) ((name##_n) < 0)
 
-/* File-scope keyword id globals for select clauses.  Cached symbol ids for
- * the reserved select keywords: from, where, by, take, asc, desc, nearest.
- * These are populated by ray_select before use in compile-time helper
- * functions like select_output_count and count_agg_subexprs. */
-static int64_t from_id = 0;
-static int64_t where_id = 0;
-static int64_t by_id = 0;
-static int64_t take_id = 0;
-static int64_t asc_id = 0;
-static int64_t desc_id = 0;
-static int64_t nearest_id = 0;
-
 /* Convert a RAY_DICT (keys, vals) into a transient interleaved
  * [k0_atom, v0, k1_atom, v1, …] RAY_LIST.  Used by select's group-by
  * aggregation paths which were written for the old in-place pair-array
@@ -2240,6 +2228,13 @@ static ray_t* match_count_distinct(ray_t* expr) {
  * fixed-16 slot arrays).  dict_n is the element count of the flattened
  * [k0 v0 k1 v1 ...] view, so outputs <= dict_n/2 <= DICT_VIEW_MAX. */
 static int64_t __attribute__((unused)) select_output_count(ray_t** dict_elems, int64_t dict_n) {
+    int64_t from_id    = ray_sym_intern("from",    4);
+    int64_t where_id   = ray_sym_intern("where",   5);
+    int64_t by_id      = ray_sym_intern("by",      2);
+    int64_t take_id    = ray_sym_intern("take",    4);
+    int64_t asc_id     = ray_sym_intern("asc",     3);
+    int64_t desc_id    = ray_sym_intern("desc",    4);
+    int64_t nearest_id = ray_sym_intern("nearest", 7);
     int64_t n = 0;
     for (int64_t i = 0; i + 1 < dict_n; i += 2) {
         int64_t kid = dict_elems[i]->i64;

--- a/src/ops/sort.c
+++ b/src/ops/sort.c
@@ -2224,7 +2224,8 @@ static void radix_decode_into(void* dst, int8_t type, const uint64_t* sorted_key
  * descs:       array of n_cols flags (0=asc, 1=desc), or NULL for all-asc
  * nulls_first: array of n_cols flags (0=nulls last, 1=nulls first), or NULL
  *              for default convention (nulls last for asc, nulls first for desc)
- * n_cols:      number of sort key columns (max 16)
+ * n_cols:      number of sort key columns (composite radix encode is used
+ *              up to 16 keys; wider sorts take the merge-sort fallback)
  * nrows:       number of rows in each column
  * sorted_keys_out: if non-NULL, receives sorted radix keys (caller frees keys_hdr_out)
  * keys_hdr_out:    if non-NULL, receives scratch header for sorted_keys_out

--- a/src/ops/sort.c
+++ b/src/ops/sort.c
@@ -2234,8 +2234,10 @@ static ray_t* sort_indices_ex(ray_t** cols, uint8_t* descs, uint8_t* nulls_first
                                uint64_t** sorted_keys_out, ray_t** keys_hdr_out) {
     if (n_cols == 0 || nrows <= 0)
         return ray_vec_new(RAY_I64, 0);
-    if (n_cols > 16)
-        return ray_error("nyi", NULL);
+    /* No n_cols cap here: the composite-radix fast path below (`fits`)
+     * uses a fixed-16-key encode context and gates itself on n_cols <= 16;
+     * anything wider (or any key type it declines) falls through to the
+     * generic comparator-based merge sort, which is n_cols-unbounded. */
 
     /* Allocate index array */
     ray_t* indices_hdr;
@@ -2731,7 +2733,12 @@ static ray_t* sort_indices_ex(ray_t** cols, uint8_t* descs, uint8_t* nulls_first
                         if (rank_hdrs[k]) scratch_free(rank_hdrs[k]);
                 }
 
-                if (fits) {
+                /* radix_encode_ctx_t (internal.h) carries fixed 16-key
+                 * mins/ranges/bit_shifts/descs/enum_ranks arrays — this
+                 * direct-encode path is only safe up to that width.  Wider
+                 * composites (any n_cols above 16) fall through to the
+                 * merge sort below rather than overrun those arrays. */
+                if (fits && n_cols <= 16) {
                     /* Compute bit-shift for each key: primary key in MSBs */
                     uint8_t bit_shifts[n_cols];
                     uint8_t accum = 0;
@@ -3335,7 +3342,6 @@ ray_t* exec_sort(ray_graph_t* g, ray_op_t* op, ray_t* tbl, int64_t limit) {
     int64_t ncols = ray_table_ncols(tbl);
     if (ncols > 4096) return ray_error("nyi", NULL); /* stack safety */
     uint8_t n_sort = ext->sort.n_cols;
-    if (n_sort > 16) return ray_error("nyi", NULL); /* radix_encode_ctx_t limit */
 
     /* ---- Top-K bounded-heap shortcut ----
      * Triggered by the SORT+HEAD fusion (HEAD passes limit > 0).  When
@@ -3345,8 +3351,11 @@ ray_t* exec_sort(ray_graph_t* g, ray_op_t* op, ray_t* tbl, int64_t limit) {
      * Single key → radix-encoded fast path; multi-key → comparator
      * heap (still O(n log K) in compares, big win when K << n).
      * Falls through to the full sort whenever the topk path returns
-     * NULL (unsupported type, computed-key sort, etc.). */
-    if (limit > 0 && n_sort >= 1 && limit < nrows && limit <= 8192 &&
+     * NULL (unsupported type, computed-key sort, etc.).  Bounded to
+     * n_sort <= 16: the shortcut's key_cols/nfs scratch below is a
+     * fixed-16 stack array; wider sorts skip straight to the general
+     * sort_indices_ex path (itself n_cols-unbounded). */
+    if (limit > 0 && n_sort >= 1 && n_sort <= 16 && limit < nrows && limit <= 8192 &&
         g && g->selection == NULL) {
         ray_t* key_cols[16];
         int    all_scan = 1;

--- a/src/ops/window.c
+++ b/src/ops/window.c
@@ -873,7 +873,10 @@ ray_t* exec_window(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
                 /* Multi-key composite radix sort */
                 ray_pool_t* pool2 = pool;
                 int64_t mins[n_sort], maxs[n_sort];
-                uint8_t total_bits = 0;
+                /* Wider accumulator: up to 16 keys * 63 bits = 1008,
+                 * which would wrap a uint8_t and let an oversized
+                 * budget falsely pass the <=64 fits check. */
+                uint16_t total_bits = 0;
                 bool fits = true;
 
                 ray_pool_t* mk_prescan_pool2 = (nrows >= SMALL_POOL_THRESHOLD) ? pool2 : NULL;
@@ -968,7 +971,12 @@ ray_t* exec_window(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
 
                 if (total_bits > 64) fits = false;
 
-                if (fits) {
+                /* radix_encode_ctx_t (internal.h) carries fixed 16-key
+                 * mins/ranges/bit_shifts/descs/enum_ranks arrays — this
+                 * direct-encode path is only safe up to that width.  Wider
+                 * composites (any n_sort above 16) fall through to the
+                 * merge sort below rather than overrun those arrays. */
+                if (fits && n_sort <= 16) {
                     uint8_t bit_shifts[n_sort];
                     uint8_t accum = 0;
                     for (int k = n_sort - 1; k >= 0; k--) {

--- a/test/rfl/query/output_slot_cap.rfl
+++ b/test/rfl/query/output_slot_cap.rfl
@@ -1,4 +1,4 @@
-;; Output-column slot cap RETIRED (was RAY_GROUP_MAX_SLOTS = 16): every
+;; Output-column slot cap RETIRED (was a fixed 16-slot array): every
 ;; select/group path now produces ALL requested outputs at any width — the
 ;; collectors are exact-size scratch, not fixed 16-slot arrays.  This file
 ;; guards correct wide results on the paths that used to error `range`.

--- a/test/rfl/query/output_slot_cap.rfl
+++ b/test/rfl/query/output_slot_cap.rfl
@@ -4,8 +4,11 @@
 
 (set t (table [k g v] (list [1 1 2 2] [5 5 6 6] [10 20 30 40])))
 
-;; DAG path (single sym key, pure agg): 17 aggregates → range error
-(select {from: t a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) a17: (sum v) by: {k: k}}) !- range
+;; DAG path (single sym key, pure agg): 17 aggregates now compile and run
+;; (the 16-slot compile cap is retired).  NOTE: currently gated on the
+;; exec-side agg-width lift (agg_engine.c v2 >16 bail + group.c legacy 8-cap)
+;; — until that lands the select returns `nyi`; this asserts the target state.
+(at (meta (select {from: t a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) a17: (sum v) by: {k: k}})) 'len) -- 18
 
 ;; eval-group path (multi-key + non-agg output): 17 outputs → range error
 (select {from: t a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) n1: v by: {k: k g: g}}) !- range

--- a/test/rfl/query/output_slot_cap.rfl
+++ b/test/rfl/query/output_slot_cap.rfl
@@ -1,17 +1,16 @@
-;; Output-column slot cap (RAY_GROUP_MAX_SLOTS = 16): every select/group
-;; path must either produce ALL requested outputs or reject loudly with
-;; `range` — never silently truncate (audit regression).
+;; Output-column slot cap RETIRED (was RAY_GROUP_MAX_SLOTS = 16): every
+;; select/group path now produces ALL requested outputs at any width — the
+;; collectors are exact-size scratch, not fixed 16-slot arrays.  This file
+;; guards correct wide results on the paths that used to error `range`.
 
 (set t (table [k g v] (list [1 1 2 2] [5 5 6 6] [10 20 30 40])))
 
-;; DAG path (single sym key, pure agg): 17 aggregates now compile and run
-;; (the 16-slot compile cap is retired).  NOTE: currently gated on the
-;; exec-side agg-width lift (agg_engine.c v2 >16 bail + group.c legacy 8-cap)
-;; — until that lands the select returns `nyi`; this asserts the target state.
+;; DAG path (single sym key, pure agg): 17 aggregates compile and run (the
+;; 16-slot compile cap and the exec-side agg-width bail are retired).
 (at (meta (select {from: t a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) a17: (sum v) by: {k: k}})) 'len) -- 18
 
-;; eval-group path (multi-key + non-agg output): 17 outputs → range error
-(select {from: t a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) n1: v by: {k: k g: g}}) !- range
+;; eval-group path (multi-key + non-agg output): 17 outputs + 2 keys = 19 cols
+(at (meta (select {from: t a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) n1: v by: {k: k g: g}})) 'len) -- 19
 
 ;; control: 16 outputs on the same eval-group shape succeeds (2 keys + 16)
 (at (meta (select {from: t a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) n1: v by: {k: k g: g}})) 'len) -- 18

--- a/test/rfl/query/parted_wide_group.rfl
+++ b/test/rfl/query/parted_wide_group.rfl
@@ -1,0 +1,48 @@
+;; parted_wide_group.rfl — regression for a pre-existing stack-buffer
+;; overflow in src/ops/group.c exec_group_parted.
+;;
+;; The parted GROUP-BY dispatch (exec_group → exec_group_parted) fills the
+;; fixed stack arrays `key_syms[8]` / `agg_syms[8]` with loops bounded by
+;; ext->n_keys / ext->n_aggs.  Those bounds can exceed 8 (compile-time slot
+;; caps were lifted on the unbounded-slots branch), and the dispatch runs
+;; BEFORE the `n_keys > 8 || (n_keys > 0 && n_aggs > 8)` nyi guard — so a
+;; parted GROUP BY with 9+ aggregate inputs writes past agg_syms[8].  ASan
+;; reports a stack-buffer-overflow WRITE.
+;;
+;; Fixture: a two-partition on-disk table, key `k` with two groups, plus 9
+;; independent value columns v1..v9 (vN is constant N in every row).  A
+;; GROUP BY k with 9 sums (sum(v1)..sum(v9)) drives n_aggs = 9 > 8.
+;;
+;; Oracle: each partition holds rows k=[1 2] and vN=[N N].  Group k=1 keeps
+;; row 0 of both partitions, group k=2 keeps row 1 of both partitions, so for
+;; EITHER group sum(vN) = vN + vN = 2*N.  Thus s1=[2 2], s2=[4 4], …,
+;; s9=[18 18].
+
+;; ─── fixture setup ───────────────────────────────────────────────────
+(.sys.exec "rm -rf /tmp/rfl_parted_wide")
+(set TW1 (table [k v1 v2 v3 v4 v5 v6 v7 v8 v9] (list (as 'I64 [1 2]) (as 'I64 [1 1]) (as 'I64 [2 2]) (as 'I64 [3 3]) (as 'I64 [4 4]) (as 'I64 [5 5]) (as 'I64 [6 6]) (as 'I64 [7 7]) (as 'I64 [8 8]) (as 'I64 [9 9]))))
+(set TW2 (table [k v1 v2 v3 v4 v5 v6 v7 v8 v9] (list (as 'I64 [1 2]) (as 'I64 [1 1]) (as 'I64 [2 2]) (as 'I64 [3 3]) (as 'I64 [4 4]) (as 'I64 [5 5]) (as 'I64 [6 6]) (as 'I64 [7 7]) (as 'I64 [8 8]) (as 'I64 [9 9]))))
+(.db.splayed.set "/tmp/rfl_parted_wide/1/t/" TW1)
+(.db.splayed.set "/tmp/rfl_parted_wide/2/t/" TW2)
+(set PW (.db.parted.get "/tmp/rfl_parted_wide/" 't))
+
+;; ─── 9-agg parted GROUP BY (n_aggs = 9 > 8, overflows agg_syms[8]) ────
+(set rw (select {from: PW s1: (sum v1) s2: (sum v2) s3: (sum v3) s4: (sum v4) s5: (sum v5) s6: (sum v6) s7: (sum v7) s8: (sum v8) s9: (sum v9) by: {k: k}}))
+(count (at rw 'k)) -- 2
+(at rw 'k) -- [1 2]
+(at rw 's1) -- [2 2]
+(at rw 's2) -- [4 4]
+(at rw 's8) -- [16 16]
+(at rw 's9) -- [18 18]
+
+;; ─── 9 keys (n_keys = 9 > 8, overflows key_syms[8]) ──────────────────
+;; k plus v1..v8 as group keys (9 keys); each row is a distinct key tuple in
+;; its partition but rows collapse across the two identical partitions.
+;; Both partitions hold identical rows, so grouping by all 9 columns yields
+;; exactly the 2 distinct tuples (one per source row), counted once each.
+(set rk (select {from: PW c: (count v9) by: {k: k a: v1 b: v2 d: v3 e: v4 f: v5 g: v6 h: v7 i: v8}}))
+(count (at rk 'k)) -- 2
+(sum (at rk 'c)) -- 4
+
+;; ─── cleanup ─────────────────────────────────────────────────────────
+(.sys.exec "rm -rf /tmp/rfl_parted_wide")

--- a/test/rfl/query/parted_wide_group.rfl
+++ b/test/rfl/query/parted_wide_group.rfl
@@ -43,6 +43,11 @@
 (set rk (select {from: PW c: (count v9) by: {k: k a: v1 b: v2 d: v3 e: v4 f: v5 g: v6 h: v7 i: v8}}))
 (count (at rk 'k)) -- 2
 (sum (at rk 'c)) -- 4
+;; 'i' is the 9th key column (v8, key index 8) — the one slot that overflows
+;; key_syms[8] if the guard regresses.  v8 is constant 8 in every row of both
+;; partitions, so both groups carry i=8; sum is order-independent across the
+;; parted merge.
+(sum (at rk 'i)) -- 16
 
 ;; ─── cleanup ─────────────────────────────────────────────────────────
 (.sys.exec "rm -rf /tmp/rfl_parted_wide")

--- a/test/rfl/query/slot_limits.rfl
+++ b/test/rfl/query/slot_limits.rfl
@@ -1,10 +1,9 @@
-;; Slot-limit guards for the select/group-by compile paths (src/ops/query.c).
-;; More than RAY_GROUP_MAX_SLOTS (16) aggregate or non-aggregate entries in
-;; one `select` are rejected with a clear error rather than silently
-;; truncating the surplus (which returned wrong results).  The sort-key
-;; collector's cap is retired (exact-size scratch carve): >16 asc:/desc:
-;; entries now compile and execute correctly instead of erroring.  Plain
-;; projections have no cap either — they route to the eval fallback and
+;; Slot-width guards for the select/group-by paths (src/ops/query.c).  The
+;; former fixed 16-slot caps on aggregate outputs, non-aggregate outputs, and
+;; sort keys are all retired (exact-size scratch carves): more than 16 entries
+;; of any kind in one `select` now compile and execute correctly instead of
+;; erroring or silently truncating the surplus (which returned wrong results).
+;; Plain projections have no cap either — they route to the eval fallback and
 ;; keep every column.
 
 (set t (table [k v] (list [1 1 2 2] (as 'F64 [10 20 30 40]))))
@@ -13,16 +12,17 @@
 ;; 16 aggregates — exactly at the cap: compiles and returns both groups.
 (count (select {by: k a: (sum v) b: (max v) c: (min v) d: (avg v) e: (sum v) f: (max v) g: (min v) h: (avg v) i: (sum v) j: (max v) l: (min v) m: (avg v) n: (sum v) o: (max v) p: (min v) q: (avg v) from: t})) -- 2
 
-;; 17 aggregates — one over the former cap: the DAG group-by compile cap is
-;; retired, so this now compiles and returns both groups.  NOTE: currently
-;; gated on the exec-side agg-width lift (agg_engine.c v2 >16 bail + group.c
-;; legacy 8-cap) — until that lands the select returns `nyi`; this asserts the
-;; target state.
+;; 17 aggregates — one over the former cap: the DAG group-by compile cap and
+;; the exec-side agg-width caps are all retired, so this compiles, runs, and
+;; returns both groups.
 (count (select {by: k a: (sum v) b: (max v) c: (min v) d: (avg v) e: (sum v) f: (max v) g: (min v) h: (avg v) i: (sum v) j: (max v) l: (min v) m: (avg v) n: (sum v) o: (max v) p: (min v) q: (avg v) s: (sum v) from: t})) -- 2
 
 ;; ─── non-aggregate outputs ──────────────────────────────────────────
-;; 17 non-aggregate outputs exercise the same cap on the scatter path.
-(select {by: k a: (+ v 1) b: (+ v 2) c: (+ v 3) d: (+ v 4) e: (+ v 5) f: (+ v 6) g: (+ v 7) h: (+ v 8) i: (+ v 9) j: (+ v 10) l: (+ v 11) m: (+ v 12) n: (+ v 13) o: (+ v 14) p: (+ v 15) q: (+ v 16) s: (+ v 17) from: t}) !- range
+;; 17 non-aggregate outputs exercise the scatter path past the former cap:
+;; each aliased expression becomes a per-group LIST column.  The 17th output
+;; `s: (+ v 17)` proves the surplus survives — group k=1 (v=[10 20]) yields
+;; [27.0 37.0], group k=2 (v=[30 40]) yields [47.0 57.0].
+(at (at (select {by: k a: (+ v 1) b: (+ v 2) c: (+ v 3) d: (+ v 4) e: (+ v 5) f: (+ v 6) g: (+ v 7) h: (+ v 8) i: (+ v 9) j: (+ v 10) l: (+ v 11) m: (+ v 12) n: (+ v 13) o: (+ v 14) p: (+ v 15) q: (+ v 16) s: (+ v 17) from: t}) 's) 1) -- [47.0 57.0]
 
 ;; ─── sort keys ──────────────────────────────────────────────────────
 ;; 17 sort keys — the DAG sort-key collector cap is retired: exact-size

--- a/test/rfl/query/slot_limits.rfl
+++ b/test/rfl/query/slot_limits.rfl
@@ -3,8 +3,8 @@
 ;; sort keys are all retired (exact-size scratch carves): more than 16 entries
 ;; of any kind in one `select` now compile and execute correctly instead of
 ;; erroring or silently truncating the surplus (which returned wrong results).
-;; Plain projections have no cap either — they route to the eval fallback and
-;; keep every column.
+;; Plain projections have no cap either — they compile through the same
+;; exact-size collectors and keep every column.
 
 (set t (table [k v] (list [1 1 2 2] (as 'F64 [10 20 30 40]))))
 

--- a/test/rfl/query/slot_limits.rfl
+++ b/test/rfl/query/slot_limits.rfl
@@ -10,8 +10,12 @@
 ;; 16 aggregates — exactly at the cap: compiles and returns both groups.
 (count (select {by: k a: (sum v) b: (max v) c: (min v) d: (avg v) e: (sum v) f: (max v) g: (min v) h: (avg v) i: (sum v) j: (max v) l: (min v) m: (avg v) n: (sum v) o: (max v) p: (min v) q: (avg v) from: t})) -- 2
 
-;; 17 aggregates — one over the cap: clear error, not a silently dropped column.
-(select {by: k a: (sum v) b: (max v) c: (min v) d: (avg v) e: (sum v) f: (max v) g: (min v) h: (avg v) i: (sum v) j: (max v) l: (min v) m: (avg v) n: (sum v) o: (max v) p: (min v) q: (avg v) s: (sum v) from: t}) !- range
+;; 17 aggregates — one over the former cap: the DAG group-by compile cap is
+;; retired, so this now compiles and returns both groups.  NOTE: currently
+;; gated on the exec-side agg-width lift (agg_engine.c v2 >16 bail + group.c
+;; legacy 8-cap) — until that lands the select returns `nyi`; this asserts the
+;; target state.
+(count (select {by: k a: (sum v) b: (max v) c: (min v) d: (avg v) e: (sum v) f: (max v) g: (min v) h: (avg v) i: (sum v) j: (max v) l: (min v) m: (avg v) n: (sum v) o: (max v) p: (min v) q: (avg v) s: (sum v) from: t})) -- 2
 
 ;; ─── non-aggregate outputs ──────────────────────────────────────────
 ;; 17 non-aggregate outputs exercise the same cap on the scatter path.

--- a/test/rfl/query/slot_limits.rfl
+++ b/test/rfl/query/slot_limits.rfl
@@ -1,8 +1,11 @@
 ;; Slot-limit guards for the select/group-by compile paths (src/ops/query.c).
-;; More than RAY_GROUP_MAX_SLOTS (16) aggregate, non-aggregate, or sort-key
-;; entries in one `select` are rejected with a clear error rather than silently
-;; truncating the surplus (which returned wrong results).  Plain projections
-;; have no such cap — they route to the eval fallback and keep every column.
+;; More than RAY_GROUP_MAX_SLOTS (16) aggregate or non-aggregate entries in
+;; one `select` are rejected with a clear error rather than silently
+;; truncating the surplus (which returned wrong results).  The sort-key
+;; collector's cap is retired (exact-size scratch carve): >16 asc:/desc:
+;; entries now compile and execute correctly instead of erroring.  Plain
+;; projections have no cap either — they route to the eval fallback and
+;; keep every column.
 
 (set t (table [k v] (list [1 1 2 2] (as 'F64 [10 20 30 40]))))
 
@@ -22,8 +25,13 @@
 (select {by: k a: (+ v 1) b: (+ v 2) c: (+ v 3) d: (+ v 4) e: (+ v 5) f: (+ v 6) g: (+ v 7) h: (+ v 8) i: (+ v 9) j: (+ v 10) l: (+ v 11) m: (+ v 12) n: (+ v 13) o: (+ v 14) p: (+ v 15) q: (+ v 16) s: (+ v 17) from: t}) !- range
 
 ;; ─── sort keys ──────────────────────────────────────────────────────
-;; 17 sort keys — over the cap: clear error, not a silently ignored key.
-(select {from: t asc: [k v k v k v k v k v k v k v k v k]}) !- range
+;; 17 sort keys — the DAG sort-key collector cap is retired: exact-size
+;; scratch carve (query.c) sizes to the real bound and ray_sort_op /
+;; exec_sort take all 17.  t is [k v] = [1 1 2 2]/[10 20 30 40], already
+;; in ascending (k,v) order, so this proves no-error + a correct
+;; pass-through result (not a genuine reorder — see width_matrix.rfl for
+;; a reorder-proving case on both the DAG and post-agg sort sites).
+(at (select {from: t asc: [k v k v k v k v k v k v k v k v k]}) 'v) -- [10.0 20.0 30.0 40.0]
 
 ;; ─── plain projection — NO cap (routes to the eval fallback) ─────────
 (set w (table [c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16] (list [1 2] [1 2] [1 2] [1 2] [1 2] [1 2] [1 2] [1 2] [1 2] [1 2] [1 2] [1 2] [1 2] [1 2] [1 2] [1 2] [9 8])))

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -101,3 +101,29 @@
 (set rp (select {from: wt p01: c01 p20: c20 p17: c17 p02: c02 p03: c03 p04: c04 p05: c05 p06: c06 p07: c07 p08: c08 p09: c09 p10: c10 p11: c11 p12: c12 p13: c13 p14: c14 p15: c15 p16: c16 p18: c18 p19: c19}))
 (at (meta rp) 'len) -- 20
 (at rp 'p20) -- [20]
+
+;; ── sort: 17 sort keys, no by: (DAG-compiled path, src/ops/query.c ~line
+;; 574) — exact-size scratch carve replaces the fixed sort_keys[16]/
+;; sort_descs[16] stack arrays.  16 all-equal dummy keys (d01..d16) plus a
+;; discriminator `sk` last: sorting ascending by [d01..d16 sk] is fully
+;; decided by `sk` (1 before 2) since every d0N tie-breaks to nothing.
+;; No output projection dict here (plain pass-through of every source
+;; column) — a narrowed projection that drops the sort-key columns hits an
+;; unrelated, pre-existing bug in exec_sort's OP_SCAN shortcut (it resolves
+;; scan nodes against the post-projection table instead of g->table; already
+;; reproducible on unmodified code with a single sort key, out of scope here).
+(set st (table [d01 d02 d03 d04 d05 d06 d07 d08 d09 d10 d11 d12 d13 d14 d15 d16 sk pay] (list [0 0] [0 0] [0 0] [0 0] [0 0] [0 0] [0 0] [0 0] [0 0] [0 0] [0 0] [0 0] [0 0] [0 0] [0 0] [0 0] [2 1] [20 10])))
+(at (select {from: st asc: [d01 d02 d03 d04 d05 d06 d07 d08 d09 d10 d11 d12 d13 d14 d15 d16 sk]}) 'pay) -- [10 20]
+
+;; ── sort: 17 sort keys, WITH by: (apply_sort_take path, src/ops/query.c
+;; ~line 8647 in this file's numbering pre-fix — post-agg sort, group-by
+;; changes the output schema so this can't be added to the DAG and instead
+;; sorts the materialized group-by result).  17 aggregate outputs a01..a17
+;; are each (sum v): within one group every a0N is numerically identical, so
+;; sorting ascending by all 17 is fully decided by that one value.  Source
+;; row order is k=2 (v=20) before k=1 (v=10) — the opposite of sorted order —
+;; so a genuine reorder (not a no-op pass-through) is required to get [10 20].
+(set gt (table [k v] (list [2 1] [20 10])))
+(set rg (select {from: gt a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) a17: (sum v) by: {k: k} asc: [a01 a02 a03 a04 a05 a06 a07 a08 a09 a10 a11 a12 a13 a14 a15 a16 a17]}))
+(at rg 'a17) -- [10 20]
+(at rg 'k) -- [1 2]

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -90,3 +90,8 @@
 (set rt (select {from: t c01: (count v) c02: (count v) c03: (count v) c04: (count v) c05: (count v) c06: (count v) c07: (count v) c08: (count v) c09: (count v) c10: (count v) c11: (count v) c12: (count v) c13: (count v) c14: (count v) c15: (count v) c16: (count v) c17: (count v) by: {k: k} take: 2}))
 (at (meta rt) 'len) -- 18
 (at rt 'c17) -- [2 2]
+
+;; ── scalar reduction (no by:): 17 aggregates — was a SILENT drop past 16 ──
+(set rs (select {from: t s01: (sum v) s02: (count v) s03: (min v) s04: (max v) s05: (sum v) s06: (count v) s07: (min v) s08: (max v) s09: (sum v) s10: (count v) s11: (min v) s12: (max v) s13: (sum v) s14: (count v) s15: (min v) s16: (max v) s17: (sum v)}))
+(at (meta rs) 'len) -- 17
+(at rs 's17) -- [100]

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -12,6 +12,33 @@
 (at r17 'a16) -- [20 40]
 (at r17 'a17) -- [30 70]
 
+;; ── DAG path: boundary widths around the former 16-agg cap (15/16/17).
+;; The 17-agg case is r17 above; these two pin the immediate neighbours so
+;; a future regression that reintroduces an off-by-one at the boundary
+;; (rather than a hard 16 cap) is still caught. ──
+(at (meta (select {from: t a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) by: {k: k}})) 'len) -- 16
+(at (meta (select {from: t a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) by: {k: k}})) 'len) -- 17
+
+;; ── DAG path: composition oracle — 33 outputs, single sym key, cycling
+;; sum/count/min/max every 4 columns (a01=sum, a02=count, a03=min, a04=max,
+;; a05=sum, ...).  Values are the same 2-group fixture as r17 (k=[1 1 2 2]
+;; v=[10 20 30 40]): group k=1 has v=[10 20], group k=2 has v=[30 40], so
+;; sum=[30 70] count=[2 2] min=[10 30] max=[20 40] regardless of which
+;; column position asks for them.  Position p's function is
+;; [sum count min max][(p-1) mod 4]: a01 (p=1) -> sum, a17 (p=17,
+;; (17-1) mod 4 = 0) -> sum, a32 (p=32, (32-1) mod 4 = 3) -> max, a33
+;; (p=33, (33-1) mod 4 = 0) -> sum.  meta len = 1 key col + 33 outputs = 34. ──
+(set r33 (select {from: t a01: (sum v) a02: (count v) a03: (min v) a04: (max v) a05: (sum v) a06: (count v) a07: (min v) a08: (max v) a09: (sum v) a10: (count v) a11: (min v) a12: (max v) a13: (sum v) a14: (count v) a15: (min v) a16: (max v) a17: (sum v) a18: (count v) a19: (min v) a20: (max v) a21: (sum v) a22: (count v) a23: (min v) a24: (max v) a25: (sum v) a26: (count v) a27: (min v) a28: (max v) a29: (sum v) a30: (count v) a31: (min v) a32: (max v) a33: (sum v) by: {k: k}}))
+(at (meta r33) 'len) -- 34
+(at r33 'k) -- [1 2]
+(at r33 'a01) -- [30 70]
+(at r33 'a02) -- [2 2]
+(at r33 'a03) -- [10 30]
+(at r33 'a04) -- [20 40]
+(at r33 'a17) -- [30 70]
+(at r33 'a32) -- [20 40]
+(at r33 'a33) -- [30 70]
+
 ;; ── DAG path: 10 compound outputs, each decomposing into 2 hidden agg slots (20 hidden > 16) ──
 (set rc (select {from: t c01: (+ (sum v) (count v)) c02: (+ (sum v) (count v)) c03: (+ (sum v) (count v)) c04: (+ (sum v) (count v)) c05: (+ (sum v) (count v)) c06: (+ (sum v) (count v)) c07: (+ (sum v) (count v)) c08: (+ (sum v) (count v)) c09: (+ (sum v) (count v)) c10: (+ (sum v) (count v)) by: {k: k}}))
 (at (meta rc) 'len) -- 11
@@ -28,8 +55,10 @@
 
 ;; ── v2 engine: same width, higher-card key, still serial dense path (not
 ;; hash/radix: nrows=5000 stays below the 65536 parallel threshold, so the
-;; serial branch runs agg_dense_plan/agg_group_keys_dense regardless of key
-;; cardinality) ──
+;; serial branch runs; key range here is 0..4999, comfortably within
+;; DENSE_MAX_SLOTS, so agg_dense_plan succeeds and agg_group_keys_dense
+;; drives it — the serial-vs-parallel choice tracks nrows, not key
+;; cardinality, but agg_dense_plan's own range check still applies) ──
 (set ht (table [k v] (list (til 5000) (til 5000))))
 (set rh (select {from: ht b01: (sum v) b02: (min v) b03: (max v) b04: (count v) b05: (sum v) b06: (min v) b07: (max v) b08: (count v) b09: (sum v) b10: (min v) b11: (max v) b12: (count v) b13: (sum v) b14: (min v) b15: (max v) b16: (count v) b17: (sum v) by: {k: k}}))
 (at (meta rh) 'len) -- 18
@@ -90,6 +119,48 @@
 (set rt (select {from: t c01: (count v) c02: (count v) c03: (count v) c04: (count v) c05: (count v) c06: (count v) c07: (count v) c08: (count v) c09: (count v) c10: (count v) c11: (count v) c12: (count v) c13: (count v) c14: (count v) c15: (count v) c16: (count v) c17: (count v) by: {k: k} take: 2}))
 (at (meta rt) 'len) -- 18
 (at rt 'c17) -- [2 2]
+
+;; ── multi-key count-only take: 17 count outputs, TWO by-keys, take: 2.
+;; Fixture: t has k=[1 1 2 2] g=[5 5 6 6] v=[10 20 30 40], so the composite
+;; groups are (k=1,g=5) and (k=2,g=6), each of size 2; take: 2 keeps both.
+;; Expected: nk(2) + 17 count columns = 19 columns total, every cNN=[2 2].
+;;
+;; ROUTING NOTE (verified by reading src/ops/query.c's by: routing, lines
+;; ~6101-6231, PLUS empirically by temporarily instrumenting that routing
+;; with an stderr probe, rebuilding, and running this exact query — the
+;; instrumentation was reverted before committing, not shipped):
+;; this shape does NOT reach the eval-group multi-key count-only pre-take
+;; block (query.c ~6353-6480, sized in commit f9c5cae7 "select: exact-size
+;; eval-group and count-only collectors").  That block only runs inside
+;; `if (use_eval_group)`, and for a >1-key by: with EVERY output a plain
+;; DAG-aggregable expr (is_group_dag_agg_expr — true for a bare `(count
+;; v)`), `use_eval_group` has no path to become true: the only multi-key
+;; trigger is a by-key column of type RAY_LIST (query.c ~6186-6189); the
+;; `n_out == 0` and `any_nonagg` triggers both require zero outputs or a
+;; non-agg output, neither of which holds for an all-count shape.  Probed
+;; directly: `use_eval_group=0` for this exact query.  A comment at query.c
+;; ~6191-6202 confirms this is intentional — a prior routing that sent
+;; bounded multi-key count-take queries to this eval-level block was
+;; removed because the parallel multi-key DAG/v2-agg path measured faster
+;; at every sampled size, so plain int/sym multi-key count-only + take:
+;; queries are answered by that DAG/v2 path instead (the same engine the
+;; rv/rh/rp/rx cells above already exercise).  Forcing entry via a
+;; RAY_LIST-typed by-key column DOES reach the count-only block
+;; (count_only=1 probed), but that block then hits an unrelated
+;; pre-existing bug building the LIST-typed key output column ("type:
+;; vec_new: type must be a positive concrete vector type, got LIST") —
+;; so no shape both reaches that exact block AND returns a correct
+;; result. This cell instead pins the width-retirement guarantee for
+;; whichever multi-key count-only path IS live (the DAG/v2 engine),
+;; which is the coverage gap an earlier review actually flagged as
+;; missing; the eval-group block itself is presently dead code for any
+;; correctness-preserving multi-key shape. ──
+(set rmk (select {from: t c01: (count v) c02: (count v) c03: (count v) c04: (count v) c05: (count v) c06: (count v) c07: (count v) c08: (count v) c09: (count v) c10: (count v) c11: (count v) c12: (count v) c13: (count v) c14: (count v) c15: (count v) c16: (count v) c17: (count v) by: {k: k g: g} take: 2}))
+(at (meta rmk) 'len) -- 19
+(at rmk 'k) -- [1 2]
+(at rmk 'g) -- [5 6]
+(at rmk 'c01) -- [2 2]
+(at rmk 'c17) -- [2 2]
 
 ;; ── scalar reduction (no by:): 17 aggregates — was a SILENT drop past 16 ──
 (set rs (select {from: t s01: (sum v) s02: (count v) s03: (min v) s04: (max v) s05: (sum v) s06: (count v) s07: (min v) s08: (max v) s09: (sum v) s10: (count v) s11: (min v) s12: (max v) s13: (sum v) s14: (count v) s15: (min v) s16: (max v) s17: (sum v)}))

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -1,0 +1,13 @@
+;; Width matrix (spec: unbounded-slots cut 1).  Each section proves a select
+;; path produces ALL requested outputs at widths beyond the former 16 cap,
+;; with values checked against per-column oracles.
+
+(set t (table [k g v] (list [1 1 2 2] [5 5 6 6] [10 20 30 40])))
+
+;; ── DAG path: single sym key, 17 aggregates ──
+(set r17 (select {from: t a01: (sum v) a02: (count v) a03: (min v) a04: (max v) a05: (sum v) a06: (count v) a07: (min v) a08: (max v) a09: (sum v) a10: (count v) a11: (min v) a12: (max v) a13: (sum v) a14: (count v) a15: (min v) a16: (max v) a17: (sum v) by: {k: k}}))
+(at (meta r17) 'len) -- 18
+(at r17 'k) -- [1 2]
+(at r17 'a01) -- [30 70]
+(at r17 'a16) -- [20 40]
+(at r17 'a17) -- [30 70]

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -127,3 +127,12 @@
 (set rg (select {from: gt a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) a17: (sum v) by: {k: k} asc: [a01 a02 a03 a04 a05 a06 a07 a08 a09 a10 a11 a12 a13 a14 a15 a16 a17]}))
 (at rg 'a17) -- [10 20]
 (at rg 'k) -- [1 2]
+
+;; ── window: 17 partition columns (src/ops/query.c ray_window_fn — exact-size
+;; scratch carve replaces the fixed part_ops[16]/order_ops[16]/order_descs[16]
+;; and func_kinds[32]/func_inputs[32]/func_params[32]/out_name_ids[32] stack
+;; arrays). p01..p17 are all constant (value 1 in both rows), so both rows
+;; fall into a single partition; v = [3.0 5.0], and `min` over the whole
+;; partition broadcasts min(3.0, 5.0) = 3.0 to every row in that partition.
+(set wp (table [p01 p02 p03 p04 p05 p06 p07 p08 p09 p10 p11 p12 p13 p14 p15 p16 p17 v] (list [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [3.0 5.0])))
+(at (window {from: wp part: [p01 p02 p03 p04 p05 p06 p07 p08 p09 p10 p11 p12 p13 p14 p15 p16 p17] funcs: {mn: (min v)}}) 'mn) -- [3.0 3.0]

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -11,3 +11,9 @@
 (at r17 'a01) -- [30 70]
 (at r17 'a16) -- [20 40]
 (at r17 'a17) -- [30 70]
+
+;; ── DAG path: 10 compound outputs, each decomposing into 2 hidden agg slots (20 hidden > 16) ──
+(set rc (select {from: t c01: (+ (sum v) (count v)) c02: (+ (sum v) (count v)) c03: (+ (sum v) (count v)) c04: (+ (sum v) (count v)) c05: (+ (sum v) (count v)) c06: (+ (sum v) (count v)) c07: (+ (sum v) (count v)) c08: (+ (sum v) (count v)) c09: (+ (sum v) (count v)) c10: (+ (sum v) (count v)) by: {k: k}}))
+(at (meta rc) 'len) -- 11
+(at rc 'c01) -- [32 72]
+(at rc 'c10) -- [32 72]

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -18,14 +18,65 @@
 (at rc 'c01) -- [32 72]
 (at rc 'c10) -- [32 72]
 
-;; ── v2 engine: 17 aggs, low-card dense ──
+;; ── v2 engine: 17 aggs, low-card dense (serial dense path: nrows=4 is far
+;; below RAY_PARALLEL_THRESHOLD = 64*RAY_MORSEL_ELEMS = 65536, so this always
+;; runs the serial agg_group_keys_dense driver, never the pool) ──
 (set bt (table [k v] (list [1 1 2 2] [1.5 2.5 3.5 4.5])))
 (set rv (select {from: bt b01: (sum v) b02: (min v) b03: (max v) b04: (count v) b05: (avg v) b06: (sum v) b07: (min v) b08: (max v) b09: (count v) b10: (avg v) b11: (sum v) b12: (min v) b13: (max v) b14: (count v) b15: (avg v) b16: (sum v) b17: (sum v) by: {k: k}}))
 (at (meta rv) 'len) -- 18
 (at rv 'b17) -- [4.0 8.0]
 
-;; ── v2 engine: same width, high-card key (hash/radix strategy) ──
+;; ── v2 engine: same width, higher-card key, still serial dense path (not
+;; hash/radix: nrows=5000 stays below the 65536 parallel threshold, so the
+;; serial branch runs agg_dense_plan/agg_group_keys_dense regardless of key
+;; cardinality) ──
 (set ht (table [k v] (list (til 5000) (til 5000))))
 (set rh (select {from: ht b01: (sum v) b02: (min v) b03: (max v) b04: (count v) b05: (sum v) b06: (min v) b07: (max v) b08: (count v) b09: (sum v) b10: (min v) b11: (max v) b12: (count v) b13: (sum v) b14: (min v) b15: (max v) b16: (count v) b17: (sum v) by: {k: k}}))
 (at (meta rh) 'len) -- 18
 (sum (at rh 'b17)) -- 12497500
+
+;; ── v2 engine: 17 aggs, PARALLEL DENSE path ──
+;; Routing (src/ops/agg_engine.c exec_group_v2_run, ~line 2569 on): once
+;; `pool && eff_n >= RAY_PARALLEL_THRESHOLD` (65536), dense_par_ok is tried
+;; FIRST and wins whenever agg_dense_plan succeeds (product of key ranges <=
+;; DENSE_MAX_SLOTS = 262144) and the per-worker slab fits the 8MB/worker cap.
+;; k = (% (til 100000) 1000): nrows=100000 >= 65536 and key range is exactly
+;; 1000 (values 0..999) <= 262144, and total_slots(1000)*(block+8) is far
+;; under 8MB for any block size — so this provably takes
+;; exec_group_v2_parallel_dense.
+;; Each group g in 0..999 has exactly 100 members {g, g+1000, ..., g+99000}
+;; (v = til 100000, so v_i = i = k-column's own row index).
+;; sum(v) over group g = 100*g + 1000*(0+1+...+99) = 100*g + 4950000.
+;; Sum of that across all 1000 groups = 100*(0+...+999) + 1000*4950000
+;;   = 100*499500 + 4950000000 = 49950000 + 4950000000 = 4999950000
+;;   = sum(til 100000) = 99999*100000/2, as expected (every v is counted
+;;   exactly once, partitioned across groups).
+(set pt (table [k v] (list (% (til 100000) 1000) (til 100000))))
+(set rp (select {from: pt p01: (sum v) p02: (min v) p03: (max v) p04: (count v) p05: (sum v) p06: (min v) p07: (max v) p08: (count v) p09: (sum v) p10: (min v) p11: (max v) p12: (count v) p13: (sum v) p14: (min v) p15: (max v) p16: (count v) p17: (sum v) by: {k: k}}))
+(at (meta rp) 'len) -- 18
+(count (at rp 'k)) -- 1000
+(sum (at rp 'p17)) -- 4999950000
+
+;; ── v2 engine: 17 aggs, RADIX path ──
+;; k = (* 5 (til 100000)) is UNIQUE per row: min=0, max=499995, range=499996,
+;; which exceeds DENSE_MAX_SLOTS (262144) — agg_dense_plan's overflow-safe
+;; product check (`total > DENSE_MAX_SLOTS / rng`) rejects it, so dp.ok=false
+;; and dense_par_ok is false (short-circuited on dp.ok before the byte-budget
+;; check). keys_intsym is true (I64 key, no nulls), and every aggregate below
+;; is ACC_STREAMING, so the router takes the cardinality-estimate branch:
+;; agg_estimate_card samples up to 65536 rows and early-exits the moment
+;; distinct count passes T_ROUTE=16384. Since every key in the sampled prefix
+;; is distinct (unique per row), the sample hits 16385 distinct groups well
+;; before exhausting its 65536-row budget and returns t_route+1 (16385) >
+;; T_ROUTE — so `est <= T_ROUTE` is false and the router falls through to
+;; exec_group_v2_parallel_radix. This provably exercises the radix path, not
+;; small-hash.
+;; Every group has exactly 1 member (keys are unique), so sum(v) per group is
+;; just that row's v = its row index; summed over all 100000 groups that is
+;; sum(til 100000) = 4999950000 again, and the result has exactly 100000
+;; groups (one per input row).
+(set xt (table [k v] (list (* 5 (til 100000)) (til 100000))))
+(set rx (select {from: xt x01: (sum v) x02: (min v) x03: (max v) x04: (count v) x05: (sum v) x06: (min v) x07: (max v) x08: (count v) x09: (sum v) x10: (min v) x11: (max v) x12: (count v) x13: (sum v) x14: (min v) x15: (max v) x16: (count v) x17: (sum v) by: {k: k}}))
+(at (meta rx) 'len) -- 18
+(count (at rx 'k)) -- 100000
+(sum (at rx 'x17)) -- 4999950000

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -115,7 +115,9 @@
 (at (meta re) 'len) -- 19
 (at re 'a16) -- [30 70]
 
-;; ── count-only pre-take fast path: 17 count outputs with take: ──
+;; ── count-only with take:: 17 count outputs, single by-key (DAG path;
+;; the eval-level count-only pre-take block is multi-key-only — see the
+;; ROUTING NOTE below) ──
 (set rt (select {from: t c01: (count v) c02: (count v) c03: (count v) c04: (count v) c05: (count v) c06: (count v) c07: (count v) c08: (count v) c09: (count v) c10: (count v) c11: (count v) c12: (count v) c13: (count v) c14: (count v) c15: (count v) c16: (count v) c17: (count v) by: {k: k} take: 2}))
 (at (meta rt) 'len) -- 18
 (at rt 'c17) -- [2 2]
@@ -207,6 +209,25 @@
 ;; partition broadcasts min(3.0, 5.0) = 3.0 to every row in that partition.
 (set wp (table [p01 p02 p03 p04 p05 p06 p07 p08 p09 p10 p11 p12 p13 p14 p15 p16 p17 v] (list [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [3.0 5.0])))
 (at (window {from: wp part: [p01 p02 p03 p04 p05 p06 p07 p08 p09 p10 p11 p12 p13 p14 p15 p16 p17] funcs: {mn: (min v)}}) 'mn) -- [3.0 3.0]
+
+;; ── window exec: 17 partition keys over >64 rows (src/ops/window.c
+;; multi-key composite radix gate).  The exec-side radix_encode_ctx_t
+;; (src/ops/internal.h) carries fixed 16-key mins/ranges/bit_shifts/descs/
+;; enum_ranks arrays; 17 narrow keys (total_bits = 17 <= 64) used to pass
+;; the `fits` check alone and overrun them — stack corruption in
+;; exec_window's frame.  Post-fix the gate is `fits && n_sort <= 16`
+;; (mirroring src/ops/sort.c), so this shape takes the unbounded
+;; merge-sort fallback instead.  100 rows forces past the nrows <= 64
+;; insertion-sort path that the 2-row wp cell above stops at.  p01..p16
+;; are constant (range 0 → 1 bit each) and p17 alternates 0/1, so the
+;; rows split into two 50-row partitions: even v (min 0) and odd v
+;; (min 1), broadcast back per row in source order → mn = [0 1 0 1 ...].
+(set wq (table [p01 p02 p03 p04 p05 p06 p07 p08 p09 p10 p11 p12 p13 p14 p15 p16 p17 v] (list (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (take [1] 100) (% (til 100) 2) (til 100))))
+(set wr (at (window {from: wq part: [p01 p02 p03 p04 p05 p06 p07 p08 p09 p10 p11 p12 p13 p14 p15 p16 p17] funcs: {mn: (min v)}}) 'mn))
+(count wr) -- 100
+(at wr 0) -- 0
+(at wr 1) -- 1
+(sum wr) -- 50
 
 ;; ── nonagg scatter path: 17 pure non-agg outputs, single key.  Retires the
 ;; DAG-compile `n_nonaggs >= 16` cap in src/ops/query.c ray_select_fn (the

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -17,3 +17,15 @@
 (at (meta rc) 'len) -- 11
 (at rc 'c01) -- [32 72]
 (at rc 'c10) -- [32 72]
+
+;; ── v2 engine: 17 aggs, low-card dense ──
+(set bt (table [k v] (list [1 1 2 2] [1.5 2.5 3.5 4.5])))
+(set rv (select {from: bt b01: (sum v) b02: (min v) b03: (max v) b04: (count v) b05: (avg v) b06: (sum v) b07: (min v) b08: (max v) b09: (count v) b10: (avg v) b11: (sum v) b12: (min v) b13: (max v) b14: (count v) b15: (avg v) b16: (sum v) b17: (sum v) by: {k: k}}))
+(at (meta rv) 'len) -- 18
+(at rv 'b17) -- [4.0 8.0]
+
+;; ── v2 engine: same width, high-card key (hash/radix strategy) ──
+(set ht (table [k v] (list (til 5000) (til 5000))))
+(set rh (select {from: ht b01: (sum v) b02: (min v) b03: (max v) b04: (count v) b05: (sum v) b06: (min v) b07: (max v) b08: (count v) b09: (sum v) b10: (min v) b11: (max v) b12: (count v) b13: (sum v) b14: (min v) b15: (max v) b16: (count v) b17: (sum v) by: {k: k}}))
+(at (meta rh) 'len) -- 18
+(sum (at rh 'b17)) -- 12497500

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -95,3 +95,9 @@
 (set rs (select {from: t s01: (sum v) s02: (count v) s03: (min v) s04: (max v) s05: (sum v) s06: (count v) s07: (min v) s08: (max v) s09: (sum v) s10: (count v) s11: (min v) s12: (max v) s13: (sum v) s14: (count v) s15: (min v) s16: (max v) s17: (sum v)}))
 (at (meta rs) 'len) -- 17
 (at rs 's17) -- [100]
+
+;; ── projection (no by:, no agg): 20 columns ──
+(set wt (table [c01 c02 c03 c04 c05 c06 c07 c08 c09 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20] (list [1] [2] [3] [4] [5] [6] [7] [8] [9] [10] [11] [12] [13] [14] [15] [16] [17] [18] [19] [20])))
+(set rp (select {from: wt p01: c01 p20: c20 p17: c17 p02: c02 p03: c03 p04: c04 p05: c05 p06: c06 p07: c07 p08: c08 p09: c09 p10: c10 p11: c11 p12: c12 p13: c13 p14: c14 p15: c15 p16: c16 p18: c18 p19: c19}))
+(at (meta rp) 'len) -- 20
+(at rp 'p20) -- [20]

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -136,3 +136,45 @@
 ;; partition broadcasts min(3.0, 5.0) = 3.0 to every row in that partition.
 (set wp (table [p01 p02 p03 p04 p05 p06 p07 p08 p09 p10 p11 p12 p13 p14 p15 p16 p17 v] (list [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [3.0 5.0])))
 (at (window {from: wp part: [p01 p02 p03 p04 p05 p06 p07 p08 p09 p10 p11 p12 p13 p14 p15 p16 p17] funcs: {mn: (min v)}}) 'mn) -- [3.0 3.0]
+
+;; ── nonagg per-group output: pure-arithmetic expression referencing 17
+;; columns, single group (src/ops/query.c collect_col_refs callers in
+;; nonagg_eval_per_group_core/eval_expr_per_row — exact-size scratch carve
+;; replaces the fixed col_syms[16]/cols[16]).  This shape is a PIN, not a
+;; regression probe: a pure-arithmetic nonagg expression with no nested
+;; aggregate is evaluated ONCE against the whole table via bind_all_columns
+;; (src/ops/query.c ray_select_fn's DAG nonagg-fill, ~"R8 fallback" region)
+;; and then split per group by row index — that fast path binds every
+;; column unconditionally and never calls collect_col_refs, so this exact
+;; shape was already correct pre-fix (verified by running it against the
+;; pre-fix binary: identical output). x sums c01..c17 per row: row0 =
+;; 16*1+2=18, row1 = 16*1+3=19; a = (sum c01) = 1+1 = 2.
+(set nw (table [k c01 c02 c03 c04 c05 c06 c07 c08 c09 c10 c11 c12 c13 c14 c15 c16 c17] (list [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [2 3])))
+(set rn (select {from: nw a: (sum c01) x: (+ c01 (+ c02 (+ c03 (+ c04 (+ c05 (+ c06 (+ c07 (+ c08 (+ c09 (+ c10 (+ c11 (+ c12 (+ c13 (+ c14 (+ c15 (+ c16 c17)))))))))))))))) by: {k: k}}))
+(at (meta rn) 'len) -- 3
+(at rn 'a) -- [2]
+(at (at rn 'x) 0) -- [18 19]
+
+;; ── nonagg per-group eval, GENUINE regression probe: same 17-column
+;; arithmetic expression but with a NESTED aggregate ((max c01)) wrapping
+;; the first operand, over TWO groups.  expr_contains_agg forces this
+;; through nonagg_eval_per_group_buf → nonagg_eval_per_group_core (a
+;; single whole-table eval would collapse (max c01) globally instead of
+;; per-group) — exactly the collect_col_refs-capped path the pin above
+;; doesn't reach.  Confirmed pre-fix: collect_col_refs truncates at 16
+;; refs (c01 via `max`, plus c02..c16), drops c17 from col_syms/cols, and
+;; since bind_col_slice only binds the first 16 refs as locals, the
+;; per-group ray_eval of `c17` raised "name: 'c17' undefined" — a hard
+;; error, not a silently wrong value (reproduced against the pre-fix
+;; binary).  Post-fix, ncols(tbl) sizes the carve so all 17 refs are
+;; collected and bound, and the group evaluates cleanly.
+;; Oracle: group k=1 (rows with c17=[2 3]): max(c01)=1, c02..c16 sum to
+;; 15, x = 1+15+c17 = [18 19].  Group k=2 (rows with c17=[4 5]): x =
+;; 1+15+c17 = [20 21].  a = (sum c01) = [2 2] (two rows of c01=1 per group).
+(set nwg (table [k c01 c02 c03 c04 c05 c06 c07 c08 c09 c10 c11 c12 c13 c14 c15 c16 c17] (list [1 1 2 2] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [1 1 1 1] [2 3 4 5])))
+(set rng (select {from: nwg a: (sum c01) x: (+ (max c01) (+ c02 (+ c03 (+ c04 (+ c05 (+ c06 (+ c07 (+ c08 (+ c09 (+ c10 (+ c11 (+ c12 (+ c13 (+ c14 (+ c15 (+ c16 c17)))))))))))))))) by: {k: k}}))
+(at (meta rng) 'len) -- 3
+(at rng 'k) -- [1 2]
+(at rng 'a) -- [2 2]
+(at (at rng 'x) 0) -- [18 19]
+(at (at rng 'x) 1) -- [20 21]

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -80,3 +80,13 @@
 (at (meta rx) 'len) -- 18
 (count (at rx 'k)) -- 100000
 (sum (at rx 'x17)) -- 4999950000
+
+;; ── eval-group path (multi-key + non-agg output): 17 outputs ──
+(set re (select {from: t a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) n1: v by: {k: k g: g}}))
+(at (meta re) 'len) -- 19
+(at re 'a16) -- [30 70]
+
+;; ── count-only pre-take fast path: 17 count outputs with take: ──
+(set rt (select {from: t c01: (count v) c02: (count v) c03: (count v) c04: (count v) c05: (count v) c06: (count v) c07: (count v) c08: (count v) c09: (count v) c10: (count v) c11: (count v) c12: (count v) c13: (count v) c14: (count v) c15: (count v) c16: (count v) c17: (count v) by: {k: k} take: 2}))
+(at (meta rt) 'len) -- 18
+(at rt 'c17) -- [2 2]

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -137,6 +137,18 @@
 (set wp (table [p01 p02 p03 p04 p05 p06 p07 p08 p09 p10 p11 p12 p13 p14 p15 p16 p17 v] (list [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [1 1] [3.0 5.0])))
 (at (window {from: wp part: [p01 p02 p03 p04 p05 p06 p07 p08 p09 p10 p11 p12 p13 p14 p15 p16 p17] funcs: {mn: (min v)}}) 'mn) -- [3.0 3.0]
 
+;; ── nonagg scatter path: 17 pure non-agg outputs, single key.  Retires the
+;; DAG-compile `n_nonaggs >= 16` cap in src/ops/query.c ray_select_fn (the
+;; last of the fixed 16-slot behaviour caps): with by: {k: k} and no aggregate
+;; outputs, each nNN: v collapses to a per-group LIST column.  Group k=1
+;; collects v=[10 20], group k=2 collects v=[30 40]; the 17th output n17
+;; proves the surplus past the former cap survives, not just the head.
+(set rna (select {from: t n01: v n02: v n03: v n04: v n05: v n06: v n07: v n08: v n09: v n10: v n11: v n12: v n13: v n14: v n15: v n16: v n17: v by: {k: k}}))
+(at (meta rna) 'len) -- 18
+(at rna 'k) -- [1 2]
+(at (at rna 'n17) 0) -- [10 20]
+(at (at rna 'n17) 1) -- [30 40]
+
 ;; ── nonagg per-group output: pure-arithmetic expression referencing 17
 ;; columns, single group (src/ops/query.c collect_col_refs callers in
 ;; nonagg_eval_per_group_core/eval_expr_per_row — exact-size scratch carve

--- a/test/test_sort.c
+++ b/test/test_sort.c
@@ -646,15 +646,41 @@ static test_result_t test_sort_indices_zero_rows(void) {
     PASS();
 }
 
-static test_result_t test_sort_indices_too_many_cols(void) {
+static test_result_t test_sort_indices_many_cols(void) {
     ray_heap_init();
     ray_sym_init();
 
-    /* n_cols=17 > 16 → error */
-    ray_t* result = ray_sort_indices(NULL, NULL, NULL, 17, 10);
-    TEST_ASSERT_NOT_NULL(result);
-    TEST_ASSERT_TRUE(RAY_IS_ERR(result));
+    /* n_cols=17 (one past the retired RAY_GROUP_MAX_SLOTS-shaped cap):
+     * sort_indices_ex has no n_cols limit of its own any more — the fixed
+     * 16-key radix_encode_ctx_t fast path just gates itself off above 16
+     * and falls through to the n_cols-unbounded comparator merge sort.
+     * 16 constant columns (every row ties) + one discriminator column
+     * last: ascending order is fully decided by the discriminator. */
+    int64_t n = 2;
+    ray_t* cols[17];
+    int64_t zeros[2] = {0, 0};
+    int64_t disc[2]  = {2, 1};
+    for (int i = 0; i < 16; i++) {
+        cols[i] = ray_vec_from_raw(RAY_I64, zeros, n);
+        TEST_ASSERT_NOT_NULL(cols[i]);
+    }
+    cols[16] = ray_vec_from_raw(RAY_I64, disc, n);
+    TEST_ASSERT_NOT_NULL(cols[16]);
 
+    uint8_t descs[17];
+    for (int i = 0; i < 17; i++) descs[i] = 0;
+
+    ray_t* result = ray_sort_indices(cols, descs, NULL, 17, n);
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(ray_len(result), n);
+    const int64_t* idx = (const int64_t*)ray_data(result);
+    /* disc = [2, 1] ascending → row 1 (disc=1) before row 0 (disc=2) */
+    TEST_ASSERT_EQ_I(idx[0], 1);
+    TEST_ASSERT_EQ_I(idx[1], 0);
+
+    ray_release(result);
+    for (int i = 0; i < 17; i++) ray_release(cols[i]);
     ray_sym_destroy();
     ray_heap_destroy();
     PASS();
@@ -1514,7 +1540,7 @@ const test_entry_t sort_entries[] = {
     /* edge cases */
     { "sort/indices_zero_cols",         test_sort_indices_zero_cols,    NULL, NULL },
     { "sort/indices_zero_rows",         test_sort_indices_zero_rows,    NULL, NULL },
-    { "sort/indices_too_many_cols",     test_sort_indices_too_many_cols, NULL, NULL },
+    { "sort/indices_many_cols",         test_sort_indices_many_cols,    NULL, NULL },
     { "sort/asc_atom_passthrough",      test_asc_atom_passthrough,      NULL, NULL },
     { "sort/asc_single_element",        test_asc_single_element,        NULL, NULL },
     { "sort/asc_not_vec_error",         test_asc_not_vec_error,         NULL, NULL },

--- a/test/test_sort.c
+++ b/test/test_sort.c
@@ -650,8 +650,8 @@ static test_result_t test_sort_indices_many_cols(void) {
     ray_heap_init();
     ray_sym_init();
 
-    /* n_cols=17 (one past the retired RAY_GROUP_MAX_SLOTS-shaped cap):
-     * sort_indices_ex has no n_cols limit of its own any more — the fixed
+    /* n_cols=17 (one past the fixed 16-key radix fast path):
+     * sort_indices_ex has no n_cols limit of its own — the fixed
      * 16-key radix_encode_ctx_t fast path just gates itself off above 16
      * and falls through to the n_cols-unbounded comparator merge sort.
      * 16 constant columns (every row ties) + one discriminator column


### PR DESCRIPTION
Cut 1 of the unbounded-slots migration (spec: docs/superpowers/specs/2026-07-03-unbounded-slots-design.md, local): every collection in the select/group-by pipeline now sizes exactly from its natural bound (dict output count, by/sort/partition spec lengths, group shape) instead of fixed [16] stack arrays. RAY_GROUP_MAX_SLOTS is deleted (grep-zero). The only remaining ceiling is the op graph's uint8_t (255), guarded once at each builder call; cut 2 removes it.

Converted: DAG group-by collectors incl. compound/hidden-agg decomposition, eval-group + count-only paths, scalar reduction, projection, sort keys (compile + executor routing), window part/order/funcs, col-ref/dep-key buffers, v2 engine descriptor tables (13 sites, consolidated into agg_desc_t/agg_vo_t), parted group path.

Bugs fixed along the way:
- scalar-reduction path silently dropped aggregate outputs past 16
- pre-existing stack-buffer overflow in exec_group_parted (key_syms/agg_syms[8], reachable with 9+ keys/aggs on a parted table; ASan-verified repro + regression test)
- keyless >8-aggregate group nyi gate lifted (scalar path is VLA-sized); >32-agg null-mask UB removed

Tests: width_matrix.rfl (per-path width cells 15/16/17/20/33 with hand-derived oracles, provably-routed parallel-dense + radix cells), parted_wide_group.rfl, output_slot_cap/slot_limits flipped from error-assertions to correct-wide-result assertions. Suite 3534/3534 under ASan/UBSan.

Bench gate (vs branch point, best-of-3, release): TAQ 55/55 neutral, agg_v2 11/11 neutral (identical checksums), ClickBench 41/43 neutral; q28/q34 regress ~5% — bisected to a register-allocation artifact of the monolithic exec_group_run (not the carves; extraction attempt measured negative). Accepted by owner; follow-up ticketed with the group-kernel restructuring.