### PR TITLE
group/pivot: retire the ght [8] layout — unbounded slots, cut 4 (migration complete)

### DIFF
--- a/src/core/runtime.c
+++ b/src/core/runtime.c
@@ -22,6 +22,7 @@
  */
 
 #include "runtime.h"
+#include "core/profile.h"   /* g_ray_profile rings — dropped on destroy */
 #include "mem/heap.h"
 #include "mem/sys.h"
 #include "table/sym.h"
@@ -425,6 +426,15 @@ void ray_runtime_destroy(ray_runtime_t* rt) {
 
     __VM = NULL;
     __RUNTIME = NULL;
+
+    /* The profiler rings hold `const char* msg` pointers whose backing
+     * (sym-arena strings, fn-object aux bytes) dies with the runtime.
+     * A process that re-initializes the runtime (the test harness does)
+     * must not let spans from a dead runtime survive into the next one —
+     * .sys.prof would strlen dangling pointers. Drop both rings here. */
+    g_ray_profile.active = false;
+    g_ray_profile.n = 0;
+    g_ray_profile_last.n = 0;
 
     ray_sym_destroy();
     ray_heap_destroy();

--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -3552,13 +3552,22 @@ ray_t* ray_eval(ray_t* obj) {
 
     /* Open a profiling span around the builtin invocation.  Gated on the
      * profiler flag FIRST so the disabled path is a single predicted branch
-     * per call — nothing else runs (pillar-4 zero-cost-off).  When active,
-     * ray_fn_name reads the label inline from the fn object (stable,
-     * NUL-terminated), so there is no allocation. */
+     * per call — nothing else runs (pillar-4 zero-cost-off).  ray_fn_name
+     * reads the label inline from the fn object's aux bytes — stable for
+     * as long as `head` lives, but NOT beyond: a builtin's env slot can be
+     * rebound (e.g. `(set + ...)`), dropping the object's refcount to zero
+     * and freeing those bytes.  The span outlives this call (read later by
+     * `.sys.prof`, possibly after such a rebind), so the raw aux pointer
+     * must not be stored directly.  Intern it instead: the sym table's
+     * arena never frees or relocates an interned string once allocated, so
+     * ray_str_ptr(ray_sym_str(...)) is valid for the rest of the process,
+     * independent of `head`'s lifetime. */
     if (g_ray_profile.active &&
         (head->type == RAY_UNARY || head->type == RAY_BINARY ||
          head->type == RAY_VARY)) {
-        ev_name = ray_fn_name(head);
+        const char* raw_name = ray_fn_name(head);
+        ray_t* name_atom = ray_sym_str(ray_sym_intern(raw_name, strlen(raw_name)));
+        ev_name = name_atom ? ray_str_ptr(name_atom) : raw_name;
         ev_span = ray_profile_span_start(ev_name);
         if (ev_span) {
             ev_idx = (int64_t)g_ray_profile.n - 1;   /* index of this START */

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -6110,10 +6110,12 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl, int64_t group_limit)
         gvm->grp_card_n = 0;
     }
     ray_t* result;
-    /* key_col/dict_sym are one scratch block sized to n_keys (a VLA can't cross
-     * the `goto grp_done` bail-outs below).  wrap_hdr stays NULL on the early
-     * bails.  The wrapper's own n_keys > 8 bail still stands in this commit;
-     * the guard-lift commit retires it so >8-key dict-STR groups are served. */
+    /* Dict-STR key substitution admits any key count (unbounded-slots cut 4):
+     * substituting each dict'd STR key with its int32 code vector rewrites the
+     * group to integer keys, which exec_group_run's v2 engine serves at any
+     * width.  The former n_keys > 8 bail is retired; key_col/dict_sym are one
+     * scratch block sized to n_keys (a VLA can't cross the `goto grp_done`
+     * bail-outs below).  wrap_hdr stays NULL on the early bails. */
     ray_t*  wrap_hdr = NULL;
     ray_t** key_col = NULL;     /* source STR column per dict'd key (for output) */
     int64_t* dict_sym = NULL;
@@ -6121,7 +6123,7 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl, int64_t group_limit)
         result = exec_group_run(g, op, tbl, group_limit); goto grp_done;
     }
     ray_op_ext_t* ext = find_ext(g, op->id);
-    if (!ext || ext->n_keys == 0 || ext->n_keys > 8) {
+    if (!ext || ext->n_keys == 0) {
         result = exec_group_run(g, op, tbl, group_limit); goto grp_done;
     }
 
@@ -6663,12 +6665,11 @@ static ray_t* exec_group_slices(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
 static ray_t* exec_group_v2_exprs(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     if (!tbl || tbl->type != RAY_TABLE) return NULL;
     ray_op_ext_t* ext = find_ext(g, op->id);
-    /* Own gate: this v2-expression shadow path's scratch (synth/names/in_ids/
-     * keys/ins/ins2) is now VLA-sized to n_aggs/n_keys and every index loop
-     * below is uint32_t, but the 16 caps still stand here — the guard-lift
-     * commit retires them. */
-    if (!ext || ext->n_keys < 1 || ext->n_keys > 16 ||
-        ext->n_aggs < 1 || ext->n_aggs > 16) return NULL;
+    /* Own gate: this v2-expression shadow path serves any key/agg count
+     * (unbounded-slots cut 4 — the former 16 caps are retired).  Its scratch
+     * (synth/names/in_ids/keys/ins/ins2) is now VLA-sized to n_aggs/n_keys and
+     * every index loop below is uint32_t. */
+    if (!ext || ext->n_keys < 1 || ext->n_aggs < 1) return NULL;
 
     /* At least one agg input must be a compiled-expression node; scans,
      * COUNT and binary/holistic second inputs pass through untouched. */
@@ -6995,12 +6996,15 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
         }
     }
 
-    /* Width guard still in force here: this commit sizes every entry-staging
-     * buffer on the legacy path to the layout (stack when it fits, one
-     * per-call/per-worker heap block when wider) and widens group_ht_t's
-     * wide-key tables to base pointers, but does NOT yet admit >8-key/>8-agg
-     * shapes — retiring this guard is the following commit. */
-    if (n_keys > 8 || (n_keys > 0 && n_aggs > 8)) return ray_error("nyi", NULL);
+    /* Width guard RETIRED (unbounded-slots cut 4): the legacy ght/scalar
+     * machinery now serves any key/agg count.  ght_layout_t is unbounded
+     * (inline-or-spill); group_ht_t's key_data/key_pool wide-key tables are
+     * base pointers (inline ≤8, heap-spilled wider); every fixed entry-staging
+     * buffer on this path (ebuf/keys/agg_vals/keybuf/ek_buf/kpool + the driver
+     * key_data/key_types/key_attrs) is layout-sized; and per-key null tracking
+     * uses ceil(n_keys/64) mask words (no <64 cap).  Shapes that reach here are
+     * exactly the v2/v2-exprs declines (F64/STR/GUID/expression keys, or
+     * v2-ineligible aggs like FIRST/LAST/PROD/narrow-int-SUM), at any width. */
 
     /* Extract selection (rowsel) for pushdown.  Prefer streaming the
      * morsel-local rowsel directly; flattening to int64 indices is kept
@@ -9118,18 +9122,12 @@ dyn_dense_done:
     }
 
 ht_path:;
-    /* Keyless n_aggs>8 guard still in force: the entry-staging buffers this
-     * fallback uses are now layout-sized, but admitting >8 aggs is deferred to
-     * the guard-lift commit. */
-    if (n_aggs > 8) {
-        for (uint32_t a = 0; a < n_aggs; a++)
-            { if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
-              if (agg_owned2[a] && agg_vecs2[a]) ray_release(agg_vecs2[a]); }
-        for (uint32_t k = 0; k < n_keys; k++)
-            if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
-        if (match_idx_block) { ray_release(match_idx_block); } scratch_free(vla_hdr);
-        return ray_error("nyi", NULL);
-    }
+    /* n_aggs > 8 guard RETIRED (unbounded-slots cut 4): the HT row-layout is
+     * now layout-sized end to end (ght_layout_t agg metadata is unbounded, the
+     * entry-staging buffers spill past 8), so this fallback — reached by the
+     * keyless shapes that skip the scalar fast path (a PEARSON_CORR binary agg,
+     * or an empty table) — serves any agg count.  n_keys > 0 shapes flow the
+     * same machinery. */
     /* The HT row-layout reads agg_vecs directly — convert any fused-product
      * slots into ordinary materialized inputs first. */
     if (!group_materialize_prod_slots(agg_prod, agg_vecs, agg_owned,

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -2308,46 +2308,105 @@ ray_t* exec_reduction(ray_graph_t* g, ray_op_t* op, ray_t* input) {
 
 /* ght_layout_t defined in exec_internal.h */
 
-ght_layout_t ght_compute_layout(uint8_t n_keys, uint8_t n_aggs,
-                                        ray_t** agg_vecs, uint8_t need_flags,
-                                        const uint16_t* agg_ops,
-                                        const int8_t* key_types) {
-    ght_layout_t ly;
-    memset(&ly, 0, sizeof(ly));
-    ly.n_keys = n_keys;
-    ly.n_aggs = n_aggs;
-    ly.need_flags = need_flags;
+/* Aim the base pointers at the in-struct inline arrays (≤ GHT_INLINE case). */
+static inline void ght_layout_point_inline(ght_layout_t* ly) {
+    ly->agg_val_slot  = ly->agg_val_slot_in;
+    ly->agg_flags     = ly->agg_flags_in;
+    ly->agg_dom       = ly->agg_dom_in;
+    ly->key_off       = ly->key_off_in;
+    ly->key_flags     = ly->key_flags_in;
+    ly->wide_key_esz  = ly->wide_key_esz_in;
+    ly->wide_key_type = ly->wide_key_type_in;
+}
 
-    /* Mark wide keys (those that don't fit in 8 bytes).  For each
-     * wide key, the fat-entry and HT-row key slot stores a source
-     * row index; probe/rehash/scatter resolve the actual bytes via
-     * group_ht_t.key_data[k].  Currently only RAY_GUID is supported. */
+/* Carve one owned heap block for a wide (> GHT_INLINE) layout and aim the
+ * base pointers into it.  8-byte-first (agg_dom is a pointer array), then the
+ * uint16 key_off vector, then the byte arrays.  Zero-initialised (scratch_calloc)
+ * to match the memset-cleared inline path.  Unreachable while the width gates
+ * hold; kept correct for later cuts.  Returns false on OOM. */
+static bool ght_layout_alloc_spill(ght_layout_t* ly, uint32_t n_keys, uint32_t n_aggs) {
+    size_t off = 0;
+    size_t dom_off = off;                       off += (size_t)n_aggs * sizeof(void*);
+    size_t koff_off = off;                       off += (size_t)(n_keys + 1) * sizeof(uint16_t);
+    off = (off + 1u) & ~(size_t)1u;              /* re-align not needed after uint16, but keep bytes packed */
+    size_t vslot_off = off;                      off += (size_t)n_aggs;
+    size_t aflags_off = off;                     off += (size_t)n_aggs;
+    size_t kflags_off = off;                     off += (size_t)n_keys;
+    size_t wesz_off = off;                       off += (size_t)n_keys;
+    size_t wtype_off = off;                      off += (size_t)n_keys;
+    char* base = (char*)scratch_calloc(&ly->spill_hdr, off ? off : 1);
+    if (!base) { ly->spill_hdr = NULL; return false; }
+    ly->agg_dom       = (struct ray_sym_domain_s**)(void*)(base + dom_off);
+    ly->key_off       = (uint16_t*)(void*)(base + koff_off);
+    ly->agg_val_slot  = (int8_t*)(base + vslot_off);
+    ly->agg_flags     = (uint8_t*)(base + aflags_off);
+    ly->key_flags     = (uint8_t*)(base + kflags_off);
+    ly->wide_key_esz  = (uint8_t*)(base + wesz_off);
+    ly->wide_key_type = (int8_t*)(base + wtype_off);
+    return true;
+}
+
+void ght_layout_free(ght_layout_t* ly) {
+    if (ly && ly->spill_hdr) { scratch_free(ly->spill_hdr); ly->spill_hdr = NULL; }
+}
+
+void ght_layout_copy(ght_layout_t* dst, const ght_layout_t* src) {
+    *dst = *src;   /* scalars + inline-array CONTENTS; the pointers are wrong */
+    if (src->spill_hdr == NULL) {
+        /* Inline: re-aim the bases at dst's own inline arrays (self-contained
+         * — no dependency on src's lifetime). */
+        ght_layout_point_inline(dst);
+    } else {
+        /* Spilled: BORROW src's shared read-only spill block.  The base
+         * pointers copied above already aim into it; drop ownership so
+         * ght_layout_free(dst) is a no-op — the original frees it, and the
+         * caller must ensure dst does not outlive src. */
+        dst->spill_hdr = NULL;
+    }
+}
+
+bool ght_compute_layout(ght_layout_t* out, uint32_t n_keys, uint32_t n_aggs,
+                        ray_t** agg_vecs, uint8_t need_flags,
+                        const uint16_t* agg_ops,
+                        const int8_t* key_types) {
+    memset(out, 0, sizeof(*out));
+    out->n_keys = (uint16_t)n_keys;
+    out->n_aggs = (uint16_t)n_aggs;
+    out->need_flags = need_flags;
+    /* Inline (≤ GHT_INLINE keys AND aggs) reuses the same cache lines as the
+     * old fixed [8] fields; wider layouts carve one owned spill block. */
+    if (n_keys > GHT_INLINE || n_aggs > GHT_INLINE) {
+        if (!ght_layout_alloc_spill(out, n_keys, n_aggs)) return false;
+    } else {
+        ght_layout_point_inline(out);
+    }
+
+    /* Mark wide keys (those that don't fit in 8 bytes).  For each wide key
+     * the fat-entry / HT-row key slot stores a source row index; probe/rehash/
+     * scatter resolve the actual bytes via group_ht_t.key_data[k].  RAY_STR
+     * keys additionally store the 16-byte ray_str_t descriptor INLINE in the
+     * key region (GHT_KEYF_INLINE_STR) so hash/eq are cache-local (key_pool[k]
+     * still used for >12 B full eq). */
     if (key_types) {
-        /* `&& k < 8`: wide_key_mask/wide_key_esz/wide_key_type are fixed
-         * uint8_t bitmask + [8] arrays in ght_layout_t — a structural cap
-         * independent of any caller's own n_keys gate (cut-4 boundary). */
-        for (uint8_t k = 0; k < n_keys && k < 8; k++) {
+        for (uint32_t k = 0; k < n_keys; k++) {
             if (key_types[k] == RAY_GUID) {
-                ly.wide_key_mask |= (uint8_t)(1u << k);
-                ly.wide_key_esz[k] = 16;
-                ly.wide_key_type[k] = RAY_GUID;
+                out->key_flags[k] = GHT_KEYF_WIDE;
+                out->wide_key_esz[k] = 16;
+                out->wide_key_type[k] = RAY_GUID;
+                out->any_wide_key = 1;
             } else if (key_types[k] == RAY_STR) {
-                /* STR key: store the 16-byte ray_str_t descriptor INLINE in the
-                 * entry/row key region (key_inline_str) so probe/rehash/compare
-                 * read it cache-locally — no key_data[k]+row*16 source chase.
-                 * key_pool[k] (source pool) is still used for >12 B full eq. */
-                ly.wide_key_mask |= (uint8_t)(1u << k);
-                ly.wide_key_esz[k] = (uint8_t)sizeof(ray_str_t);
-                ly.wide_key_type[k] = RAY_STR;
-                ly.key_inline_str |= (uint8_t)(1u << k);
+                out->key_flags[k] = (uint8_t)(GHT_KEYF_WIDE | GHT_KEYF_INLINE_STR);
+                out->wide_key_esz[k] = (uint8_t)sizeof(ray_str_t);
+                out->wide_key_type[k] = RAY_STR;
+                out->any_wide_key = 1;
+                out->any_inline_str = 1;
             }
         }
     }
 
-    uint8_t nv = 0;
-    /* `&& a < 8`: the agg_is_* fields below are uint8_t bitmasks / [8]
-     * arrays in ght_layout_t — same structural cap as the key loop above. */
-    for (uint8_t a = 0; a < n_aggs && a < 8; a++) {
+    uint16_t nv = 0;
+    uint8_t agg_any = 0;
+    for (uint32_t a = 0; a < n_aggs; a++) {
         /* OP_MEDIAN / OP_TOP_N / OP_BOT_N reserve no row-layout slot —
          * the column is materialized in agg_vecs[a] but values are not
          * packed into entries or HT rows.  A post-radix pass over
@@ -2365,92 +2424,97 @@ ght_layout_t ght_compute_layout(uint8_t n_keys, uint8_t n_aggs,
         bool holistic = agg_ops && (agg_ops[a] == OP_MEDIAN ||
                                     agg_ops[a] == OP_TOP_N ||
                                     agg_ops[a] == OP_BOT_N || wide_mm);
+        uint8_t af = 0;
         if (holistic) {
-            ly.agg_is_holistic |= (uint8_t)(1u << a);
-            if (wide_mm) ly.agg_is_wide |= (uint8_t)(1u << a);
-            ly.agg_val_slot[a] = -1;
+            af |= GHT_AF_HOLISTIC;
+            if (wide_mm) af |= GHT_AF_WIDE;
+            out->agg_val_slot[a] = -1;
         } else if (agg_vecs[a]) {
-            ly.agg_val_slot[a] = (int8_t)nv;
+            out->agg_val_slot[a] = (int8_t)nv;
             if (agg_vecs[a]->type == RAY_F64)
-                ly.agg_is_f64 |= (1u << a);
+                af |= GHT_AF_F64;
             if (agg_vecs[a]->type == RAY_SYM) {
-                ly.agg_is_sym |= (1u << a);
+                af |= GHT_AF_SYM;
                 /* lex MIN/MAX resolves cell ids through the COLUMN's
                  * domain (borrowed; the agg vec outlives the layout). */
-                ly.agg_dom[a] = ray_sym_vec_domain(agg_vecs[a]);
+                out->agg_dom[a] = ray_sym_vec_domain(agg_vecs[a]);
             }
             nv++;
             /* Binary aggregator (OP_PEARSON_CORR): the y-side input
              * occupies the very next slot so phase1 packs (x, y)
-             * consecutively.  agg_is_binary bit drives that packing. */
+             * consecutively.  GHT_AF_BINARY drives that packing. */
             if (agg_ops && agg_ops[a] == OP_PEARSON_CORR) {
-                ly.agg_is_binary |= (uint8_t)(1u << a);
+                af |= GHT_AF_BINARY;
                 nv++;
             }
         } else {
-            ly.agg_val_slot[a] = -1;
+            out->agg_val_slot[a] = -1;
         }
         if (agg_ops && !wide_mm) {
             /* wide first/last are resolved holistically and need no
              * entry-tail row slot, so they are excluded here. */
-            if (agg_ops[a] == OP_FIRST) ly.agg_is_first |= (1u << a);
-            if (agg_ops[a] == OP_LAST)  ly.agg_is_last  |= (1u << a);
-            if (agg_ops[a] == OP_PROD)  ly.agg_is_prod  |= (1u << a);
+            if (agg_ops[a] == OP_FIRST) af |= GHT_AF_FIRST;
+            if (agg_ops[a] == OP_LAST)  af |= GHT_AF_LAST;
+            if (agg_ops[a] == OP_PROD)  af |= GHT_AF_PROD;
         }
+        out->agg_flags[a] = af;
+        agg_any |= af;
     }
-    ly.n_agg_vals = nv;
-    /* Key region = n_keys*8 + 8-byte null mask slot (stored after last key).
+    out->n_agg_vals = nv;
+    out->agg_flags_any = agg_any;
+    /* Key region = keys + 8-byte null mask slot (stored after last key).
      * The null mask slot holds a bitmap of which keys were null in the source
      * row (bit k = key k is null). Folding this slot into hash/memcmp lets
-     * null and 0 form distinct groups. */
-    /* Per-key byte offsets within the key region.  Inline-STR keys are 16 B,
-     * all others 8 B; key_off[n_keys] is the trailing 8-byte null-mask slot.
-     * When no inline-STR key is present every offset is k*8 (byte-identical to
-     * the legacy fixed-8 layout, so non-STR group-bys are unchanged). */
+     * null and 0 form distinct groups.  Inline-STR keys are 16 B, all others
+     * 8 B; when no inline-STR key is present every offset is k*8 (byte-identical
+     * to the legacy fixed-8 layout, so non-STR group-bys are unchanged). */
     {
-        uint16_t koff = 0;
-        /* `&& k < 8`: key_off is a fixed [9] array in ght_layout_t (same
-         * structural cap as the loops above). */
-        for (uint8_t k = 0; k < n_keys && k < 8; k++) {
-            ly.key_off[k] = koff;
-            koff += (ly.key_inline_str & (1u << k)) ? 16 : 8;
+        uint32_t koff = 0;
+        for (uint32_t k = 0; k < n_keys; k++) {
+            /* stride budget, not a slot count: key_off / key_region are uint16,
+             * so the whole key region must fit in 64 KiB. */
+            if (koff > UINT16_MAX) { ght_layout_free(out); return false; }
+            out->key_off[k] = (uint16_t)koff;
+            koff += (out->key_flags[k] & GHT_KEYF_INLINE_STR) ? 16 : 8;
         }
-        ly.key_off[n_keys] = koff;   /* null mask */
+        if (koff > UINT16_MAX) { ght_layout_free(out); return false; }
+        out->key_off[n_keys] = (uint16_t)koff;   /* null mask */
         koff += 8;
-        ly.key_region = koff;
+        if (koff > UINT16_MAX) { ght_layout_free(out); return false; }  /* stride budget, not a slot count */
+        out->key_region = (uint16_t)koff;
     }
-    uint16_t key_region = ly.key_region;
+    uint16_t key_region = out->key_region;
     /* Entry layout: hash | keys | null_mask | agg_vals | [entry_row?]
      * Tail entry_row slot is appended only when any agg is FIRST/LAST,
      * carrying the source-row index needed to merge correctly under
      * work-stealing dispatch (see radix_phase1_fn / accum_from_entry). */
-    bool has_first_last = (ly.agg_is_first | ly.agg_is_last) != 0;
+    bool has_first_last = (agg_any & (GHT_AF_FIRST | GHT_AF_LAST)) != 0;
     uint16_t entry_tail = has_first_last ? (uint16_t)8 : (uint16_t)0;
-    ly.entry_stride = (uint16_t)(8 + key_region + (uint16_t)nv * 8 + entry_tail);
+    out->entry_stride = (uint16_t)(8 + key_region + (uint16_t)nv * 8 + entry_tail);
 
     uint16_t off = (uint16_t)(8 + key_region);
     uint16_t block = (uint16_t)nv * 8;
-    if (need_flags & GHT_NEED_SUM)   { ly.off_sum   = off; off += block; }
-    if (need_flags & GHT_NEED_MIN)   { ly.off_min   = off; off += block; }
-    if (need_flags & GHT_NEED_MAX)   { ly.off_max   = off; off += block; }
-    if (need_flags & GHT_NEED_SUMSQ) { ly.off_sumsq = off; off += block; }
+    if (need_flags & GHT_NEED_SUM)   { out->off_sum   = off; off += block; }
+    if (need_flags & GHT_NEED_MIN)   { out->off_min   = off; off += block; }
+    if (need_flags & GHT_NEED_MAX)   { out->off_max   = off; off += block; }
+    if (need_flags & GHT_NEED_SUMSQ) { out->off_sumsq = off; off += block; }
     /* Per-slot row-index bounds for FIRST/LAST.  Two int64 blocks of
      * n_agg_vals slots each, allocated only when needed. */
     if (has_first_last) {
-        ly.off_first_row = off; off += block;
-        ly.off_last_row  = off; off += block;
+        out->off_first_row = off; off += block;
+        out->off_last_row  = off; off += block;
     }
     /* PEARSON y-side accumulators (Σy, Σy², Σxy).  Allocated when any
      * OP_PEARSON_CORR agg is present.  x-side reuses off_sum + off_sumsq
      * at the same slot index; the y value lives at slot+1 in agg_vals,
      * but its derived accumulators live in their own blocks below. */
     if (need_flags & GHT_NEED_PEARSON) {
-        ly.off_sum_y   = off; off += block;
-        ly.off_sumsq_y = off; off += block;
-        ly.off_sumxy   = off; off += block;
+        out->off_sum_y   = off; off += block;
+        out->off_sumsq_y = off; off += block;
+        out->off_sumxy   = off; off += block;
     }
-    ly.row_stride = off;
-    return ly;
+    out->row_stride = off;
+    return true;
 }
 
 /* Packed HT slots: [salt:8 | gid:24] in 4 bytes.
@@ -2467,7 +2531,10 @@ static bool group_ht_init_sized(group_ht_t* ht, uint32_t cap,
                                  const ght_layout_t* ly, uint32_t init_grp_cap) {
     ht->ht_cap = cap;
     ht->oom = 0;
-    ht->layout = *ly;
+    /* By-value embed: re-point the layout's bases at this HT's own inline
+     * arrays (inline src) or borrow the shared spill (wide src).  The source
+     * layout (owned by the caller's exec_group/pivot master) outlives this HT. */
+    ght_layout_copy(&ht->layout, ly);
     /* key_data must be populated by the caller via group_ht_set_key_data
      * whenever wide_key_mask != 0. */
     memset(ht->key_data, 0, sizeof(ht->key_data));
@@ -2489,11 +2556,11 @@ bool group_ht_init(group_ht_t* ht, uint32_t cap, const ght_layout_t* ly) {
 /* Populate key_data[k] for wide-key resolution. Called by the HT path
  * right after group_ht_init / group_ht_init_sized when any key is wide. */
 static inline void group_ht_set_key_data(group_ht_t* ht, void** kd) {
-    uint8_t mask = ht->layout.wide_key_mask;
-    if (!mask || !kd) return;
+    if (!ht->layout.any_wide_key || !kd) return;
+    const uint8_t* const kflags = ht->layout.key_flags;
     /* `&& k < 8`: group_ht_t.key_data is a fixed [8] array (internal.h). */
-    for (uint8_t k = 0; k < ht->layout.n_keys && k < 8; k++) {
-        if (mask & (1u << k)) ht->key_data[k] = kd[k];
+    for (uint16_t k = 0; k < ht->layout.n_keys && k < 8; k++) {
+        if (kflags[k] & GHT_KEYF_WIDE) ht->key_data[k] = kd[k];
     }
 }
 
@@ -2503,9 +2570,9 @@ static inline void group_ht_set_key_data(group_ht_t* ht, void** kd) {
 static inline void derive_key_pool(const ght_layout_t* ly, ray_t* const* key_vecs,
                                    const void** out) {
     /* `&& k < 8`: `out` is the caller's key_pool[8] (group_ht_t, fixed). */
-    for (uint8_t k = 0; k < ly->n_keys && k < 8; k++) {
+    for (uint16_t k = 0; k < ly->n_keys && k < 8; k++) {
         out[k] = NULL;
-        if ((ly->wide_key_mask & (1u << k)) && ly->wide_key_type[k] == RAY_STR
+        if ((ly->key_flags[k] & GHT_KEYF_WIDE) && ly->wide_key_type[k] == RAY_STR
             && key_vecs && key_vecs[k]) {
             ray_t* kv = key_vecs[k];
             ray_t* owner = (kv->attrs & RAY_ATTR_SLICE) ? kv->slice_parent : kv;
@@ -2517,16 +2584,16 @@ static inline void derive_key_pool(const ght_layout_t* ly, ray_t* const* key_vec
 
 /* From key columns (derives the pool). */
 static inline void group_ht_set_key_pool(group_ht_t* ht, ray_t* const* key_vecs) {
-    if (ht->layout.wide_key_mask && key_vecs)
+    if (ht->layout.any_wide_key && key_vecs)
         derive_key_pool(&ht->layout, key_vecs, ht->key_pool);
 }
 /* From a precomputed pool array (ctxs that carry it but not the key columns). */
 static inline void group_ht_copy_key_pool(group_ht_t* ht, const void* const* kp) {
-    uint8_t mask = ht->layout.wide_key_mask;
-    if (!mask || !kp) return;
+    if (!ht->layout.any_wide_key || !kp) return;
+    const uint8_t* const kflags = ht->layout.key_flags;
     /* `&& k < 8`: group_ht_t.key_pool is a fixed [8] array (internal.h). */
-    for (uint8_t k = 0; k < ht->layout.n_keys && k < 8; k++)
-        if (mask & (1u << k)) ht->key_pool[k] = kp[k];
+    for (uint16_t k = 0; k < ht->layout.n_keys && k < 8; k++)
+        if (kflags[k] & GHT_KEYF_WIDE) ht->key_pool[k] = kp[k];
 }
 
 void group_ht_free(group_ht_t* ht) {
@@ -2598,10 +2665,10 @@ static inline uint64_t inline_layout_key_hash(const ght_layout_t* ly, uint8_t k,
                                               const int8_t* key_types,
                                               const void* keybase, void* const* key_data,
                                               const void* const* key_pool) {
-    if (ly->key_inline_str & (1u << k))
+    if (ly->key_flags[k] & GHT_KEYF_INLINE_STR)
         return inline_str_hash(ly, k, keybase, key_pool);
     int64_t v = *(const int64_t*)((const char*)keybase + ly->key_off[k]);
-    if (ly->wide_key_mask & (1u << k))            /* GUID: v is a source row idx */
+    if (ly->key_flags[k] & GHT_KEYF_WIDE)         /* GUID: v is a source row idx */
         return wide_key_hash_at(ly, k, key_data, key_pool, v);
     if (key_types[k] == RAY_F64) {
         double dv; memcpy(&dv, &v, 8); return ray_hash_f64(dv);
@@ -2623,22 +2690,24 @@ static inline uint64_t inline_build_keys(const ght_layout_t* ly, const int8_t* k
      * `null_mask |= ((int64_t)1 << k)` site in this file shifts in the int64
      * domain (not 32-bit then widen) so it stays defined once it is. */
     int64_t null_mask = 0;
-    uint8_t nk = ly->n_keys;
+    uint16_t nk = ly->n_keys;
+    const uint8_t* const kflags = ly->key_flags;
+    const uint16_t* const koff = ly->key_off;
     for (uint32_t k = 0; k < nk; k++) {
-        char* slot = keybase + ly->key_off[k];
+        char* slot = keybase + koff[k];
         uint64_t kh;
         bool is_null = (nullable & (1u << k)) && key_vecs && key_vecs[k]
                        && ray_vec_is_null(key_vecs[k], row);
         if (is_null) {
             null_mask |= ((int64_t)1 << k);
-            if (ly->key_inline_str & (1u << k)) memset(slot, 0, sizeof(ray_str_t));
+            if (kflags[k] & GHT_KEYF_INLINE_STR) memset(slot, 0, sizeof(ray_str_t));
             else *(int64_t*)slot = 0;
             kh = ray_hash_i64(0);
-        } else if (ly->key_inline_str & (1u << k)) {
+        } else if (kflags[k] & GHT_KEYF_INLINE_STR) {
             *(ray_str_t*)slot = ((const ray_str_t*)key_data[k])[row];
             kh = ray_str_t_hash((const ray_str_t*)slot,
                                 key_pool ? (const char*)key_pool[k] : NULL);
-        } else if (ly->wide_key_mask & (1u << k)) {        /* GUID: row index */
+        } else if (kflags[k] & GHT_KEYF_WIDE) {            /* GUID: row index */
             *(int64_t*)slot = row;
             kh = wide_key_hash_at(ly, k, key_data, key_pool, row);
         } else if (key_types[k] == RAY_F64) {
@@ -2651,7 +2720,7 @@ static inline uint64_t inline_build_keys(const ght_layout_t* ly, const int8_t* k
         }
         h = (k == 0) ? kh : ray_hash_combine(h, kh);
     }
-    *(int64_t*)(keybase + ly->key_off[nk]) = null_mask;
+    *(int64_t*)(keybase + koff[nk]) = null_mask;
     if (null_mask) h = ray_hash_combine(h, ray_hash_i64(null_mask));
     *out_null_mask = null_mask;
     return h;
@@ -2660,11 +2729,10 @@ static inline uint64_t inline_build_keys(const ght_layout_t* ly, const int8_t* k
 /* Hash inline int64_t keys (for rehash — resolves wide keys via
  * the HT's key_data pointers). */
 static inline uint64_t hash_keys_inline(const int64_t* keys, const int8_t* key_types,
-                                         uint8_t n_keys, uint8_t wide_mask,
-                                         const uint8_t* wide_esz, void* const* key_data,
+                                         uint16_t n_keys, void* const* key_data,
                                          const ght_layout_t* ly,
                                          const void* const* key_pool) {
-    if (ly->key_inline_str) {
+    if (ly->any_inline_str) {
         /* Inline-STR layout: key offsets are shifted by 16-byte descriptors,
          * so address every key via key_off[k] and hash the inline descriptor. */
         uint64_t h = 0;
@@ -2676,10 +2744,11 @@ static inline uint64_t hash_keys_inline(const int64_t* keys, const int8_t* key_t
         if (null_mask) h = ray_hash_combine(h, ray_hash_i64(null_mask));
         return h;
     }
+    const uint8_t* const kflags = ly->key_flags;
     uint64_t h = 0;
     for (uint32_t k = 0; k < n_keys; k++) {
         uint64_t kh;
-        if (wide_mask & (1u << k)) {
+        if (kflags[k] & GHT_KEYF_WIDE) {
             /* Wide key: keys[k] is the source row index.  Resolve + hash the
              * actual bytes (GUID fixed / STR SSO via pool). */
             kh = wide_key_hash_at(ly, k, key_data, key_pool, keys[k]);
@@ -2711,12 +2780,10 @@ static void group_ht_rehash(group_ht_t* ht, const int8_t* key_types) {
     ht->ht_cap = new_cap;
     uint32_t mask = new_cap - 1;
     uint16_t rs = ht->layout.row_stride;
-    uint8_t nk = ht->layout.n_keys;
-    uint8_t wide = ht->layout.wide_key_mask;
+    uint16_t nk = ht->layout.n_keys;
     for (uint32_t gi = 0; gi < ht->grp_count; gi++) {
         const int64_t* row_keys = (const int64_t*)(ht->rows + (size_t)gi * rs + 8);
-        uint64_t h = hash_keys_inline(row_keys, key_types, nk, wide,
-                                       ht->layout.wide_key_esz, ht->key_data,
+        uint64_t h = hash_keys_inline(row_keys, key_types, nk, ht->key_data,
                                        &ht->layout, ht->key_pool);
         uint32_t slot = (uint32_t)(h & mask);
         while (ht->slots[slot] != HT_EMPTY)
@@ -2734,25 +2801,31 @@ static inline void init_accum_from_entry(char* row, const char* entry,
         memset(row + accum_start, 0, ly->row_stride - accum_start);
 
     const char* agg_data = entry + 8 + (size_t)ly->key_region;
-    uint8_t na = ly->n_aggs;
+    uint16_t na = ly->n_aggs;
     uint8_t nf = ly->need_flags;
-    bool has_fl = (ly->agg_is_first | ly->agg_is_last) != 0;
+    bool has_fl = (ly->agg_flags_any & (GHT_AF_FIRST | GHT_AF_LAST)) != 0;
     /* Entry tail slot carries the source-row index when has_fl. */
     int64_t entry_row = 0;
     if (has_fl)
         memcpy(&entry_row, entry + ly->entry_stride - 8, 8);
 
-    uint8_t bin_mask = ly->agg_is_binary;
+    /* Hoist the per-agg base pointers to const locals before the row loop
+     * (cut-3 register-promotion doctrine): each agg reads one agg_flags[a]
+     * byte (register bit-tests) instead of several distinct in-struct mask
+     * loads. */
+    const int8_t*  const vslot  = ly->agg_val_slot;
+    const uint8_t* const aflags = ly->agg_flags;
     for (uint32_t a = 0; a < na; a++) {
-        int8_t s = ly->agg_val_slot[a];
+        int8_t s = vslot[a];
         if (s < 0) continue;
+        uint8_t af = aflags[a];
         /* Copy raw 8 bytes from entry into each enabled accumulator block */
         if (nf & GHT_NEED_SUM) memcpy(row + ly->off_sum + s * 8, agg_data + s * 8, 8);
         if (nf & GHT_NEED_MIN) memcpy(row + ly->off_min + s * 8, agg_data + s * 8, 8);
         if (nf & GHT_NEED_MAX) memcpy(row + ly->off_max + s * 8, agg_data + s * 8, 8);
         if (nf & GHT_NEED_SUMSQ) {
             /* sumsq = v * v for the first entry */
-            if (ly->agg_is_f64 & (1u << a)) {
+            if (af & GHT_AF_F64) {
                 double v; memcpy(&v, agg_data + s * 8, 8);
                 double sq = v * v;
                 memcpy(row + ly->off_sumsq + s * 8, &sq, 8);
@@ -2767,9 +2840,9 @@ static inline void init_accum_from_entry(char* row, const char* entry,
          * blocks above (OP_PEARSON_CORR sets both need-flags).  Reads
          * the typed bit-pattern packed by phase1 — F64 stays double,
          * i64 reinterprets and casts. */
-        if ((nf & GHT_NEED_PEARSON) && (bin_mask & (1u << a))) {
+        if ((nf & GHT_NEED_PEARSON) && (af & GHT_AF_BINARY)) {
             double x, y;
-            if (ly->agg_is_f64 & (1u << a)) {
+            if (af & GHT_AF_F64) {
                 memcpy(&x, agg_data +  s      * 8, 8);
                 memcpy(&y, agg_data + (s + 1) * 8, 8);
             } else {
@@ -2803,47 +2876,55 @@ static inline void init_accum_from_entry(char* row, const char* entry,
 static inline void accum_from_entry(char* row, const char* entry,
                                      const ght_layout_t* ly) {
     const char* agg_data = entry + 8 + (size_t)ly->key_region;
-    uint8_t na = ly->n_aggs;
+    uint16_t na = ly->n_aggs;
     uint8_t nf = ly->need_flags;
     /* Entry's source-row index — only present when any agg is FIRST/LAST.
      * Pool dispatch is work-stealing (atomic_fetch_add), so phase1 may
      * scatter entries into radix bufs out of source-row order; reading
      * the row index from the entry restores the absolute ordering that
      * "keep init / always overwrite" assumed. */
-    bool has_fl = (ly->agg_is_first | ly->agg_is_last) != 0;
+    bool has_fl = (ly->agg_flags_any & (GHT_AF_FIRST | GHT_AF_LAST)) != 0;
     int64_t entry_row = 0;
     if (has_fl)
         memcpy(&entry_row, entry + ly->entry_stride - 8, 8);
 
+    /* Hoist the per-agg base pointers to const locals BEFORE the row loop —
+     * the single most-exposed layout read in the engine (once per agg per
+     * aggregating row).  Each agg loads one agg_flags[a] byte and bit-tests
+     * it in registers, replacing the old six distinct in-struct mask loads
+     * (agg_is_f64/first/last/prod/sym/binary). */
+    const int8_t*  const vslot  = ly->agg_val_slot;
+    const uint8_t* const aflags = ly->agg_flags;
+    struct ray_sym_domain_s* const* const adom = ly->agg_dom;
     for (uint32_t a = 0; a < na; a++) {
-        int8_t s = ly->agg_val_slot[a];
+        int8_t s = vslot[a];
         if (s < 0) continue;
         const char* val = agg_data + s * 8;
 
-        uint8_t amask = (1u << a);
+        uint8_t af = aflags[a];
         bool take_first = false, take_last = false;
-        if (has_fl && (ly->agg_is_first & amask)) {
+        if (has_fl && (af & GHT_AF_FIRST)) {
             int64_t fr; memcpy(&fr, row + ly->off_first_row + s * 8, 8);
             take_first = (entry_row < fr);
         }
-        if (has_fl && (ly->agg_is_last & amask)) {
+        if (has_fl && (af & GHT_AF_LAST)) {
             int64_t lr; memcpy(&lr, row + ly->off_last_row + s * 8, 8);
             take_last = (entry_row > lr);
         }
-        if (ly->agg_is_f64 & amask) {
+        if (af & GHT_AF_F64) {
             double v;
             memcpy(&v, val, 8);
             if (nf & GHT_NEED_SUM) {
-                if (ly->agg_is_first & amask) { if (take_first) memcpy(row + ly->off_sum + s * 8, val, 8); }
-                else if (ly->agg_is_last & amask) { if (take_last) memcpy(row + ly->off_sum + s * 8, val, 8); }
-                else if (ly->agg_is_prod & amask) { ROW_WR_F64(row, ly->off_sum, s) *= v; }
+                if (af & GHT_AF_FIRST) { if (take_first) memcpy(row + ly->off_sum + s * 8, val, 8); }
+                else if (af & GHT_AF_LAST) { if (take_last) memcpy(row + ly->off_sum + s * 8, val, 8); }
+                else if (af & GHT_AF_PROD) { ROW_WR_F64(row, ly->off_sum, s) *= v; }
                 else { ROW_WR_F64(row, ly->off_sum, s) += v; }
             }
             if (nf & GHT_NEED_MIN) { double* p = &ROW_WR_F64(row, ly->off_min, s); if (v < *p) *p = v; }
             if (nf & GHT_NEED_MAX) { double* p = &ROW_WR_F64(row, ly->off_max, s); if (v > *p) *p = v; }
             if (nf & GHT_NEED_SUMSQ) { ROW_WR_F64(row, ly->off_sumsq, s) += v * v; }
             /* PEARSON y-side: accumulate Σy, Σy², Σxy.  v above is x. */
-            if ((nf & GHT_NEED_PEARSON) && (ly->agg_is_binary & amask)) {
+            if ((nf & GHT_NEED_PEARSON) && (af & GHT_AF_BINARY)) {
                 double y;
                 memcpy(&y, agg_data + (s + 1) * 8, 8);
                 ROW_WR_F64(row, ly->off_sum_y,   s) += y;
@@ -2854,27 +2935,27 @@ static inline void accum_from_entry(char* row, const char* entry,
             int64_t v;
             memcpy(&v, val, 8);
             if (nf & GHT_NEED_SUM) {
-                if (ly->agg_is_first & amask) { if (take_first) memcpy(row + ly->off_sum + s * 8, val, 8); }
-                else if (ly->agg_is_last & amask) { if (take_last) memcpy(row + ly->off_sum + s * 8, val, 8); }
-                else if (ly->agg_is_prod & amask) { ROW_WR_I64(row, ly->off_sum, s) = (int64_t)((uint64_t)ROW_RD_I64(row, ly->off_sum, s) * (uint64_t)v); }
+                if (af & GHT_AF_FIRST) { if (take_first) memcpy(row + ly->off_sum + s * 8, val, 8); }
+                else if (af & GHT_AF_LAST) { if (take_last) memcpy(row + ly->off_sum + s * 8, val, 8); }
+                else if (af & GHT_AF_PROD) { ROW_WR_I64(row, ly->off_sum, s) = (int64_t)((uint64_t)ROW_RD_I64(row, ly->off_sum, s) * (uint64_t)v); }
                 else { ROW_WR_I64(row, ly->off_sum, s) += v; }
             }
             if (nf & GHT_NEED_MIN) {
                 int64_t* p = &ROW_WR_I64(row, ly->off_min, s);
-                if (ly->agg_is_sym & amask) {
-                    if (*p == INT64_MAX || sym_lex_lt(ly->agg_dom[a], v, *p)) *p = v;
+                if (af & GHT_AF_SYM) {
+                    if (*p == INT64_MAX || sym_lex_lt(adom[a], v, *p)) *p = v;
                 } else if (v < *p) *p = v;
             }
             if (nf & GHT_NEED_MAX) {
                 int64_t* p = &ROW_WR_I64(row, ly->off_max, s);
-                if (ly->agg_is_sym & amask) {
-                    if (*p == INT64_MIN || sym_lex_gt(ly->agg_dom[a], v, *p)) *p = v;
+                if (af & GHT_AF_SYM) {
+                    if (*p == INT64_MIN || sym_lex_gt(adom[a], v, *p)) *p = v;
                 } else if (v > *p) *p = v;
             }
             if (nf & GHT_NEED_SUMSQ) { ROW_WR_F64(row, ly->off_sumsq, s) += (double)v * (double)v; }
             /* PEARSON y-side (i64 input branch): y was packed via
              * read_col_i64 — reinterpret as int64 then cast to double. */
-            if ((nf & GHT_NEED_PEARSON) && (ly->agg_is_binary & amask)) {
+            if ((nf & GHT_NEED_PEARSON) && (af & GHT_AF_BINARY)) {
                 int64_t yi; memcpy(&yi, agg_data + (s + 1) * 8, 8);
                 double y  = (double)yi;
                 double xd = (double)v;
@@ -2897,34 +2978,35 @@ static inline void accum_from_entry(char* row, const char* entry,
 static inline bool group_keys_equal(const int64_t* a_keys, const int64_t* b_keys,
                                       const ght_layout_t* ly, void* const* key_data,
                                       const void* const* key_pool) {
-    uint8_t wide = ly->wide_key_mask;
-    uint8_t nk = ly->n_keys;
-    if (wide == 0) {
+    uint16_t nk = ly->n_keys;
+    if (!ly->any_wide_key) {
         /* memcmp covers nk values + trailing 8-byte null mask slot */
         return memcmp(a_keys, b_keys, (size_t)(nk + 1) * 8) == 0;
     }
-    if (ly->key_inline_str) {
+    const uint8_t* const kflags = ly->key_flags;
+    const uint16_t* const koff = ly->key_off;
+    if (ly->any_inline_str) {
         /* Inline-STR layout: address every key via key_off[k]; STR keys compare
          * their inline descriptors cache-locally (pool only for >12 B). */
         const char* a = (const char*)a_keys;
         const char* b = (const char*)b_keys;
         for (uint32_t k = 0; k < nk; k++) {
-            if (ly->key_inline_str & (1u << k)) {
+            if (kflags[k] & GHT_KEYF_INLINE_STR) {
                 if (!inline_str_eq(ly, k, a_keys, b_keys, key_pool)) return false;
-            } else if (wide & (1u << k)) {           /* GUID: row indices */
-                int64_t ra = *(const int64_t*)(a + ly->key_off[k]);
-                int64_t rb = *(const int64_t*)(b + ly->key_off[k]);
+            } else if (kflags[k] & GHT_KEYF_WIDE) {  /* GUID: row indices */
+                int64_t ra = *(const int64_t*)(a + koff[k]);
+                int64_t rb = *(const int64_t*)(b + koff[k]);
                 if (!wide_key_eq_at(ly, k, key_data, key_pool, ra, rb)) return false;
             } else {
-                if (*(const int64_t*)(a + ly->key_off[k]) !=
-                    *(const int64_t*)(b + ly->key_off[k])) return false;
+                if (*(const int64_t*)(a + koff[k]) !=
+                    *(const int64_t*)(b + koff[k])) return false;
             }
         }
-        return *(const int64_t*)(a + ly->key_off[nk]) ==
-               *(const int64_t*)(b + ly->key_off[nk]);
+        return *(const int64_t*)(a + koff[nk]) ==
+               *(const int64_t*)(b + koff[nk]);
     }
     for (uint32_t k = 0; k < nk; k++) {
-        if (wide & (1u << k)) {
+        if (kflags[k] & GHT_KEYF_WIDE) {
             if (!wide_key_eq_at(ly, k, key_data, key_pool, a_keys[k], b_keys[k]))
                 return false;
         } else {
@@ -2955,7 +3037,7 @@ static inline uint32_t group_probe_entry(group_ht_t* ht,
      * rows, ~7 ms wall on q15.  Skip the call when none of the flags
      * that drive its writes are set. */
     uint8_t accum_skip = (ly->need_flags == 0
-        && (ly->agg_is_first | ly->agg_is_last | ly->agg_is_binary) == 0);
+        && (ly->agg_flags_any & (GHT_AF_FIRST | GHT_AF_LAST | GHT_AF_BINARY)) == 0);
     for (;;) {
         uint32_t sv = ht->slots[slot];
         if (sv == HT_EMPTY) {
@@ -3027,10 +3109,16 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
                               int64_t start, int64_t end,
                               const int64_t* match_idx) {
     const ght_layout_t* ly = &ht->layout;
-    uint8_t nk = ly->n_keys;
-    uint8_t na = ly->n_aggs;
-    uint8_t wide = ly->wide_key_mask;
-    bool has_fl = (ly->agg_is_first | ly->agg_is_last) != 0;
+    uint16_t nk = ly->n_keys;
+    uint16_t na = ly->n_aggs;
+    /* Hoisted per-key / per-agg flag bases + scalar shape guards (cut-3
+     * register-promotion doctrine): the common int/sym-key numeric path has
+     * both guards 0, so the wide/inline/holistic per-slot branches short-
+     * circuit on a register test without touching the flag arrays. */
+    const uint8_t* const kflags = ly->key_flags;
+    const uint8_t* const aflags = ly->agg_flags;
+    uint8_t wide_any = ly->any_wide_key;
+    bool has_fl = (ly->agg_flags_any & (GHT_AF_FIRST | GHT_AF_LAST)) != 0;
     uint32_t mask = ht->ht_cap - 1;
     /* Stack buffer for one entry: hash + (nk+1) key slots + nv agg_vals
      * + optional 8-byte source-row tail (FIRST/LAST).
@@ -3050,7 +3138,7 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
 
     /* Wire the HT's key_data + key_pool tables so probe/rehash can
      * resolve wide keys (GUID bytes / STR descriptors) via the source columns. */
-    if (wide) { group_ht_set_key_data(ht, key_data); group_ht_set_key_pool(ht, key_vecs); }
+    if (wide_any) { group_ht_set_key_data(ht, key_data); group_ht_set_key_pool(ht, key_vecs); }
 
     for (int64_t i = start; i < end; i++) {
         /* Cancellation checkpoint every 65536 rows — ~150 polls on a
@@ -3062,7 +3150,7 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
         uint64_t h = 0;
         int64_t* ek = (int64_t*)(ebuf + 8);
         int64_t null_mask = 0;
-        if (ly->key_inline_str) {
+        if (ly->any_inline_str) {
             h = inline_build_keys(ly, key_types, key_data, key_attrs, ht->key_pool,
                                   key_vecs, nullable_mask, row, ebuf + 8, &null_mask);
         } else {
@@ -3075,7 +3163,7 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
                 null_mask |= ((int64_t)1 << k);
                 ek[k] = 0;  /* canonical null value — real 0 differs via null_mask */
                 kh = ray_hash_i64(0);
-            } else if (wide & (1u << k)) {
+            } else if (wide_any && (kflags[k] & GHT_KEYF_WIDE)) {
                 /* Wide key: store source row index, hash the actual bytes
                  * (GUID fixed / STR SSO via pool). */
                 ek[k] = row;
@@ -3099,12 +3187,11 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
 
         int64_t* ev = (int64_t*)(ebuf + 8 + (size_t)ly->key_region);
         uint8_t vi = 0;
-        uint8_t bin_mask = ly->agg_is_binary;
-        uint8_t hol_mask = ly->agg_is_holistic;
         for (uint32_t a = 0; a < na; a++) {
+            uint8_t af = aflags[a];
             /* Holistic agg (OP_MEDIAN): no slot reserved — skip packing.
              * Source column read in the post-radix pass. */
-            if (hol_mask & (1u << a)) continue;
+            if (af & GHT_AF_HOLISTIC) continue;
             ray_t* ac = agg_vecs[a];
             if (!ac) continue;
             if (agg_strlen && agg_strlen[a])
@@ -3115,7 +3202,7 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
                 ev[vi] = read_col_i64(ray_data(ac), row, ac->type, ac->attrs);
             vi++;
             /* Binary aggregator: pack y after x in the same entry. */
-            if ((bin_mask & (1u << a)) && agg_vecs2 && agg_vecs2[a]) {
+            if ((af & GHT_AF_BINARY) && agg_vecs2 && agg_vecs2[a]) {
                 ray_t* ay = agg_vecs2[a];
                 if (ay->type == RAY_F64)
                     memcpy(&ev[vi], &((double*)ray_data(ay))[row], 8);
@@ -3229,12 +3316,15 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
     radix_phase1_ctx_t* c = (radix_phase1_ctx_t*)ctx;
     const ght_layout_t* ly = &c->layout;
     radix_buf_t* my_bufs = &c->bufs[(size_t)worker_id * RADIX_P];
-    uint8_t nk = ly->n_keys;
-    uint8_t na = ly->n_aggs;
-    uint8_t nv = ly->n_agg_vals;
-    uint8_t wide = ly->wide_key_mask;
+    uint16_t nk = ly->n_keys;
+    uint16_t na = ly->n_aggs;
+    uint16_t nv = ly->n_agg_vals;
+    const uint8_t* const kflags = ly->key_flags;
+    const uint8_t* const aflags = ly->agg_flags;
+    uint8_t wide_any = ly->any_wide_key;
+    uint8_t inline_str = ly->any_inline_str;
     uint16_t estride = ly->entry_stride;
-    bool has_fl = (ly->agg_is_first | ly->agg_is_last) != 0;
+    bool has_fl = (ly->agg_flags_any & (GHT_AF_FIRST | GHT_AF_LAST)) != 0;
     const int64_t* match_idx = c->match_idx;
 
     int64_t keys[8];
@@ -3251,7 +3341,7 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
         if (!match_idx && c->rowsel && !group_rowsel_pass(c->rowsel, row)) continue;
         uint64_t h = 0;
         int64_t null_mask = 0;
-        if (ly->key_inline_str) {
+        if (inline_str) {
             h = inline_build_keys(ly, c->key_types, c->key_data, c->key_attrs,
                                   c->key_pool, c->key_vecs, nullable, row,
                                   keybuf, &null_mask);
@@ -3265,7 +3355,7 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
                 null_mask |= ((int64_t)1 << k);
                 keys[k] = 0;
                 kh = ray_hash_i64(0);
-            } else if (wide & (1u << k)) {
+            } else if (wide_any && (kflags[k] & GHT_KEYF_WIDE)) {
                 keys[k] = row;
                 kh = wide_key_hash_at(ly, k, c->key_data, c->key_pool, row);
             } else if (t == RAY_F64) {
@@ -3284,12 +3374,11 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
         }
 
         uint8_t vi = 0;
-        uint8_t bin_mask = ly->agg_is_binary;
-        uint8_t hol_mask = ly->agg_is_holistic;
         for (uint32_t a = 0; a < na; a++) {
+            uint8_t af = aflags[a];
             /* Holistic agg (OP_MEDIAN): no slot reserved — skip
              * packing.  Source column is read in the post-radix pass. */
-            if (hol_mask & (1u << a)) continue;
+            if (af & GHT_AF_HOLISTIC) continue;
             ray_t* ac = c->agg_vecs[a];
             if (!ac) continue;
             if (c->agg_strlen && c->agg_strlen[a])
@@ -3304,7 +3393,7 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
              * finalize reads both slots as F64 doubles regardless of
              * input type (i64 will be reinterpreted; for now we only
              * support F64 inputs cleanly — i64 path is a perf followup). */
-            if ((bin_mask & (1u << a)) && c->agg_vecs2 && c->agg_vecs2[a]) {
+            if ((af & GHT_AF_BINARY) && c->agg_vecs2 && c->agg_vecs2[a]) {
                 ray_t* ay = c->agg_vecs2[a];
                 if (ay->type == RAY_F64)
                     memcpy(&agg_vals[vi], &((double*)ray_data(ay))[row], 8);
@@ -3316,8 +3405,8 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
 
         uint32_t part = RADIX_PART(h);
         radix_buf_push(&my_bufs[part], estride, h,
-                       ly->key_inline_str ? (const int64_t*)keybuf : keys, nk, null_mask,
-                       agg_vals, nv, has_fl, row, ly->key_region, ly->key_inline_str != 0);
+                       inline_str ? (const int64_t*)keybuf : keys, (uint8_t)nk, null_mask,
+                       agg_vals, (uint8_t)nv, has_fl, row, ly->key_region, inline_str != 0);
     }
 }
 
@@ -3393,6 +3482,10 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
         uint32_t off = c->part_offsets[p];
         const ght_layout_t* ly = &ph->layout;
         uint16_t rs = ly->row_stride;
+        const uint16_t* const koff = ly->key_off;
+        const uint8_t*  const kflags = ly->key_flags;
+        const uint8_t*  const aflags = ly->agg_flags;
+        const int8_t*   const vslot = ly->agg_val_slot;
 
         /* Single pass over group rows: read each row once, scatter keys + aggs.
          * Reduces memory traffic from nk+na passes over group data to 1 pass. */
@@ -3400,7 +3493,7 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
             const char* row = ph->rows + (size_t)gi * rs;
             const char* rk = row + 8;     /* key region (key_off-addressed) */
             int64_t cnt = *(const int64_t*)(const void*)row;
-            int64_t null_mask = *(const int64_t*)(const void*)(rk + ly->key_off[nk]);
+            int64_t null_mask = *(const int64_t*)(const void*)(rk + koff[nk]);
             uint32_t di = off + gi;
 
             /* Scatter keys to result columns */
@@ -3431,14 +3524,14 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
                     }
                     continue;
                 }
-                if (ly->key_inline_str & (1u << k)) {
+                if (kflags[k] & GHT_KEYF_INLINE_STR) {
                     /* Inline STR key: the 16-byte descriptor lives in the row;
                      * copy it to the output (which shares the source pool). */
-                    memcpy(dst + doff, rk + ly->key_off[k], sizeof(ray_str_t));
+                    memcpy(dst + doff, rk + koff[k], sizeof(ray_str_t));
                     continue;
                 }
-                int64_t kv = *(const int64_t*)(const void*)(rk + ly->key_off[k]);
-                if (ly->wide_key_mask & (1u << k)) {
+                int64_t kv = *(const int64_t*)(const void*)(rk + koff[k]);
+                if (kflags[k] & GHT_KEYF_WIDE) {
                     /* Wide key: kv is the source row index; copy the
                      * bytes from the source column into the output. */
                     const char* src = (const char*)c->key_src_data[k];
@@ -3454,12 +3547,12 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
             for (uint32_t a = 0; a < na; a++) {
                 /* Holistic aggs (OP_MEDIAN) are filled by the
                  * post-radix pass — skip emitting from the row layout. */
-                if (ly->agg_is_holistic & (1u << a)) continue;
+                if (aflags[a] & GHT_AF_HOLISTIC) continue;
                 agg_out_t* ao = &c->agg_outs[a];
                 if (!ao->dst) continue; /* allocation failed (OOM) */
                 uint16_t op = ao->agg_op;
                 bool sf = ao->src_f64;
-                int8_t s = ly->agg_val_slot[a];
+                int8_t s = vslot[a];
                 if (ao->out_type == RAY_F64) {
                     double v;
                     switch (op) {
@@ -3592,7 +3685,7 @@ static void radix_phase2_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
         if (!group_ht_init_sized(&c->part_hts[p], part_ht_cap, &c->layout, init_grp))
             continue;
         /* Wide keys need source-column resolution during probe/rehash. */
-        if (c->layout.wide_key_mask && c->key_data) {
+        if (c->layout.any_wide_key && c->key_data) {
             group_ht_set_key_data(&c->part_hts[p], c->key_data);
             group_ht_copy_key_pool(&c->part_hts[p], c->key_pool);
         }
@@ -3641,12 +3734,12 @@ static inline uint32_t group_merge_row(group_ht_t* ht,
     int64_t src_count = *(const int64_t*)src_row;
     const int64_t* skeys = (const int64_t*)(src_row + 8);
     uint64_t h = hash_keys_inline(skeys, key_types, ly->n_keys,
-                                  ly->wide_key_mask, ly->wide_key_esz,
                                   ht->key_data, ly, ht->key_pool);
     uint8_t salt = HT_SALT(h);
     uint32_t slot = (uint32_t)(h & mask);
-    uint8_t na = ly->n_aggs;
-    uint8_t f64_mask = ly->agg_is_f64;
+    uint16_t na = ly->n_aggs;
+    const uint8_t* const aflags = ly->agg_flags;
+    const int8_t*  const vslot = ly->agg_val_slot;
     uint16_t off_sum = ly->off_sum;
     bool need_sum = (ly->need_flags & GHT_NEED_SUM) != 0;
     for (;;) {
@@ -3674,10 +3767,10 @@ static inline uint32_t group_merge_row(group_ht_t* ht,
                 *(int64_t*)row += src_count;
                 if (need_sum) {
                     for (uint32_t a = 0; a < na; a++) {
-                        int8_t s = ly->agg_val_slot[a];
+                        int8_t s = vslot[a];
                         if (s < 0) continue;
                         size_t off = (size_t)off_sum + (size_t)s * 8;
-                        if (f64_mask & (1u << a)) {
+                        if (aflags[a] & GHT_AF_F64) {
                             double sv_f;
                             memcpy(&sv_f, src_row + off, 8);
                             *(double*)(row + off) += sv_f;
@@ -3717,8 +3810,11 @@ static void radix_v2_phase1_fn(void* ctx, uint32_t worker_id,
     radix_v2_phase1_ctx_t* c = (radix_v2_phase1_ctx_t*)ctx;
     if (atomic_load_explicit(&c->oom, memory_order_relaxed)) return;
     const ght_layout_t* ly = &c->layout;
-    uint8_t nk = ly->n_keys;
-    uint8_t wide = ly->wide_key_mask;
+    uint16_t nk = ly->n_keys;
+    const uint8_t* const kflags = ly->key_flags;
+    const uint8_t* const aflags = ly->agg_flags;
+    uint8_t wide_any = ly->any_wide_key;
+    uint8_t inline_str = ly->any_inline_str;
     uint8_t nullable = c->nullable_mask;
     const int64_t* match_idx = c->match_idx;
 
@@ -3730,7 +3826,7 @@ static void radix_v2_phase1_fn(void* ctx, uint32_t worker_id,
                 atomic_store_explicit(&c->oom, 1, memory_order_relaxed);
                 return;
             }
-            if (wide && c->key_data) {
+            if (wide_any && c->key_data) {
                 group_ht_set_key_data(&my_hts[p], c->key_data);
                 group_ht_set_key_pool(&my_hts[p], c->key_vecs);
             }
@@ -3751,7 +3847,7 @@ static void radix_v2_phase1_fn(void* ctx, uint32_t worker_id,
         uint64_t h = 0;
         int64_t* ek = (int64_t*)(ebuf + 8);
         int64_t null_mask = 0;
-        if (ly->key_inline_str) {
+        if (inline_str) {
             h = inline_build_keys(ly, c->key_types, c->key_data, c->key_attrs,
                                   kpool, c->key_vecs, nullable, row, ebuf + 8, &null_mask);
         } else {
@@ -3764,7 +3860,7 @@ static void radix_v2_phase1_fn(void* ctx, uint32_t worker_id,
                 null_mask |= ((int64_t)1 << k);
                 ek[k] = 0;
                 kh = ray_hash_i64(0);
-            } else if (wide & (1u << k)) {
+            } else if (wide_any && (kflags[k] & GHT_KEYF_WIDE)) {
                 ek[k] = row;
                 kh = wide_key_hash_at(ly, k, c->key_data, kpool, row);
             } else if (t == RAY_F64) {
@@ -3790,11 +3886,10 @@ static void radix_v2_phase1_fn(void* ctx, uint32_t worker_id,
         if (ly->need_flags) {
             int64_t* ev = (int64_t*)(ebuf + 8 + (size_t)ly->key_region);
             uint8_t vi = 0;
-            uint8_t na = ly->n_aggs;
-            uint8_t bin_mask = ly->agg_is_binary;
-            uint8_t hol_mask = ly->agg_is_holistic;
+            uint16_t na = ly->n_aggs;
             for (uint32_t a = 0; a < na; a++) {
-                if (hol_mask & (1u << a)) continue;
+                uint8_t af = aflags[a];
+                if (af & GHT_AF_HOLISTIC) continue;
                 ray_t* ac = c->agg_vecs ? c->agg_vecs[a] : NULL;
                 if (!ac) continue;
                 if (c->agg_strlen && c->agg_strlen[a])
@@ -3804,7 +3899,7 @@ static void radix_v2_phase1_fn(void* ctx, uint32_t worker_id,
                 else
                     ev[vi] = read_col_i64(ray_data(ac), row, ac->type, ac->attrs);
                 vi++;
-                if ((bin_mask & (1u << a)) && c->agg_vecs2 && c->agg_vecs2[a]) {
+                if ((af & GHT_AF_BINARY) && c->agg_vecs2 && c->agg_vecs2[a]) {
                     ray_t* ay = c->agg_vecs2[a];
                     if (ay->type == RAY_F64)
                         memcpy(&ev[vi], &((double*)ray_data(ay))[row], 8);
@@ -3862,7 +3957,7 @@ static void radix_v2_phase2_fn(void* ctx, uint32_t worker_id,
             atomic_store_explicit(&c->oom, 1, memory_order_relaxed);
             return;
         }
-        if (c->layout.wide_key_mask && c->key_data) {
+        if (c->layout.any_wide_key && c->key_data) {
             group_ht_set_key_data(&c->part_hts[p], c->key_data);
             group_ht_copy_key_pool(&c->part_hts[p], c->key_pool);
         }
@@ -5314,9 +5409,7 @@ typedef struct {
     ray_t**       key_vecs;
     uint8_t       n_keys;
     uint8_t       nullable_mask;
-    uint8_t       wide_mask;
-    const uint8_t* wide_esz;
-    const ght_layout_t* layout;     /* for wide_key_type (STR vs GUID resolution) */
+    const ght_layout_t* layout;     /* borrowed; carries key_flags/wide_key_type */
     const void*   key_pool[8];      /* str-pool base per wide STR key (NULL else) */
     group_ht_t*   part_hts;
     const uint32_t* part_offsets;
@@ -5337,7 +5430,8 @@ static void reprobe_rows_fn(void* vctx, uint32_t worker_id,
     uint8_t* key_attrs = c->key_attrs;
     ray_t** key_vecs = c->key_vecs;
     uint8_t nullable = c->nullable_mask;
-    uint8_t wide = c->wide_mask;
+    const uint8_t* const kflags = c->layout->key_flags;
+    uint8_t wide_any = c->layout->any_wide_key;
     const int64_t* match_idx = c->match_idx;
     ray_t* rowsel = c->rowsel;
     for (int64_t i = start; i < end; i++) {
@@ -5353,7 +5447,7 @@ static void reprobe_rows_fn(void* vctx, uint32_t worker_id,
         uint64_t h = 0;
         int64_t null_mask = 0;
         const int64_t* lookup_keys;
-        if (c->layout->key_inline_str) {
+        if (c->layout->any_inline_str) {
             h = inline_build_keys(c->layout, key_types, key_data, key_attrs,
                                   c->key_pool, key_vecs, nullable, row, keybuf, &null_mask);
             lookup_keys = (const int64_t*)keybuf;
@@ -5367,7 +5461,7 @@ static void reprobe_rows_fn(void* vctx, uint32_t worker_id,
                 null_mask |= ((int64_t)1 << k);
                 ek_buf[k] = 0;
                 kh = ray_hash_i64(0);
-            } else if (wide & (1u << k)) {
+            } else if (wide_any && (kflags[k] & GHT_KEYF_WIDE)) {
                 ek_buf[k] = row;
                 kh = wide_key_hash_at(c->layout, k, key_data, c->key_pool, row);
             } else if (t == RAY_F64) {
@@ -8907,10 +9001,21 @@ ht_path:;
     /* RAY_STR keys are now handled inline by the wide-key mechanism (row
      * indirection + SSO-aware hash/eq via key_pool); see ght_layout_t. */
 
-    /* Compute row-layout: keys + agg values inline */
-    /* narrowing into uint8_t params is safe: this path is gated ≤8 keys/aggs
-     * by the exec_group_run width guard; ght widens in cut 4 */
-    ght_layout_t ght_layout = ght_compute_layout(n_keys, n_aggs, agg_vecs, ght_need, ext->agg_ops, key_types);
+    /* Compute row-layout: keys + agg values inline.  This path is gated ≤8
+     * keys/aggs by the exec_group_run width guard, so the layout is always
+     * inline (no spill); ght_compute_layout only fails here on the uint16
+     * key-stride budget, which ≤8 keys can never exceed. */
+    ght_layout_t ght_layout;
+    if (!ght_compute_layout(&ght_layout, n_keys, n_aggs, agg_vecs, ght_need,
+                            ext->agg_ops, key_types)) {
+        for (uint32_t a = 0; a < n_aggs; a++)
+            { if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
+              if (agg_owned2[a] && agg_vecs2[a]) ray_release(agg_vecs2[a]); }
+        for (uint32_t k = 0; k < n_keys; k++)
+            if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
+        if (match_idx_block) { ray_release(match_idx_block); } scratch_free(vla_hdr);
+        return ray_error("limit", "group: key stride budget exceeded");
+    }
 
     /* Right-sized hash table: start small, rehash on load > 0.5 */
     uint32_t ht_cap = 256;
@@ -8990,9 +9095,8 @@ ht_path:;
                     v2_ok = false;
             }
         }
-        if (v2_ok && !(ght_layout.agg_is_first | ght_layout.agg_is_last
-                        | ght_layout.agg_is_holistic
-                        | ght_layout.agg_is_binary)) {
+        if (v2_ok && !(ght_layout.agg_flags_any & (GHT_AF_FIRST | GHT_AF_LAST
+                        | GHT_AF_HOLISTIC | GHT_AF_BINARY))) {
             ray_t* wpart_hdr = NULL;
             size_t v2_n_w = (size_t)n_total * RADIX_P;
             group_ht_t* wpart_hts = (group_ht_t*)scratch_calloc(
@@ -9049,11 +9153,14 @@ ht_path:;
                 .nullable_mask = v2_nullable,
                 .n_workers     = n_total,
                 .wpart_hts     = wpart_hts,
-                .layout        = ght_layout,
                 .rowsel        = rowsel,
                 .match_idx     = sel_match,
                 .oom           = 0,
             };
+            /* By-value embed the layout, fixing its base pointers to v2p1's
+             * own inline arrays (inline) / shared spill (wide); the master
+             * ght_layout outlives this dispatch. */
+            ght_layout_copy(&v2p1.layout, &ght_layout);
             ray_pool_dispatch(pool, radix_v2_phase1_fn, &v2p1,
                               sel_match ? sel_n : n_scan);
             if (sel_match_block) ray_release(sel_match_block);
@@ -9070,11 +9177,11 @@ ht_path:;
                 .part_hts  = v2_part_hts,
                 .key_types = key_types,
                 .n_workers = n_total,
-                .layout    = ght_layout,
                 .key_data  = key_data,
                 .oom       = 0,
             };
-            if (ght_layout.wide_key_mask) derive_key_pool(&ght_layout, key_vecs, v2p2.key_pool);
+            ght_layout_copy(&v2p2.layout, &ght_layout);
+            if (ght_layout.any_wide_key) derive_key_pool(&ght_layout, key_vecs, v2p2.key_pool);
             ray_pool_dispatch_n(pool, radix_v2_phase2_fn, &v2p2, RADIX_P);
             CHECK_CANCEL_GOTO(pool, cleanup);
             /* Worker HTs are no longer needed once the merge is done. */
@@ -9142,11 +9249,11 @@ v2_done:;
             .agg_strlen    = agg_strlen,
             .n_workers     = n_total,
             .bufs          = radix_bufs,
-            .layout        = ght_layout,
             .rowsel        = rowsel,
             .match_idx     = match_idx,
         };
-        if (ght_layout.wide_key_mask)
+        ght_layout_copy(&p1ctx.layout, &ght_layout);
+        if (ght_layout.any_wide_key)
             derive_key_pool(&ght_layout, key_vecs, p1ctx.key_pool);
         ray_pool_dispatch(pool, radix_phase1_fn, &p1ctx, n_scan);
         CHECK_CANCEL_GOTO(pool, cleanup);
@@ -9181,10 +9288,10 @@ v2_done:;
             .n_workers   = n_total,
             .bufs        = radix_bufs,
             .part_hts    = part_hts,
-            .layout      = ght_layout,
             .key_data    = key_data,
         };
-        if (ght_layout.wide_key_mask) derive_key_pool(&ght_layout, key_vecs, p2ctx.key_pool);
+        ght_layout_copy(&p2ctx.layout, &ght_layout);
+        if (ght_layout.any_wide_key) derive_key_pool(&ght_layout, key_vecs, p2ctx.key_pool);
         ray_pool_dispatch_n(pool, radix_phase2_fn, &p2ctx, RADIX_P);
         CHECK_CANCEL_GOTO(pool, cleanup);
 
@@ -9241,7 +9348,7 @@ v2_emit:;
             uint16_t order_off = 0;  /* default: COUNT at row+0 */
             bool order_is_f64 = false;
             if (agg_index_local < n_aggs &&
-                (ght_layout.agg_is_f64 & (1u << agg_index_local)))
+                (ght_layout.agg_flags[agg_index_local] & GHT_AF_F64))
                 order_is_f64 = true;
             int8_t agg_slot = ght_layout.agg_val_slot[agg_index_local];
             if (order_op == OP_SUM) {
@@ -9250,13 +9357,13 @@ v2_emit:;
                                        + (uint16_t)agg_slot * 8u);
             } else if (order_op == OP_MIN) {
                 if (agg_slot < 0 || order_is_f64) goto topn_compact_skip;
-                if (ght_layout.agg_is_sym & (1u << agg_index_local))
+                if (ght_layout.agg_flags[agg_index_local] & GHT_AF_SYM)
                     goto topn_compact_skip;
                 order_off = (uint16_t)(ght_layout.off_min
                                        + (uint16_t)agg_slot * 8u);
             } else if (order_op == OP_MAX) {
                 if (agg_slot < 0 || order_is_f64) goto topn_compact_skip;
-                if (ght_layout.agg_is_sym & (1u << agg_index_local))
+                if (ght_layout.agg_flags[agg_index_local] & GHT_AF_SYM)
                     goto topn_compact_skip;
                 order_off = (uint16_t)(ght_layout.off_max
                                        + (uint16_t)agg_slot * 8u);
@@ -9505,7 +9612,7 @@ v2_emit:;
          * Re-probe source rows to recover global gids, build a
          * group-contiguous idx_buf, then dispatch ray_median_per_group_buf
          * once per OP_MEDIAN agg.  See helpers above for the rationale. */
-        if (ght_layout.agg_is_holistic) {
+        if (ght_layout.agg_flags_any & GHT_AF_HOLISTIC) {
             int64_t n_groups = (int64_t)total_grps;
 
             /* row_gid[nrows] — global group id per source row, or -1 on
@@ -9530,8 +9637,6 @@ v2_emit:;
                 .key_vecs = key_vecs,
                 .n_keys = n_keys,
                 .nullable_mask = reprobe_nullable,
-                .wide_mask = ght_layout.wide_key_mask,
-                .wide_esz = ght_layout.wide_key_esz,
                 .layout = &ght_layout,
                 .part_hts = part_hts,
                 .part_offsets = part_offsets,
@@ -9539,7 +9644,7 @@ v2_emit:;
                 .match_idx = match_idx,
                 .rowsel = rowsel,
             };
-            if (ght_layout.wide_key_mask)
+            if (ght_layout.any_wide_key)
                 derive_key_pool(&ght_layout, key_vecs, rp.key_pool);
             ray_pool_dispatch(pool, reprobe_rows_fn, &rp, n_scan);
 
@@ -9616,7 +9721,7 @@ v2_emit:;
 
             if (idx_buf) {
                 for (uint32_t a = 0; a < n_aggs; a++) {
-                    if (!(ght_layout.agg_is_holistic & (1u << a))) continue;
+                    if (!(ght_layout.agg_flags[a] & GHT_AF_HOLISTIC)) continue;
                     if (!agg_vecs[a] || !agg_cols[a]) continue;
                     uint16_t aop = ext->agg_ops[a];
                     ray_t* hol_vec = NULL;
@@ -9805,10 +9910,10 @@ sequential_fallback:;
             ray_sym_vec_adopt_domain(new_col, sym_domain_rep(src_col));
         new_col->len = (int64_t)grp_count;
 
-        bool is_wide = (ly->wide_key_mask & (1u << k)) != 0;
+        bool is_wide = (ly->key_flags[k] & GHT_KEYF_WIDE) != 0;
         const char* src_base = is_wide ? (const char*)key_data[k] : NULL;
 
-        bool inline_str_k = (ly->key_inline_str & (1u << k)) != 0;
+        bool inline_str_k = (ly->key_flags[k] & GHT_KEYF_INLINE_STR) != 0;
         for (uint32_t gi = 0; gi < grp_count; gi++) {
             const char* row = final_ht->rows + (size_t)gi * ly->row_stride;
             const char* rk = row + 8;
@@ -9861,7 +9966,7 @@ sequential_fallback:;
      * Built lazily on first need and reused across all median slots. */
     ray_t** med_out = NULL;
     ray_t* med_hdr = NULL;
-    if (ly->agg_is_holistic) {
+    if (ly->agg_flags_any & GHT_AF_HOLISTIC) {
         med_out = (ray_t**)scratch_calloc(&med_hdr,
             (size_t)n_aggs * sizeof(ray_t*));
         if (med_out) {
@@ -9907,7 +10012,7 @@ sequential_fallback:;
                     uint64_t h = 0;
                     int64_t null_mask = 0;
                     const int64_t* lookup_keys;
-                    if (ly->key_inline_str) {
+                    if (ly->any_inline_str) {
                         h = inline_build_keys(ly, key_types, key_data, key_attrs,
                                               reprobe_pool, key_vecs, reprobe_nullable_s,
                                               row, keybuf, &null_mask);
@@ -9922,7 +10027,7 @@ sequential_fallback:;
                             null_mask |= ((int64_t)1 << k);
                             ek_buf[k] = 0;
                             kh = ray_hash_i64(0);
-                        } else if (ly->wide_key_mask & (1u << k)) {
+                        } else if (ly->key_flags[k] & GHT_KEYF_WIDE) {
                             ek_buf[k] = row;
                             kh = wide_key_hash_at(ly, k, key_data, reprobe_pool, row);
                         } else if (t == RAY_F64) {
@@ -9962,7 +10067,7 @@ sequential_fallback:;
                         if (gi >= 0) idx_buf_s[pos_s[gi]++] = row;
                     }
                     for (uint32_t a = 0; a < n_aggs; a++) {
-                        if (!(ly->agg_is_holistic & (1u << a))) continue;
+                        if (!(ly->agg_flags[a] & GHT_AF_HOLISTIC)) continue;
                         if (!agg_vecs[a]) continue;
                         uint16_t aop = ext->agg_ops[a];
                         ray_t* hol_vec = NULL;
@@ -10032,7 +10137,7 @@ sequential_fallback:;
         /* Drive off the layout bitmask, not the op literal: wide-element
          * (STR/GUID) min/max/first/last are holistic too and their column
          * lives in med_out[a], not the truncating row-layout read below. */
-        bool is_holistic = (ly->agg_is_holistic & (1u << a)) != 0;
+        bool is_holistic = (ly->agg_flags[a] & GHT_AF_HOLISTIC) != 0;
         if (is_holistic && med_out && med_out[a]
             && !RAY_IS_ERR(med_out[a])) {
             new_col = med_out[a];
@@ -10217,6 +10322,10 @@ cleanup:
         }
         scratch_free(part_hts_hdr);
     }
+    /* Master layout owns any spill block; every by-value copy borrowed it.
+     * cleanup: is reached only after ght_layout is initialised (all gotos to
+     * it are below the ght_compute_layout call).  NULL-safe / no-op inline. */
+    ght_layout_free(&ght_layout);
     for (uint32_t a = 0; a < n_aggs; a++)
         { if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]); if (agg_owned2[a] && agg_vecs2[a]) ray_release(agg_vecs2[a]); }
     for (uint32_t k = 0; k < n_keys; k++)
@@ -10971,10 +11080,10 @@ bool pivot_ingest_run(pivot_ingest_t* out,
         .agg_vecs2     = NULL,   /* this scratch path doesn't use binary aggs */
         .n_workers     = n_total,
         .bufs          = radix_bufs,
-        .layout        = *ly,
         .match_idx     = NULL,
     };
-    if (ly->wide_key_mask)
+    ght_layout_copy(&p1ctx.layout, ly);
+    if (ly->any_wide_key)
         derive_key_pool(ly, key_vecs, p1ctx.key_pool);
     ray_pool_dispatch(pool, radix_phase1_fn, &p1ctx, n_scan);
     if (ray_interrupted()) return true; /* caller checks ray_interrupted() */
@@ -10994,10 +11103,10 @@ bool pivot_ingest_run(pivot_ingest_t* out,
         .n_workers = n_total,
         .bufs      = radix_bufs,
         .part_hts  = part_hts,
-        .layout    = *ly,
         .key_data  = key_data,
     };
-    if (ly->wide_key_mask) derive_key_pool(ly, key_vecs, p2ctx.key_pool);
+    ght_layout_copy(&p2ctx.layout, ly);
+    if (ly->any_wide_key) derive_key_pool(ly, key_vecs, p2ctx.key_pool);
     ray_pool_dispatch_n(pool, radix_phase2_fn, &p2ctx, RADIX_P);
     out->part_hts = part_hts;
     out->n_parts = RADIX_P;

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -2312,6 +2312,8 @@ ray_t* exec_reduction(ray_graph_t* g, ray_op_t* op, ray_t* input) {
 static inline void ght_layout_point_inline(ght_layout_t* ly) {
     ly->agg_val_slot  = ly->agg_val_slot_in;
     ly->agg_flags     = ly->agg_flags_in;
+    ly->agg_flags2    = ly->agg_flags2_in;
+    ly->agg_null_sentinel = ly->agg_null_sentinel_in;
     ly->agg_dom       = ly->agg_dom_in;
     ly->key_off       = ly->key_off_in;
     ly->key_flags     = ly->key_flags_in;
@@ -2326,20 +2328,26 @@ static inline void ght_layout_point_inline(ght_layout_t* ly) {
  * hold; kept correct for later cuts.  Returns false on OOM. */
 static bool ght_layout_alloc_spill(ght_layout_t* ly, uint32_t n_keys, uint32_t n_aggs) {
     size_t off = 0;
-    size_t dom_off = off;                       off += (size_t)n_aggs * sizeof(void*);
+    /* 8-byte-first: pointer array (agg_dom) then the int64 sentinel array,
+     * then the uint16 key_off vector, then the byte arrays. */
+    size_t dom_off = off;                        off += (size_t)n_aggs * sizeof(void*);
+    size_t sent_off = off;                        off += (size_t)n_aggs * sizeof(int64_t);
     size_t koff_off = off;                       off += (size_t)(n_keys + 1) * sizeof(uint16_t);
     off = (off + 1u) & ~(size_t)1u;              /* re-align not needed after uint16, but keep bytes packed */
     size_t vslot_off = off;                      off += (size_t)n_aggs;
     size_t aflags_off = off;                     off += (size_t)n_aggs;
+    size_t aflags2_off = off;                     off += (size_t)n_aggs;
     size_t kflags_off = off;                     off += (size_t)n_keys;
     size_t wesz_off = off;                       off += (size_t)n_keys;
     size_t wtype_off = off;                      off += (size_t)n_keys;
     char* base = (char*)scratch_calloc(&ly->spill_hdr, off ? off : 1);
     if (!base) { ly->spill_hdr = NULL; return false; }
     ly->agg_dom       = (struct ray_sym_domain_s**)(void*)(base + dom_off);
+    ly->agg_null_sentinel = (int64_t*)(void*)(base + sent_off);
     ly->key_off       = (uint16_t*)(void*)(base + koff_off);
     ly->agg_val_slot  = (int8_t*)(base + vslot_off);
     ly->agg_flags     = (uint8_t*)(base + aflags_off);
+    ly->agg_flags2    = (uint8_t*)(base + aflags2_off);
     ly->key_flags     = (uint8_t*)(base + kflags_off);
     ly->wide_key_esz  = (uint8_t*)(base + wesz_off);
     ly->wide_key_type = (int8_t*)(base + wtype_off);
@@ -2482,6 +2490,25 @@ bool ght_compute_layout(ght_layout_t* out, uint32_t n_keys, uint32_t n_aggs,
         }
         out->agg_flags[a] = af;
         agg_any |= af;
+        /* Null metadata for value-slot aggs whose input column advertises
+         * HAS_NULLS.  Holistic/wide aggs reserve no accum slot (their per-group
+         * pass skips nulls itself), so they carry no nullable flag here.  A
+         * nullable value-slot agg makes the row-layout accumulators skip nulls
+         * (F64 NaN or the type's NULL_I* sentinel) and count non-nulls in the
+         * off_nn block. */
+        uint8_t af2 = 0;
+        int64_t sent = 0;
+        if (!holistic && agg_vecs[a]) {
+            ray_t* src = (agg_vecs[a]->attrs & RAY_ATTR_SLICE)
+                         ? agg_vecs[a]->slice_parent : agg_vecs[a];
+            if (src && (src->attrs & RAY_ATTR_HAS_NULLS)) {
+                af2 |= GHT_AF2_NULLABLE;
+                sent = agg_int_null_sentinel_for(agg_vecs[a]->type);
+                out->any_agg_null = 1;
+            }
+        }
+        out->agg_flags2[a] = af2;
+        out->agg_null_sentinel[a] = sent;
     }
     out->n_agg_vals = nv;
     out->agg_flags_any = agg_any;
@@ -2542,6 +2569,10 @@ bool ght_compute_layout(ght_layout_t* out, uint32_t n_keys, uint32_t n_aggs,
         out->off_sumsq_y = off; off += block;
         out->off_sumxy   = off; off += block;
     }
+    /* Per-slot non-null count block — only when a nullable agg is present.
+     * Null-free shapes leave off_nn == 0 and finalize on the group row count,
+     * so their row_stride and layout are byte-identical to before. */
+    if (out->any_agg_null) { out->off_nn = off; off += block; }
     out->row_stride = off;
     return true;
 }
@@ -2868,10 +2899,20 @@ static void group_ht_rehash(group_ht_t* ht, const int8_t* key_types) {
     }
 }
 
+/* Null-aware accumulator variants (defined below).  Reached only when the
+ * layout carries a nullable agg (ly->any_agg_null) — a single hoisted,
+ * perfectly-predicted branch, so the null-free hot path is byte-for-byte
+ * unchanged. */
+static void init_accum_from_entry_nullable(char* row, const char* entry,
+                                            const ght_layout_t* ly);
+static void accum_from_entry_nullable(char* row, const char* entry,
+                                      const ght_layout_t* ly);
+
 /* Initialize accumulators for a new group from entry's inline agg values.
  * Each unified block has n_agg_vals slots of 8 bytes, typed by agg_is_f64. */
 static inline void init_accum_from_entry(char* row, const char* entry,
                                           const ght_layout_t* ly) {
+    if (ly->any_agg_null) { init_accum_from_entry_nullable(row, entry, ly); return; }
     uint16_t accum_start = (uint16_t)(8 + ((uint16_t)ly->n_keys + 1) * 8);
     if (ly->row_stride > accum_start)
         memset(row + accum_start, 0, ly->row_stride - accum_start);
@@ -2951,6 +2992,7 @@ static inline void init_accum_from_entry(char* row, const char* entry,
 /* Accumulate into existing group from entry's inline agg values */
 static inline void accum_from_entry(char* row, const char* entry,
                                      const ght_layout_t* ly) {
+    if (ly->any_agg_null) { accum_from_entry_nullable(row, entry, ly); return; }
     const char* agg_data = entry + 8 + (size_t)ly->key_region;
     uint16_t na = ly->n_aggs;
     uint8_t nf = ly->need_flags;
@@ -3045,6 +3087,150 @@ static inline void accum_from_entry(char* row, const char* entry,
         if (take_first) memcpy(row + ly->off_first_row + s * 8, &entry_row, 8);
         if (take_last)  memcpy(row + ly->off_last_row  + s * 8, &entry_row, 8);
     }
+}
+
+/* ── Null-aware row-layout accumulators ──────────────────────────────────
+ * Reached only when the layout carries a nullable agg input.  They skip
+ * null values (F64 NaN, or the per-agg NULL_I* sentinel for integer/temporal
+ * columns) and maintain a per-slot non-null count in the off_nn block, so
+ * finalize divides AVG/VAR/STDDEV by the non-null count and emits a typed
+ * null for an all-null group — identical semantics to the DA and scalar
+ * paths (agg_int_null_mask + nn_count).  A new group seeds accumulator
+ * IDENTITIES (SUM 0 / PROD 1 / MIN +max / MAX −max) rather than the opening
+ * value, so a null opening row neither poisons MIN/MAX/FIRST/LAST nor is
+ * summed. */
+static inline bool agg_entry_is_null(uint8_t af, uint8_t af2, int64_t sentinel,
+                                     const char* val) {
+    if (!(af2 & GHT_AF2_NULLABLE)) return false;
+    if (af & GHT_AF_F64) { double v; memcpy(&v, val, 8); return v != v; }
+    int64_t v; memcpy(&v, val, 8); return v == sentinel;
+}
+
+static void accum_from_entry_nullable(char* row, const char* entry,
+                                      const ght_layout_t* ly) {
+    const char* agg_data = entry + 8 + (size_t)ly->key_region;
+    uint16_t na = ly->n_aggs;
+    uint8_t nf = ly->need_flags;
+    bool has_fl = (ly->agg_flags_any & (GHT_AF_FIRST | GHT_AF_LAST)) != 0;
+    int64_t entry_row = 0;
+    if (has_fl)
+        memcpy(&entry_row, entry + ly->entry_stride - 8, 8);
+    const int8_t*  const vslot  = ly->agg_val_slot;
+    const uint8_t* const aflags = ly->agg_flags;
+    const uint8_t* const aflags2 = ly->agg_flags2;
+    const int64_t* const asent  = ly->agg_null_sentinel;
+    struct ray_sym_domain_s* const* const adom = ly->agg_dom;
+    int64_t* const nn = (int64_t*)(void*)(row + ly->off_nn);
+    for (uint32_t a = 0; a < na; a++) {
+        int8_t s = vslot[a];
+        if (s < 0) continue;
+        const char* val = agg_data + s * 8;
+        uint8_t af = aflags[a];
+        if (agg_entry_is_null(af, aflags2[a], asent[a], val))
+            continue;                     /* null: no accumulate, no nn++ */
+        nn[s]++;
+        if (af & GHT_AF_F64) {
+            double v; memcpy(&v, val, 8);
+            if (nf & GHT_NEED_SUM) {
+                if (af & GHT_AF_FIRST) {
+                    if (entry_row < ROW_RD_I64(row, ly->off_first_row, s)) {
+                        memcpy(row + ly->off_sum + s * 8, val, 8);
+                        ROW_WR_I64(row, ly->off_first_row, s) = entry_row;
+                    }
+                } else if (af & GHT_AF_LAST) {
+                    if (entry_row > ROW_RD_I64(row, ly->off_last_row, s)) {
+                        memcpy(row + ly->off_sum + s * 8, val, 8);
+                        ROW_WR_I64(row, ly->off_last_row, s) = entry_row;
+                    }
+                } else if (af & GHT_AF_PROD) { ROW_WR_F64(row, ly->off_sum, s) *= v; }
+                else { ROW_WR_F64(row, ly->off_sum, s) += v; }
+            }
+            if (nf & GHT_NEED_MIN) { double* p = &ROW_WR_F64(row, ly->off_min, s); if (v < *p) *p = v; }
+            if (nf & GHT_NEED_MAX) { double* p = &ROW_WR_F64(row, ly->off_max, s); if (v > *p) *p = v; }
+            if (nf & GHT_NEED_SUMSQ) { ROW_WR_F64(row, ly->off_sumsq, s) += v * v; }
+            if ((nf & GHT_NEED_PEARSON) && (af & GHT_AF_BINARY)) {
+                double y; memcpy(&y, agg_data + (s + 1) * 8, 8);
+                ROW_WR_F64(row, ly->off_sum_y,   s) += y;
+                ROW_WR_F64(row, ly->off_sumsq_y, s) += y * y;
+                ROW_WR_F64(row, ly->off_sumxy,   s) += v * y;
+            }
+        } else {
+            int64_t v; memcpy(&v, val, 8);
+            if (nf & GHT_NEED_SUM) {
+                if (af & GHT_AF_FIRST) {
+                    if (entry_row < ROW_RD_I64(row, ly->off_first_row, s)) {
+                        memcpy(row + ly->off_sum + s * 8, val, 8);
+                        ROW_WR_I64(row, ly->off_first_row, s) = entry_row;
+                    }
+                } else if (af & GHT_AF_LAST) {
+                    if (entry_row > ROW_RD_I64(row, ly->off_last_row, s)) {
+                        memcpy(row + ly->off_sum + s * 8, val, 8);
+                        ROW_WR_I64(row, ly->off_last_row, s) = entry_row;
+                    }
+                } else if (af & GHT_AF_PROD) { ROW_WR_I64(row, ly->off_sum, s) = (int64_t)((uint64_t)ROW_RD_I64(row, ly->off_sum, s) * (uint64_t)v); }
+                else { ROW_WR_I64(row, ly->off_sum, s) += v; }
+            }
+            if (nf & GHT_NEED_MIN) {
+                int64_t* p = &ROW_WR_I64(row, ly->off_min, s);
+                if (af & GHT_AF_SYM) { if (*p == INT64_MAX || sym_lex_lt(adom[a], v, *p)) *p = v; }
+                else if (v < *p) *p = v;
+            }
+            if (nf & GHT_NEED_MAX) {
+                int64_t* p = &ROW_WR_I64(row, ly->off_max, s);
+                if (af & GHT_AF_SYM) { if (*p == INT64_MIN || sym_lex_gt(adom[a], v, *p)) *p = v; }
+                else if (v > *p) *p = v;
+            }
+            if (nf & GHT_NEED_SUMSQ) { ROW_WR_F64(row, ly->off_sumsq, s) += (double)v * (double)v; }
+            if ((nf & GHT_NEED_PEARSON) && (af & GHT_AF_BINARY)) {
+                int64_t yi; memcpy(&yi, agg_data + (s + 1) * 8, 8);
+                double y = (double)yi; double xd = (double)v;
+                ROW_WR_F64(row, ly->off_sum_y,   s) += y;
+                ROW_WR_F64(row, ly->off_sumsq_y, s) += y * y;
+                ROW_WR_F64(row, ly->off_sumxy,   s) += xd * y;
+            }
+        }
+    }
+}
+
+static void init_accum_from_entry_nullable(char* row, const char* entry,
+                                            const ght_layout_t* ly) {
+    /* Zero the entire accumulator region (incl. off_nn); key_region-based
+     * start is correct for every key shape (inline STR, >1 null word). */
+    uint16_t accum_start = (uint16_t)(8 + ly->key_region);
+    if (ly->row_stride > accum_start)
+        memset(row + accum_start, 0, ly->row_stride - accum_start);
+
+    uint16_t na = ly->n_aggs;
+    uint8_t nf = ly->need_flags;
+    bool has_fl = (ly->agg_flags_any & (GHT_AF_FIRST | GHT_AF_LAST)) != 0;
+    const int8_t*  const vslot  = ly->agg_val_slot;
+    const uint8_t* const aflags = ly->agg_flags;
+    for (uint32_t a = 0; a < na; a++) {
+        int8_t s = vslot[a];
+        if (s < 0) continue;
+        uint8_t af = aflags[a];
+        /* Identities: MIN +max, MAX −max, PROD 1.  SUM / SUMSQ / nn / y-side
+         * stay 0 from the memset above.  Row-index bounds seed so any
+         * non-null row beats them. */
+        if (nf & GHT_NEED_MIN) {
+            if (af & GHT_AF_F64) ROW_WR_F64(row, ly->off_min, s) = DBL_MAX;
+            else                 ROW_WR_I64(row, ly->off_min, s) = INT64_MAX;
+        }
+        if (nf & GHT_NEED_MAX) {
+            if (af & GHT_AF_F64) ROW_WR_F64(row, ly->off_max, s) = -DBL_MAX;
+            else                 ROW_WR_I64(row, ly->off_max, s) = INT64_MIN;
+        }
+        if ((nf & GHT_NEED_SUM) && (af & GHT_AF_PROD)) {
+            if (af & GHT_AF_F64) ROW_WR_F64(row, ly->off_sum, s) = 1.0;
+            else                 ROW_WR_I64(row, ly->off_sum, s) = 1;
+        }
+        if (has_fl) {
+            ROW_WR_I64(row, ly->off_first_row, s) = INT64_MAX;
+            ROW_WR_I64(row, ly->off_last_row,  s) = INT64_MIN;
+        }
+    }
+    /* Fold the opening row in through the same null-aware update. */
+    accum_from_entry_nullable(row, entry, ly);
 }
 
 /* Compare the n_keys key slots of two rows, handling wide keys via
@@ -3602,6 +3788,10 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
             const char* rk = row + 8;     /* key region (key_off-addressed) */
             int64_t cnt = *(const int64_t*)(const void*)row;
             const int64_t* nullw = (const int64_t*)(const void*)(rk + koff[nk]);
+            /* Per-slot non-null count when nullable aggs are present; NULL
+             * (→ use cnt) for null-free layouts (byte-identical to before). */
+            const int64_t* nnbase = ly->off_nn
+                ? (const int64_t*)(const void*)(row + ly->off_nn) : NULL;
             uint32_t di = off + gi;
 
             /* Scatter keys to result columns */
@@ -3661,6 +3851,10 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
                 uint16_t op = ao->agg_op;
                 bool sf = ao->src_f64;
                 int8_t s = vslot[a];
+                /* nn = per-slot non-null count (nullable layout) or the group
+                 * row count (null-free).  Drives the AVG/VAR/STDDEV divisor
+                 * and the all-null → typed-null decision, matching the DA path. */
+                int64_t nn = nnbase ? nnbase[s] : cnt;
                 if (ao->out_type == RAY_F64) {
                     double v;
                     switch (op) {
@@ -3670,40 +3864,45 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
                             if (ao->affine) v += ao->bias_f64 * cnt;
                             break;
                         case OP_PROD:
+                            if (nn == 0) { v = NULL_F64; grp_set_null(ao->vec, di); break; }
                             v = sf ? ROW_RD_F64(row, ly->off_sum, s)
                                    : (double)ROW_RD_I64(row, ly->off_sum, s);
                             break;
                         case OP_AVG:
-                            v = sf ? ROW_RD_F64(row, ly->off_sum, s) / cnt
-                                   : (double)ROW_RD_I64(row, ly->off_sum, s) / cnt;
+                            if (nn == 0) { v = NULL_F64; grp_set_null(ao->vec, di); break; }
+                            v = sf ? ROW_RD_F64(row, ly->off_sum, s) / nn
+                                   : (double)ROW_RD_I64(row, ly->off_sum, s) / nn;
                             if (ao->affine) v += ao->bias_f64;
                             break;
                         case OP_MIN:
+                            if (nn == 0) { v = NULL_F64; grp_set_null(ao->vec, di); break; }
                             v = sf ? ROW_RD_F64(row, ly->off_min, s)
                                    : (double)ROW_RD_I64(row, ly->off_min, s);
                             break;
                         case OP_MAX:
+                            if (nn == 0) { v = NULL_F64; grp_set_null(ao->vec, di); break; }
                             v = sf ? ROW_RD_F64(row, ly->off_max, s)
                                    : (double)ROW_RD_I64(row, ly->off_max, s);
                             break;
                         case OP_FIRST: case OP_LAST:
+                            if (nn == 0) { v = NULL_F64; grp_set_null(ao->vec, di); break; }
                             v = sf ? ROW_RD_F64(row, ly->off_sum, s)
                                    : (double)ROW_RD_I64(row, ly->off_sum, s);
                             break;
                         case OP_VAR: case OP_VAR_POP:
                         case OP_STDDEV: case OP_STDDEV_POP: {
-                            bool insuf = (op == OP_VAR || op == OP_STDDEV) ? cnt <= 1 : cnt <= 0;
+                            bool insuf = (op == OP_VAR || op == OP_STDDEV) ? nn <= 1 : nn <= 0;
                             if (insuf) { v = NULL_F64; grp_set_null(ao->vec, di); break; }
                             double sum_val = sf ? ROW_RD_F64(row, ly->off_sum, s)
                                                 : (double)ROW_RD_I64(row, ly->off_sum, s);
                             double sq_val = ly->off_sumsq ? ROW_RD_F64(row, ly->off_sumsq, s) : 0.0;
-                            double mean = sum_val / cnt;
-                            double var_pop = sq_val / cnt - mean * mean;
+                            double mean = sum_val / nn;
+                            double var_pop = sq_val / nn - mean * mean;
                             if (var_pop < 0) var_pop = 0;
                             if (op == OP_VAR_POP) v = var_pop;
-                            else if (op == OP_VAR) v = var_pop * cnt / (cnt - 1);
+                            else if (op == OP_VAR) v = var_pop * nn / (nn - 1);
                             else if (op == OP_STDDEV_POP) v = sqrt(var_pop);
-                            else v = sqrt(var_pop * cnt / (cnt - 1));
+                            else v = sqrt(var_pop * nn / (nn - 1));
                             break;
                         }
                         case OP_PEARSON_CORR: {
@@ -3735,16 +3934,27 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
                     ((double*)(void*)ao->dst)[di] = ray_f64_fin(v);
                 } else {
                     int64_t v;
+                    /* All-null group emits the width-correct sentinel (matches
+                     * the DA int emit); SUM/COUNT are never nulled. */
+                    int64_t int_null = agg_int_null_sentinel_for(ao->out_type);
                     switch (op) {
                         case OP_SUM:
                             v = ROW_RD_I64(row, ly->off_sum, s);
                             if (ao->affine) v += ao->bias_i64 * cnt;
                             break;
-                        case OP_PROD:  v = ROW_RD_I64(row, ly->off_sum, s); break;
+                        case OP_PROD:
+                            if (nn == 0) { v = int_null; grp_set_null(ao->vec, di); break; }
+                            v = ROW_RD_I64(row, ly->off_sum, s); break;
                         case OP_COUNT: v = cnt; break;
-                        case OP_MIN:   v = ROW_RD_I64(row, ly->off_min, s); break;
-                        case OP_MAX:   v = ROW_RD_I64(row, ly->off_max, s); break;
-                        case OP_FIRST: case OP_LAST: v = ROW_RD_I64(row, ly->off_sum, s); break;
+                        case OP_MIN:
+                            if (nn == 0) { v = int_null; grp_set_null(ao->vec, di); break; }
+                            v = ROW_RD_I64(row, ly->off_min, s); break;
+                        case OP_MAX:
+                            if (nn == 0) { v = int_null; grp_set_null(ao->vec, di); break; }
+                            v = ROW_RD_I64(row, ly->off_max, s); break;
+                        case OP_FIRST: case OP_LAST:
+                            if (nn == 0) { v = int_null; grp_set_null(ao->vec, di); break; }
+                            v = ROW_RD_I64(row, ly->off_sum, s); break;
                         default:       v = 0; break;
                     }
                     ((int64_t*)(void*)ao->dst)[di] = v;
@@ -4222,8 +4432,6 @@ static inline void da_accum_free(da_accum_t* a) {
     scratch_free(a->_h_first_row);
     scratch_free(a->_h_last_row);
 }
-
-static inline int64_t agg_int_null_sentinel_for(int8_t t);
 
 /* Unified agg result emitter — used by both DA and HT paths.
  * Arrays indexed by [gi * n_aggs + a], counts by [gi].  nn_counts (if
@@ -4841,17 +5049,7 @@ static ray_t* materialize_broadcast_input(ray_t* src, int64_t nrows) {
     }
 }
 
-/* Per-type integer null sentinel for an aggregation column.  Returns 0 for
- * non-nullable / non-integer types (BOOL, U8, SYM, F64) since 0 will never
- * match a read_col_i64 value flagged as null via agg_int_null_mask. */
-static inline int64_t agg_int_null_sentinel_for(int8_t t) {
-    switch (t) {
-        case RAY_I64: case RAY_TIMESTAMP:            return NULL_I64;
-        case RAY_I32: case RAY_DATE: case RAY_TIME:  return (int64_t)NULL_I32;
-        case RAY_I16:                                return (int64_t)NULL_I16;
-        default:                                     return 0;
-    }
-}
+/* agg_int_null_sentinel_for moved to internal.h (shared with pivot.c). */
 
 /* Fused SUM/AVG(a*b) per-row product — both sides promoted to double,
  * matching the expr path exactly (see try_prod_sumavg_input_f64). */
@@ -10375,6 +10573,10 @@ sequential_fallback:;
         for (uint32_t gi = 0; gi < grp_count; gi++) {
             const char* row = final_ht->rows + (size_t)gi * ly->row_stride;
             int64_t cnt = *(const int64_t*)(const void*)row;
+            /* nn = per-slot non-null count (nullable layout) or the group row
+             * count (null-free — byte-identical to before). */
+            int64_t nn = ly->off_nn
+                ? ((const int64_t*)(const void*)(row + ly->off_nn))[s] : cnt;
             if (out_type == RAY_F64) {
                 double v;
                 switch (agg_op) {
@@ -10384,40 +10586,45 @@ sequential_fallback:;
                         if (agg_affine[a].enabled) v += agg_affine[a].bias_f64 * cnt;
                         break;
                     case OP_PROD:
+                        if (nn == 0) { v = NULL_F64; ray_vec_set_null(new_col, gi, true); break; }
                         v = is_f64 ? ROW_RD_F64(row, ly->off_sum, s)
                                    : (double)ROW_RD_I64(row, ly->off_sum, s);
                         break;
                     case OP_AVG:
-                        v = is_f64 ? ROW_RD_F64(row, ly->off_sum, s) / cnt
-                                   : (double)ROW_RD_I64(row, ly->off_sum, s) / cnt;
+                        if (nn == 0) { v = NULL_F64; ray_vec_set_null(new_col, gi, true); break; }
+                        v = is_f64 ? ROW_RD_F64(row, ly->off_sum, s) / nn
+                                   : (double)ROW_RD_I64(row, ly->off_sum, s) / nn;
                         if (agg_affine[a].enabled) v += agg_affine[a].bias_f64;
                         break;
                     case OP_MIN:
+                        if (nn == 0) { v = NULL_F64; ray_vec_set_null(new_col, gi, true); break; }
                         v = is_f64 ? ROW_RD_F64(row, ly->off_min, s)
                                    : (double)ROW_RD_I64(row, ly->off_min, s);
                         break;
                     case OP_MAX:
+                        if (nn == 0) { v = NULL_F64; ray_vec_set_null(new_col, gi, true); break; }
                         v = is_f64 ? ROW_RD_F64(row, ly->off_max, s)
                                    : (double)ROW_RD_I64(row, ly->off_max, s);
                         break;
                     case OP_FIRST: case OP_LAST:
+                        if (nn == 0) { v = NULL_F64; ray_vec_set_null(new_col, gi, true); break; }
                         v = is_f64 ? ROW_RD_F64(row, ly->off_sum, s)
                                    : (double)ROW_RD_I64(row, ly->off_sum, s);
                         break;
                     case OP_VAR: case OP_VAR_POP:
                     case OP_STDDEV: case OP_STDDEV_POP: {
-                        bool insuf = (agg_op == OP_VAR || agg_op == OP_STDDEV) ? cnt <= 1 : cnt <= 0;
+                        bool insuf = (agg_op == OP_VAR || agg_op == OP_STDDEV) ? nn <= 1 : nn <= 0;
                         if (insuf) { v = NULL_F64; ray_vec_set_null(new_col, gi, true); break; }
                         double sum_val = is_f64 ? ROW_RD_F64(row, ly->off_sum, s)
                                                 : (double)ROW_RD_I64(row, ly->off_sum, s);
                         double sq_val = ly->off_sumsq ? ROW_RD_F64(row, ly->off_sumsq, s) : 0.0;
-                        double mean = sum_val / cnt;
-                        double var_pop = sq_val / cnt - mean * mean;
+                        double mean = sum_val / nn;
+                        double var_pop = sq_val / nn - mean * mean;
                         if (var_pop < 0) var_pop = 0;
                         if (agg_op == OP_VAR_POP) v = var_pop;
-                        else if (agg_op == OP_VAR) v = var_pop * cnt / (cnt - 1);
+                        else if (agg_op == OP_VAR) v = var_pop * nn / (nn - 1);
                         else if (agg_op == OP_STDDEV_POP) v = sqrt(var_pop);
-                        else v = sqrt(var_pop * cnt / (cnt - 1));
+                        else v = sqrt(var_pop * nn / (nn - 1));
                         break;
                     }
                     case OP_PEARSON_CORR: {
@@ -10443,16 +10650,27 @@ sequential_fallback:;
                 ((double*)ray_data(new_col))[gi] = ray_f64_fin(v);
             } else {
                 int64_t v;
+                /* All-null group emits the width-correct sentinel; SUM/COUNT
+                 * are never nulled. */
+                int64_t int_null = agg_int_null_sentinel_for(out_type);
                 switch (agg_op) {
                     case OP_SUM:
                         v = ROW_RD_I64(row, ly->off_sum, s);
                         if (agg_affine[a].enabled) v += agg_affine[a].bias_i64 * cnt;
                         break;
-                    case OP_PROD:  v = ROW_RD_I64(row, ly->off_sum, s); break;
+                    case OP_PROD:
+                        if (nn == 0) { v = int_null; ray_vec_set_null(new_col, gi, true); break; }
+                        v = ROW_RD_I64(row, ly->off_sum, s); break;
                     case OP_COUNT: v = cnt; break;
-                    case OP_MIN:   v = ROW_RD_I64(row, ly->off_min, s); break;
-                    case OP_MAX:   v = ROW_RD_I64(row, ly->off_max, s); break;
-                    case OP_FIRST: case OP_LAST: v = ROW_RD_I64(row, ly->off_sum, s); break;
+                    case OP_MIN:
+                        if (nn == 0) { v = int_null; ray_vec_set_null(new_col, gi, true); break; }
+                        v = ROW_RD_I64(row, ly->off_min, s); break;
+                    case OP_MAX:
+                        if (nn == 0) { v = int_null; ray_vec_set_null(new_col, gi, true); break; }
+                        v = ROW_RD_I64(row, ly->off_max, s); break;
+                    case OP_FIRST: case OP_LAST:
+                        if (nn == 0) { v = int_null; ray_vec_set_null(new_col, gi, true); break; }
+                        v = ROW_RD_I64(row, ly->off_sum, s); break;
                     default:       v = 0; break;
                 }
                 /* Narrow-int / adaptive-width SYM store: see the matching

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -4452,8 +4452,8 @@ typedef struct {
     uint16_t*      agg_ops;      /* per-agg operation code */
     uint8_t        n_aggs;
     uint8_t        need_flags;   /* DA_NEED_* bitmask */
-    uint32_t       agg_f64_mask; /* bitmask: bit a set if agg[a] is RAY_F64 */
-    uint32_t       agg_int_null_mask; /* bitmask: bit a set if agg[a] is an integer col with HAS_NULLS */
+    uint64_t       agg_f64_mask; /* bitmask: bit a set if agg[a] is RAY_F64 */
+    uint64_t       agg_int_null_mask; /* bitmask: bit a set if agg[a] is an integer col with HAS_NULLS */
     int64_t*       agg_int_null_sentinel; /* per-agg int sentinel (NULL_I64 etc) when bit set in mask */
     bool           all_sum;      /* true when all ops are SUM/AVG/COUNT (no MIN/MAX/FIRST/LAST) */
     uint32_t       n_slots;
@@ -5116,8 +5116,8 @@ static inline void da_accum_row(da_ctx_t* c, da_accum_t* acc, int32_t gid, int64
         /* SUM/AVG/COUNT fast path — no op-code dispatch, typed read only.
          * COUNT-only queries have acc->sum==NULL; count[gid]++ above suffices. */
         if (!acc->sum) return;
-        uint32_t f64m = c->agg_f64_mask;
-        uint32_t inm = c->agg_int_null_mask;
+        uint64_t f64m = c->agg_f64_mask;
+        uint64_t inm = c->agg_int_null_mask;
         int64_t* nn = acc->nn_count;
         for (uint32_t a = 0; a < n_aggs; a++) {
             size_t idx = base + a;
@@ -5132,7 +5132,7 @@ static inline void da_accum_row(da_ctx_t* c, da_accum_t* acc, int32_t gid, int64
                 acc->sum[idx].i += group_strlen_at_cached(
                     c->agg_cols[a], r, c->sym_strings, c->sym_count);
                 if (nn) nn[idx]++;
-            } else if (f64m & (1u << a)) {
+            } else if (f64m & ((uint64_t)1 << a)) {
                 /* NaN payload = null, skip from sum. */
                 double v = ((const double*)c->agg_ptrs[a])[r];
                 if (RAY_LIKELY(v == v)) { acc->sum[idx].f += v; if (nn) nn[idx]++; }
@@ -5193,7 +5193,7 @@ static inline void da_accum_row(da_ctx_t* c, da_accum_t* acc, int32_t gid, int64
         /* NULL_I* sentinel = null.  Bit set in agg_int_null_mask AND
          * value equal to per-agg sentinel means this row is null for
          * an integer aggregation column. */
-        bool int_null = (c->agg_int_null_mask & (1u << a)) &&
+        bool int_null = (c->agg_int_null_mask & ((uint64_t)1 << a)) &&
                         iv == c->agg_int_null_sentinel[a];
         bool is_null = is_f ? !(fv == fv) : int_null;
         if (op == OP_SUM || op == OP_AVG || op == OP_STDDEV || op == OP_STDDEV_POP || op == OP_VAR || op == OP_VAR_POP) {
@@ -7662,7 +7662,12 @@ da_path:;
     #define DA_MEM_BUDGET      (256ULL << 20)  /* 256 MB total across all workers */
     #define DA_PER_WORKER_MAX  (6ULL << 20)    /* 6 MB per-worker max */
     {
-        bool da_eligible = (nrows > 0 && n_keys > 0 && n_keys <= 8);
+        /* n_aggs <= 64 is not a slot cap — it is the width of the da_ctx_t
+         * agg_f64_mask/agg_int_null_mask bitmasks (uint64_t, one bit per
+         * agg).  Wider agg lists route to the hash (HT) path instead, which
+         * carries per-agg arrays rather than a fixed-width bitmask. */
+        bool da_eligible = (nrows > 0 && n_keys > 0 && n_keys <= 8 &&
+                             n_aggs <= 64);
         if (da_eligible && rowsel && n_keys == 1) {
             ray_rowsel_t* sm = ray_rowsel_meta(rowsel);
             if (sm && sm->total_pass * 4 < nrows)
@@ -7852,15 +7857,17 @@ da_path:;
             uint32_t n_slots = (uint32_t)total_slots;
             size_t total = (size_t)n_slots * n_aggs;
 
-            /* VLA bounded ≤8: this whole block is under da_fits, which
-             * requires da_eligible, which requires n_keys > 0 (da_eligible's
-             * definition) — and n_keys > 0 forces n_aggs ≤ 8 via the
-             * exec_group_run width guard. */
+            /* VLA sized to vla_aggs (== n_aggs): agg_ptrs/agg_types/
+             * da_int_null_sentinel are per-element arrays, not bitmasks, so
+             * they scale with n_aggs directly.  This whole block is under
+             * da_fits, which requires da_eligible, which caps n_aggs <= 64 —
+             * the width of the agg_f64_mask/da_int_null_mask bitmasks built
+             * just below, not a VLA bound. */
             void* agg_ptrs[vla_aggs];
             int8_t agg_types[vla_aggs];
             int64_t da_int_null_sentinel[vla_aggs];
-            uint32_t agg_f64_mask = 0;
-            uint32_t da_int_null_mask = 0;
+            uint64_t agg_f64_mask = 0;
+            uint64_t da_int_null_mask = 0;
             /* Track whether any agg column can produce a null so we can
              * allocate per-(group, agg) non-null counts only when required.
              * F64 with HAS_NULLS uses NaN-skip; sentinel-typed integers
@@ -7871,7 +7878,7 @@ da_path:;
                     /* Fused product: F64 accumulate, no source vec. */
                     agg_ptrs[a]  = NULL;
                     agg_types[a] = RAY_F64;
-                    agg_f64_mask |= (1u << a);
+                    agg_f64_mask |= ((uint64_t)1 << a);
                     da_int_null_sentinel[a] = 0;
                     continue;
                 }
@@ -7879,7 +7886,7 @@ da_path:;
                     agg_ptrs[a]  = ray_data(agg_vecs[a]);
                     agg_types[a] = agg_vecs[a]->type;
                     if (agg_vecs[a]->type == RAY_F64)
-                        agg_f64_mask |= (1u << a);
+                        agg_f64_mask |= ((uint64_t)1 << a);
                     da_int_null_sentinel[a] = agg_int_null_sentinel_for(agg_vecs[a]->type);
                     /* Only set the int-null mask bit for storage types whose
                      * sentinel is meaningful.  BOOL/U8/SYM use 0 as their default
@@ -7890,7 +7897,7 @@ da_path:;
                     bool is_sentinel_typed = (t == RAY_I16 || t == RAY_I32 || t == RAY_I64 ||
                                               t == RAY_DATE || t == RAY_TIME || t == RAY_TIMESTAMP);
                     if (is_sentinel_typed && (agg_vecs[a]->attrs & RAY_ATTR_HAS_NULLS))
-                        da_int_null_mask |= (1u << a);
+                        da_int_null_mask |= ((uint64_t)1 << a);
                     if ((agg_vecs[a]->attrs & RAY_ATTR_HAS_NULLS) &&
                         (agg_vecs[a]->type == RAY_F64 || is_sentinel_typed))
                         da_any_nullable = true;
@@ -8360,7 +8367,11 @@ da_path:;
     }
 
     {
-        bool sp_eligible = (nrows > 0 && n_keys == 1 && key_data[0] != NULL);
+        /* n_aggs <= 64: same mask-width bound as da_eligible above — this
+         * path's independent agg_f64_mask is also a uint64_t.  Beyond 64
+         * aggs, fall through to the hash path. */
+        bool sp_eligible = (nrows > 0 && n_keys == 1 && key_data[0] != NULL &&
+                             n_aggs <= 64);
         int8_t kt = sp_eligible ? key_types[0] : 0;
         if (sp_eligible && kt != RAY_I64 && kt != RAY_I32 && kt != RAY_I16 &&
             kt != RAY_U8 && kt != RAY_BOOL && kt != RAY_DATE &&
@@ -8399,18 +8410,19 @@ da_path:;
             if (!group_materialize_prod_slots(agg_prod, agg_vecs, agg_owned,
                                               n_aggs, nrows))
                 goto ht_path;
-            /* VLA bounded ≤8: sp_eligible requires n_keys == 1 (sp_eligible's
-             * definition), and n_keys > 0 forces n_aggs ≤ 8 via the
-             * exec_group_run width guard. */
+            /* VLA sized to vla_aggs (== n_aggs): agg_ptrs/agg_types are
+             * per-element arrays, not bitmasks.  sp_eligible caps n_aggs <=
+             * 64 — the width of the agg_f64_mask bitmask built just below,
+             * not a VLA bound. */
             void* agg_ptrs[vla_aggs];
             int8_t agg_types[vla_aggs];
-            uint32_t agg_f64_mask = 0;
+            uint64_t agg_f64_mask = 0;
             for (uint32_t a = 0; a < n_aggs; a++) {
                 if (agg_vecs[a]) {
                     agg_ptrs[a] = ray_data(agg_vecs[a]);
                     agg_types[a] = agg_vecs[a]->type;
                     if (agg_vecs[a]->type == RAY_F64)
-                        agg_f64_mask |= (1u << a);
+                        agg_f64_mask |= ((uint64_t)1 << a);
                 } else {
                     agg_ptrs[a] = NULL;
                     agg_types[a] = 0;
@@ -8498,7 +8510,7 @@ da_path:;
                 if (agg_strlen[a])                                               \
                     sums[a].i += group_strlen_at_cached(                         \
                         agg_vecs[a], dyn_row, strlen_sym_strings, strlen_sym_count); \
-                else if (agg_f64_mask & (1u << a))                               \
+                else if (agg_f64_mask & ((uint64_t)1 << a))                      \
                     sums[a].f += ((const double*)agg_ptrs[a])[dyn_row];          \
                 else                                                             \
                     sums[a].i += read_col_i64(agg_ptrs[a], dyn_row, agg_types[a], 0); \
@@ -8631,7 +8643,7 @@ dyn_dense_done:
             if (agg_strlen[a])                                                   \
                 sums[a].i += group_strlen_at_cached(                             \
                     agg_vecs[a], dyn_row, strlen_sym_strings, strlen_sym_count); \
-            else if (agg_f64_mask & (1u << a))                                   \
+            else if (agg_f64_mask & ((uint64_t)1 << a))                          \
                 sums[a].f += ((const double*)agg_ptrs[a])[dyn_row];              \
             else                                                                 \
                 sums[a].i += read_col_i64(agg_ptrs[a], dyn_row, agg_types[a], 0);\
@@ -8752,7 +8764,7 @@ dyn_dense_done:
                                     sums[a].i += group_strlen_at_cached(
                                         agg_vecs[a], r, strlen_sym_strings,
                                         strlen_sym_count);
-                                else if (agg_f64_mask & (1u << a))
+                                else if (agg_f64_mask & ((uint64_t)1 << a))
                                     sums[a].f += ((const double*)agg_ptrs[a])[r];
                                 else
                                     sums[a].i += read_col_i64(agg_ptrs[a], r,
@@ -8860,7 +8872,7 @@ dyn_dense_done:
                                     sums[a].i += group_strlen_at_cached(
                                         agg_vecs[a], r, strlen_sym_strings,
                                         strlen_sym_count);
-                                else if (agg_f64_mask & (1u << a))
+                                else if (agg_f64_mask & ((uint64_t)1 << a))
                                     sums[a].f += ((const double*)agg_ptrs[a])[r];
                                 else
                                     sums[a].i += read_col_i64(agg_ptrs[a], r,
@@ -8948,7 +8960,7 @@ dyn_dense_done:
                             sums[a].i += group_strlen_at_cached(
                                 agg_vecs[a], r, strlen_sym_strings,
                                 strlen_sym_count);
-                        else if (agg_f64_mask & (1u << a))
+                        else if (agg_f64_mask & ((uint64_t)1 << a))
                             sums[a].f += ((const double*)agg_ptrs[a])[r];
                         else
                             sums[a].i += read_col_i64(agg_ptrs[a], r, agg_types[a], 0);
@@ -9089,7 +9101,7 @@ dyn_dense_done:
                             sums[a].i += group_strlen_at_cached(
                                 agg_vecs[a], r, strlen_sym_strings,
                                 strlen_sym_count);
-                        else if (agg_f64_mask & (1u << a))
+                        else if (agg_f64_mask & ((uint64_t)1 << a))
                             sums[a].f += ((const double*)agg_ptrs[a])[r];
                         else
                             sums[a].i += read_col_i64(agg_ptrs[a], r, agg_types[a], 0);

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -2485,12 +2485,18 @@ bool ght_compute_layout(ght_layout_t* out, uint32_t n_keys, uint32_t n_aggs,
     }
     out->n_agg_vals = nv;
     out->agg_flags_any = agg_any;
-    /* Key region = keys + 8-byte null mask slot (stored after last key).
-     * The null mask slot holds a bitmap of which keys were null in the source
-     * row (bit k = key k is null). Folding this slot into hash/memcmp lets
-     * null and 0 form distinct groups.  Inline-STR keys are 16 B, all others
-     * 8 B; when no inline-STR key is present every offset is k*8 (byte-identical
-     * to the legacy fixed-8 layout, so non-STR group-bys are unchanged). */
+    /* Null tracking: ceil(n_keys/64) int64 words, floored at 1 so the rare
+     * n_keys==0 HT fallback keeps a (trivially-zero) null slot — byte-identical
+     * to the legacy single-int64 layout for every ≤64-key shape. */
+    uint32_t null_words = n_keys ? ((n_keys + 63u) >> 6) : 1u;
+    out->null_words = (uint16_t)null_words;
+    /* Key region = keys + null_words*8 null-mask words (stored after last key).
+     * The null-mask words hold a bitmap of which keys were null in the source
+     * row (word k>>6 bit k&63 = key k is null).  Folding them into hash/memcmp
+     * lets null and 0 form distinct groups.  Inline-STR keys are 16 B, all
+     * others 8 B; when no inline-STR key is present every offset is k*8 and the
+     * single null word sits at n_keys*8 (byte-identical to the legacy fixed-8
+     * layout, so non-STR ≤64-key group-bys are unchanged). */
     {
         uint32_t koff = 0;
         for (uint32_t k = 0; k < n_keys; k++) {
@@ -2501,8 +2507,8 @@ bool ght_compute_layout(ght_layout_t* out, uint32_t n_keys, uint32_t n_aggs,
             koff += (out->key_flags[k] & GHT_KEYF_INLINE_STR) ? 16 : 8;
         }
         if (koff > UINT16_MAX) { ght_layout_free(out); return false; }
-        out->key_off[n_keys] = (uint16_t)koff;   /* null mask */
-        koff += 8;
+        out->key_off[n_keys] = (uint16_t)koff;   /* null-mask word 0 */
+        koff += null_words * 8;
         if (koff > UINT16_MAX) { ght_layout_free(out); return false; }  /* stride budget, not a slot count */
         out->key_region = (uint16_t)koff;
     }
@@ -2665,6 +2671,17 @@ static inline bool wide_key_eq_at(const ght_layout_t* ly, uint8_t k,
     return memcmp(base + (size_t)ra * esz, base + (size_t)rb * esz, esz) == 0;
 }
 
+/* Fold the null-mask words [nullw, nullw+null_words) into the running key
+ * hash.  Mirrors the historical `if (null_mask) combine` exactly, word-wise:
+ * an all-zero word contributes nothing, so a single-word (≤64-key) layout
+ * produces the byte-identical hash of the legacy single-int64 null slot. */
+static inline uint64_t ght_hash_null_words(uint64_t h, const int64_t* nullw,
+                                           uint32_t null_words) {
+    for (uint32_t w = 0; w < null_words; w++)
+        if (nullw[w]) h = ray_hash_combine(h, ray_hash_i64(nullw[w]));
+    return h;
+}
+
 /* ── Inline-STR key resolution (descriptor stored in the entry/row) ──
  * key_inline_str keys hold their 16-byte ray_str_t descriptor at
  * keybase+key_off[k], so hash/compare are cache-local; key_pool[k] (the source
@@ -2700,29 +2717,30 @@ static inline uint64_t inline_layout_key_hash(const ght_layout_t* ly, uint8_t k,
 }
 
 /* Build the key region of a fat entry for an inline-STR layout (offsets
- * shifted by 16-byte descriptors).  Writes keys + null mask at keybase (entry+8
- * / row+8), returns the combined hash and the null mask.  Mirrors the legacy
+ * shifted by 16-byte descriptors).  Writes keys + null-mask words at keybase
+ * (entry+8 / row+8) and returns the combined hash.  Mirrors the legacy
  * fixed-8 build but addresses every slot via key_off[k]. */
 static inline uint64_t inline_build_keys(const ght_layout_t* ly, const int8_t* key_types,
         void* const* key_data, const uint8_t* key_attrs, const void* const* key_pool,
         ray_t* const* key_vecs, uint8_t nullable, int64_t row,
-        char* keybase, int64_t* out_null_mask) {
+        char* keybase) {
     uint64_t h = 0;
-    /* int64 null mask: null-tracking tops out at 64 keys — revisit when key
-     * admission passes 64 (cut 3+).  Untriggerable today (keys ≤ 16) — every
-     * `null_mask |= ((int64_t)1 << k)` site in this file shifts in the int64
-     * domain (not 32-bit then widen) so it stays defined once it is. */
-    int64_t null_mask = 0;
     uint16_t nk = ly->n_keys;
     const uint8_t* const kflags = ly->key_flags;
     const uint16_t* const koff = ly->key_off;
+    /* Null-mask words live in the key region at koff[nk]; ceil(nk/64) words,
+     * so bit k is word (k>>6) bit (k&63).  Written in-place — no scalar
+     * accumulator caps the key count at 64. */
+    int64_t* nullw = (int64_t*)(keybase + koff[nk]);
+    uint32_t null_words = ly->null_words;
+    for (uint32_t w = 0; w < null_words; w++) nullw[w] = 0;
     for (uint32_t k = 0; k < nk; k++) {
         char* slot = keybase + koff[k];
         uint64_t kh;
         bool is_null = (nullable & (1u << k)) && key_vecs && key_vecs[k]
                        && ray_vec_is_null(key_vecs[k], row);
         if (is_null) {
-            null_mask |= ((int64_t)1 << k);
+            nullw[k >> 6] |= (int64_t)1 << (k & 63);
             if (kflags[k] & GHT_KEYF_INLINE_STR) memset(slot, 0, sizeof(ray_str_t));
             else *(int64_t*)slot = 0;
             kh = ray_hash_i64(0);
@@ -2743,10 +2761,7 @@ static inline uint64_t inline_build_keys(const ght_layout_t* ly, const int8_t* k
         }
         h = (k == 0) ? kh : ray_hash_combine(h, kh);
     }
-    *(int64_t*)(keybase + koff[nk]) = null_mask;
-    if (null_mask) h = ray_hash_combine(h, ray_hash_i64(null_mask));
-    *out_null_mask = null_mask;
-    return h;
+    return ght_hash_null_words(h, nullw, null_words);
 }
 
 /* Hash inline int64_t keys (for rehash — resolves wide keys via
@@ -2763,9 +2778,8 @@ static inline uint64_t hash_keys_inline(const int64_t* keys, const int8_t* key_t
             uint64_t kh = inline_layout_key_hash(ly, k, key_types, keys, key_data, key_pool);
             h = (k == 0) ? kh : ray_hash_combine(h, kh);
         }
-        int64_t null_mask = *(const int64_t*)((const char*)keys + ly->key_off[n_keys]);
-        if (null_mask) h = ray_hash_combine(h, ray_hash_i64(null_mask));
-        return h;
+        const int64_t* nullw = (const int64_t*)((const char*)keys + ly->key_off[n_keys]);
+        return ght_hash_null_words(h, nullw, ly->null_words);
     }
     const uint8_t* const kflags = ly->key_flags;
     uint64_t h = 0;
@@ -2784,11 +2798,9 @@ static inline uint64_t hash_keys_inline(const int64_t* keys, const int8_t* key_t
         }
         h = (k == 0) ? kh : ray_hash_combine(h, kh);
     }
-    /* Fold null mask (slot n_keys) into hash so null/0 form distinct groups */
-    int64_t null_mask = keys[n_keys];
-    if (null_mask)
-        h = ray_hash_combine(h, ray_hash_i64(null_mask));
-    return h;
+    /* Fold null-mask words (at slot n_keys) into hash so null/0 form distinct
+     * groups.  Non-inline keys are 8 B each, so word w is keys[n_keys+w]. */
+    return ght_hash_null_words(h, keys + n_keys, ly->null_words);
 }
 
 static void group_ht_rehash(group_ht_t* ht, const int8_t* key_types) {
@@ -3003,8 +3015,10 @@ static inline bool group_keys_equal(const int64_t* a_keys, const int64_t* b_keys
                                       const void* const* key_pool) {
     uint16_t nk = ly->n_keys;
     if (!ly->any_wide_key) {
-        /* memcmp covers nk values + trailing 8-byte null mask slot */
-        return memcmp(a_keys, b_keys, (size_t)(nk + 1) * 8) == 0;
+        /* memcmp covers nk 8-byte values + the null_words trailing words:
+         * key_region == (nk + null_words)*8 with no wide/inline-STR keys, so
+         * the compare length widens with the null region — no shape change. */
+        return memcmp(a_keys, b_keys, (size_t)ly->key_region) == 0;
     }
     const uint8_t* const kflags = ly->key_flags;
     const uint16_t* const koff = ly->key_off;
@@ -3025,8 +3039,8 @@ static inline bool group_keys_equal(const int64_t* a_keys, const int64_t* b_keys
                     *(const int64_t*)(b + koff[k])) return false;
             }
         }
-        return *(const int64_t*)(a + koff[nk]) ==
-               *(const int64_t*)(b + koff[nk]);
+        return memcmp(a + koff[nk], b + koff[nk],
+                      (size_t)ly->null_words * 8) == 0;
     }
     for (uint32_t k = 0; k < nk; k++) {
         if (kflags[k] & GHT_KEYF_WIDE) {
@@ -3036,8 +3050,10 @@ static inline bool group_keys_equal(const int64_t* a_keys, const int64_t* b_keys
             if (a_keys[k] != b_keys[k]) return false;
         }
     }
-    /* Null mask slot must match too */
-    if (a_keys[nk] != b_keys[nk]) return false;
+    /* Null-mask words must match too (non-inline keys are 8 B, so the words
+     * start at slot nk). */
+    if (memcmp(a_keys + nk, b_keys + nk, (size_t)ly->null_words * 8) != 0)
+        return false;
     return true;
 }
 
@@ -3172,19 +3188,23 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
         if (!match_idx && rowsel && !group_rowsel_pass(rowsel, row)) continue;
         uint64_t h = 0;
         int64_t* ek = (int64_t*)(ebuf + 8);
-        int64_t null_mask = 0;
         if (ly->any_inline_str) {
             h = inline_build_keys(ly, key_types, key_data, key_attrs, ht->key_pool,
-                                  key_vecs, nullable_mask, row, ebuf + 8, &null_mask);
+                                  key_vecs, nullable_mask, row, ebuf + 8);
         } else {
+        /* Non-inline keys are 8 B each, so the null-mask words start at ek[nk]
+         * (== ebuf+8+key_off[nk]); write bit k into word k>>6 in place. */
+        int64_t* nullw = ek + nk;
+        uint32_t null_words = ly->null_words;
+        for (uint32_t w = 0; w < null_words; w++) nullw[w] = 0;
         for (uint32_t k = 0; k < nk; k++) {
             int8_t t = key_types[k];
             uint64_t kh;
             bool is_null = (nullable_mask & (1u << k))
                            && ray_vec_is_null(key_vecs[k], row);
             if (is_null) {
-                null_mask |= ((int64_t)1 << k);
-                ek[k] = 0;  /* canonical null value — real 0 differs via null_mask */
+                nullw[k >> 6] |= (int64_t)1 << (k & 63);
+                ek[k] = 0;  /* canonical null value — real 0 differs via null mask */
                 kh = ray_hash_i64(0);
             } else if (wide_any && (kflags[k] & GHT_KEYF_WIDE)) {
                 /* Wide key: store source row index, hash the actual bytes
@@ -3203,8 +3223,7 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
             }
             h = (k == 0) ? kh : ray_hash_combine(h, kh);
         }
-        ek[nk] = null_mask;
-        if (null_mask) h = ray_hash_combine(h, ray_hash_i64(null_mask));
+        h = ght_hash_null_words(h, nullw, null_words);
         }
         *(uint64_t*)ebuf = h;
 
@@ -3277,12 +3296,14 @@ typedef struct {
     ray_t*    _hdr;
 } radix_buf_t;
 
+/* key_region_buf holds the full prebuilt key region (keys + null-mask words),
+ * contiguous, key_region bytes — inline-STR and plain layouts both stage it
+ * this way, so one memcpy serves both. */
 static inline void radix_buf_push(radix_buf_t* buf, uint16_t entry_stride,
-                                   uint64_t hash, const int64_t* keys, uint8_t n_keys,
-                                   int64_t null_mask,
+                                   uint64_t hash, const int64_t* key_region_buf,
                                    const int64_t* agg_vals, uint8_t n_agg_vals,
                                    bool has_first_last, int64_t row,
-                                   uint16_t key_region, bool inline_keys) {
+                                   uint16_t key_region) {
     if (__builtin_expect(buf->count >= buf->cap, 0)) {
         uint32_t old_cap = buf->cap;
         uint32_t new_cap = old_cap * 2;
@@ -3295,15 +3316,7 @@ static inline void radix_buf_push(radix_buf_t* buf, uint16_t entry_stride,
     }
     char* dst = buf->data + (size_t)buf->count * entry_stride;
     *(uint64_t*)dst = hash;
-    if (inline_keys) {
-        /* keys points at a prebuilt key-region buffer (incl. null mask) with
-         * 16-byte inline STR descriptors at shifted offsets. */
-        memcpy(dst + 8, keys, key_region);
-    } else {
-        memcpy(dst + 8, keys, (size_t)n_keys * 8);
-        /* Null mask slot sits right after the keys */
-        memcpy(dst + 8 + (size_t)n_keys * 8, &null_mask, 8);
-    }
+    memcpy(dst + 8, key_region_buf, key_region);
     if (n_agg_vals)
         memcpy(dst + 8 + key_region, agg_vals, (size_t)n_agg_vals * 8);
     /* Tail slot: source row index for FIRST/LAST tie-breaking. */
@@ -3350,7 +3363,7 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
     bool has_fl = (ly->agg_flags_any & (GHT_AF_FIRST | GHT_AF_LAST)) != 0;
     const int64_t* match_idx = c->match_idx;
 
-    int64_t keys[8];
+    int64_t keys[9];       /* non-inline key region: 8 keys + 1 null-mask word */
     int64_t agg_vals[8];
     char    keybuf[136];   /* inline-STR key region: max 8*16 + 8 null mask */
 
@@ -3363,19 +3376,23 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
         int64_t row = match_idx ? match_idx[i] : i;
         if (!match_idx && c->rowsel && !group_rowsel_pass(c->rowsel, row)) continue;
         uint64_t h = 0;
-        int64_t null_mask = 0;
         if (inline_str) {
             h = inline_build_keys(ly, c->key_types, c->key_data, c->key_attrs,
                                   c->key_pool, c->key_vecs, nullable, row,
-                                  keybuf, &null_mask);
+                                  keybuf);
         } else {
+        /* Stage keys + null-mask words contiguously (key-region shaped) so the
+         * push is one memcpy; null words start at keys[nk]. */
+        int64_t* nullw = keys + nk;
+        uint32_t null_words = ly->null_words;
+        for (uint32_t w = 0; w < null_words; w++) nullw[w] = 0;
         for (uint32_t k = 0; k < nk; k++) {
             int8_t t = c->key_types[k];
             uint64_t kh;
             bool is_null = (nullable & (1u << k))
                            && ray_vec_is_null(c->key_vecs[k], row);
             if (is_null) {
-                null_mask |= ((int64_t)1 << k);
+                nullw[k >> 6] |= (int64_t)1 << (k & 63);
                 keys[k] = 0;
                 kh = ray_hash_i64(0);
             } else if (wide_any && (kflags[k] & GHT_KEYF_WIDE)) {
@@ -3393,7 +3410,7 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
             }
             h = (k == 0) ? kh : ray_hash_combine(h, kh);
         }
-        if (null_mask) h = ray_hash_combine(h, ray_hash_i64(null_mask));
+        h = ght_hash_null_words(h, nullw, null_words);
         }
 
         uint8_t vi = 0;
@@ -3428,8 +3445,8 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
 
         uint32_t part = RADIX_PART(h);
         radix_buf_push(&my_bufs[part], estride, h,
-                       inline_str ? (const int64_t*)keybuf : keys, (uint8_t)nk, null_mask,
-                       agg_vals, (uint8_t)nv, has_fl, row, ly->key_region, inline_str != 0);
+                       inline_str ? (const int64_t*)keybuf : keys,
+                       agg_vals, (uint8_t)nv, has_fl, row, ly->key_region);
     }
 }
 
@@ -3516,7 +3533,7 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
             const char* row = ph->rows + (size_t)gi * rs;
             const char* rk = row + 8;     /* key region (key_off-addressed) */
             int64_t cnt = *(const int64_t*)(const void*)row;
-            int64_t null_mask = *(const int64_t*)(const void*)(rk + koff[nk]);
+            const int64_t* nullw = (const int64_t*)(const void*)(rk + koff[nk]);
             uint32_t di = off + gi;
 
             /* Scatter keys to result columns */
@@ -3525,7 +3542,7 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
                 uint8_t esz = c->key_esizes[k];
                 int8_t kt = c->key_types[k];
                 size_t doff = (size_t)di * esz;
-                if (null_mask & ((int64_t)1 << k)) {
+                if (nullw[k >> 6] & ((int64_t)1 << (k & 63))) {
                     if (c->key_cols && c->key_cols[k])
                         grp_set_null(c->key_cols[k], di);
                     /* Fill the correct-width sentinel. */
@@ -3869,18 +3886,20 @@ static void radix_v2_phase1_fn(void* ctx, uint32_t worker_id,
             continue;
         uint64_t h = 0;
         int64_t* ek = (int64_t*)(ebuf + 8);
-        int64_t null_mask = 0;
         if (inline_str) {
             h = inline_build_keys(ly, c->key_types, c->key_data, c->key_attrs,
-                                  kpool, c->key_vecs, nullable, row, ebuf + 8, &null_mask);
+                                  kpool, c->key_vecs, nullable, row, ebuf + 8);
         } else {
+        int64_t* nullw = ek + nk;   /* null-mask words at key_off[nk]==nk*8 */
+        uint32_t null_words = ly->null_words;
+        for (uint32_t w = 0; w < null_words; w++) nullw[w] = 0;
         for (uint32_t k = 0; k < nk; k++) {
             int8_t t = c->key_types[k];
             uint64_t kh;
             bool is_null = (nullable & (1u << k))
                            && ray_vec_is_null(c->key_vecs[k], row);
             if (is_null) {
-                null_mask |= ((int64_t)1 << k);
+                nullw[k >> 6] |= (int64_t)1 << (k & 63);
                 ek[k] = 0;
                 kh = ray_hash_i64(0);
             } else if (wide_any && (kflags[k] & GHT_KEYF_WIDE)) {
@@ -3898,8 +3917,7 @@ static void radix_v2_phase1_fn(void* ctx, uint32_t worker_id,
             }
             h = (k == 0) ? kh : ray_hash_combine(h, kh);
         }
-        ek[nk] = null_mask;
-        if (null_mask) h = ray_hash_combine(h, ray_hash_i64(null_mask));
+        h = ght_hash_null_words(h, nullw, null_words);
         }
         *(uint64_t*)ebuf = h;
         /* Pack agg values into entry — only when the HT layout actually
@@ -5468,20 +5486,22 @@ static void reprobe_rows_fn(void* vctx, uint32_t worker_id,
             continue;
         }
         uint64_t h = 0;
-        int64_t null_mask = 0;
         const int64_t* lookup_keys;
         if (c->layout->any_inline_str) {
             h = inline_build_keys(c->layout, key_types, key_data, key_attrs,
-                                  c->key_pool, key_vecs, nullable, row, keybuf, &null_mask);
+                                  c->key_pool, key_vecs, nullable, row, keybuf);
             lookup_keys = (const int64_t*)keybuf;
         } else {
+        int64_t* nullw = ek_buf + nk;   /* null-mask words at key_off[nk]==nk*8 */
+        uint32_t null_words = c->layout->null_words;
+        for (uint32_t w = 0; w < null_words; w++) nullw[w] = 0;
         for (uint32_t k = 0; k < nk; k++) {
             int8_t t = key_types[k];
             uint64_t kh;
             bool is_null = (nullable & (1u << k))
                            && ray_vec_is_null(key_vecs[k], row);
             if (is_null) {
-                null_mask |= ((int64_t)1 << k);
+                nullw[k >> 6] |= (int64_t)1 << (k & 63);
                 ek_buf[k] = 0;
                 kh = ray_hash_i64(0);
             } else if (wide_any && (kflags[k] & GHT_KEYF_WIDE)) {
@@ -5499,8 +5519,7 @@ static void reprobe_rows_fn(void* vctx, uint32_t worker_id,
             }
             h = (k == 0) ? kh : ray_hash_combine(h, kh);
         }
-        ek_buf[nk] = null_mask;
-        if (null_mask) h = ray_hash_combine(h, ray_hash_i64(null_mask));
+        h = ght_hash_null_words(h, nullw, null_words);
         lookup_keys = ek_buf;
         }
 
@@ -9963,11 +9982,14 @@ sequential_fallback:;
         const char* src_base = is_wide ? (const char*)key_data[k] : NULL;
 
         bool inline_str_k = (ly->key_flags[k] & GHT_KEYF_INLINE_STR) != 0;
+        /* Key k's null bit lives in null-mask word (k>>6), bit (k&63). */
+        size_t null_woff = (size_t)ly->key_off[n_keys] + (size_t)(k >> 6) * 8;
+        int64_t null_kbit = (int64_t)1 << (k & 63);
         for (uint32_t gi = 0; gi < grp_count; gi++) {
             const char* row = final_ht->rows + (size_t)gi * ly->row_stride;
             const char* rk = row + 8;
-            int64_t null_mask = *(const int64_t*)(rk + ly->key_off[n_keys]);
-            if (null_mask & ((int64_t)1 << k)) {
+            int64_t null_word = *(const int64_t*)(rk + null_woff);
+            if (null_word & null_kbit) {
                 ray_vec_set_null(new_col, (int64_t)gi, true);
                 /* Fill the correct-width sentinel. */
                 switch (kt) {
@@ -10059,21 +10081,23 @@ sequential_fallback:;
                      * agg which already respects the selection. */
                     if (!match_idx && !group_rowsel_pass(rowsel, row)) continue;
                     uint64_t h = 0;
-                    int64_t null_mask = 0;
                     const int64_t* lookup_keys;
                     if (ly->any_inline_str) {
                         h = inline_build_keys(ly, key_types, key_data, key_attrs,
                                               reprobe_pool, key_vecs, reprobe_nullable_s,
-                                              row, keybuf, &null_mask);
+                                              row, keybuf);
                         lookup_keys = (const int64_t*)keybuf;
                     } else {
+                    int64_t* nullw = ek_buf + n_keys;   /* null-mask words at key_off[nk] */
+                    uint32_t null_words = ly->null_words;
+                    for (uint32_t w = 0; w < null_words; w++) nullw[w] = 0;
                     for (uint32_t k = 0; k < n_keys; k++) {
                         int8_t t = key_types[k];
                         uint64_t kh;
                         bool is_null = (reprobe_nullable_s & (1u << k))
                                        && ray_vec_is_null(key_vecs[k], row);
                         if (is_null) {
-                            null_mask |= ((int64_t)1 << k);
+                            nullw[k >> 6] |= (int64_t)1 << (k & 63);
                             ek_buf[k] = 0;
                             kh = ray_hash_i64(0);
                         } else if (ly->key_flags[k] & GHT_KEYF_WIDE) {
@@ -10091,8 +10115,7 @@ sequential_fallback:;
                         }
                         h = (k == 0) ? kh : ray_hash_combine(h, kh);
                     }
-                    ek_buf[n_keys] = null_mask;
-                    if (null_mask) h = ray_hash_combine(h, ray_hash_i64(null_mask));
+                    h = ght_hash_null_words(h, nullw, null_words);
                     lookup_keys = ek_buf;
                     }
                     uint32_t gid = group_ht_lookup_gid(final_ht, h, lookup_keys, key_types);

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -2492,13 +2492,21 @@ bool ght_compute_layout(ght_layout_t* out, uint32_t n_keys, uint32_t n_aggs,
         agg_any |= af;
         /* Null metadata for value-slot aggs whose input column advertises
          * HAS_NULLS.  Holistic/wide aggs reserve no accum slot (their per-group
-         * pass skips nulls itself), so they carry no nullable flag here.  A
-         * nullable value-slot agg makes the row-layout accumulators skip nulls
-         * (F64 NaN or the type's NULL_I* sentinel) and count non-nulls in the
-         * off_nn block. */
+         * pass skips nulls itself), so they carry no nullable flag here.
+         * COUNT reserves an nv slot for generic bookkeeping (phase1 still
+         * stages its raw value) but its emit reads the group's row count
+         * (cnt) directly, never off_nn — so a nullable COUNT input must not
+         * flip any_agg_null either, or a count-only nullable group-by
+         * allocates an off_nn block no agg ever reads.  Gate on the agg
+         * actually owning a value slot (vslot >= 0) and not being COUNT.  A
+         * nullable value-slot agg makes the row-layout accumulators skip
+         * nulls (F64 NaN or the type's NULL_I* sentinel) and count non-nulls
+         * in the off_nn block. */
         uint8_t af2 = 0;
         int64_t sent = 0;
-        if (!holistic && agg_vecs[a]) {
+        int8_t vslot = out->agg_val_slot[a];
+        bool is_count = agg_ops && agg_ops[a] == OP_COUNT;
+        if (vslot >= 0 && !is_count && agg_vecs[a]) {
             ray_t* src = (agg_vecs[a]->attrs & RAY_ATTR_SLICE)
                          ? agg_vecs[a]->slice_parent : agg_vecs[a];
             if (src && (src->attrs & RAY_ATTR_HAS_NULLS)) {
@@ -3957,7 +3965,13 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
                             v = ROW_RD_I64(row, ly->off_sum, s); break;
                         default:       v = 0; break;
                     }
-                    ((int64_t*)(void*)ao->dst)[di] = v;
+                    /* MIN/MAX/PROD/FIRST/LAST keep out_type = agg_col->type
+                     * (~9955 region), so ao->vec/ao->dst may be a narrow-int
+                     * (I32/I16/U8) column — mirror the serial emit (~4586):
+                     * a fixed 8-byte store overshoots a narrower slot,
+                     * corrupting/segfaulting past index 0. */
+                    topk_write_i64(ao->dst, di, v,
+                                   ray_sym_elem_size(ao->out_type, ao->vec->attrs));
                 }
             }
         }

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -6999,6 +6999,343 @@ static ray_t* exec_group_v2_exprs(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     return result;   /* NULL → legacy path */
 }
 
+/* ---- q34/count hot path extracted from exec_group_run ------------------
+ * Single-key (n_keys==1) sparse-dense emit-filter path: the dict-SYM
+ * count-only scatter (`range_count[off]++`) plus its keep-min compaction
+ * and result emit.  Pulled out of exec_group_run — a 3700-line monolith
+ * whose ~1600-line cut-4 growth degraded this loop's register allocation
+ * (stack spills at ~1MB frame offsets, +5.5% executed instructions on q34)
+ * and unseated the alignment the checkpoint pin had tuned.  Isolating it in
+ * its own noinline function gives it an independent register allocation and
+ * code layout (mirrors exec_group_per_partition's noinline isolation).
+ * Called once per dispatch — no per-row overhead at the boundary.
+ * Returns the group result (or an OOM/error object) when it handled the
+ * query; returns NULL when the dynamic-dense probe bailed (unbounded key or
+ * no surviving row), leaving all shared resources untouched so the caller
+ * continues on the next sp path. */
+typedef struct {
+    ray_graph_t*   g;
+    ray_op_ext_t*  ext;
+    void**         key_data;
+    int8_t*        key_types;
+    ray_t**        key_vecs;
+    uint8_t*       key_owned;
+    void**         agg_ptrs;
+    int8_t*        agg_types;
+    uint8_t*       agg_strlen;
+    ray_t**        agg_vecs;
+    uint8_t*       agg_owned;
+    agg_affine_t*  agg_affine;
+    agg_prod_t*    agg_prod;
+    ray_t**        strlen_sym_strings;
+    uint32_t       strlen_sym_count;
+    uint64_t       agg_f64_mask;
+    uint32_t       n_aggs;
+    uint32_t       n_keys;
+    int64_t        n_scan;
+    uint8_t        key_esz;
+    bool           sp_need_sum;
+    const int64_t* match_idx;
+    ray_t*         rowsel;
+    ray_t*         match_idx_block;
+    ray_t*         vla_hdr;
+    ray_group_emit_filter_t emit_filter;
+} sp_dyn_ctx_t;
+
+static ray_t* __attribute__((noinline))
+exec_group_sp_dyn_emit(const sp_dyn_ctx_t* c) {
+    ray_graph_t*   g          = c->g;
+    ray_op_ext_t*  ext        = c->ext;
+    void**         key_data   = c->key_data;
+    int8_t*        key_types  = c->key_types;
+    ray_t**        key_vecs   = c->key_vecs;
+    uint8_t*       key_owned  = c->key_owned;
+    void**         agg_ptrs   = c->agg_ptrs;
+    int8_t*        agg_types  = c->agg_types;
+    uint8_t*       agg_strlen = c->agg_strlen;
+    ray_t**        agg_vecs   = c->agg_vecs;
+    uint8_t*       agg_owned  = c->agg_owned;
+    agg_affine_t*  agg_affine = c->agg_affine;
+    agg_prod_t*    agg_prod   = c->agg_prod;
+    ray_t**        strlen_sym_strings = c->strlen_sym_strings;
+    uint32_t       strlen_sym_count   = c->strlen_sym_count;
+    uint64_t       agg_f64_mask = c->agg_f64_mask;
+    uint32_t       n_aggs     = c->n_aggs;
+    uint32_t       n_keys     = c->n_keys;
+    int64_t        n_scan     = c->n_scan;
+    uint8_t        key_esz    = c->key_esz;
+    bool           sp_need_sum = c->sp_need_sum;
+    const int64_t* match_idx  = c->match_idx;
+    ray_t*         rowsel     = c->rowsel;
+    ray_t*         match_idx_block = c->match_idx_block;
+    ray_t*         vla_hdr    = c->vla_hdr;
+    ray_group_emit_filter_t emit_filter = c->emit_filter;
+
+                uint64_t cap = key_esz == 1 ? 256u
+                             : key_esz == 2 ? (1u << 16)
+                             : (1u << 20);
+                const uint64_t max_dense_cap = 1u << 24;
+                bool count_only_first = (key_types[0] == RAY_SYM);
+                ray_t *cnt_hdr = NULL, *range_sum_hdr = NULL;
+                uint32_t* range_count = (uint32_t*)scratch_calloc(
+                    &cnt_hdr, (size_t)cap * sizeof(uint32_t));
+                da_val_t* range_sum = NULL;
+                bool dyn_ok = range_count != NULL;
+                if (dyn_ok && sp_need_sum && !count_only_first) {
+                    range_sum = (da_val_t*)scratch_calloc(
+                        &range_sum_hdr,
+                        (size_t)cap * n_aggs * sizeof(da_val_t));
+                    dyn_ok = range_sum != NULL;
+                }
+
+	                uint64_t max_seen = 0;
+	                bool have_dyn_key = false;
+#define DYN_DENSE_ACCUM_ROW(row_expr)                                            \
+    do {                                                                         \
+        int64_t dyn_row = (row_expr);                                            \
+        int64_t key = read_by_esz(key_data[0], dyn_row, key_esz);                \
+        if (key < 0 || (uint64_t)key >= max_dense_cap) {                         \
+            dyn_ok = false;                                                      \
+            goto dyn_dense_done;                                                 \
+        }                                                                        \
+        uint64_t off = (uint64_t)key;                                            \
+        if (off >= cap) {                                                        \
+            uint64_t old_cap = cap;                                              \
+            while (off >= cap) cap <<= 1;                                        \
+            uint32_t* new_count = (uint32_t*)scratch_realloc(                    \
+                &cnt_hdr, (size_t)old_cap * sizeof(uint32_t),                    \
+                (size_t)cap * sizeof(uint32_t));                                 \
+            if (!new_count) {                                                    \
+                dyn_ok = false;                                                  \
+                goto dyn_dense_done;                                             \
+            }                                                                    \
+            range_count = new_count;                                             \
+            memset(range_count + old_cap, 0,                                     \
+                   (size_t)(cap - old_cap) * sizeof(uint32_t));                  \
+            if (sp_need_sum && !count_only_first) {                              \
+                da_val_t* new_sum = (da_val_t*)scratch_realloc(                  \
+                    &range_sum_hdr,                                              \
+                    (size_t)old_cap * n_aggs * sizeof(da_val_t),                 \
+                    (size_t)cap * n_aggs * sizeof(da_val_t));                    \
+                if (!new_sum) {                                                  \
+                    dyn_ok = false;                                              \
+                    goto dyn_dense_done;                                         \
+                }                                                                \
+                range_sum = new_sum;                                             \
+                memset(range_sum + (size_t)old_cap * n_aggs, 0,                 \
+                       (size_t)(cap - old_cap) * n_aggs * sizeof(da_val_t));     \
+            }                                                                    \
+        }                                                                        \
+        have_dyn_key = true;                                                     \
+        if (off > max_seen) max_seen = off;                                      \
+        if (range_count[off] != UINT32_MAX) range_count[off]++;                  \
+        if (range_sum) {                                                         \
+            da_val_t* sums = &range_sum[(size_t)off * n_aggs];                   \
+            for (uint32_t a = 0; a < n_aggs; a++) {                               \
+                if (ext->agg_ops[a] == OP_COUNT || !agg_ptrs[a]) continue;       \
+                if (agg_strlen[a])                                               \
+                    sums[a].i += group_strlen_at_cached(                         \
+                        agg_vecs[a], dyn_row, strlen_sym_strings, strlen_sym_count); \
+                else if (agg_f64_mask & ((uint64_t)1 << a))                      \
+                    sums[a].f += ((const double*)agg_ptrs[a])[dyn_row];          \
+                else                                                             \
+                    sums[a].i += read_col_i64(agg_ptrs[a], dyn_row, agg_types[a], 0); \
+            }                                                                    \
+        }                                                                        \
+    } while (0)
+
+	                if (dyn_ok && match_idx) {
+	                    for (int64_t i = 0; i < n_scan; i++)
+	                        DYN_DENSE_ACCUM_ROW(match_idx[i]);
+	                } else if (dyn_ok && rowsel) {
+	                    ray_rowsel_t* m = ray_rowsel_meta(rowsel);
+	                    const uint8_t* flags = ray_rowsel_flags(rowsel);
+	                    const uint32_t* offs = ray_rowsel_offsets(rowsel);
+	                    const uint16_t* idx = ray_rowsel_idx(rowsel);
+	                    uint32_t nseg = (uint32_t)((m->nrows + RAY_MORSEL_ELEMS - 1) /
+	                                              RAY_MORSEL_ELEMS);
+	                    for (uint32_t seg = 0; seg < nseg; seg++) {
+	                        int64_t base = (int64_t)seg * RAY_MORSEL_ELEMS;
+	                        if (flags[seg] == RAY_SEL_NONE) continue;
+	                        if (flags[seg] == RAY_SEL_ALL) {
+	                            int64_t end = base + RAY_MORSEL_ELEMS;
+	                            if (end > m->nrows) end = m->nrows;
+	                            for (int64_t r = base; r < end; r++)
+	                                DYN_DENSE_ACCUM_ROW(r);
+	                        } else {
+	                            for (uint32_t p = offs[seg]; p < offs[seg + 1]; p++)
+	                                DYN_DENSE_ACCUM_ROW(base + idx[p]);
+	                        }
+	                    }
+	                } else if (dyn_ok) {
+	                    for (int64_t r = 0; r < n_scan; r++)
+	                        DYN_DENSE_ACCUM_ROW(r);
+	                }
+dyn_dense_done:
+#undef DYN_DENSE_ACCUM_ROW
+
+	                if (dyn_ok && have_dyn_key) {
+                    uint32_t total_groups = 0;
+                    for (uint64_t off = 0; off <= max_seen; off++)
+                        if (range_count[off] > 0)
+                            total_groups++;
+                    int64_t keep_min = da_count_emit_keep_min_u32(
+                        range_count, max_seen + 1, total_groups, emit_filter);
+                    uint32_t grp_count = 0;
+                    for (uint64_t off = 0; off <= max_seen; off++)
+                        if ((int64_t)range_count[off] >= keep_min)
+                            grp_count++;
+
+                    ray_t* result = ray_table_new((int64_t)n_keys + n_aggs);
+                    if (!result || RAY_IS_ERR(result)) {
+                        scratch_free(range_sum_hdr); scratch_free(cnt_hdr);
+                        for (uint32_t a = 0; a < n_aggs; a++)
+                            if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
+                        for (uint32_t k = 0; k < n_keys; k++)
+                            if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
+                        if (match_idx_block) { ray_release(match_idx_block); } scratch_free(vla_hdr);
+                        return result ? result : ray_error("oom", NULL);
+                    }
+
+                    ray_t* key_col = col_vec_new(key_vecs[0], (int64_t)grp_count);
+                    out_col_adopt_str_pool(key_col, key_vecs[0]);
+                    if (key_col && !RAY_IS_ERR(key_col) && key_col->type == RAY_SYM)
+                        /* raw cell ids from key_vecs[0] — adopt its domain */
+                        ray_sym_vec_adopt_domain(key_col, sym_domain_rep(key_vecs[0]));
+                    if (!key_col || RAY_IS_ERR(key_col)) {
+                        scratch_free(range_sum_hdr); scratch_free(cnt_hdr);
+                        ray_release(result);
+                        for (uint32_t a = 0; a < n_aggs; a++)
+                            if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
+                        for (uint32_t k = 0; k < n_keys; k++)
+                            if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
+                        if (match_idx_block) { ray_release(match_idx_block); } scratch_free(vla_hdr);
+                        return key_col ? key_col : ray_error("oom", NULL);
+                    }
+                    key_col->len = (int64_t)grp_count;
+
+                    ray_t *_h_sum = NULL, *_h_cnt = NULL;
+                    da_val_t* dense_sum = sp_need_sum
+                        ? (da_val_t*)scratch_alloc(&_h_sum,
+                            (size_t)grp_count * n_aggs * sizeof(da_val_t))
+                        : NULL;
+                    int64_t* dense_count = (int64_t*)scratch_alloc(
+                        &_h_cnt, (size_t)grp_count * sizeof(int64_t));
+                    if ((sp_need_sum && !dense_sum) || !dense_count) {
+                        scratch_free(_h_sum); scratch_free(_h_cnt);
+                        scratch_free(range_sum_hdr); scratch_free(cnt_hdr);
+                        ray_release(key_col); ray_release(result);
+                        for (uint32_t a = 0; a < n_aggs; a++)
+                            if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
+                        for (uint32_t k = 0; k < n_keys; k++)
+                            if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
+                        if (match_idx_block) { ray_release(match_idx_block); } scratch_free(vla_hdr);
+                        return ray_error("oom", NULL);
+                    }
+                    if (sp_need_sum && !range_sum)
+                        memset(dense_sum, 0,
+                               (size_t)grp_count * n_aggs * sizeof(da_val_t));
+
+                    uint32_t gi = 0;
+                    for (uint64_t off = 0; off <= max_seen; off++) {
+                        uint32_t cnt = range_count[off];
+                        if ((int64_t)cnt < keep_min) {
+                            if (!range_sum) range_count[off] = 0;
+                            continue;
+                        }
+                        write_col_i64(ray_data(key_col), gi, (int64_t)off,
+                                      key_col->type, key_col->attrs);
+                        dense_count[gi] = (int64_t)cnt;
+                        if (range_sum) {
+                            memcpy(&dense_sum[(size_t)gi * n_aggs],
+                                   &range_sum[(size_t)off * n_aggs],
+                                   (size_t)n_aggs * sizeof(da_val_t));
+                        }
+                        if (!range_sum) range_count[off] = gi + 1u;
+                        gi++;
+                    }
+
+                    if (sp_need_sum && !range_sum) {
+#define DYN_DENSE_SUM_ROW(row_expr)                                              \
+    do {                                                                         \
+        int64_t dyn_row = (row_expr);                                            \
+        int64_t key = read_by_esz(key_data[0], dyn_row, key_esz);                \
+        if (key < 0 || (uint64_t)key > max_seen) break;                          \
+        uint32_t marker = range_count[(uint64_t)key];                            \
+        if (!marker) break;                                                      \
+        da_val_t* sums = &dense_sum[(size_t)(marker - 1u) * n_aggs];             \
+        for (uint32_t a = 0; a < n_aggs; a++) {                                   \
+            if (ext->agg_ops[a] == OP_COUNT || !agg_ptrs[a]) continue;           \
+            if (agg_strlen[a])                                                   \
+                sums[a].i += group_strlen_at_cached(                             \
+                    agg_vecs[a], dyn_row, strlen_sym_strings, strlen_sym_count); \
+            else if (agg_f64_mask & ((uint64_t)1 << a))                          \
+                sums[a].f += ((const double*)agg_ptrs[a])[dyn_row];              \
+            else                                                                 \
+                sums[a].i += read_col_i64(agg_ptrs[a], dyn_row, agg_types[a], 0);\
+        }                                                                        \
+    } while (0)
+                        if (match_idx) {
+                            for (int64_t i = 0; i < n_scan; i++)
+                                DYN_DENSE_SUM_ROW(match_idx[i]);
+                        } else if (rowsel) {
+                            ray_rowsel_t* m = ray_rowsel_meta(rowsel);
+                            const uint8_t* flags = ray_rowsel_flags(rowsel);
+                            const uint32_t* offs = ray_rowsel_offsets(rowsel);
+                            const uint16_t* idx = ray_rowsel_idx(rowsel);
+                            uint32_t nseg = (uint32_t)((m->nrows + RAY_MORSEL_ELEMS - 1) /
+                                                      RAY_MORSEL_ELEMS);
+                            for (uint32_t seg = 0; seg < nseg; seg++) {
+                                int64_t base = (int64_t)seg * RAY_MORSEL_ELEMS;
+                                if (flags[seg] == RAY_SEL_NONE) continue;
+                                if (flags[seg] == RAY_SEL_ALL) {
+                                    int64_t end = base + RAY_MORSEL_ELEMS;
+                                    if (end > m->nrows) end = m->nrows;
+                                    for (int64_t r = base; r < end; r++)
+                                        DYN_DENSE_SUM_ROW(r);
+                                } else {
+                                    for (uint32_t p = offs[seg]; p < offs[seg + 1]; p++)
+                                        DYN_DENSE_SUM_ROW(base + idx[p]);
+                                }
+                            }
+                        } else {
+                            for (int64_t r = 0; r < n_scan; r++)
+                                DYN_DENSE_SUM_ROW(r);
+                        }
+#undef DYN_DENSE_SUM_ROW
+                    }
+
+                    ray_op_ext_t* key_ext = find_ext(g, ext->keys[0]);
+                    int64_t name_id = key_ext ? key_ext->sym : 0;
+                    result = ray_table_add_col(result, name_id, key_col);
+                    ray_release(key_col);
+                    /* nn_counts == NULL: this fast path rejected HAS_NULLS
+                     * inputs at the sp_eligible gate (~line 5737), so every
+                     * row is non-null and the legacy count-based divisor is
+                     * correct. */
+                    emit_agg_columns(&result, g, ext, agg_vecs, grp_count, n_aggs,
+                                     (double*)dense_sum, (int64_t*)dense_sum,
+                                     NULL, NULL, NULL, NULL,
+                                     dense_count, agg_affine, agg_prod, NULL, NULL);
+
+                    scratch_free(_h_sum); scratch_free(_h_cnt);
+                    scratch_free(range_sum_hdr); scratch_free(cnt_hdr);
+                    for (uint32_t a = 0; a < n_aggs; a++)
+                        if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
+                    for (uint32_t k = 0; k < n_keys; k++)
+                        if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
+                    if (match_idx_block) { ray_release(match_idx_block); } scratch_free(vla_hdr);
+                    return result;
+                }
+
+                scratch_free(range_sum_hdr);
+                scratch_free(cnt_hdr);
+
+    /* Dynamic-dense probe bailed (unbounded key or no surviving row): shared
+     * resources are untouched — caller continues on the next sp path. */
+    return NULL;
+}
+
 /* Pin the DA-prescan dense-group finalize alignment.  This function owns the
  * dict/dense-array (DA) group path whose finalize loop (the total_groups /
  * keep_min / range_count compaction region below, ~line 8395-8475, family
@@ -8665,265 +9002,23 @@ da_path:;
                 (emit_filter.min_count_exclusive > 0 ||
                  emit_filter.top_count_take > 0) &&
                 n_scan <= UINT32_MAX) {
-                uint64_t cap = key_esz == 1 ? 256u
-                             : key_esz == 2 ? (1u << 16)
-                             : (1u << 20);
-                const uint64_t max_dense_cap = 1u << 24;
-                bool count_only_first = (key_types[0] == RAY_SYM);
-                ray_t *cnt_hdr = NULL, *range_sum_hdr = NULL;
-                uint32_t* range_count = (uint32_t*)scratch_calloc(
-                    &cnt_hdr, (size_t)cap * sizeof(uint32_t));
-                da_val_t* range_sum = NULL;
-                bool dyn_ok = range_count != NULL;
-                if (dyn_ok && sp_need_sum && !count_only_first) {
-                    range_sum = (da_val_t*)scratch_calloc(
-                        &range_sum_hdr,
-                        (size_t)cap * n_aggs * sizeof(da_val_t));
-                    dyn_ok = range_sum != NULL;
-                }
-
-	                uint64_t max_seen = 0;
-	                bool have_dyn_key = false;
-#define DYN_DENSE_ACCUM_ROW(row_expr)                                            \
-    do {                                                                         \
-        int64_t dyn_row = (row_expr);                                            \
-        int64_t key = read_by_esz(key_data[0], dyn_row, key_esz);                \
-        if (key < 0 || (uint64_t)key >= max_dense_cap) {                         \
-            dyn_ok = false;                                                      \
-            goto dyn_dense_done;                                                 \
-        }                                                                        \
-        uint64_t off = (uint64_t)key;                                            \
-        if (off >= cap) {                                                        \
-            uint64_t old_cap = cap;                                              \
-            while (off >= cap) cap <<= 1;                                        \
-            uint32_t* new_count = (uint32_t*)scratch_realloc(                    \
-                &cnt_hdr, (size_t)old_cap * sizeof(uint32_t),                    \
-                (size_t)cap * sizeof(uint32_t));                                 \
-            if (!new_count) {                                                    \
-                dyn_ok = false;                                                  \
-                goto dyn_dense_done;                                             \
-            }                                                                    \
-            range_count = new_count;                                             \
-            memset(range_count + old_cap, 0,                                     \
-                   (size_t)(cap - old_cap) * sizeof(uint32_t));                  \
-            if (sp_need_sum && !count_only_first) {                              \
-                da_val_t* new_sum = (da_val_t*)scratch_realloc(                  \
-                    &range_sum_hdr,                                              \
-                    (size_t)old_cap * n_aggs * sizeof(da_val_t),                 \
-                    (size_t)cap * n_aggs * sizeof(da_val_t));                    \
-                if (!new_sum) {                                                  \
-                    dyn_ok = false;                                              \
-                    goto dyn_dense_done;                                         \
-                }                                                                \
-                range_sum = new_sum;                                             \
-                memset(range_sum + (size_t)old_cap * n_aggs, 0,                 \
-                       (size_t)(cap - old_cap) * n_aggs * sizeof(da_val_t));     \
-            }                                                                    \
-        }                                                                        \
-        have_dyn_key = true;                                                     \
-        if (off > max_seen) max_seen = off;                                      \
-        if (range_count[off] != UINT32_MAX) range_count[off]++;                  \
-        if (range_sum) {                                                         \
-            da_val_t* sums = &range_sum[(size_t)off * n_aggs];                   \
-            for (uint32_t a = 0; a < n_aggs; a++) {                               \
-                if (ext->agg_ops[a] == OP_COUNT || !agg_ptrs[a]) continue;       \
-                if (agg_strlen[a])                                               \
-                    sums[a].i += group_strlen_at_cached(                         \
-                        agg_vecs[a], dyn_row, strlen_sym_strings, strlen_sym_count); \
-                else if (agg_f64_mask & ((uint64_t)1 << a))                      \
-                    sums[a].f += ((const double*)agg_ptrs[a])[dyn_row];          \
-                else                                                             \
-                    sums[a].i += read_col_i64(agg_ptrs[a], dyn_row, agg_types[a], 0); \
-            }                                                                    \
-        }                                                                        \
-    } while (0)
-
-	                if (dyn_ok && match_idx) {
-	                    for (int64_t i = 0; i < n_scan; i++)
-	                        DYN_DENSE_ACCUM_ROW(match_idx[i]);
-	                } else if (dyn_ok && rowsel) {
-	                    ray_rowsel_t* m = ray_rowsel_meta(rowsel);
-	                    const uint8_t* flags = ray_rowsel_flags(rowsel);
-	                    const uint32_t* offs = ray_rowsel_offsets(rowsel);
-	                    const uint16_t* idx = ray_rowsel_idx(rowsel);
-	                    uint32_t nseg = (uint32_t)((m->nrows + RAY_MORSEL_ELEMS - 1) /
-	                                              RAY_MORSEL_ELEMS);
-	                    for (uint32_t seg = 0; seg < nseg; seg++) {
-	                        int64_t base = (int64_t)seg * RAY_MORSEL_ELEMS;
-	                        if (flags[seg] == RAY_SEL_NONE) continue;
-	                        if (flags[seg] == RAY_SEL_ALL) {
-	                            int64_t end = base + RAY_MORSEL_ELEMS;
-	                            if (end > m->nrows) end = m->nrows;
-	                            for (int64_t r = base; r < end; r++)
-	                                DYN_DENSE_ACCUM_ROW(r);
-	                        } else {
-	                            for (uint32_t p = offs[seg]; p < offs[seg + 1]; p++)
-	                                DYN_DENSE_ACCUM_ROW(base + idx[p]);
-	                        }
-	                    }
-	                } else if (dyn_ok) {
-	                    for (int64_t r = 0; r < n_scan; r++)
-	                        DYN_DENSE_ACCUM_ROW(r);
-	                }
-dyn_dense_done:
-#undef DYN_DENSE_ACCUM_ROW
-
-	                if (dyn_ok && have_dyn_key) {
-                    uint32_t total_groups = 0;
-                    for (uint64_t off = 0; off <= max_seen; off++)
-                        if (range_count[off] > 0)
-                            total_groups++;
-                    int64_t keep_min = da_count_emit_keep_min_u32(
-                        range_count, max_seen + 1, total_groups, emit_filter);
-                    uint32_t grp_count = 0;
-                    for (uint64_t off = 0; off <= max_seen; off++)
-                        if ((int64_t)range_count[off] >= keep_min)
-                            grp_count++;
-
-                    ray_t* result = ray_table_new((int64_t)n_keys + n_aggs);
-                    if (!result || RAY_IS_ERR(result)) {
-                        scratch_free(range_sum_hdr); scratch_free(cnt_hdr);
-                        for (uint32_t a = 0; a < n_aggs; a++)
-                            if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
-                        for (uint32_t k = 0; k < n_keys; k++)
-                            if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
-                        if (match_idx_block) { ray_release(match_idx_block); } scratch_free(vla_hdr);
-                        return result ? result : ray_error("oom", NULL);
-                    }
-
-                    ray_t* key_col = col_vec_new(key_vecs[0], (int64_t)grp_count);
-                    out_col_adopt_str_pool(key_col, key_vecs[0]);
-                    if (key_col && !RAY_IS_ERR(key_col) && key_col->type == RAY_SYM)
-                        /* raw cell ids from key_vecs[0] — adopt its domain */
-                        ray_sym_vec_adopt_domain(key_col, sym_domain_rep(key_vecs[0]));
-                    if (!key_col || RAY_IS_ERR(key_col)) {
-                        scratch_free(range_sum_hdr); scratch_free(cnt_hdr);
-                        ray_release(result);
-                        for (uint32_t a = 0; a < n_aggs; a++)
-                            if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
-                        for (uint32_t k = 0; k < n_keys; k++)
-                            if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
-                        if (match_idx_block) { ray_release(match_idx_block); } scratch_free(vla_hdr);
-                        return key_col ? key_col : ray_error("oom", NULL);
-                    }
-                    key_col->len = (int64_t)grp_count;
-
-                    ray_t *_h_sum = NULL, *_h_cnt = NULL;
-                    da_val_t* dense_sum = sp_need_sum
-                        ? (da_val_t*)scratch_alloc(&_h_sum,
-                            (size_t)grp_count * n_aggs * sizeof(da_val_t))
-                        : NULL;
-                    int64_t* dense_count = (int64_t*)scratch_alloc(
-                        &_h_cnt, (size_t)grp_count * sizeof(int64_t));
-                    if ((sp_need_sum && !dense_sum) || !dense_count) {
-                        scratch_free(_h_sum); scratch_free(_h_cnt);
-                        scratch_free(range_sum_hdr); scratch_free(cnt_hdr);
-                        ray_release(key_col); ray_release(result);
-                        for (uint32_t a = 0; a < n_aggs; a++)
-                            if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
-                        for (uint32_t k = 0; k < n_keys; k++)
-                            if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
-                        if (match_idx_block) { ray_release(match_idx_block); } scratch_free(vla_hdr);
-                        return ray_error("oom", NULL);
-                    }
-                    if (sp_need_sum && !range_sum)
-                        memset(dense_sum, 0,
-                               (size_t)grp_count * n_aggs * sizeof(da_val_t));
-
-                    uint32_t gi = 0;
-                    for (uint64_t off = 0; off <= max_seen; off++) {
-                        uint32_t cnt = range_count[off];
-                        if ((int64_t)cnt < keep_min) {
-                            if (!range_sum) range_count[off] = 0;
-                            continue;
-                        }
-                        write_col_i64(ray_data(key_col), gi, (int64_t)off,
-                                      key_col->type, key_col->attrs);
-                        dense_count[gi] = (int64_t)cnt;
-                        if (range_sum) {
-                            memcpy(&dense_sum[(size_t)gi * n_aggs],
-                                   &range_sum[(size_t)off * n_aggs],
-                                   (size_t)n_aggs * sizeof(da_val_t));
-                        }
-                        if (!range_sum) range_count[off] = gi + 1u;
-                        gi++;
-                    }
-
-                    if (sp_need_sum && !range_sum) {
-#define DYN_DENSE_SUM_ROW(row_expr)                                              \
-    do {                                                                         \
-        int64_t dyn_row = (row_expr);                                            \
-        int64_t key = read_by_esz(key_data[0], dyn_row, key_esz);                \
-        if (key < 0 || (uint64_t)key > max_seen) break;                          \
-        uint32_t marker = range_count[(uint64_t)key];                            \
-        if (!marker) break;                                                      \
-        da_val_t* sums = &dense_sum[(size_t)(marker - 1u) * n_aggs];             \
-        for (uint32_t a = 0; a < n_aggs; a++) {                                   \
-            if (ext->agg_ops[a] == OP_COUNT || !agg_ptrs[a]) continue;           \
-            if (agg_strlen[a])                                                   \
-                sums[a].i += group_strlen_at_cached(                             \
-                    agg_vecs[a], dyn_row, strlen_sym_strings, strlen_sym_count); \
-            else if (agg_f64_mask & ((uint64_t)1 << a))                          \
-                sums[a].f += ((const double*)agg_ptrs[a])[dyn_row];              \
-            else                                                                 \
-                sums[a].i += read_col_i64(agg_ptrs[a], dyn_row, agg_types[a], 0);\
-        }                                                                        \
-    } while (0)
-                        if (match_idx) {
-                            for (int64_t i = 0; i < n_scan; i++)
-                                DYN_DENSE_SUM_ROW(match_idx[i]);
-                        } else if (rowsel) {
-                            ray_rowsel_t* m = ray_rowsel_meta(rowsel);
-                            const uint8_t* flags = ray_rowsel_flags(rowsel);
-                            const uint32_t* offs = ray_rowsel_offsets(rowsel);
-                            const uint16_t* idx = ray_rowsel_idx(rowsel);
-                            uint32_t nseg = (uint32_t)((m->nrows + RAY_MORSEL_ELEMS - 1) /
-                                                      RAY_MORSEL_ELEMS);
-                            for (uint32_t seg = 0; seg < nseg; seg++) {
-                                int64_t base = (int64_t)seg * RAY_MORSEL_ELEMS;
-                                if (flags[seg] == RAY_SEL_NONE) continue;
-                                if (flags[seg] == RAY_SEL_ALL) {
-                                    int64_t end = base + RAY_MORSEL_ELEMS;
-                                    if (end > m->nrows) end = m->nrows;
-                                    for (int64_t r = base; r < end; r++)
-                                        DYN_DENSE_SUM_ROW(r);
-                                } else {
-                                    for (uint32_t p = offs[seg]; p < offs[seg + 1]; p++)
-                                        DYN_DENSE_SUM_ROW(base + idx[p]);
-                                }
-                            }
-                        } else {
-                            for (int64_t r = 0; r < n_scan; r++)
-                                DYN_DENSE_SUM_ROW(r);
-                        }
-#undef DYN_DENSE_SUM_ROW
-                    }
-
-                    ray_op_ext_t* key_ext = find_ext(g, ext->keys[0]);
-                    int64_t name_id = key_ext ? key_ext->sym : 0;
-                    result = ray_table_add_col(result, name_id, key_col);
-                    ray_release(key_col);
-                    /* nn_counts == NULL: this fast path rejected HAS_NULLS
-                     * inputs at the sp_eligible gate (~line 5737), so every
-                     * row is non-null and the legacy count-based divisor is
-                     * correct. */
-                    emit_agg_columns(&result, g, ext, agg_vecs, grp_count, n_aggs,
-                                     (double*)dense_sum, (int64_t*)dense_sum,
-                                     NULL, NULL, NULL, NULL,
-                                     dense_count, agg_affine, agg_prod, NULL, NULL);
-
-                    scratch_free(_h_sum); scratch_free(_h_cnt);
-                    scratch_free(range_sum_hdr); scratch_free(cnt_hdr);
-                    for (uint32_t a = 0; a < n_aggs; a++)
-                        if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
-                    for (uint32_t k = 0; k < n_keys; k++)
-                        if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
-                    if (match_idx_block) { ray_release(match_idx_block); } scratch_free(vla_hdr);
-                    return result;
-                }
-
-                scratch_free(range_sum_hdr);
-                scratch_free(cnt_hdr);
+                sp_dyn_ctx_t sc = {
+                    .g = g, .ext = ext, .key_data = key_data,
+                    .key_types = key_types, .key_vecs = key_vecs,
+                    .key_owned = key_owned, .agg_ptrs = agg_ptrs,
+                    .agg_types = agg_types, .agg_strlen = agg_strlen,
+                    .agg_vecs = agg_vecs, .agg_owned = agg_owned,
+                    .agg_affine = agg_affine, .agg_prod = agg_prod,
+                    .strlen_sym_strings = strlen_sym_strings,
+                    .strlen_sym_count = strlen_sym_count,
+                    .agg_f64_mask = agg_f64_mask, .n_aggs = n_aggs,
+                    .n_keys = n_keys, .n_scan = n_scan, .key_esz = key_esz,
+                    .sp_need_sum = sp_need_sum, .match_idx = match_idx,
+                    .rowsel = rowsel, .match_idx_block = match_idx_block,
+                    .vla_hdr = vla_hdr, .emit_filter = emit_filter,
+                };
+                ray_t* sp_r = exec_group_sp_dyn_emit(&sc);
+                if (sp_r) return sp_r;
             }
 
             if (use_emit_filter &&

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -2547,37 +2547,54 @@ bool ght_compute_layout(ght_layout_t* out, uint32_t n_keys, uint32_t n_aggs,
     /* Entry layout: hash | keys | null_mask | agg_vals | [entry_row?]
      * Tail entry_row slot is appended only when any agg is FIRST/LAST,
      * carrying the source-row index needed to merge correctly under
-     * work-stealing dispatch (see radix_phase1_fn / accum_from_entry). */
+     * work-stealing dispatch (see radix_phase1_fn / accum_from_entry).
+     *
+     * The agg region is a representational budget, exactly like the key
+     * region above: agg_val_slot is int8 (so ≤ INT8_MAX value slots), and
+     * entry_stride / row_stride / every off_* are uint16 (so the whole
+     * entry and HT row must fit in 64 KiB).  Accumulate the strides in
+     * uint32 and REFUSE a layout that would overflow either budget — a
+     * silent wrap here scatters aggs to wrong offsets (the key region was
+     * already budget-guarded; the agg region was not). */
     bool has_first_last = (agg_any & (GHT_AF_FIRST | GHT_AF_LAST)) != 0;
-    uint16_t entry_tail = has_first_last ? (uint16_t)8 : (uint16_t)0;
-    out->entry_stride = (uint16_t)(8 + key_region + (uint16_t)nv * 8 + entry_tail);
+    uint32_t entry_tail = has_first_last ? 8u : 0u;
+    uint32_t entry_stride = 8u + key_region + (uint32_t)nv * 8 + entry_tail;
 
-    uint16_t off = (uint16_t)(8 + key_region);
-    uint16_t block = (uint16_t)nv * 8;
-    if (need_flags & GHT_NEED_SUM)   { out->off_sum   = off; off += block; }
-    if (need_flags & GHT_NEED_MIN)   { out->off_min   = off; off += block; }
-    if (need_flags & GHT_NEED_MAX)   { out->off_max   = off; off += block; }
-    if (need_flags & GHT_NEED_SUMSQ) { out->off_sumsq = off; off += block; }
+    uint32_t off = 8u + key_region;
+    uint32_t block = (uint32_t)nv * 8;
+    if (need_flags & GHT_NEED_SUM)   { out->off_sum   = (uint16_t)off; off += block; }
+    if (need_flags & GHT_NEED_MIN)   { out->off_min   = (uint16_t)off; off += block; }
+    if (need_flags & GHT_NEED_MAX)   { out->off_max   = (uint16_t)off; off += block; }
+    if (need_flags & GHT_NEED_SUMSQ) { out->off_sumsq = (uint16_t)off; off += block; }
     /* Per-slot row-index bounds for FIRST/LAST.  Two int64 blocks of
      * n_agg_vals slots each, allocated only when needed. */
     if (has_first_last) {
-        out->off_first_row = off; off += block;
-        out->off_last_row  = off; off += block;
+        out->off_first_row = (uint16_t)off; off += block;
+        out->off_last_row  = (uint16_t)off; off += block;
     }
     /* PEARSON y-side accumulators (Σy, Σy², Σxy).  Allocated when any
      * OP_PEARSON_CORR agg is present.  x-side reuses off_sum + off_sumsq
      * at the same slot index; the y value lives at slot+1 in agg_vals,
      * but its derived accumulators live in their own blocks below. */
     if (need_flags & GHT_NEED_PEARSON) {
-        out->off_sum_y   = off; off += block;
-        out->off_sumsq_y = off; off += block;
-        out->off_sumxy   = off; off += block;
+        out->off_sum_y   = (uint16_t)off; off += block;
+        out->off_sumsq_y = (uint16_t)off; off += block;
+        out->off_sumxy   = (uint16_t)off; off += block;
     }
     /* Per-slot non-null count block — only when a nullable agg is present.
      * Null-free shapes leave off_nn == 0 and finalize on the group row count,
      * so their row_stride and layout are byte-identical to before. */
-    if (out->any_agg_null) { out->off_nn = off; off += block; }
-    out->row_stride = off;
+    if (out->any_agg_null) { out->off_nn = (uint16_t)off; off += block; }
+    /* Refuse (not wrap) any layout past the int8 value-slot count or the
+     * uint16 entry/row-stride budget.  On overflow the off_* casts above
+     * stored wrapped junk, but nothing reads it — the layout is freed and
+     * the caller sees a clean failure (mirrors the key-region guards). */
+    if (nv > INT8_MAX || entry_stride > UINT16_MAX || off > UINT16_MAX) {
+        ght_layout_free(out);
+        return false;
+    }
+    out->entry_stride = (uint16_t)entry_stride;
+    out->row_stride = (uint16_t)off;
     return true;
 }
 
@@ -2923,12 +2940,15 @@ static inline void init_accum_from_entry(char* row, const char* entry,
      * by (null_words-1)*8 bytes, so this memset's zero-fill reached
      * backward into the last null-mask word — clobbering it to 0
      * immediately after group_probe_entry's memcpy stored it correctly.
-     * Invisible to plain GROUP BY (which never re-reads null words from a
-     * stored HT row after ingest — the emitted key values come from a
-     * separate source-column re-scan), but wrong for PIVOT, whose own
-     * ix-dedupe/emit code (pivot.c) reads the null words directly back out
-     * of these same rows: the 65-index conflation-detector cell in
-     * tblop_branch_cov.rfl is the regression pin. */
+     * Not structurally invisible to plain GROUP BY — the radix phase-3
+     * scatter DOES re-read these same null words straight out of the HT row
+     * (radix_phase3_fn) — but empirically it surfaced first through PIVOT:
+     * no pre-existing GROUP-BY test exercised a >64-key null in the trailing
+     * null-mask word, whereas PIVOT's own ix-dedupe/emit code (pivot.c) reads
+     * the null words directly back out of these rows and its 65-index
+     * conflation-detector cell (tblop_branch_cov.rfl) caught the clobber.
+     * The 65-key null GROUP cell (width_matrix.rfl) now covers the GROUP
+     * side of the same fix. */
     uint16_t accum_start = (uint16_t)(8 + ly->key_region);
     if (ly->row_stride > accum_start)
         memset(row + accum_start, 0, ly->row_stride - accum_start);
@@ -3553,7 +3573,7 @@ typedef struct {
  * this way, so one memcpy serves both. */
 static inline void radix_buf_push(radix_buf_t* buf, uint16_t entry_stride,
                                    uint64_t hash, const int64_t* key_region_buf,
-                                   const int64_t* agg_vals, uint8_t n_agg_vals,
+                                   const int64_t* agg_vals, uint16_t n_agg_vals,
                                    bool has_first_last, int64_t row,
                                    uint16_t key_region) {
     if (__builtin_expect(buf->count >= buf->cap, 0)) {
@@ -3715,7 +3735,7 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
         uint32_t part = RADIX_PART(h);
         radix_buf_push(&my_bufs[part], estride, h,
                        inline_str ? (const int64_t*)keybuf : keys,
-                       agg_vals, (uint8_t)nv, has_fl, row, ly->key_region);
+                       agg_vals, nv, has_fl, row, ly->key_region);
     }
     scratch_free(stage_hdr);   /* NULL (inline staging) → no-op */
 }
@@ -3770,9 +3790,9 @@ typedef struct {
     uint8_t*      key_attrs;
     uint8_t*      key_esizes;
     ray_t**       key_cols;       /* [n_keys] output key vecs (for null bit writes) */
-    uint8_t       n_keys;
+    uint32_t      n_keys;         /* full width — a uint8 here wrapped 256 keys to 0 */
     agg_out_t*    agg_outs;
-    uint8_t       n_aggs;
+    uint32_t      n_aggs;
     /* For wide-key columns (RAY_GUID), the stored key slot is a
      * source row index and we copy the actual bytes from the source
      * column here during the result scatter. */
@@ -3782,8 +3802,8 @@ typedef struct {
 static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_t end) {
     (void)worker_id;
     radix_phase3_ctx_t* c = (radix_phase3_ctx_t*)ctx;
-    uint8_t nk = c->n_keys;
-    uint8_t na = c->n_aggs;
+    uint32_t nk = c->n_keys;
+    uint32_t na = c->n_aggs;
 
     for (int64_t p = start; p < end; p++) {
         group_ht_t* ph = &c->part_hts[p];
@@ -7574,7 +7594,8 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
         rowsel = g->selection;
     }
 
-    /* Resolve key columns (VLA — n_keys ≤ 8; use ≥1 to avoid zero-size VLA UB) */
+    /* Resolve key columns (VLA scales with n_keys — the ≤8-key guard is
+     * retired; use ≥1 to avoid zero-size VLA UB). */
     uint32_t vla_keys = n_keys > 0 ? n_keys : 1;
     ray_t* key_vecs[vla_keys];
     memset(key_vecs, 0, vla_keys * sizeof(ray_t*));
@@ -7609,10 +7630,11 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
         }
     }
 
-    /* Resolve agg input columns.  n_aggs is ≤ 8 here whenever n_keys > 0
-     * (the 6713 guard), but the keyless path (n_keys == 0) admits any
-     * n_aggs — the cut-2 flip lifted query.c's 255 compile cap — so these
-     * per-agg arrays scale with the query and must not sit on the stack.
+    /* Resolve agg input columns.  n_aggs is unbounded regardless of n_keys
+     * (the old ≤8-agg keyed guard is retired — 2-key 9-agg FIRST/LAST shapes
+     * flow here — and the keyless path never capped it; the cut-2 flip also
+     * lifted query.c's 255 compile cap), so these per-agg arrays scale with
+     * the query and must not sit on the stack.
      * One consolidated scratch carve: the two ray_t* arrays first, then the
      * affine/linear/prod structs (all int64/pointer-backed, so 8-aligned and
      * multiple-of-8 sized), then the three byte-flag arrays last.  Second
@@ -9487,10 +9509,12 @@ ht_path:;
     /* RAY_STR keys are now handled inline by the wide-key mechanism (row
      * indirection + SSO-aware hash/eq via key_pool); see ght_layout_t. */
 
-    /* Compute row-layout: keys + agg values inline.  This path is gated ≤8
-     * keys/aggs by the exec_group_run width guard, so the layout is always
-     * inline (no spill); ght_compute_layout only fails here on the uint16
-     * key-stride budget, which ≤8 keys can never exceed. */
+    /* Compute row-layout: keys + agg values inline.  The ≤8-key/≤8-agg width
+     * guards are retired: any key/agg count is served, with ght_compute_layout
+     * carving an owned spill block past GHT_INLINE.  It fails here only on
+     * spill OOM or a representational budget overflow — the uint16 key/agg
+     * stride budgets or the int8 value-slot count — none of which a ≤8 shape
+     * can hit. */
     ght_layout_t ght_layout;
     if (!ght_compute_layout(&ght_layout, n_keys, n_aggs, agg_vecs, ght_need,
                             ext->agg_ops, key_types)) {
@@ -9500,7 +9524,7 @@ ht_path:;
         for (uint32_t k = 0; k < n_keys; k++)
             if (key_owned[k] && key_vecs[k]) ray_release(key_vecs[k]);
         if (match_idx_block) { ray_release(match_idx_block); } scratch_free(vla_hdr);
-        return ray_error("limit", "group: key stride budget exceeded");
+        return ray_error("limit", "group: layout stride/slot budget exceeded (or OOM)");
     }
 
     /* Right-sized hash table: start small, rehash on load > 0.5 */
@@ -9669,7 +9693,16 @@ ht_path:;
             if (ght_layout.any_wide_key) {
                 v2p2.key_pool = (const void**)scratch_alloc(&v2p2_kp_hdr,
                     (size_t)(n_keys ? n_keys : 1) * sizeof(void*));
-                if (!v2p2.key_pool) { result = ray_error("oom", NULL); goto cleanup; }
+                if (!v2p2.key_pool) {
+                    /* cleanup frees only part_hts (wired at v2_emit, below); the
+                     * worker HTs + both partition-table blocks are still local
+                     * here — free them like the phase1-OOM bail above. */
+                    for (size_t i = 0; i < v2_n_w; i++)
+                        group_ht_free(&wpart_hts[i]);
+                    scratch_free(wpart_hdr);
+                    scratch_free(v2_part_hdr);
+                    result = ray_error("oom", NULL); goto cleanup;
+                }
                 derive_key_pool(&ght_layout, key_vecs, v2p2.key_pool);
             }
             ray_pool_dispatch_n(pool, radix_v2_phase2_fn, &v2p2, RADIX_P);
@@ -10038,12 +10071,10 @@ v2_emit:;
             key_esizes[k] = esz;
         }
 
-        /* Pre-allocate agg result vectors.
-         * VLA bounded ≤8: this finalize step is inside ht_path, which
-         * rejects n_aggs > 8 at its own ht_path n_aggs guard before any of
-         * this runs — keyless-unbounded queries that fell through the
-         * scalar/DA/sparse fast paths are turned away there, never reaching
-         * here. */
+        /* Pre-allocate agg result vectors.  These VLAs scale with n_aggs
+         * (the ≤8-agg ht_path guard is retired — 9/17/65-agg legacy shapes
+         * reach here); ght_compute_layout has already accepted this n_aggs,
+         * so it is within the layout stride/slot budget. */
         agg_out_t agg_outs[n_aggs];
         ray_t* agg_cols[n_aggs];
         for (uint32_t a = 0; a < n_aggs; a++) {
@@ -10150,7 +10181,7 @@ v2_emit:;
             if (ght_layout.any_wide_key) {
                 rp.key_pool = (const void**)scratch_alloc(&rp_kp_hdr,
                     (size_t)n_keys * sizeof(void*));
-                if (!rp.key_pool) { result = ray_error("oom", NULL); goto cleanup; }
+                if (!rp.key_pool) { scratch_free(rg_hdr); result = ray_error("oom", NULL); goto cleanup; }
                 derive_key_pool(&ght_layout, key_vecs, rp.key_pool);
             }
             ray_pool_dispatch(pool, reprobe_rows_fn, &rp, n_scan);
@@ -11658,6 +11689,11 @@ bool pivot_ingest_run(pivot_ingest_t* out,
     group_ht_t* part_hts = (group_ht_t*)scratch_calloc(&out->_part_hts_hdr,
         RADIX_P * sizeof(group_ht_t));
     if (!part_hts) return false;
+    /* Wire out->part_hts/n_parts at alloc time (like the sequential path) so
+     * every failure below funnels through pivot_ingest_free — the calloc-zeroed
+     * HTs are skipped by its rows||slots guard until phase2 fills them. */
+    out->part_hts = part_hts;
+    out->n_parts = RADIX_P;
 
     radix_phase2_ctx_t p2ctx = {
         .key_types = key_types,
@@ -11678,8 +11714,6 @@ bool pivot_ingest_run(pivot_ingest_t* out,
     }
     ray_pool_dispatch_n(pool, radix_phase2_fn, &p2ctx, RADIX_P);
     scratch_free(p2_kp_hdr);
-    out->part_hts = part_hts;
-    out->n_parts = RADIX_P;
     if (ray_interrupted()) return true;
     /* Sync point — partitions materialized; show RADIX_P/RADIX_P. */
     ray_progress_update(NULL, "per-partition aggregate", RADIX_P, RADIX_P);

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -4050,7 +4050,7 @@ typedef struct {
     uint32_t      n_workers;
     ght_layout_t  layout;
     void**        key_data;
-    const void*  key_pool[8];  /* str-pool base per wide STR key */
+    const void**  key_pool;    /* [n_keys] str-pool base per wide STR key */
     _Atomic(int)  oom;
 } radix_v2_phase2_ctx_t;
 
@@ -9335,8 +9335,18 @@ ht_path:;
                 .oom       = 0,
             };
             ght_layout_copy(&v2p2.layout, &ght_layout);
-            if (ght_layout.any_wide_key) derive_key_pool(&ght_layout, key_vecs, v2p2.key_pool);
+            /* Wide-key str-pool table: phase2 copies each into its part_hts
+             * (whose bases point into the source columns), so this temp is
+             * freed right after the dispatch — mirrors p2ctx below. */
+            ray_t* v2p2_kp_hdr = NULL;
+            if (ght_layout.any_wide_key) {
+                v2p2.key_pool = (const void**)scratch_alloc(&v2p2_kp_hdr,
+                    (size_t)(n_keys ? n_keys : 1) * sizeof(void*));
+                if (!v2p2.key_pool) { result = ray_error("oom", NULL); goto cleanup; }
+                derive_key_pool(&ght_layout, key_vecs, v2p2.key_pool);
+            }
             ray_pool_dispatch_n(pool, radix_v2_phase2_fn, &v2p2, RADIX_P);
+            scratch_free(v2p2_kp_hdr);
             CHECK_CANCEL_GOTO(pool, cleanup);
             /* Worker HTs are no longer needed once the merge is done. */
             for (size_t i = 0; i < v2_n_w; i++)

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -2495,18 +2495,14 @@ bool ght_compute_layout(ght_layout_t* out, uint32_t n_keys, uint32_t n_aggs,
          * pass skips nulls itself), so they carry no nullable flag here.
          * COUNT reserves an nv slot for generic bookkeeping (phase1 still
          * stages its raw value) but its emit reads the group's row count
-         * (cnt) directly, never off_nn — so a nullable COUNT input must not
-         * flip any_agg_null either, or a count-only nullable group-by
-         * allocates an off_nn block no agg ever reads.  Gate on the agg
-         * actually owning a value slot (vslot >= 0) and not being COUNT.  A
-         * nullable value-slot agg makes the row-layout accumulators skip
-         * nulls (F64 NaN or the type's NULL_I* sentinel) and count non-nulls
-         * in the off_nn block. */
+         * (cnt) directly, never off_nn.  Gate on the agg actually owning a
+         * value slot (vslot >= 0).  A nullable value-slot agg makes the
+         * row-layout accumulators skip nulls (F64 NaN or the type's NULL_I*
+         * sentinel) and count non-nulls in the off_nn block. */
         uint8_t af2 = 0;
         int64_t sent = 0;
         int8_t vslot = out->agg_val_slot[a];
-        bool is_count = agg_ops && agg_ops[a] == OP_COUNT;
-        if (vslot >= 0 && !is_count && agg_vecs[a]) {
+        if (vslot >= 0 && agg_vecs[a]) {
             ray_t* src = (agg_vecs[a]->attrs & RAY_ATTR_SLICE)
                          ? agg_vecs[a]->slice_parent : agg_vecs[a];
             if (src && (src->attrs & RAY_ATTR_HAS_NULLS)) {

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -6651,6 +6651,26 @@ static ray_t* exec_group_v2_exprs(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     return result;   /* NULL → legacy path */
 }
 
+/* Pin the DA-prescan dense-group finalize alignment.  This function owns the
+ * dict/dense-array (DA) group path whose finalize loop (the total_groups /
+ * keep_min / range_count compaction region below, ~line 8395-8475, family
+ * da_count_emit_keep_min_u32) is the sole hot symbol for ClickBench q34
+ * (group-by-URL + count + desc-sort + take 10), 66% of self cycles.  Task 1
+ * of the unbounded-slots cut added ~230 net lines ELSEWHERE in group.c
+ * (the legacy ght_layout_t hash path — unrelated, byte-identical to baseline
+ * at the hot lines), shifting this loop's absolute address/alignment and
+ * dropping IPC 2.07→1.96 (+7.2% cycles, +1.6% instructions — a placement
+ * artifact, not new work; RCA in .superpowers/sdd/task-2-bench-checkpoint.md).
+ * Same remedy as reduce_range's cut-3 pin: aligned(64) stabilizes the entry
+ * cacheline; align-loops=32 re-pins every loop head and align-jumps=32 the
+ * unrolled branch targets, making the finalize loop's internal alignment
+ * invariant to future whole-TU layout churn.  Per-function attributes only —
+ * no global codegen flag.  GCC-only: clang lacks the `optimize` attribute and
+ * -Werror would promote the unknown-attribute warning; the pin is
+ * performance-only, so clang builds go without it. */
+#if defined(__GNUC__) && !defined(__clang__)
+__attribute__((aligned(64), optimize("align-loops=32","align-jumps=32")))
+#endif
 static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
                   int64_t group_limit) {
     if (!tbl || RAY_IS_ERR(tbl)) return tbl;

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -2352,15 +2352,38 @@ void ght_layout_free(ght_layout_t* ly) {
 
 void ght_layout_copy(ght_layout_t* dst, const ght_layout_t* src) {
     *dst = *src;   /* scalars + inline-array CONTENTS; the pointers are wrong */
-    if (src->spill_hdr == NULL) {
-        /* Inline: re-aim the bases at dst's own inline arrays (self-contained
-         * — no dependency on src's lifetime). */
+    /* Decide by STORAGE, not ownership: src->spill_hdr == NULL is true both
+     * for a genuine inline layout AND for a BORROWER (a prior copy of a
+     * spilled master — its bases point into the master's spill block but it
+     * does not own that block, so its own spill_hdr is NULL).  Testing
+     * spill_hdr here would send a borrower-of-a-borrower down the inline
+     * branch, re-pointing it at its own zeroed size-8 *_in arrays — silently
+     * truncating any layout with > GHT_INLINE keys/aggs two copies deep
+     * (e.g. master ctx -> per-partition ctx -> per-partition group_ht_t).
+     *
+     * The storage-identity test below is depth-invariant: src->agg_val_slot
+     * == src->agg_val_slot_in is true iff src's bases are self-referential,
+     * i.e. src itself is inline storage (whether or not src owns it) — a
+     * spilled master, a borrower, and a borrower-of-a-borrower all read
+     * false here alike, so master -> b1 -> b2 -> b3 ... all correctly keep
+     * borrowing the one shared spill block.  This needs no new field: the
+     * inline arrays already carry a unique identity (dst's own struct
+     * address), so pointer identity against them IS the storage test. */
+    if (src->agg_val_slot == src->agg_val_slot_in) {
+        /* Inline storage: re-aim the bases at dst's own inline arrays
+         * (self-contained — no dependency on src's lifetime). */
         ght_layout_point_inline(dst);
+        dst->spill_hdr = NULL;
     } else {
-        /* Spilled: BORROW src's shared read-only spill block.  The base
-         * pointers copied above already aim into it; drop ownership so
-         * ght_layout_free(dst) is a no-op — the original frees it, and the
-         * caller must ensure dst does not outlive src. */
+        /* Spill storage (src is either the owning master or a prior
+         * borrower): BORROW the shared read-only spill block.  The base
+         * pointers copied above already aim into it — that's true whether
+         * src owns the block or is itself borrowing it, since a borrower's
+         * bases are copied verbatim from what it borrowed.  Drop ownership
+         * so ght_layout_free(dst) is a no-op.  Lifetime rule: the OWNING
+         * MASTER must outlive every borrower transitively copied from it —
+         * all borrowers (at any depth) must be done with / freed before the
+         * master frees the spill. */
         dst->spill_hdr = NULL;
     }
 }
@@ -6825,15 +6848,17 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
         }
     }
 
-    /* The ght `[8]` fast layout (key_data[8]/key_pool[8], and the per-agg
-     * agg_is_binary/agg_is_holistic/agg_is_wide bitmasks) structurally caps
-     * n_keys and n_aggs at 8 there — kept until a future cut (see the
-     * unbounded-slots design doc: "group-HT [8] fast layout ... until cut
-     * 4").  The scalar-reduction fast path below (n_keys == 0) is a
-     * separate, VLA-sized accumulator with no such limit, so let n_aggs > 8
-     * through when there are no group keys; the guard just before
-     * ght_compute_layout (`ht_path:`) still rejects the rare fallback
-     * (accumulator OOM / oversized scan) that would actually need the
+    /* ght_layout_t itself is now unbounded (inline-or-spill, this cut) —
+     * n_keys/n_aggs no longer structurally cap at 8 there.  But group_ht_t's
+     * own key_data[8]/key_pool[8] (wide-key source-column resolution) are
+     * still fixed [8] arrays, so the n_keys/n_aggs > 8 gate below stays as a
+     * deliberate behavior-freeze for this cut, not a ght_layout_t limit —
+     * lifting it is follow-up work (widen key_data/key_pool alongside).  The
+     * scalar-reduction fast path below (n_keys == 0) is a separate,
+     * VLA-sized accumulator with no such limit, so let n_aggs > 8 through
+     * when there are no group keys; the guard just before ght_compute_layout
+     * (`ht_path:`) still rejects the rare fallback (accumulator OOM /
+     * oversized scan) that would actually need the
      * capped HT layout. */
     if (n_keys > 8 || (n_keys > 0 && n_aggs > 8)) return ray_error("nyi", NULL);
 
@@ -8957,9 +8982,13 @@ ht_path:;
      * on the assumption the scalar fast path (VLA-sized) will serve it —
      * that path returns before reaching here in the common case.  The rare
      * fallback into this HT row-layout (accumulator OOM / oversized scan)
-     * still can't serve n_aggs > 8: agg_is_binary/agg_is_holistic/agg_is_wide
-     * are single-byte bitmasks in ght_layout_t.  n_keys > 0 with n_aggs > 8
-     * already returned at the top of the function and never reaches here. */
+     * still can't serve n_aggs > 8 this cut: ght_layout_t's per-agg
+     * metadata (agg_flags etc.) is unbounded as of this cut, but this HT
+     * row-layout path as a whole remains gated to ≤8 keys/aggs as a
+     * deliberate behavior-freeze (see the exec_group_run width guard and
+     * group_ht_t's still-fixed key_data[8]/key_pool[8]) — lifting it is
+     * follow-up work.  n_keys > 0 with n_aggs > 8 already returned at the
+     * top of the function and never reaches here. */
     if (n_aggs > 8) {
         for (uint32_t a = 0; a < n_aggs; a++)
             { if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -2917,7 +2917,19 @@ static void accum_from_entry_nullable(char* row, const char* entry,
 static inline void init_accum_from_entry(char* row, const char* entry,
                                           const ght_layout_t* ly) {
     if (ly->any_agg_null) { init_accum_from_entry_nullable(row, entry, ly); return; }
-    uint16_t accum_start = (uint16_t)(8 + ((uint16_t)ly->n_keys + 1) * 8);
+    /* key_region-based (mirrors init_accum_from_entry_nullable): the old
+     * `8 + (n_keys+1)*8` assumed exactly one trailing null-mask word.  For
+     * null_words > 1 (n_keys > 64) that understates the accumulator start
+     * by (null_words-1)*8 bytes, so this memset's zero-fill reached
+     * backward into the last null-mask word — clobbering it to 0
+     * immediately after group_probe_entry's memcpy stored it correctly.
+     * Invisible to plain GROUP BY (which never re-reads null words from a
+     * stored HT row after ingest — the emitted key values come from a
+     * separate source-column re-scan), but wrong for PIVOT, whose own
+     * ix-dedupe/emit code (pivot.c) reads the null words directly back out
+     * of these same rows: the 65-index conflation-detector cell in
+     * tblop_branch_cov.rfl is the regression pin. */
+    uint16_t accum_start = (uint16_t)(8 + ly->key_region);
     if (ly->row_stride > accum_start)
         memset(row + accum_start, 0, ly->row_stride - accum_start);
 
@@ -11453,7 +11465,15 @@ bool pivot_ingest_run(pivot_ingest_t* out,
         (size_t)(RADIX_P + 1) * sizeof(uint32_t));
     if (!out->part_offsets) return false;
 
-    uint8_t n_keys = ly->n_keys;
+    /* uint32_t, not uint8_t: ly->n_keys is uint16_t (unbounded-ready, Task
+     * 1).  This local used to truncate mod 256 — dormant while every
+     * caller's n_keys stayed <=8, but pivot.c (the only caller of this
+     * function) now admits any n_idx, so n_keys > 255 is reachable.  A
+     * truncated value here undersizes the key_pool carve below while
+     * derive_key_pool still writes ly->n_keys (untruncated) entries into
+     * it — a heap buffer overflow, not just a wrong answer, once any
+     * index key is wide (RAY_GUID/RAY_STR) and n_keys > 255. */
+    uint32_t n_keys = ly->n_keys;
 
     ray_pool_t* pool = ray_pool_get();
     uint32_t n_total = pool ? ray_pool_total_workers(pool) : 1;

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -2556,6 +2556,30 @@ bool ght_compute_layout(ght_layout_t* out, uint32_t n_keys, uint32_t n_aggs,
 
 /* group_ht_t defined in exec_internal.h */
 
+/* Aim the HT's wide-key resolution tables (key_data / key_pool) at the inline
+ * [8] arrays (n_keys ≤ 8 — byte-identical to the legacy fixed layout) or at one
+ * owned heap block carved for wider layouts (unbounded-slots cut 4).  Zeroes the
+ * live slots so unset wide keys resolve to NULL.  Returns false on spill OOM. */
+static bool group_ht_wire_wide(group_ht_t* ht, uint32_t nk) {
+    uint32_t n = nk > 8 ? nk : 8;
+    if (nk <= 8) {
+        ht->key_wide_hdr = NULL;
+        ht->key_data = ht->key_data_in;
+        ht->key_pool = ht->key_pool_in;
+    } else {
+        ht->key_wide_hdr = NULL;
+        /* One block: [key_data: nk ptrs][key_pool: nk ptrs].  Per-HT, carved
+         * once at init (never per row); freed by group_ht_free. */
+        void* blk = scratch_alloc(&ht->key_wide_hdr, (size_t)nk * 2 * sizeof(void*));
+        if (!blk) return false;
+        ht->key_data = (void**)blk;
+        ht->key_pool = (const void**)((void**)blk + nk);
+    }
+    memset(ht->key_data, 0, (size_t)n * sizeof(void*));
+    memset((void*)ht->key_pool, 0, (size_t)n * sizeof(void*));
+    return true;
+}
+
 static bool group_ht_init_sized(group_ht_t* ht, uint32_t cap,
                                  const ght_layout_t* ly, uint32_t init_grp_cap) {
     ht->ht_cap = cap;
@@ -2564,9 +2588,11 @@ static bool group_ht_init_sized(group_ht_t* ht, uint32_t cap,
      * arrays (inline src) or borrow the shared spill (wide src).  The source
      * layout (owned by the caller's exec_group/pivot master) outlives this HT. */
     ght_layout_copy(&ht->layout, ly);
-    /* key_data must be populated by the caller via group_ht_set_key_data
-     * whenever wide_key_mask != 0. */
-    memset(ht->key_data, 0, sizeof(ht->key_data));
+    /* Wire the wide-key resolution tables (key_data/key_pool base pointers) —
+     * inline [8] for ≤8 keys, one owned heap block for wider.  key_data[k]
+     * must still be populated by the caller via group_ht_set_key_data whenever
+     * any_wide_key != 0. */
+    if (!group_ht_wire_wide(ht, ly->n_keys)) return false;
     ht->slots = (uint32_t*)scratch_alloc(&ht->_h_slots, (size_t)cap * sizeof(uint32_t));
     if (!ht->slots) return false;
     memset(ht->slots, 0xFF, (size_t)cap * sizeof(uint32_t)); /* HT_EMPTY = all-1s */
@@ -2587,8 +2613,8 @@ bool group_ht_init(group_ht_t* ht, uint32_t cap, const ght_layout_t* ly) {
 static inline void group_ht_set_key_data(group_ht_t* ht, void** kd) {
     if (!ht->layout.any_wide_key || !kd) return;
     const uint8_t* const kflags = ht->layout.key_flags;
-    /* `&& k < 8`: group_ht_t.key_data is a fixed [8] array (internal.h). */
-    for (uint16_t k = 0; k < ht->layout.n_keys && k < 8; k++) {
+    /* key_data is a base pointer sized to n_keys (inline ≤8, spilled wider). */
+    for (uint16_t k = 0; k < ht->layout.n_keys; k++) {
         if (kflags[k] & GHT_KEYF_WIDE) ht->key_data[k] = kd[k];
     }
 }
@@ -2598,8 +2624,10 @@ static inline void group_ht_set_key_data(group_ht_t* ht, void** kd) {
  * SSO-aware resolution. */
 static inline void derive_key_pool(const ght_layout_t* ly, ray_t* const* key_vecs,
                                    const void** out) {
-    /* `&& k < 8`: `out` is the caller's key_pool[8] (group_ht_t, fixed). */
-    for (uint16_t k = 0; k < ly->n_keys && k < 8; k++) {
+    /* `out` holds n_keys pool slots (group_ht_t base pointer, or a caller
+     * buffer sized to n_keys — every derive_key_pool call site provides at
+     * least n_keys slots). */
+    for (uint16_t k = 0; k < ly->n_keys; k++) {
         out[k] = NULL;
         if ((ly->key_flags[k] & GHT_KEYF_WIDE) && ly->wide_key_type[k] == RAY_STR
             && key_vecs && key_vecs[k]) {
@@ -2620,14 +2648,15 @@ static inline void group_ht_set_key_pool(group_ht_t* ht, ray_t* const* key_vecs)
 static inline void group_ht_copy_key_pool(group_ht_t* ht, const void* const* kp) {
     if (!ht->layout.any_wide_key || !kp) return;
     const uint8_t* const kflags = ht->layout.key_flags;
-    /* `&& k < 8`: group_ht_t.key_pool is a fixed [8] array (internal.h). */
-    for (uint16_t k = 0; k < ht->layout.n_keys && k < 8; k++)
+    /* key_pool is a base pointer sized to n_keys (inline ≤8, spilled wider). */
+    for (uint16_t k = 0; k < ht->layout.n_keys; k++)
         if (kflags[k] & GHT_KEYF_WIDE) ht->key_pool[k] = kp[k];
 }
 
 void group_ht_free(group_ht_t* ht) {
     scratch_free(ht->_h_slots);
     scratch_free(ht->_h_rows);
+    scratch_free(ht->key_wide_hdr);   /* NULL (inline) → no-op */
 }
 
 static bool group_ht_grow(group_ht_t* ht) {
@@ -2682,6 +2711,18 @@ static inline uint64_t ght_hash_null_words(uint64_t h, const int64_t* nullw,
     return h;
 }
 
+/* True when key column kv (or its slice parent) carries the HAS_NULLS attr and
+ * so may yield a null at some row.  Replaces the old per-key `1u << k` nullable
+ * bitmask (which silently dropped keys past index 7 / was UB past 31): callers
+ * hoist a single any_nullable summary out of the row loop, then re-test this
+ * per key ONLY on the rare null-bearing path — correct at any key count
+ * (unbounded-slots cut 4). */
+static inline bool ray_key_may_be_null(const ray_t* kv) {
+    if (!kv) return false;
+    const ray_t* src = (kv->attrs & RAY_ATTR_SLICE) ? kv->slice_parent : kv;
+    return src && (src->attrs & RAY_ATTR_HAS_NULLS);
+}
+
 /* ── Inline-STR key resolution (descriptor stored in the entry/row) ──
  * key_inline_str keys hold their 16-byte ray_str_t descriptor at
  * keybase+key_off[k], so hash/compare are cache-local; key_pool[k] (the source
@@ -2722,7 +2763,7 @@ static inline uint64_t inline_layout_key_hash(const ght_layout_t* ly, uint8_t k,
  * fixed-8 build but addresses every slot via key_off[k]. */
 static inline uint64_t inline_build_keys(const ght_layout_t* ly, const int8_t* key_types,
         void* const* key_data, const uint8_t* key_attrs, const void* const* key_pool,
-        ray_t* const* key_vecs, uint8_t nullable, int64_t row,
+        ray_t* const* key_vecs, uint8_t any_nullable, int64_t row,
         char* keybase) {
     uint64_t h = 0;
     uint16_t nk = ly->n_keys;
@@ -2737,10 +2778,10 @@ static inline uint64_t inline_build_keys(const ght_layout_t* ly, const int8_t* k
     for (uint32_t k = 0; k < nk; k++) {
         char* slot = keybase + koff[k];
         uint64_t kh;
-        bool is_null = (nullable & (1u << k)) && key_vecs && key_vecs[k]
+        bool is_null = any_nullable && key_vecs && ray_key_may_be_null(key_vecs[k])
                        && ray_vec_is_null(key_vecs[k], row);
         if (is_null) {
-            nullw[k >> 6] |= (int64_t)1 << (k & 63);
+            nullw[k >> 6] |= (int64_t)((uint64_t)1 << (k & 63));
             if (kflags[k] & GHT_KEYF_INLINE_STR) memset(slot, 0, sizeof(ray_str_t));
             else *(int64_t*)slot = 0;
             kh = ray_hash_i64(0);
@@ -3160,20 +3201,28 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
     bool has_fl = (ly->agg_flags_any & (GHT_AF_FIRST | GHT_AF_LAST)) != 0;
     uint32_t mask = ht->ht_cap - 1;
     /* Stack buffer for one entry: hash + (nk+1) key slots + nv agg_vals
-     * + optional 8-byte source-row tail (FIRST/LAST).
-     * Max size: 8 + 9*8 + 8*8 + 8 = 152 bytes. */
-    char ebuf[8 + 9 * 8 + 8 * 8 + 8];
-
-    /* Check which key columns can produce nulls (parent vec's HAS_NULLS
-     * attr for slices) — skips per-row null checks on the fast path. */
-    uint8_t nullable_mask = 0;
-    for (uint32_t k = 0; k < nk; k++) {
-        if (!key_vecs || !key_vecs[k]) continue;
-        ray_t* kv = key_vecs[k];
-        ray_t* src = (kv->attrs & RAY_ATTR_SLICE) ? kv->slice_parent : kv;
-        if (src && (src->attrs & RAY_ATTR_HAS_NULLS))
-            nullable_mask |= (uint8_t)(1u << k);
+     * + optional 8-byte source-row tail (FIRST/LAST).  The ≤8-key/≤8-agg
+     * layout fits 8 + 9*8 + 8*8 + 8 = 152 bytes (byte-identical to the legacy
+     * fixed buffer); a wider layout spills to one per-call heap block sized
+     * to entry_stride (carved once here, never per row — unbounded-slots
+     * cut 4). */
+    char ebuf_stk[8 + 9 * 8 + 8 * 8 + 8];
+    char* ebuf = ebuf_stk;
+    ray_t* ebuf_hdr = NULL;
+    if (ly->entry_stride > sizeof(ebuf_stk)) {
+        ebuf = (char*)scratch_alloc(&ebuf_hdr, ly->entry_stride);
+        if (!ebuf) { ht->oom = 1; return; }
     }
+
+    /* Any key column that can produce nulls (parent vec's HAS_NULLS attr for
+     * slices)?  When none, every per-row null check short-circuits on this
+     * register test (common fast path).  A precomputed per-key bitmask is
+     * avoided so key indices past 63 track correctly (unbounded-slots cut 4);
+     * with any_nullable set, the per-key nullability is re-derived cheaply
+     * from the key vec's attr (only on the rare null-bearing path). */
+    uint8_t any_nullable = 0;
+    for (uint32_t k = 0; k < nk; k++)
+        if (key_vecs && ray_key_may_be_null(key_vecs[k])) { any_nullable = 1; break; }
 
     /* Wire the HT's key_data + key_pool tables so probe/rehash can
      * resolve wide keys (GUID bytes / STR descriptors) via the source columns. */
@@ -3190,7 +3239,7 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
         int64_t* ek = (int64_t*)(ebuf + 8);
         if (ly->any_inline_str) {
             h = inline_build_keys(ly, key_types, key_data, key_attrs, ht->key_pool,
-                                  key_vecs, nullable_mask, row, ebuf + 8);
+                                  key_vecs, any_nullable, row, ebuf + 8);
         } else {
         /* Non-inline keys are 8 B each, so the null-mask words start at ek[nk]
          * (== ebuf+8+key_off[nk]); write bit k into word k>>6 in place. */
@@ -3200,10 +3249,10 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
         for (uint32_t k = 0; k < nk; k++) {
             int8_t t = key_types[k];
             uint64_t kh;
-            bool is_null = (nullable_mask & (1u << k))
+            bool is_null = any_nullable && ray_key_may_be_null(key_vecs[k])
                            && ray_vec_is_null(key_vecs[k], row);
             if (is_null) {
-                nullw[k >> 6] |= (int64_t)1 << (k & 63);
+                nullw[k >> 6] |= (int64_t)((uint64_t)1 << (k & 63));
                 ek[k] = 0;  /* canonical null value — real 0 differs via null mask */
                 kh = ray_hash_i64(0);
             } else if (wide_any && (kflags[k] & GHT_KEYF_WIDE)) {
@@ -3261,6 +3310,7 @@ void group_rows_range(group_ht_t* ht, void** key_data, int8_t* key_types,
 
         mask = group_probe_entry(ht, ebuf, key_types, mask);
     }
+    scratch_free(ebuf_hdr);   /* NULL (inline ebuf) → no-op */
 }
 
 /* ============================================================================
@@ -3327,11 +3377,11 @@ static inline void radix_buf_push(radix_buf_t* buf, uint16_t entry_stride,
 
 typedef struct {
     void**       key_data;
-    const void*  key_pool[8];     /* str-pool base per wide STR key (NULL else) */
+    const void** key_pool;        /* [n_keys] str-pool base per wide STR key (NULL else) */
     int8_t*      key_types;
     uint8_t*     key_attrs;
     ray_t**      key_vecs;
-    uint8_t      nullable_mask;   /* bit k = key k column may contain nulls */
+    uint8_t      nullable_mask;   /* 0/1: any key may be null (see build) */
     ray_t**       agg_vecs;
     /* Second input column per agg; NULL when no binary aggs in this
      * OP_GROUP.  Pass 1 reads agg_vecs2[a] alongside agg_vecs[a] and
@@ -3363,11 +3413,28 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
     bool has_fl = (ly->agg_flags_any & (GHT_AF_FIRST | GHT_AF_LAST)) != 0;
     const int64_t* match_idx = c->match_idx;
 
-    int64_t keys[9];       /* non-inline key region: 8 keys + 1 null-mask word */
-    int64_t agg_vals[8];
-    char    keybuf[136];   /* inline-STR key region: max 8*16 + 8 null mask */
+    /* Per-worker key/agg staging.  The ≤8-key/≤8-agg layout stages through
+     * stack arrays (keys: 8 keys + 1 null word; agg_vals: 8 slots; keybuf:
+     * 8*16 + 8 inline-STR region) — byte-identical to the legacy fixed
+     * buffers.  A wider layout carves one per-worker heap block ONCE here
+     * (never per row — unbounded-slots cut 4): keybuf | keys | agg_vals. */
+    int64_t keys_stk[9];
+    int64_t agg_vals_stk[8];
+    char    keybuf_stk[136];
+    int64_t* keys = keys_stk;
+    int64_t* agg_vals = agg_vals_stk;
+    char*    keybuf = keybuf_stk;
+    ray_t*   stage_hdr = NULL;
+    if (ly->key_region > sizeof(keys_stk) || nv > 8) {
+        size_t kb = ly->key_region;
+        char* blk = (char*)scratch_alloc(&stage_hdr, kb + kb + (size_t)nv * 8);
+        if (!blk) return;   /* OOM on a pathologically wide layout: drop worker */
+        keybuf   = blk;
+        keys     = (int64_t*)(blk + kb);
+        agg_vals = (int64_t*)(blk + kb + kb);
+    }
 
-    uint8_t nullable = c->nullable_mask;
+    uint8_t nullable = c->nullable_mask;   /* 0/1: any key may be null (see build) */
     for (int64_t i = start; i < end; i++) {
         /* Cancellation checkpoint every 65536 rows — ~150 polls on a
          * 10M-row ingest, imperceptible in the inner loop and still
@@ -3389,10 +3456,10 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
         for (uint32_t k = 0; k < nk; k++) {
             int8_t t = c->key_types[k];
             uint64_t kh;
-            bool is_null = (nullable & (1u << k))
+            bool is_null = nullable && ray_key_may_be_null(c->key_vecs[k])
                            && ray_vec_is_null(c->key_vecs[k], row);
             if (is_null) {
-                nullw[k >> 6] |= (int64_t)1 << (k & 63);
+                nullw[k >> 6] |= (int64_t)((uint64_t)1 << (k & 63));
                 keys[k] = 0;
                 kh = ray_hash_i64(0);
             } else if (wide_any && (kflags[k] & GHT_KEYF_WIDE)) {
@@ -3448,6 +3515,7 @@ static void radix_phase1_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
                        inline_str ? (const int64_t*)keybuf : keys,
                        agg_vals, (uint8_t)nv, has_fl, row, ly->key_region);
     }
+    scratch_free(stage_hdr);   /* NULL (inline staging) → no-op */
 }
 
 /* Process pre-partitioned fat entries into an HT with prefetch batching.
@@ -3542,7 +3610,7 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
                 uint8_t esz = c->key_esizes[k];
                 int8_t kt = c->key_types[k];
                 size_t doff = (size_t)di * esz;
-                if (nullw[k >> 6] & ((int64_t)1 << (k & 63))) {
+                if (nullw[k >> 6] & ((int64_t)((uint64_t)1 << (k & 63)))) {
                     if (c->key_cols && c->key_cols[k])
                         grp_set_null(c->key_cols[k], di);
                     /* Fill the correct-width sentinel. */
@@ -3689,7 +3757,7 @@ static void radix_phase3_fn(void* ctx, uint32_t worker_id, int64_t start, int64_
 /* Pass 2: aggregate each partition independently using inline data */
 typedef struct {
     int8_t*      key_types;
-    uint8_t      n_keys;
+    uint32_t     n_keys;       /* widened from uint8_t (unbounded-ready) */
     uint32_t     n_workers;
     radix_buf_t* bufs;
     group_ht_t*  part_hts;
@@ -3697,7 +3765,7 @@ typedef struct {
     /* Shared (read-only) source column bases for wide-key resolution.
      * Each partition HT stashes the ones matching wide_key_mask. */
     void**       key_data;
-    const void*  key_pool[8];  /* str-pool base per wide STR key */
+    const void** key_pool;     /* [n_keys] str-pool base per wide STR key */
 } radix_phase2_ctx_t;
 
 static void radix_phase2_fn(void* ctx, uint32_t worker_id, int64_t start, int64_t end) {
@@ -3875,9 +3943,22 @@ static void radix_v2_phase1_fn(void* ctx, uint32_t worker_id,
     uint32_t masks[RADIX_P];
     for (uint32_t p = 0; p < RADIX_P; p++) masks[p] = my_hts[p].ht_cap - 1;
 
-    /* Stack-resident transient entry, same layout as group_rows_range. */
-    char ebuf[8 + 9 * 8 + 8 * 8 + 8];
-    const void* kpool[8];
+    /* Stack-resident transient entry + per-key str-pool table, same layout as
+     * group_rows_range.  ≤8 keys/aggs stay on the stack (byte-identical);
+     * wider layouts carve one per-worker heap block ONCE (never per row —
+     * unbounded-slots cut 4): ebuf(entry_stride) | kpool(n_keys ptrs). */
+    char ebuf_stk[8 + 9 * 8 + 8 * 8 + 8];
+    const void* kpool_stk[8];
+    char* ebuf = ebuf_stk;
+    const void** kpool = kpool_stk;
+    ray_t* v2_stage_hdr = NULL;
+    if (ly->entry_stride > sizeof(ebuf_stk) || nk > 8) {
+        char* blk = (char*)scratch_alloc(&v2_stage_hdr,
+            (size_t)ly->entry_stride + (size_t)nk * sizeof(void*));
+        if (!blk) { atomic_store_explicit(&c->oom, 1, memory_order_relaxed); return; }
+        ebuf  = blk;
+        kpool = (const void**)(blk + ly->entry_stride);
+    }
     derive_key_pool(ly, c->key_vecs, kpool);
     for (int64_t i = start; i < end; i++) {
         if (((i - start) & 65535) == 0 && ray_interrupted()) break;
@@ -3896,10 +3977,10 @@ static void radix_v2_phase1_fn(void* ctx, uint32_t worker_id,
         for (uint32_t k = 0; k < nk; k++) {
             int8_t t = c->key_types[k];
             uint64_t kh;
-            bool is_null = (nullable & (1u << k))
+            bool is_null = nullable && ray_key_may_be_null(c->key_vecs[k])
                            && ray_vec_is_null(c->key_vecs[k], row);
             if (is_null) {
-                nullw[k >> 6] |= (int64_t)1 << (k & 63);
+                nullw[k >> 6] |= (int64_t)((uint64_t)1 << (k & 63));
                 ek[k] = 0;
                 kh = ray_hash_i64(0);
             } else if (wide_any && (kflags[k] & GHT_KEYF_WIDE)) {
@@ -3955,10 +4036,11 @@ static void radix_v2_phase1_fn(void* ctx, uint32_t worker_id,
                                               c->key_types, masks[p]);
         if (my_hts[p].oom) {
             atomic_store_explicit(&c->oom, 1, memory_order_relaxed);
-            return;
+            break;
         }
         masks[p] = new_mask;
     }
+    scratch_free(v2_stage_hdr);   /* NULL (inline staging) → no-op */
 }
 
 typedef struct {
@@ -5448,10 +5530,10 @@ typedef struct {
     int8_t*       key_types;
     uint8_t*      key_attrs;
     ray_t**       key_vecs;
-    uint8_t       n_keys;
-    uint8_t       nullable_mask;
+    uint32_t      n_keys;           /* widened from uint8_t (unbounded-ready) */
+    uint8_t       nullable_mask;    /* 0/1: any key may be null (see build) */
     const ght_layout_t* layout;     /* borrowed; carries key_flags/wide_key_type */
-    const void*   key_pool[8];      /* str-pool base per wide STR key (NULL else) */
+    const void**  key_pool;         /* [n_keys] str-pool base per wide STR key */
     group_ht_t*   part_hts;
     const uint32_t* part_offsets;
     int64_t*      row_gid;          /* output [nrows] */
@@ -5463,9 +5545,22 @@ static void reprobe_rows_fn(void* vctx, uint32_t worker_id,
                             int64_t start, int64_t end) {
     (void)worker_id;
     reprobe_ctx_t* c = (reprobe_ctx_t*)vctx;
-    uint8_t nk = c->n_keys;
-    int64_t ek_buf[9];           /* nk + null_mask slot */
-    char    keybuf[136];         /* inline-STR key region */
+    uint32_t nk = c->n_keys;
+    /* Key lookup staging: ≤8 keys stay on the stack (ek_buf: 8 keys + 1 null
+     * word; keybuf: inline-STR region), wider layouts carve one per-worker
+     * heap block ONCE (never per row — unbounded-slots cut 4). */
+    int64_t  ek_buf_stk[9];
+    char     keybuf_stk[136];
+    int64_t* ek_buf = ek_buf_stk;
+    char*    keybuf = keybuf_stk;
+    ray_t*   rp_stage_hdr = NULL;
+    if ((size_t)c->layout->key_region > sizeof(ek_buf_stk)) {
+        size_t kb = c->layout->key_region;
+        char* blk = (char*)scratch_alloc(&rp_stage_hdr, kb + kb);
+        if (!blk) return;   /* OOM on a pathologically wide layout: drop worker */
+        keybuf = blk;
+        ek_buf = (int64_t*)(blk + kb);
+    }
     int8_t* key_types = c->key_types;
     void** key_data = c->key_data;
     uint8_t* key_attrs = c->key_attrs;
@@ -5498,10 +5593,10 @@ static void reprobe_rows_fn(void* vctx, uint32_t worker_id,
         for (uint32_t k = 0; k < nk; k++) {
             int8_t t = key_types[k];
             uint64_t kh;
-            bool is_null = (nullable & (1u << k))
+            bool is_null = nullable && ray_key_may_be_null(key_vecs[k])
                            && ray_vec_is_null(key_vecs[k], row);
             if (is_null) {
-                nullw[k >> 6] |= (int64_t)1 << (k & 63);
+                nullw[k >> 6] |= (int64_t)((uint64_t)1 << (k & 63));
                 ek_buf[k] = 0;
                 kh = ray_hash_i64(0);
             } else if (wide_any && (kflags[k] & GHT_KEYF_WIDE)) {
@@ -5532,6 +5627,7 @@ static void reprobe_rows_fn(void* vctx, uint32_t worker_id,
             c->row_gid[row] = (int64_t)c->part_offsets[part] + (int64_t)local;
         }
     }
+    scratch_free(rp_stage_hdr);   /* NULL (inline staging) → no-op */
 }
 
 /* Histogram + scatter for idx_buf construction.  Identical pattern to
@@ -6014,6 +6110,13 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl, int64_t group_limit)
         gvm->grp_card_n = 0;
     }
     ray_t* result;
+    /* key_col/dict_sym are one scratch block sized to n_keys (a VLA can't cross
+     * the `goto grp_done` bail-outs below).  wrap_hdr stays NULL on the early
+     * bails.  The wrapper's own n_keys > 8 bail still stands in this commit;
+     * the guard-lift commit retires it so >8-key dict-STR groups are served. */
+    ray_t*  wrap_hdr = NULL;
+    ray_t** key_col = NULL;     /* source STR column per dict'd key (for output) */
+    int64_t* dict_sym = NULL;
     if (!tbl || RAY_IS_ERR(tbl) || tbl->type != RAY_TABLE) {
         result = exec_group_run(g, op, tbl, group_limit); goto grp_done;
     }
@@ -6023,8 +6126,11 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl, int64_t group_limit)
     }
 
     uint32_t nk = ext->n_keys;
-    ray_t*  key_col[8] = {0};   /* source STR column per dict'd key (for output) */
-    int64_t dict_sym[8];
+    key_col = (ray_t**)scratch_alloc(&wrap_hdr,
+        (size_t)nk * (sizeof(ray_t*) + sizeof(int64_t)));
+    if (!key_col) { result = exec_group_run(g, op, tbl, group_limit); goto grp_done; }
+    dict_sym = (int64_t*)(key_col + nk);
+    for (uint32_t k = 0; k < nk; k++) key_col[k] = NULL;
     bool any = false;
     for (uint32_t k = 0; k < nk; k++) {
         ray_op_t* key_op = op_node(g, ext->keys[k]);
@@ -6095,6 +6201,7 @@ ray_t* exec_group(ray_graph_t* g, ray_op_t* op, ray_t* tbl, int64_t group_limit)
         }
     }
 grp_done:
+    scratch_free(wrap_hdr);   /* NULL on early bails → no-op */
     if (gvm) {
         gvm->grp_card_n = sv_grp_n;
         memcpy(gvm->grp_card_sym, sv_grp_sym, sizeof sv_grp_sym);
@@ -6556,12 +6663,10 @@ static ray_t* exec_group_slices(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
 static ray_t* exec_group_v2_exprs(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     if (!tbl || tbl->type != RAY_TABLE) return NULL;
     ray_op_ext_t* ext = find_ext(g, op->id);
-    /* Own gate: this v2-expression shadow path caps both counts at 16 here
-     * (independent of the exec_group_run width guard and ht_path n_aggs
-     * guard below — this helper runs before those, straight off
-     * ext->n_keys/n_aggs) and uses
-     * fixed [16] scratch (synth/names/in_ids/keys/ins/ins2) throughout, so
-     * every uint8_t loop below stays uint8_t. */
+    /* Own gate: this v2-expression shadow path's scratch (synth/names/in_ids/
+     * keys/ins/ins2) is now VLA-sized to n_aggs/n_keys and every index loop
+     * below is uint32_t, but the 16 caps still stand here — the guard-lift
+     * commit retires them. */
     if (!ext || ext->n_keys < 1 || ext->n_keys > 16 ||
         ext->n_aggs < 1 || ext->n_aggs > 16) return NULL;
 
@@ -6569,8 +6674,9 @@ static ray_t* exec_group_v2_exprs(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
      * COUNT and binary/holistic second inputs pass through untouched. */
     int64_t nrows = ray_table_nrows(tbl);
     if (nrows <= 0) return NULL;
+    uint32_t na = ext->n_aggs, nkk = ext->n_keys;
     bool any_expr = false;
-    for (uint8_t a = 0; a < ext->n_aggs; a++) {
+    for (uint32_t a = 0; a < na; a++) {
         if (ext->agg_ops[a] == OP_COUNT) continue;
         ray_op_t* in = op_node(g, ext->agg_ins[a]);
         if (!in) return NULL;
@@ -6580,12 +6686,14 @@ static ray_t* exec_group_v2_exprs(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     if (!any_expr) return NULL;
 
     /* Materialize expression inputs (full length — the selection, if any,
-     * is applied by exec_group_v2 itself). */
-    ray_t* synth[16] = {0};
-    char   names[16][8];
+     * is applied by exec_group_v2 itself).  VLA scratch, n_aggs/n_keys-sized;
+     * names[a] holds "_e" + up to 10 uint32 digits + NUL ≤ 16. */
+    ray_t* synth[na];
+    char   names[na][16];
+    for (uint32_t a = 0; a < na; a++) synth[a] = NULL;
     ray_t* sub = NULL;
     bool ok = true;
-    for (uint8_t a = 0; a < ext->n_aggs && ok; a++) {
+    for (uint32_t a = 0; a < na && ok; a++) {
         if (ext->agg_ops[a] == OP_COUNT) continue;
         ray_op_t* in = op_node(g, ext->agg_ins[a]);
         if (in->opcode == OP_SCAN || in->opcode == OP_CONST) continue;
@@ -6605,14 +6713,14 @@ static ray_t* exec_group_v2_exprs(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     }
     if (ok) {
         int64_t ncols = ray_table_ncols(tbl);
-        sub = ray_table_new(ncols + ext->n_aggs);
+        sub = ray_table_new(ncols + na);
         if (!sub || RAY_IS_ERR(sub)) { ok = false; }
         for (int64_t c = 0; c < ncols && ok; c++) {
             sub = ray_table_add_col(sub, ray_table_col_name(tbl, c),
                                     ray_table_get_col_idx(tbl, c));
             if (!sub || RAY_IS_ERR(sub)) ok = false;
         }
-        for (uint8_t a = 0; a < ext->n_aggs && ok; a++) {
+        for (uint32_t a = 0; a < na && ok; a++) {
             if (!synth[a]) continue;
             sub = ray_table_add_col(sub,
                     ray_sym_intern(names[a], strlen(names[a])), synth[a]);
@@ -6625,9 +6733,9 @@ static ray_t* exec_group_v2_exprs(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
          * expression inputs replaced by scans of the synthetic columns.
          * Build all scans BEFORE the group node — node creation may
          * realloc g->nodes and dangle earlier ray_op_t pointers. */
-        uint32_t in_ids[16];
+        uint32_t in_ids[na];
         bool has2 = false, hask = false;
-        for (uint8_t a = 0; a < ext->n_aggs && ok; a++) {
+        for (uint32_t a = 0; a < na && ok; a++) {
             if (synth[a]) {
                 ray_op_t* sc = ray_scan(g, names[a]);
                 if (!sc) { ok = false; break; }
@@ -6639,12 +6747,12 @@ static ray_t* exec_group_v2_exprs(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
             if (ext->agg_k && ext->agg_k[a]) hask = true;
         }
         if (ok) {
-            ray_op_t* keys[16];
-            ray_op_t* ins[16];
-            ray_op_t* ins2[16];
-            for (uint8_t k = 0; k < ext->n_keys; k++)
+            ray_op_t* keys[nkk];
+            ray_op_t* ins[na];
+            ray_op_t* ins2[na];
+            for (uint32_t k = 0; k < nkk; k++)
                 keys[k] = op_node(g, ext->keys[k]);
-            for (uint8_t a = 0; a < ext->n_aggs; a++) {
+            for (uint32_t a = 0; a < na; a++) {
                 ins[a] = op_node(g, in_ids[a]);
                 ins2[a] = (ext->agg_ins2 && ext->agg_ins2[a] != RAY_OP_NONE)
                     ? op_node(g, ext->agg_ins2[a]) : NULL;
@@ -6664,7 +6772,7 @@ static ray_t* exec_group_v2_exprs(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     ray_t* result = NULL;
     if (ok && agg_v2_can_handle(g, op2, sub))
         result = exec_group_v2(g, op2, sub);
-    for (uint8_t a = 0; a < ext->n_aggs; a++)
+    for (uint32_t a = 0; a < na; a++)
         if (synth[a]) ray_release(synth[a]);
     if (sub) ray_release(sub);
     return result;   /* NULL → legacy path */
@@ -6887,18 +6995,11 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
         }
     }
 
-    /* ght_layout_t itself is now unbounded (inline-or-spill, this cut) —
-     * n_keys/n_aggs no longer structurally cap at 8 there.  But group_ht_t's
-     * own key_data[8]/key_pool[8] (wide-key source-column resolution) are
-     * still fixed [8] arrays, so the n_keys/n_aggs > 8 gate below stays as a
-     * deliberate behavior-freeze for this cut, not a ght_layout_t limit —
-     * lifting it is follow-up work (widen key_data/key_pool alongside).  The
-     * scalar-reduction fast path below (n_keys == 0) is a separate,
-     * VLA-sized accumulator with no such limit, so let n_aggs > 8 through
-     * when there are no group keys; the guard just before ght_compute_layout
-     * (`ht_path:`) still rejects the rare fallback (accumulator OOM /
-     * oversized scan) that would actually need the
-     * capped HT layout. */
+    /* Width guard still in force here: this commit sizes every entry-staging
+     * buffer on the legacy path to the layout (stack when it fits, one
+     * per-call/per-worker heap block when wider) and widens group_ht_t's
+     * wide-key tables to base pointers, but does NOT yet admit >8-key/>8-agg
+     * shapes — retiring this guard is the following commit. */
     if (n_keys > 8 || (n_keys > 0 && n_aggs > 8)) return ray_error("nyi", NULL);
 
     /* Extract selection (rowsel) for pushdown.  Prefer streaming the
@@ -7127,13 +7228,13 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
         agg_owned[a] = 1;
     }
 
-    /* Pre-compute key metadata.  Fixed [8], not VLA: the ~6713 guard above
-     * (`n_keys > 8 || ...`) caps n_keys <= 8 on this path, but under -O3 gcc's
-     * range analysis can't chain that bound through a VLA sized off vla_keys
-     * to prove `k < n_keys` writes stay in-bounds (-Wstringop-overflow). */
-    void* key_data[8];
-    int8_t key_types[8];
-    uint8_t key_attrs[8];
+    /* Pre-compute key metadata.  VLA sized to vla_keys (== max(n_keys,1)),
+     * matching key_vecs above: the width guard is retired (unbounded-slots
+     * cut 4), so n_keys is no longer capped at 8 here — every k < n_keys write
+     * is provably within the vla_keys-sized array. */
+    void* key_data[vla_keys];
+    int8_t key_types[vla_keys];
+    uint8_t key_attrs[vla_keys];
     for (uint32_t k = 0; k < n_keys; k++) {
         if (key_vecs[k]) {
             key_data[k]  = ray_data(key_vecs[k]);
@@ -9017,17 +9118,9 @@ dyn_dense_done:
     }
 
 ht_path:;
-    /* n_keys == 0 with n_aggs > 8 is let through the top-of-function guard
-     * on the assumption the scalar fast path (VLA-sized) will serve it —
-     * that path returns before reaching here in the common case.  The rare
-     * fallback into this HT row-layout (accumulator OOM / oversized scan)
-     * still can't serve n_aggs > 8 this cut: ght_layout_t's per-agg
-     * metadata (agg_flags etc.) is unbounded as of this cut, but this HT
-     * row-layout path as a whole remains gated to ≤8 keys/aggs as a
-     * deliberate behavior-freeze (see the exec_group_run width guard and
-     * group_ht_t's still-fixed key_data[8]/key_pool[8]) — lifting it is
-     * follow-up work.  n_keys > 0 with n_aggs > 8 already returned at the
-     * top of the function and never reaches here. */
+    /* Keyless n_aggs>8 guard still in force: the entry-staging buffers this
+     * fallback uses are now layout-sized, but admitting >8 aggs is deferred to
+     * the guard-lift commit. */
     if (n_aggs > 8) {
         for (uint32_t a = 0; a < n_aggs; a++)
             { if (agg_owned[a] && agg_vecs[a]) ray_release(agg_vecs[a]);
@@ -9179,14 +9272,9 @@ ht_path:;
                 if (v2_part_hts) scratch_free(v2_part_hdr);
                 goto v2_done;
             }
-            uint8_t v2_nullable = 0;
-            for (uint32_t k = 0; k < n_keys; k++) {
-                if (!key_vecs[k]) continue;
-                ray_t* src = (key_vecs[k]->attrs & RAY_ATTR_SLICE)
-                             ? key_vecs[k]->slice_parent : key_vecs[k];
-                if (src && (src->attrs & RAY_ATTR_HAS_NULLS))
-                    v2_nullable |= (uint8_t)(1u << k);
-            }
+            uint8_t v2_nullable = 0;   /* 0/1: any key may be null (per-key re-checked in phase1) */
+            for (uint32_t k = 0; k < n_keys; k++)
+                if (ray_key_may_be_null(key_vecs[k])) { v2_nullable = 1; break; }
             /* Selection-aware iteration: for a sparse WHERE, iterate the
              * survivor row list instead of scanning all nrows with a per-row
              * rowsel check.  Scoped to this v2 build; freed right after the
@@ -9294,16 +9382,12 @@ v2_done:;
             radix_bufs[i].cap = buf_init;
         }
 
-        /* Compute per-key nullability — lets phase1 skip null checks on
-         * key columns with no nulls (the common case). */
+        /* Any key column that may hold nulls — lets phase1 skip the per-key
+         * null check on the common (no-nulls) fast path.  0/1 summary so key
+         * indices past 63 track correctly; phase1 re-derives per-key. */
         uint8_t p1_nullable = 0;
-        for (uint32_t k = 0; k < n_keys; k++) {
-            if (!key_vecs[k]) continue;
-            ray_t* src = (key_vecs[k]->attrs & RAY_ATTR_SLICE)
-                         ? key_vecs[k]->slice_parent : key_vecs[k];
-            if (src && (src->attrs & RAY_ATTR_HAS_NULLS))
-                p1_nullable |= (uint8_t)(1u << k);
-        }
+        for (uint32_t k = 0; k < n_keys; k++)
+            if (ray_key_may_be_null(key_vecs[k])) { p1_nullable = 1; break; }
 
         /* Pass 1: parallel hash + copy keys/agg values into fat entries */
         radix_phase1_ctx_t p1ctx = {
@@ -9321,9 +9405,17 @@ v2_done:;
             .match_idx     = match_idx,
         };
         ght_layout_copy(&p1ctx.layout, &ght_layout);
-        if (ght_layout.any_wide_key)
+        /* Wide-key str-pool table (n_keys slots): carve once (never per row);
+         * consumed within the phase1 dispatch, freed right after — cut 4. */
+        ray_t* p1_kp_hdr = NULL;
+        if (ght_layout.any_wide_key) {
+            p1ctx.key_pool = (const void**)scratch_alloc(&p1_kp_hdr,
+                (size_t)n_keys * sizeof(void*));
+            if (!p1ctx.key_pool) { result = ray_error("oom", NULL); goto cleanup; }
             derive_key_pool(&ght_layout, key_vecs, p1ctx.key_pool);
+        }
         ray_pool_dispatch(pool, radix_phase1_fn, &p1ctx, n_scan);
+        scratch_free(p1_kp_hdr);
         CHECK_CANCEL_GOTO(pool, cleanup);
 
         /* Check for OOM during phase 1 radix buffer growth */
@@ -9359,8 +9451,18 @@ v2_done:;
             .key_data    = key_data,
         };
         ght_layout_copy(&p2ctx.layout, &ght_layout);
-        if (ght_layout.any_wide_key) derive_key_pool(&ght_layout, key_vecs, p2ctx.key_pool);
+        /* Wide-key str-pool table: phase2 copies each into its part_hts (whose
+         * bases point into the source columns), so this temp is freed right
+         * after the dispatch — cut 4. */
+        ray_t* p2_kp_hdr = NULL;
+        if (ght_layout.any_wide_key) {
+            p2ctx.key_pool = (const void**)scratch_alloc(&p2_kp_hdr,
+                (size_t)n_keys * sizeof(void*));
+            if (!p2ctx.key_pool) { result = ray_error("oom", NULL); goto cleanup; }
+            derive_key_pool(&ght_layout, key_vecs, p2ctx.key_pool);
+        }
         ray_pool_dispatch_n(pool, radix_phase2_fn, &p2ctx, RADIX_P);
+        scratch_free(p2_kp_hdr);
         CHECK_CANCEL_GOTO(pool, cleanup);
 
         if (radix_bufs) {
@@ -9690,14 +9792,9 @@ v2_emit:;
                 (size_t)nrows * sizeof(int64_t));
             if (!row_gid) { result = ray_error("oom", NULL); goto cleanup; }
 
-            uint8_t reprobe_nullable = 0;
-            for (uint32_t k = 0; k < n_keys; k++) {
-                if (!key_vecs[k]) continue;
-                ray_t* src = (key_vecs[k]->attrs & RAY_ATTR_SLICE)
-                             ? key_vecs[k]->slice_parent : key_vecs[k];
-                if (src && (src->attrs & RAY_ATTR_HAS_NULLS))
-                    reprobe_nullable |= (uint8_t)(1u << k);
-            }
+            uint8_t reprobe_nullable = 0;   /* 0/1: any key may be null */
+            for (uint32_t k = 0; k < n_keys; k++)
+                if (ray_key_may_be_null(key_vecs[k])) { reprobe_nullable = 1; break; }
             reprobe_ctx_t rp = {
                 .key_data = key_data,
                 .key_types = key_types,
@@ -9712,9 +9809,17 @@ v2_emit:;
                 .match_idx = match_idx,
                 .rowsel = rowsel,
             };
-            if (ght_layout.any_wide_key)
+            /* Wide-key str-pool table (n_keys slots): carve once here (never
+             * per row); NULL when no wide keys — cut 4. */
+            ray_t* rp_kp_hdr = NULL;
+            if (ght_layout.any_wide_key) {
+                rp.key_pool = (const void**)scratch_alloc(&rp_kp_hdr,
+                    (size_t)n_keys * sizeof(void*));
+                if (!rp.key_pool) { result = ray_error("oom", NULL); goto cleanup; }
                 derive_key_pool(&ght_layout, key_vecs, rp.key_pool);
+            }
             ray_pool_dispatch(pool, reprobe_rows_fn, &rp, n_scan);
+            scratch_free(rp_kp_hdr);
 
             /* Build idx_buf + offsets + grp_cnt via histogram/scatter.
              *
@@ -9984,7 +10089,7 @@ sequential_fallback:;
         bool inline_str_k = (ly->key_flags[k] & GHT_KEYF_INLINE_STR) != 0;
         /* Key k's null bit lives in null-mask word (k>>6), bit (k&63). */
         size_t null_woff = (size_t)ly->key_off[n_keys] + (size_t)(k >> 6) * 8;
-        int64_t null_kbit = (int64_t)1 << (k & 63);
+        int64_t null_kbit = (int64_t)((uint64_t)1 << (k & 63));
         for (uint32_t gi = 0; gi < grp_count; gi++) {
             const char* row = final_ht->rows + (size_t)gi * ly->row_stride;
             const char* rk = row + 8;
@@ -10058,18 +10163,32 @@ sequential_fallback:;
             int64_t* pos_s = (int64_t*)scratch_alloc(&pos_hdr_s,
                 (size_t)grp_count * sizeof(int64_t));
             if (row_gid && grp_cnt_s && offsets_s && pos_s) {
-                uint8_t reprobe_nullable_s = 0;
-                for (uint32_t k = 0; k < n_keys; k++) {
-                    if (!key_vecs[k]) continue;
-                    ray_t* src = (key_vecs[k]->attrs & RAY_ATTR_SLICE)
-                                 ? key_vecs[k]->slice_parent : key_vecs[k];
-                    if (src && (src->attrs & RAY_ATTR_HAS_NULLS))
-                        reprobe_nullable_s |= (uint8_t)(1u << k);
+                uint8_t reprobe_nullable_s = 0;   /* 0/1: any key may be null */
+                for (uint32_t k = 0; k < n_keys; k++)
+                    if (ray_key_may_be_null(key_vecs[k])) { reprobe_nullable_s = 1; break; }
+                /* Key lookup staging + per-key str-pool table: stack for ≤8
+                 * keys, one heap block for wider (carved once — cut 4). */
+                const void* reprobe_pool_stk[8];
+                int64_t ek_buf_stk[9];
+                char    keybuf_stk[136];
+                const void** reprobe_pool = reprobe_pool_stk;
+                int64_t* ek_buf = ek_buf_stk;
+                char*    keybuf = keybuf_stk;
+                ray_t*   hol_stage_hdr = NULL;
+                if ((size_t)ly->key_region > sizeof(ek_buf_stk) || n_keys > 8) {
+                    size_t kb = ly->key_region;
+                    char* blk = (char*)scratch_alloc(&hol_stage_hdr,
+                        kb + kb + (size_t)n_keys * sizeof(void*));
+                    if (!blk) {
+                        scratch_free(rg_hdr); scratch_free(cnt_hdr_s);
+                        scratch_free(off_hdr_s); scratch_free(pos_hdr_s);
+                        result = ray_error("oom", NULL); goto cleanup;
+                    }
+                    keybuf       = blk;
+                    ek_buf       = (int64_t*)(blk + kb);
+                    reprobe_pool = (const void**)(blk + kb + kb);
                 }
-                const void* reprobe_pool[8];
                 derive_key_pool(ly, key_vecs, reprobe_pool);
-                int64_t ek_buf[9];
-                char    keybuf[136];   /* inline-STR key region */
                 for (int64_t i = 0; i < n_scan; i++) {
                     int64_t row = match_idx ? match_idx[i] : i;
                     /* Holistic fill re-scans rows independently of the streaming
@@ -10094,10 +10213,10 @@ sequential_fallback:;
                     for (uint32_t k = 0; k < n_keys; k++) {
                         int8_t t = key_types[k];
                         uint64_t kh;
-                        bool is_null = (reprobe_nullable_s & (1u << k))
+                        bool is_null = reprobe_nullable_s && ray_key_may_be_null(key_vecs[k])
                                        && ray_vec_is_null(key_vecs[k], row);
                         if (is_null) {
-                            nullw[k >> 6] |= (int64_t)1 << (k & 63);
+                            nullw[k >> 6] |= (int64_t)((uint64_t)1 << (k & 63));
                             ek_buf[k] = 0;
                             kh = ray_hash_i64(0);
                         } else if (ly->key_flags[k] & GHT_KEYF_WIDE) {
@@ -10165,6 +10284,7 @@ sequential_fallback:;
                     }
                     scratch_free(ix_hdr_s);
                 }
+                scratch_free(hol_stage_hdr);   /* NULL (inline staging) → no-op */
             }
             scratch_free(rg_hdr);
             scratch_free(cnt_hdr_s);
@@ -10434,9 +10554,14 @@ exec_group_per_partition(ray_t* parted_tbl, ray_op_ext_t* ext,
     uint32_t n_keys = ext->n_keys;
     uint32_t n_aggs = ext->n_aggs;
 
-    /* Guard: fixed-size arrays below cap at 24 agg ops.
-     * Each AVG adds 1 extra (COUNT), each STDDEV/VAR adds 2 (SUM_SQ + COUNT).
-     * n_aggs + n_avg + 2*n_std must stay within 24. */
+    /* Width guard STAYS (unbounded-slots cut 4): this per-partition optimizer
+     * keeps fixed [8]/[24] arrays (mc_sym_ids/pk_syms/per-agg decomposition).
+     * It is NOT the server of wide parted groups — on NULL here exec_group_parted
+     * falls back to the concat path, which materializes the needed columns into
+     * one flat table and recurses through exec_group, reaching the now-unbounded
+     * v2/legacy machinery.  So a >8-key/>8-agg parted group is served correctly
+     * (via concat), just without this per-partition materialization-avoidance.
+     * Each AVG adds 1 extra (COUNT), each STDDEV/VAR adds 2 (SUM_SQ + COUNT). */
     if (n_aggs > 8 || n_keys > 8) return NULL;
 
     /* Identify MAPCOMMON vs PARTED keys.  MAPCOMMON keys are constant
@@ -11133,14 +11258,9 @@ bool pivot_ingest_run(pivot_ingest_t* out,
         radix_bufs[i].cap = buf_init;
     }
 
-    uint8_t p1_nullable = 0;
-    for (uint32_t k = 0; k < n_keys; k++) {
-        if (!key_vecs[k]) continue;
-        ray_t* src = (key_vecs[k]->attrs & RAY_ATTR_SLICE)
-                     ? key_vecs[k]->slice_parent : key_vecs[k];
-        if (src && (src->attrs & RAY_ATTR_HAS_NULLS))
-            p1_nullable |= (uint8_t)(1u << k);
-    }
+    uint8_t p1_nullable = 0;   /* 0/1: any key may be null (per-key re-checked in phase1) */
+    for (uint32_t k = 0; k < n_keys; k++)
+        if (ray_key_may_be_null(key_vecs[k])) { p1_nullable = 1; break; }
 
     radix_phase1_ctx_t p1ctx = {
         .key_data      = key_data,
@@ -11155,9 +11275,16 @@ bool pivot_ingest_run(pivot_ingest_t* out,
         .match_idx     = NULL,
     };
     ght_layout_copy(&p1ctx.layout, ly);
-    if (ly->any_wide_key)
+    /* Wide-key str-pool table (n_keys slots): carved once, freed post-dispatch. */
+    ray_t* p1_kp_hdr = NULL;
+    if (ly->any_wide_key) {
+        p1ctx.key_pool = (const void**)scratch_alloc(&p1_kp_hdr,
+            (size_t)n_keys * sizeof(void*));
+        if (!p1ctx.key_pool) return false;
         derive_key_pool(ly, key_vecs, p1ctx.key_pool);
+    }
     ray_pool_dispatch(pool, radix_phase1_fn, &p1ctx, n_scan);
+    scratch_free(p1_kp_hdr);
     if (ray_interrupted()) return true; /* caller checks ray_interrupted() */
     /* Sync point — phase1 drained all rows, so rows_done == n_scan. */
     ray_progress_update(NULL, "hash-partition", (uint64_t)n_scan, (uint64_t)n_scan);
@@ -11178,8 +11305,16 @@ bool pivot_ingest_run(pivot_ingest_t* out,
         .key_data  = key_data,
     };
     ght_layout_copy(&p2ctx.layout, ly);
-    if (ly->any_wide_key) derive_key_pool(ly, key_vecs, p2ctx.key_pool);
+    /* Wide-key str-pool table: copied into part_hts by phase2, freed after. */
+    ray_t* p2_kp_hdr = NULL;
+    if (ly->any_wide_key) {
+        p2ctx.key_pool = (const void**)scratch_alloc(&p2_kp_hdr,
+            (size_t)n_keys * sizeof(void*));
+        if (!p2ctx.key_pool) return false;
+        derive_key_pool(ly, key_vecs, p2ctx.key_pool);
+    }
     ray_pool_dispatch_n(pool, radix_phase2_fn, &p2ctx, RADIX_P);
+    scratch_free(p2_kp_hdr);
     out->part_hts = part_hts;
     out->n_parts = RADIX_P;
     if (ray_interrupted()) return true;

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -1028,6 +1028,11 @@ ray_t* desc_vec_eager(ray_t* x);
 #define GHT_AF_BINARY   32u  /* two inputs (OP_PEARSON_CORR): packs (x,y) */
 #define GHT_AF_HOLISTIC 64u  /* OP_MEDIAN/TOP/BOT/wide-mm: no accum slot */
 #define GHT_AF_WIDE     128u /* subset of HOLISTIC: wide-element min/max/first/last */
+/* agg_flags2 bits (agg_flags is full — 8 bits used) */
+#define GHT_AF2_NULLABLE 1u  /* agg input column advertises HAS_NULLS: the row-layout
+                              * accumulators skip F64 NaN / NULL_I* sentinels and track
+                              * a per-slot non-null count (off_nn) for the divisor and
+                              * all-null → typed-null finalization. */
 /* key_flags bits */
 #define GHT_KEYF_WIDE       1u  /* key does not fit in 8 B (RAY_GUID / RAY_STR) */
 #define GHT_KEYF_INLINE_STR 2u  /* key stores a 16 B ray_str_t descriptor inline */
@@ -1059,6 +1064,13 @@ typedef struct {
     uint16_t off_sum_y;
     uint16_t off_sumsq_y;
     uint16_t off_sumxy;
+    /* Per-slot non-null count block (n_agg_vals int64 slots), allocated only
+     * when any_agg_null (any agg input column HAS_NULLS).  Zero otherwise —
+     * finalize then divides by the group row count exactly as before, so
+     * every null-free shape is byte-identical.  When present, AVG/VAR/STDDEV
+     * use nn[s] as the divisor and MIN/MAX/PROD/FIRST/LAST/AVG/VAR/STDDEV
+     * emit a typed null for nn[s]==0 (all-null group), matching the DA path. */
+    uint16_t off_nn;
     uint16_t key_region;       /* total key region bytes = key_off[n_keys] + null_words*8 */
     /* Number of int64 null-mask words carried after the keys: ceil(n_keys/64)
      * (floored at 1 so the n_keys==0 fallback keeps a null slot).  Key null
@@ -1069,6 +1081,7 @@ typedef struct {
     uint8_t  agg_flags_any;    /* OR of all agg_flags[a] — scalar shape guard */
     uint8_t  any_wide_key;     /* replaces wide_key_mask != 0 */
     uint8_t  any_inline_str;   /* replaces key_inline_str != 0 */
+    uint8_t  any_agg_null;     /* OR of GHT_AF2_NULLABLE over aggs — hoisted hot-loop gate */
     /* ── base pointers: aim at the *_in inline arrays (≤8) or the spill block ── */
     int8_t*  agg_val_slot;     /* [n_aggs] accum slot per agg, -1 = none */
     uint8_t* agg_flags;        /* [n_aggs] GHT_AF_* per agg */
@@ -1078,6 +1091,13 @@ typedef struct {
      * lex MIN/MAX resolves cell ids through it (cell ids are positions
      * in the COLUMN's domain, not the global intern table). */
     struct ray_sym_domain_s** agg_dom;   /* [n_aggs] */
+    /* Per-agg null metadata (populated only when any_agg_null).  agg_flags2[a]
+     * bit GHT_AF2_NULLABLE marks a HAS_NULLS agg input; agg_null_sentinel[a]
+     * is the NULL_I* sentinel for its integer/temporal type (0 for F64, which
+     * detects null via NaN, and for non-nullable aggs).  Same inline-or-spill
+     * base-pointer discipline as agg_flags/agg_val_slot. */
+    uint8_t*  agg_flags2;      /* [n_aggs] GHT_AF2_* per agg */
+    int64_t*  agg_null_sentinel; /* [n_aggs] integer null sentinel per agg */
     /* Byte offset of each key within the entry/HT-row key region (relative to
      * the start of the key region, i.e. entry+8 / row+8).  key_off[n_keys] is
      * the offset of null-mask word 0 (null_words words follow contiguously).
@@ -1095,6 +1115,8 @@ typedef struct {
     /* ── inline storage (used when n_keys ≤ 8 AND n_aggs ≤ 8) ── */
     int8_t    agg_val_slot_in[GHT_INLINE];
     uint8_t   agg_flags_in[GHT_INLINE];
+    uint8_t   agg_flags2_in[GHT_INLINE];
+    int64_t   agg_null_sentinel_in[GHT_INLINE];
     struct ray_sym_domain_s* agg_dom_in[GHT_INLINE];
     uint16_t  key_off_in[GHT_INLINE + 2];
     uint8_t   key_flags_in[GHT_INLINE];
@@ -1159,6 +1181,19 @@ typedef struct {
  * failure (key stride budget overflow, or spill-block OOM for wide layouts);
  * on false *out carries no owned spill.  On success *out owns its spill_hdr
  * (NULL when inline) and every base pointer aims at *out's own storage. */
+/* Per-type integer null sentinel for an aggregation column.  Returns 0 for
+ * non-nullable / non-integer types (BOOL, U8, SYM, F64) since 0 will never
+ * match a value flagged as null via HAS_NULLS.  Shared by the group row-layout
+ * accumulators/finalizers and the pivot finalizer. */
+static inline int64_t agg_int_null_sentinel_for(int8_t t) {
+    switch (t) {
+        case RAY_I64: case RAY_TIMESTAMP:            return NULL_I64;
+        case RAY_I32: case RAY_DATE: case RAY_TIME:  return (int64_t)NULL_I32;
+        case RAY_I16:                                return (int64_t)NULL_I16;
+        default:                                     return 0;
+    }
+}
+
 bool ght_compute_layout(ght_layout_t* out, uint32_t n_keys, uint32_t n_aggs,
                         ray_t** agg_vecs, uint8_t need_flags,
                         const uint16_t* agg_ops,

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -1001,25 +1001,43 @@ ray_t* desc_vec_eager(ray_t* x);
  * SUMSQ blocks; this flag enables the y-side blocks (Σy, Σy², Σxy). */
 #define GHT_NEED_PEARSON 0x10
 
+/* ── ght_layout_t — inline-or-spill, fixed-size, by-value embeddable ──
+ *
+ * The per-agg and per-key metadata that used to live in fixed [8] arrays +
+ * uint8 bitmasks now lives behind BASE POINTERS.  Widths ≤ GHT_INLINE (8)
+ * point the bases at the in-struct inline arrays (same cache lines, same
+ * memory locality as the old fixed [8] fields); wider layouts point them at
+ * one owned heap spill block (spill_hdr).  Because a struct with pointers to
+ * its own members does NOT survive a raw memcpy / by-value return, every
+ * by-value materialisation MUST fix the bases: ght_compute_layout aims them
+ * at the caller-provided out struct, and ght_layout_copy re-aims them at the
+ * destination's own inline arrays (inline) or shares the source's spill
+ * (spilled — the ORIGINAL owns/frees it, copies must not outlive it).
+ *
+ * The eight former per-agg / per-key bitmasks become per-element FLAG BYTES
+ * (agg_flags[a] / key_flags[k]); agg_flags_any / any_wide_key / any_inline_str
+ * are OR-summaries kept as scalar fast guards for the old `mask != 0` shape
+ * tests. */
+#define GHT_INLINE 8
+/* agg_flags bits */
+#define GHT_AF_F64      1u
+#define GHT_AF_SYM      2u   /* lex compare for MIN/MAX (sym_lex_lt) */
+#define GHT_AF_FIRST    4u
+#define GHT_AF_LAST     8u
+#define GHT_AF_PROD     16u
+#define GHT_AF_BINARY   32u  /* two inputs (OP_PEARSON_CORR): packs (x,y) */
+#define GHT_AF_HOLISTIC 64u  /* OP_MEDIAN/TOP/BOT/wide-mm: no accum slot */
+#define GHT_AF_WIDE     128u /* subset of HOLISTIC: wide-element min/max/first/last */
+/* key_flags bits */
+#define GHT_KEYF_WIDE       1u  /* key does not fit in 8 B (RAY_GUID / RAY_STR) */
+#define GHT_KEYF_INLINE_STR 2u  /* key stores a 16 B ray_str_t descriptor inline */
 typedef struct {
     uint16_t entry_stride;
     uint16_t row_stride;
-    uint8_t  n_keys;
-    uint8_t  n_aggs;
-    uint8_t  n_agg_vals;
+    uint16_t n_keys;           /* widened from uint8_t (unbounded-ready) */
+    uint16_t n_aggs;
+    uint16_t n_agg_vals;
     uint8_t  need_flags;
-    uint8_t  agg_is_f64;
-    uint8_t  agg_is_sym;   /* lex compare for MIN/MAX (sym_lex_lt) */
-    /* Per-agg SYM resolution domain (sym-domain Phase 2): the domain of
-     * agg_vecs[a] when it is a SYM column, NULL otherwise.  Borrowed —
-     * the agg input vec outlives every layout use.  accum_from_entry's
-     * lex MIN/MAX resolves cell ids through it (cell ids are positions
-     * in the COLUMN's domain, not the global intern table). */
-    struct ray_sym_domain_s* agg_dom[8];
-    uint8_t  agg_is_first;
-    uint8_t  agg_is_last;
-    uint8_t  agg_is_prod;
-    int8_t   agg_val_slot[8];
     uint16_t off_sum;
     uint16_t off_min;
     uint16_t off_max;
@@ -1041,43 +1059,43 @@ typedef struct {
     uint16_t off_sum_y;
     uint16_t off_sumsq_y;
     uint16_t off_sumxy;
-    /* Per-agg "binary input" bitset: bit a set iff agg a takes two
-     * inputs (OP_PEARSON_CORR).  Drives phase-1 packing — binary aggs
-     * pack TWO consecutive 8-byte values per row (x then y) starting at
-     * agg_val_slot[a]. */
-    uint8_t  agg_is_binary;
-    /* Holistic aggregators (OP_MEDIAN): no accumulator slot reserved,
-     * agg_val_slot[a] == -1, phase-1 doesn't pack a value, phase-3
-     * skips emitting from the row layout.  A separate post-radix pass
-     * runs ray_median_per_group_buf over the source column using a
-     * row_gid+grp_cnt-derived idx_buf. */
-    uint8_t  agg_is_holistic;
-    /* Subset of agg_is_holistic: bit a set iff agg a is a wide-element
-     * (STR/GUID) min/max/first/last resolved via the per-group winner
-     * scan (ray_wide_minmax_per_group_buf) instead of a numeric kernel. */
-    uint8_t  agg_is_wide;
-    /* Wide-key support: bit k set iff key k does not fit in 8 bytes
-     * (e.g. RAY_GUID = 16 B).  For wide keys the 8-byte key slot
-     * stores a source-row index and the actual key bytes live in the
-     * original column, so probe/rehash/scatter must redirect through
-     * key_data[k].  wide_key_esz[k] is the per-element byte size of
-     * the source column. */
-    uint8_t  wide_key_mask;
-    uint8_t  wide_key_esz[8];
-    /* Per wide key, the source element type so resolution can branch:
-     * RAY_GUID → fixed wide_key_esz bytes; RAY_STR → ray_str_t descriptor
-     * (16 B) resolved via the string pool (key_pool[k]) with SSO-aware
-     * hash/eq (inline ≤12 B keys need no pool deref). */
-    int8_t   wide_key_type[8];
+    uint16_t key_region;       /* total key region bytes = key_off[n_keys] + 8 */
+    uint8_t  agg_flags_any;    /* OR of all agg_flags[a] — scalar shape guard */
+    uint8_t  any_wide_key;     /* replaces wide_key_mask != 0 */
+    uint8_t  any_inline_str;   /* replaces key_inline_str != 0 */
+    /* ── base pointers: aim at the *_in inline arrays (≤8) or the spill block ── */
+    int8_t*  agg_val_slot;     /* [n_aggs] accum slot per agg, -1 = none */
+    uint8_t* agg_flags;        /* [n_aggs] GHT_AF_* per agg */
+    /* Per-agg SYM resolution domain (sym-domain Phase 2): the domain of
+     * agg_vecs[a] when it is a SYM column, NULL otherwise.  Borrowed —
+     * the agg input vec outlives every layout use.  accum_from_entry's
+     * lex MIN/MAX resolves cell ids through it (cell ids are positions
+     * in the COLUMN's domain, not the global intern table). */
+    struct ray_sym_domain_s** agg_dom;   /* [n_aggs] */
     /* Byte offset of each key within the entry/HT-row key region (relative to
      * the start of the key region, i.e. entry+8 / row+8).  key_off[n_keys] is
      * the null-mask slot.  Most keys are 8 B (key_off[k]==k*8); a RAY_STR key
      * stores its ray_str_t descriptor INLINE (16 B) so probe/rehash compare it
-     * cache-locally instead of chasing key_data[k]+row*16 in the source column.
-     * key_inline_str bit k set iff key k stores an inline 16 B STR descriptor. */
-    uint16_t key_off[9];
-    uint16_t key_region;       /* total key region bytes = key_off[n_keys] + 8 */
-    uint8_t  key_inline_str;   /* bitset: key k is an inline STR descriptor */
+     * cache-locally instead of chasing key_data[k]+row*16 in the source column. */
+    uint16_t* key_off;         /* [n_keys + 1] */
+    uint8_t*  key_flags;       /* [n_keys] GHT_KEYF_* per key */
+    uint8_t*  wide_key_esz;    /* [n_keys] per-element byte size of source col */
+    /* Per wide key, the source element type so resolution can branch:
+     * RAY_GUID → fixed wide_key_esz bytes; RAY_STR → ray_str_t descriptor
+     * (16 B) resolved via the string pool (key_pool[k]) with SSO-aware
+     * hash/eq (inline ≤12 B keys need no pool deref). */
+    int8_t*   wide_key_type;   /* [n_keys] */
+    /* ── inline storage (used when n_keys ≤ 8 AND n_aggs ≤ 8) ── */
+    int8_t    agg_val_slot_in[GHT_INLINE];
+    uint8_t   agg_flags_in[GHT_INLINE];
+    struct ray_sym_domain_s* agg_dom_in[GHT_INLINE];
+    uint16_t  key_off_in[GHT_INLINE + 2];
+    uint8_t   key_flags_in[GHT_INLINE];
+    uint8_t   wide_key_esz_in[GHT_INLINE];
+    int8_t    wide_key_type_in[GHT_INLINE];
+    /* Owned heap spill block for wider layouts; NULL when inline.  Freed by
+     * ght_layout_free (the owner only — copies borrow, see ght_layout_copy). */
+    ray_t*    spill_hdr;
 } ght_layout_t;
 
 typedef struct {
@@ -1112,10 +1130,21 @@ typedef struct {
 #define ROW_WR_F64(row, off, slot) (((double*)((void*)((row) + (off))))[(slot)])
 #define ROW_WR_I64(row, off, slot) (((int64_t*)((void*)((row) + (off))))[(slot)])
 
-ght_layout_t ght_compute_layout(uint8_t n_keys, uint8_t n_aggs,
-                                ray_t** agg_vecs, uint8_t need_flags,
-                                const uint16_t* agg_ops,
-                                const int8_t* key_types);
+/* Fill *out with the row/entry layout.  Returns false on unrecoverable
+ * failure (key stride budget overflow, or spill-block OOM for wide layouts);
+ * on false *out carries no owned spill.  On success *out owns its spill_hdr
+ * (NULL when inline) and every base pointer aims at *out's own storage. */
+bool ght_compute_layout(ght_layout_t* out, uint32_t n_keys, uint32_t n_aggs,
+                        ray_t** agg_vecs, uint8_t need_flags,
+                        const uint16_t* agg_ops,
+                        const int8_t* key_types);
+/* By-value copy that fixes the base pointers: for an inline src, dst's bases
+ * aim at dst's own inline arrays (self-contained); for a spilled src, dst
+ * BORROWS src's spill read-only (dst->spill_hdr = NULL, so ght_layout_free(dst)
+ * is a no-op) — the original owns/frees it and MUST outlive every copy. */
+void ght_layout_copy(ght_layout_t* dst, const ght_layout_t* src);
+/* NULL-safe; frees the owned spill block (no-op when inline / already freed). */
+void ght_layout_free(ght_layout_t* ly);
 bool group_ht_init(group_ht_t* ht, uint32_t cap, const ght_layout_t* ly);
 void group_ht_free(group_ht_t* ht);
 typedef struct {

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -1059,7 +1059,13 @@ typedef struct {
     uint16_t off_sum_y;
     uint16_t off_sumsq_y;
     uint16_t off_sumxy;
-    uint16_t key_region;       /* total key region bytes = key_off[n_keys] + 8 */
+    uint16_t key_region;       /* total key region bytes = key_off[n_keys] + null_words*8 */
+    /* Number of int64 null-mask words carried after the keys: ceil(n_keys/64)
+     * (floored at 1 so the n_keys==0 fallback keeps a null slot).  Key null
+     * bit k lives at word (k>>6), bit (k&63); word w is at key_off[n_keys]+w*8.
+     * ≤64 keys use exactly one word — byte-identical to the legacy single-int64
+     * null slot, so every reachable (≤8-key) shape is unchanged. */
+    uint16_t null_words;
     uint8_t  agg_flags_any;    /* OR of all agg_flags[a] — scalar shape guard */
     uint8_t  any_wide_key;     /* replaces wide_key_mask != 0 */
     uint8_t  any_inline_str;   /* replaces key_inline_str != 0 */
@@ -1074,7 +1080,8 @@ typedef struct {
     struct ray_sym_domain_s** agg_dom;   /* [n_aggs] */
     /* Byte offset of each key within the entry/HT-row key region (relative to
      * the start of the key region, i.e. entry+8 / row+8).  key_off[n_keys] is
-     * the null-mask slot.  Most keys are 8 B (key_off[k]==k*8); a RAY_STR key
+     * the offset of null-mask word 0 (null_words words follow contiguously).
+     * Most keys are 8 B (key_off[k]==k*8); a RAY_STR key
      * stores its ray_str_t descriptor INLINE (16 B) so probe/rehash compare it
      * cache-locally instead of chasing key_data[k]+row*16 in the source column. */
     uint16_t* key_off;         /* [n_keys + 1] */

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -1123,14 +1123,21 @@ typedef struct {
     uint32_t     grp_count;
     uint32_t     grp_cap;
     ght_layout_t layout;
-    /* Non-NULL only when layout.any_wide_key != 0.  Pointers into
-     * the original key columns (slice-unaware raw data), used by
-     * group_probe_entry / group_ht_rehash to resolve row-indexed
-     * wide keys. */
-    void*        key_data[8];
-    /* String pool base per wide STR key (NULL otherwise) — paired with
-     * key_data[k] (the ray_str_t descriptor array) for SSO-aware resolve. */
-    const void*  key_pool[8];
+    /* Wide-key source-column resolution (non-NULL slots only when
+     * layout.any_wide_key != 0).  key_data[k] = raw data pointer into the
+     * original key column (slice-unaware) for group_probe_entry /
+     * group_ht_rehash to resolve row-indexed wide keys; key_pool[k] = its
+     * str-pool base for SSO-aware STR resolve.  BASE POINTERS (unbounded-
+     * slots cut 4): aimed at the in-struct inline [8] arrays when n_keys ≤ 8
+     * (byte-identical to the legacy fixed layout), or at one owned heap spill
+     * (key_wide_hdr) carved by group_ht_init_sized when n_keys > 8.  Because
+     * group_ht_t is only ever memset-then-init'd in place (never memcpy'd by
+     * value), self-referential inline bases are safe.  Freed with the HT. */
+    void**       key_data;
+    const void** key_pool;
+    void*        key_data_in[8];
+    const void*  key_pool_in[8];
+    ray_t*       key_wide_hdr;   /* owned spill for the >8-key key_data+key_pool block */
     ray_t*        _h_slots;
     ray_t*        _h_rows;
     uint8_t       oom;        /* set by group_probe_entry on grow failure */

--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -1093,8 +1093,19 @@ typedef struct {
     uint8_t   key_flags_in[GHT_INLINE];
     uint8_t   wide_key_esz_in[GHT_INLINE];
     int8_t    wide_key_type_in[GHT_INLINE];
-    /* Owned heap spill block for wider layouts; NULL when inline.  Freed by
-     * ght_layout_free (the owner only — copies borrow, see ght_layout_copy). */
+    /* Owned heap spill block for wider layouts; NULL when inline OR when
+     * this instance is a borrower (a copy of a spilled layout — its bases
+     * point into the ORIGINAL owner's spill block, but spill_hdr stays NULL
+     * so ght_layout_free is a no-op on it).  Because a borrower's own
+     * spill_hdr reads NULL exactly like true-inline storage, ght_layout_copy
+     * cannot dispatch on spill_hdr == NULL — it must test STORAGE identity
+     * (agg_val_slot == agg_val_slot_in) instead; see ght_layout_copy.  That
+     * test is depth-invariant: master -> borrower -> borrower -> ... all
+     * correctly re-borrow the one shared block, however many copies deep.
+     * Freed by ght_layout_free (the owning master only).  Lifetime rule:
+     * the owning master must outlive every borrower transitively copied
+     * from it — all borrowers, at any depth, must be done with before the
+     * master frees the spill. */
     ray_t*    spill_hdr;
 } ght_layout_t;
 
@@ -1105,7 +1116,7 @@ typedef struct {
     uint32_t     grp_count;
     uint32_t     grp_cap;
     ght_layout_t layout;
-    /* Non-NULL only when layout.wide_key_mask != 0.  Pointers into
+    /* Non-NULL only when layout.any_wide_key != 0.  Pointers into
      * the original key columns (slice-unaware raw data), used by
      * group_probe_entry / group_ht_rehash to resolve row-indexed
      * wide keys. */
@@ -1138,10 +1149,18 @@ bool ght_compute_layout(ght_layout_t* out, uint32_t n_keys, uint32_t n_aggs,
                         ray_t** agg_vecs, uint8_t need_flags,
                         const uint16_t* agg_ops,
                         const int8_t* key_types);
-/* By-value copy that fixes the base pointers: for an inline src, dst's bases
- * aim at dst's own inline arrays (self-contained); for a spilled src, dst
- * BORROWS src's spill read-only (dst->spill_hdr = NULL, so ght_layout_free(dst)
- * is a no-op) — the original owns/frees it and MUST outlive every copy. */
+/* By-value copy that fixes the base pointers.  Dispatches on STORAGE, not
+ * ownership (src->spill_hdr == NULL is true both for genuine inline layouts
+ * AND for borrowers, so it cannot be the test): when src->agg_val_slot ==
+ * src->agg_val_slot_in, src's bases are self-referential inline storage and
+ * dst's bases are re-aimed at dst's OWN inline arrays (self-contained).
+ * Otherwise dst BORROWS the shared spill block that src's bases already
+ * point into (dst->spill_hdr = NULL, so ght_layout_free(dst) is a no-op).
+ * This makes the copy depth-invariant: master -> borrower -> borrower -> ...
+ * all correctly borrow the one spill block regardless of copy depth.
+ * Lifetime rule: the owning master MUST outlive every borrower copied from
+ * it, transitively — all borrowers at any depth must be done with / freed
+ * before the master frees the spill. */
 void ght_layout_copy(ght_layout_t* dst, const ght_layout_t* src);
 /* NULL-safe; frees the owned spill block (no-op when inline / already freed). */
 void ght_layout_free(ght_layout_t* ly);

--- a/src/ops/pivot.c
+++ b/src/ops/pivot.c
@@ -286,60 +286,67 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     uint16_t agg_op = ext->pivot.agg_op;
     int64_t nrows   = ray_table_nrows(tbl);
 
-    /* VLA, exact-size: n_idx is no longer capped at 7 (task 6 lifts both
-     * this function's own former n_keys > 8 gate and tblop.c's caller-side
-     * check — the ght layout below spills to a heap block for n_keys > 8,
-     * same mechanism group.c's exec_group_run already relies on).  Sized
-     * ≥1 to sidestep zero-length VLA UB when n_idx == 0 (a pivot with no
-     * index columns is legal — grouping is by the pivot column alone).
-     * Scope-lifetime: every one of this function's many early returns
-     * below frees it via ordinary C stack unwind, so there is no
-     * carve-then-forget-to-free hazard to track across those exits. */
-    ray_t* idx_vecs[n_idx ? n_idx : 1];
+    /* n_idx is USER-DATA-sized (the index-arg vector's length, tblop.c's
+     * pivot_fn_impl), not AST-bounded — task 6 lifts both this function's
+     * own former n_keys > 8 gate and tblop.c's caller-side check (the ght
+     * layout below spills to a heap block for n_keys > 8, same mechanism
+     * group.c's exec_group_run already relies on), so a caller can drive
+     * n_idx into the millions.  A stack VLA at that size is a stack-clash
+     * SIGSEGV waiting to happen; heap-carve instead.  One consolidated
+     * block holds all six per-index/per-key arrays below (idx_vecs,
+     * key_data, key_vecs — pointer-sized, placed first so every array
+     * after the first stays 8-byte aligned — then idx_wide, key_types,
+     * key_attrs, the byte-sized ones); freed on every exit from here to
+     * pivot_cleanup below.  n_idx_cap floors n_idx at 1 (an index-less
+     * pivot is legal — grouping by the pivot column alone), n_keys = n_idx
+     * + 1 is already >= 1. */
+    uint32_t n_idx_cap = n_idx ? n_idx : 1;
+    uint32_t n_keys = n_idx + 1;
+    size_t key_ptr_bytes  = (size_t)n_idx_cap * sizeof(ray_t*)   /* idx_vecs */
+                          + (size_t)n_keys   * sizeof(void*)     /* key_data */
+                          + (size_t)n_keys   * sizeof(ray_t*);   /* key_vecs */
+    size_t key_byte_bytes = (size_t)n_idx_cap * sizeof(bool)     /* idx_wide */
+                          + (size_t)n_keys   * sizeof(int8_t)    /* key_types */
+                          + (size_t)n_keys   * sizeof(uint8_t);  /* key_attrs */
+    ray_t* key_hdr = NULL;
+    uint8_t* key_base = (uint8_t*)scratch_alloc(&key_hdr, key_ptr_bytes + key_byte_bytes);
+    if (!key_base) return ray_error("oom", NULL);
+    ray_t**  idx_vecs  = (ray_t**)key_base;
+    void**   key_data  = (void**)(idx_vecs + n_idx_cap);
+    ray_t**  key_vecs  = (ray_t**)(key_data + n_keys);
+    bool*    idx_wide  = (bool*)(key_vecs + n_keys);
+    int8_t*  key_types = (int8_t*)(idx_wide + n_idx_cap);
+    uint8_t* key_attrs = (uint8_t*)(key_types + n_keys);
+    memset(idx_wide, 0, (size_t)n_idx_cap * sizeof(bool));
+
     for (uint32_t i = 0; i < n_idx; i++) {
         ray_op_ext_t* ie = find_ext(g, ext->pivot.index_cols[i]);
         idx_vecs[i] = (ie && ie->base.opcode == OP_SCAN)
                      ? ray_table_get_col(tbl, ie->sym) : NULL;
-        if (!idx_vecs[i]) return ray_error("domain", "pivot: index column not found");
+        if (!idx_vecs[i]) { scratch_free(key_hdr); return ray_error("domain", "pivot: index column not found"); }
     }
 
     ray_op_ext_t* pe = find_ext(g, ext->pivot.pivot_col);
     ray_t* pcol = (pe && pe->base.opcode == OP_SCAN)
                 ? ray_table_get_col(tbl, pe->sym) : NULL;
-    if (!pcol) return ray_error("domain", "pivot: pivot column not found");
+    if (!pcol) { scratch_free(key_hdr); return ray_error("domain", "pivot: pivot column not found"); }
 
     ray_op_ext_t* ve = find_ext(g, ext->pivot.value_col);
     ray_t* vcol = (ve && ve->base.opcode == OP_SCAN)
                 ? ray_table_get_col(tbl, ve->sym) : NULL;
-    if (!vcol) return ray_error("domain", "pivot: value column not found");
+    if (!vcol) { scratch_free(key_hdr); return ray_error("domain", "pivot: value column not found"); }
 
-    if (nrows == 0) return ray_table_new(0);
+    if (nrows == 0) { scratch_free(key_hdr); return ray_table_new(0); }
 
     /* Combined keys: index_cols + pivot_col.  No count cap — the ght
      * layout below (ght_compute_layout) spills to an owned heap block
      * whenever n_keys exceeds its GHT_INLINE (8) inline capacity; its own
      * key-stride budget (uint16 byte offsets) is the only remaining limit,
      * unreachable at any index-column count a real table could carry. */
-    uint32_t n_keys = n_idx + 1;
-
-    /* VLA, exact-size (see idx_vecs above for the rationale/precedent).
-     * Wide-key resolution: for RAY_GUID the HT slot holds a source row
-     * index rather than the 16 raw bytes, so phase2 dedupe and emit
-     * route wide keys through the source column (key_data[k]).  These
-     * arrays are indexed up to n_idx inclusive (the pivot key itself
-     * lives at key_data[n_idx] etc.), so key_data/key_types/key_attrs/
-     * key_vecs are sized to n_keys (always >= 1); idx_wide only covers
-     * the n_idx index keys, floored at 1 for the same zero-VLA reason. */
-    bool idx_wide[n_idx ? n_idx : 1];
-    memset(idx_wide, 0, sizeof(idx_wide));
     for (uint32_t k = 0; k < n_idx; k++)
         idx_wide[k] = (idx_vecs[k]->type == RAY_GUID);
     bool pvt_wide = (pcol->type == RAY_GUID);
 
-    void*   key_data[n_keys];
-    int8_t  key_types[n_keys];
-    uint8_t key_attrs[n_keys];
-    ray_t*  key_vecs[n_keys];
     for (uint32_t k = 0; k < n_idx; k++) {
         key_data[k]  = ray_data(idx_vecs[k]);
         key_types[k] = idx_vecs[k]->type;
@@ -367,8 +374,10 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
      * point; every exit below (early return AND pivot_cleanup) must call
      * it exactly once so a spilled layout's heap block is never leaked. */
     ght_layout_t ly;
-    if (!ght_compute_layout(&ly, n_keys, 1, agg_vecs, need_flags, agg_ops, key_types))
+    if (!ght_compute_layout(&ly, n_keys, 1, agg_vecs, need_flags, agg_ops, key_types)) {
+        scratch_free(key_hdr);
         return ray_error("limit", "pivot: key stride budget exceeded");
+    }
 
     /* Hash-aggregate all rows via the shared radix pipeline — parallel
      * across thread-pool workers for n_scan ≥ RAY_PARALLEL_THRESHOLD,
@@ -379,18 +388,21 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
                           key_vecs, agg_vecs, nrows)) {
         pivot_ingest_free(&pg);
         ght_layout_free(&ly);
+        scratch_free(key_hdr);
         return ray_error("oom", NULL);
     }
     ray_progress_update("pivot", "dedupe", 0, (uint64_t)pg.total_grps);
     if (ray_interrupted()) {
         pivot_ingest_free(&pg);
         ght_layout_free(&ly);
+        scratch_free(key_hdr);
         return ray_error("cancel", "interrupted");
     }
     uint32_t grp_count = pg.total_grps;
     if (grp_count == 0) {
         pivot_ingest_free(&pg);
         ght_layout_free(&ly);
+        scratch_free(key_hdr);
         return ray_table_new(0);
     }
 
@@ -415,7 +427,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     uint32_t pv_cap = 64, pv_count = 0;
     ray_t* pv_hdr = NULL;
     int64_t* pv_vals = (int64_t*)scratch_alloc(&pv_hdr, pv_cap * sizeof(int64_t));
-    if (!pv_vals) { pivot_ingest_free(&pg); ght_layout_free(&ly); return ray_error("oom", NULL); }
+    if (!pv_vals) { pivot_ingest_free(&pg); ght_layout_free(&ly); scratch_free(key_hdr); return ray_error("oom", NULL); }
 
     const char* pvt_base = pvt_wide ? (const char*)key_data[n_idx] : NULL;
     for (uint32_t _p = 0; _p < pg.n_parts; _p++) {
@@ -440,7 +452,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
                     uint32_t new_cap = pv_cap * 2;
                     int64_t* new_pv = (int64_t*)scratch_realloc(&pv_hdr,
                         pv_cap * sizeof(int64_t), new_cap * sizeof(int64_t));
-                    if (!new_pv) { pivot_ingest_free(&pg); ght_layout_free(&ly); return ray_error("oom", NULL); }
+                    if (!new_pv) { pivot_ingest_free(&pg); ght_layout_free(&ly); scratch_free(key_hdr); return ray_error("oom", NULL); }
                     pv_vals = new_pv;
                     pv_cap = new_cap;
                 }
@@ -464,7 +476,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     ray_t* ix_hdr = NULL;
     size_t ix_entry = 8 + (size_t)n_idx * 8 + (size_t)null_words * 8;
     char* ix_rows = (char*)scratch_alloc(&ix_hdr, ix_cap * ix_entry);
-    if (!ix_rows) { scratch_free(pv_hdr); pivot_ingest_free(&pg); ght_layout_free(&ly); return ray_error("oom", NULL); }
+    if (!ix_rows) { scratch_free(pv_hdr); pivot_ingest_free(&pg); ght_layout_free(&ly); scratch_free(key_hdr); return ray_error("oom", NULL); }
 
     /* Secondary HT: hash slot -> ix_row index; empty = UINT32_MAX. */
     uint32_t ix_ht_cap = 256;
@@ -473,6 +485,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     uint32_t* ix_ht = (uint32_t*)scratch_alloc(&ix_ht_hdr, ix_ht_cap * sizeof(uint32_t));
     if (!ix_ht) {
         scratch_free(ix_hdr); scratch_free(pv_hdr); pivot_ingest_free(&pg); ght_layout_free(&ly);
+        scratch_free(key_hdr);
         return ray_error("oom", NULL);
     }
     memset(ix_ht, 0xFF, ix_ht_cap * sizeof(uint32_t));
@@ -484,6 +497,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     if (!grp_ix) {
         scratch_free(ix_ht_hdr); scratch_free(ix_hdr); scratch_free(pv_hdr);
         pivot_ingest_free(&pg); ght_layout_free(&ly);
+        scratch_free(key_hdr);
         return ray_error("oom", NULL);
     }
     uint32_t* grp_pv = grp_ix + grp_count;
@@ -563,6 +577,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
                 if (!new_rows) {
                     scratch_free(map_hdr); scratch_free(ix_ht_hdr);
                     scratch_free(pv_hdr); pivot_ingest_free(&pg); ght_layout_free(&ly);
+                    scratch_free(key_hdr);
                     return ray_error("oom", NULL);
                 }
                 ix_rows = new_rows;
@@ -859,6 +874,9 @@ pivot_cleanup:
     scratch_free(ix_ht_hdr);
     scratch_free(ix_hdr);
     scratch_free(pv_hdr);
+    scratch_free(key_hdr); /* idx_vecs/idx_wide/key_data/key_types/key_attrs/
+                             * key_vecs consolidated carve, alive since the
+                             * top of this function (see key_hdr above) */
     pivot_ingest_free(&pg);
     return result;
 }

--- a/src/ops/pivot.c
+++ b/src/ops/pivot.c
@@ -257,6 +257,18 @@ ray_t* exec_if(ray_graph_t* g, ray_op_t* op) {
     return result;
 }
 
+/* Fold the null-mask words [nullw, nullw+null_words) into a running hash.
+ * Mirrors group.c's ght_hash_null_words (file-local there, so pivot.c
+ * carries its own copy): an all-zero word contributes nothing, so the
+ * single-word (<=64-key) case is byte-identical to the historical
+ * `if (idx_nmask) combine` this replaces. */
+static inline uint64_t pivot_hash_null_words(uint64_t h, const int64_t* nullw,
+                                             uint32_t null_words) {
+    for (uint32_t w = 0; w < null_words; w++)
+        if (nullw[w]) h = ray_hash_combine(h, ray_hash_i64(nullw[w]));
+    return h;
+}
+
 /* ============================================================================
  * exec_pivot — single-pass hash-aggregated pivot table
  *
@@ -274,11 +286,16 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     uint16_t agg_op = ext->pivot.agg_op;
     int64_t nrows   = ray_table_nrows(tbl);
 
-    /* Fixed [8]: n_idx (pivot index-column count) is gated to ≤7 at
-     * the compile-side caller (tblop.c pivot_fn_impl: "too many index
-     * columns, max 7") before OP_PIVOT is ever built — the honest cut-3
-     * cap, matching this function's own n_keys > 8 gate just below. */
-    ray_t* idx_vecs[8];
+    /* VLA, exact-size: n_idx is no longer capped at 7 (task 6 lifts both
+     * this function's own former n_keys > 8 gate and tblop.c's caller-side
+     * check — the ght layout below spills to a heap block for n_keys > 8,
+     * same mechanism group.c's exec_group_run already relies on).  Sized
+     * ≥1 to sidestep zero-length VLA UB when n_idx == 0 (a pivot with no
+     * index columns is legal — grouping is by the pivot column alone).
+     * Scope-lifetime: every one of this function's many early returns
+     * below frees it via ordinary C stack unwind, so there is no
+     * carve-then-forget-to-free hazard to track across those exits. */
+    ray_t* idx_vecs[n_idx ? n_idx : 1];
     for (uint32_t i = 0; i < n_idx; i++) {
         ray_op_ext_t* ie = find_ext(g, ext->pivot.index_cols[i]);
         idx_vecs[i] = (ie && ie->base.opcode == OP_SCAN)
@@ -298,32 +315,31 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
 
     if (nrows == 0) return ray_table_new(0);
 
-    /* Combined keys: index_cols + pivot_col */
+    /* Combined keys: index_cols + pivot_col.  No count cap — the ght
+     * layout below (ght_compute_layout) spills to an owned heap block
+     * whenever n_keys exceeds its GHT_INLINE (8) inline capacity; its own
+     * key-stride budget (uint16 byte offsets) is the only remaining limit,
+     * unreachable at any index-column count a real table could carry. */
     uint32_t n_keys = n_idx + 1;
-    /* Defensive: tblop.c's caller-side cap (max 7 index cols) already
-     * enforces n_keys <= 8 before OP_PIVOT is built, so this is
-     * unreachable from the language surface today — kept as the real
-     * structural gate on the [8]-slot ght layout below (and as a
-     * backstop against any future caller that builds OP_PIVOT
-     * directly, bypassing tblop.c's check). */
-    if (n_keys > 8) return ray_error("limit", "pivot: too many index columns");
 
-    /* Wide-key resolution: for RAY_GUID the HT slot holds a source row
+    /* VLA, exact-size (see idx_vecs above for the rationale/precedent).
+     * Wide-key resolution: for RAY_GUID the HT slot holds a source row
      * index rather than the 16 raw bytes, so phase2 dedupe and emit
-     * route wide keys through the source column (key_data[k]).
-     * Fixed [8]: n_idx <= 7 here — the n_keys > 8 check just above
-     * (n_keys = n_idx + 1) already rejected anything wider, so these
-     * arrays (indexed up to n_idx inclusive, for the pivot key at
-     * key_data[n_idx] etc.) are sized with exactly one spare slot. */
-    bool idx_wide[8] = {0};
+     * route wide keys through the source column (key_data[k]).  These
+     * arrays are indexed up to n_idx inclusive (the pivot key itself
+     * lives at key_data[n_idx] etc.), so key_data/key_types/key_attrs/
+     * key_vecs are sized to n_keys (always >= 1); idx_wide only covers
+     * the n_idx index keys, floored at 1 for the same zero-VLA reason. */
+    bool idx_wide[n_idx ? n_idx : 1];
+    memset(idx_wide, 0, sizeof(idx_wide));
     for (uint32_t k = 0; k < n_idx; k++)
         idx_wide[k] = (idx_vecs[k]->type == RAY_GUID);
     bool pvt_wide = (pcol->type == RAY_GUID);
 
-    void*   key_data[8];
-    int8_t  key_types[8];
-    uint8_t key_attrs[8];
-    ray_t*  key_vecs[8];
+    void*   key_data[n_keys];
+    int8_t  key_types[n_keys];
+    uint8_t key_attrs[n_keys];
+    ray_t*  key_vecs[n_keys];
     for (uint32_t k = 0; k < n_idx; k++) {
         key_data[k]  = ray_data(idx_vecs[k]);
         key_types[k] = idx_vecs[k]->type;
@@ -344,12 +360,12 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     if (agg_op == OP_MIN) need_flags |= GHT_NEED_MIN;
     if (agg_op == OP_MAX) need_flags |= GHT_NEED_MAX;
 
-    /* n_keys ≤ 8 (gated above) and n_aggs == 1, so the layout is always
-     * inline (spill_hdr == NULL); ght_compute_layout can only fail on the
-     * uint16 key-stride budget, unreachable at ≤8 keys.  ly owns no spill;
-     * ght_layout_free(&ly) at pivot_cleanup is therefore a no-op (kept for
-     * hygiene / future gate lift).  The early-return paths below likewise
-     * free nothing. */
+    /* n_keys/n_aggs are no longer capped: ght_compute_layout spills to an
+     * owned heap block (ly.spill_hdr) whenever n_keys exceeds GHT_INLINE
+     * (8) — the same path group.c's exec_group_run already exercises.
+     * ght_layout_free(&ly) is therefore no longer always a no-op past this
+     * point; every exit below (early return AND pivot_cleanup) must call
+     * it exactly once so a spilled layout's heap block is never leaked. */
     ght_layout_t ly;
     if (!ght_compute_layout(&ly, n_keys, 1, agg_vecs, need_flags, agg_ops, key_types))
         return ray_error("limit", "pivot: key stride budget exceeded");
@@ -362,33 +378,44 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     if (!pivot_ingest_run(&pg, &ly, key_data, key_types, key_attrs,
                           key_vecs, agg_vecs, nrows)) {
         pivot_ingest_free(&pg);
+        ght_layout_free(&ly);
         return ray_error("oom", NULL);
     }
     ray_progress_update("pivot", "dedupe", 0, (uint64_t)pg.total_grps);
-    if (ray_interrupted()) { pivot_ingest_free(&pg); return ray_error("cancel", "interrupted"); }
+    if (ray_interrupted()) {
+        pivot_ingest_free(&pg);
+        ght_layout_free(&ly);
+        return ray_error("cancel", "interrupted");
+    }
     uint32_t grp_count = pg.total_grps;
-    if (grp_count == 0) { pivot_ingest_free(&pg); return ray_table_new(0); }
+    if (grp_count == 0) {
+        pivot_ingest_free(&pg);
+        ght_layout_free(&ly);
+        return ray_table_new(0);
+    }
 
     /* Pass 2: Collect distinct pivot values and distinct index keys.
-     * Each group row layout: [hash:8][key0:8]...[keyN-1:8][null_mask:8][accum...]
-     * where the keys region holds n_idx index keys + 1 pivot key,
-     * followed by the key-null bitmap written by group_rows_range. */
+     * Each group row layout: [hash:8][key0:8]...[keyN-1:8][null_word0:8]
+     * ...[null_wordM-1:8][accum...] where the keys region holds n_idx
+     * index keys + 1 pivot key, followed by the ceil(n_keys/64) key-null
+     * mask words written by group_rows_range (ly.null_words; Task 3). */
 
     /* SQL PIVOT treats a null pivot key as "no column" — drop those groups.
-     * Read as a full int64 from the group row's first null-mask word.  The
-     * ght layout now carries ceil(n_keys/64) null words, but pivot's own
-     * n_idx <= 7 admission gate (n_keys = n_idx+1 <= 8, independent of the
-     * ght-path key gate this migration lifts) pins pivot at exactly one word,
-     * so every null bit here lives in word 0 and this single-word read stays
-     * correct.  Widening this to word-indexed is contingent on pivot's own
-     * index-column gate rising, not on the ght key gate. */
-    const int64_t pvt_null_bit = ((int64_t)1 << n_idx);
+     * The pivot key is the LAST of the n_keys keys, at bit position n_idx —
+     * word-indexed per the Task-3/4 convention (word k>>6, bit k&63; the
+     * unsigned-shift idiom sidesteps UB at bit 63) since n_idx can now
+     * exceed 63 (pivot's own admission gate lifts along with the ght-path
+     * key gate this migration also lifts — the two are no longer
+     * independent facts once BOTH caps are gone). */
+    const uint32_t null_words     = ly.null_words;
+    const uint32_t pvt_null_word  = n_idx >> 6;
+    const int64_t  pvt_null_bit   = (int64_t)((uint64_t)1 << (n_idx & 63));
 
     /* Collect distinct pivot values */
     uint32_t pv_cap = 64, pv_count = 0;
     ray_t* pv_hdr = NULL;
     int64_t* pv_vals = (int64_t*)scratch_alloc(&pv_hdr, pv_cap * sizeof(int64_t));
-    if (!pv_vals) { pivot_ingest_free(&pg); return ray_error("oom", NULL); }
+    if (!pv_vals) { pivot_ingest_free(&pg); ght_layout_free(&ly); return ray_error("oom", NULL); }
 
     const char* pvt_base = pvt_wide ? (const char*)key_data[n_idx] : NULL;
     for (uint32_t _p = 0; _p < pg.n_parts; _p++) {
@@ -397,8 +424,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
         for (uint32_t gi_local = 0; gi_local < pcount; gi_local++) {
             const char* row = ph->rows + (size_t)gi_local * pg.row_stride;
             const int64_t* rkeys = (const int64_t*)(row + 8);
-            int64_t nmask = rkeys[n_keys];
-            if (nmask & pvt_null_bit) continue;
+            if (rkeys[n_keys + pvt_null_word] & pvt_null_bit) continue;
             int64_t pval = rkeys[n_idx];
             bool found = false;
             for (uint32_t p = 0; p < pv_count; p++) {
@@ -414,7 +440,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
                     uint32_t new_cap = pv_cap * 2;
                     int64_t* new_pv = (int64_t*)scratch_realloc(&pv_hdr,
                         pv_cap * sizeof(int64_t), new_cap * sizeof(int64_t));
-                    if (!new_pv) { pivot_ingest_free(&pg); return ray_error("oom", NULL); }
+                    if (!new_pv) { pivot_ingest_free(&pg); ght_layout_free(&ly); return ray_error("oom", NULL); }
                     pv_vals = new_pv;
                     pv_cap = new_cap;
                 }
@@ -425,19 +451,20 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
 
     /* Collect distinct index keys.
      * Flat append-only entry array + secondary open-addressed HT keyed by
-     * the hash of (idx_keys + idx_null_mask). The HT makes phase2 dedupe
+     * the hash of (idx_keys + idx_null_words). The HT makes phase2 dedupe
      * O(grp_count) instead of the previous O(grp_count * ix_count)
      * linear scan which hung on large pivots.
-     * Entry layout: [hash:8 | idx_keys:8*n_idx | idx_null_mask:8]. */
+     * Entry layout: [hash:8 | idx_keys:8*n_idx | idx_null_words:8*null_words].
+     * Widened from a single trailing null word (Task-3 carryover finding):
+     * a single word only ever compared/hashed/stored bits 0..63, silently
+     * conflating two index tuples that agree on keys/nulls < 64 but differ
+     * in a null bit >= 64 (index key 64+) into one dedupe entry — the
+     * 65-index cell in tblop_branch_cov.rfl is the regression pin. */
     uint32_t ix_cap = 256, ix_count = 0;
     ray_t* ix_hdr = NULL;
-    size_t ix_entry = 8 + (size_t)n_idx * 8 + 8;
-    /* int64 for the same reason as pvt_null_bit above: pivot's n_idx <= 7 gate
-     * pins the null mask at one word, so the low n_idx bits (the index-key null
-     * flags, excluding the pivot key at bit n_idx) all live in word 0. */
-    const int64_t idx_null_bits = (((int64_t)1 << n_idx) - 1);
+    size_t ix_entry = 8 + (size_t)n_idx * 8 + (size_t)null_words * 8;
     char* ix_rows = (char*)scratch_alloc(&ix_hdr, ix_cap * ix_entry);
-    if (!ix_rows) { scratch_free(pv_hdr); pivot_ingest_free(&pg); return ray_error("oom", NULL); }
+    if (!ix_rows) { scratch_free(pv_hdr); pivot_ingest_free(&pg); ght_layout_free(&ly); return ray_error("oom", NULL); }
 
     /* Secondary HT: hash slot -> ix_row index; empty = UINT32_MAX. */
     uint32_t ix_ht_cap = 256;
@@ -445,7 +472,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     ray_t* ix_ht_hdr = NULL;
     uint32_t* ix_ht = (uint32_t*)scratch_alloc(&ix_ht_hdr, ix_ht_cap * sizeof(uint32_t));
     if (!ix_ht) {
-        scratch_free(ix_hdr); scratch_free(pv_hdr); pivot_ingest_free(&pg);
+        scratch_free(ix_hdr); scratch_free(pv_hdr); pivot_ingest_free(&pg); ght_layout_free(&ly);
         return ray_error("oom", NULL);
     }
     memset(ix_ht, 0xFF, ix_ht_cap * sizeof(uint32_t));
@@ -454,7 +481,11 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     /* Map: group_id -> (ix_row, pv_idx) for result cell placement */
     ray_t* map_hdr = NULL;
     uint32_t* grp_ix  = (uint32_t*)scratch_alloc(&map_hdr, grp_count * 2 * sizeof(uint32_t));
-    if (!grp_ix) { scratch_free(ix_ht_hdr); scratch_free(ix_hdr); scratch_free(pv_hdr); pivot_ingest_free(&pg); return ray_error("oom", NULL); }
+    if (!grp_ix) {
+        scratch_free(ix_ht_hdr); scratch_free(ix_hdr); scratch_free(pv_hdr);
+        pivot_ingest_free(&pg); ght_layout_free(&ly);
+        return ray_error("oom", NULL);
+    }
     uint32_t* grp_pv = grp_ix + grp_count;
 
     for (uint32_t _p = 0; _p < pg.n_parts; _p++) {
@@ -468,15 +499,19 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
             uint32_t gi = gi_base + gi_local;
             const char* row = ph->rows + (size_t)gi_local * pg.row_stride;
             const int64_t* keys = (const int64_t*)(row + 8);
-            int64_t nmask = keys[n_keys];
-            if (nmask & pvt_null_bit) {
+            if (keys[n_keys + pvt_null_word] & pvt_null_bit) {
                 grp_ix[gi] = UINT32_MAX;
                 grp_pv[gi] = UINT32_MAX;
                 continue;
             }
-        int64_t idx_nmask = nmask & idx_null_bits;
+        /* Index-key null words: keys[n_keys .. n_keys+null_words) as-is.
+         * The pivot key's own null bit (position n_idx, word pvt_null_word)
+         * is guaranteed 0 here — the check just above already `continue`d
+         * on it being set — so these words already carry exactly the
+         * index-key null flags with no separate masking needed. */
+        const int64_t* idx_nwords = keys + n_keys;
 
-        /* Hash index keys only (exclude pivot key) + null mask.
+        /* Hash index keys only (exclude pivot key) + null words.
          * Wide keys (GUID) resolve actual bytes via key_data[k]. */
         uint64_t ih = 0;
         for (uint32_t k = 0; k < n_idx; k++) {
@@ -491,7 +526,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
             }
             ih = (k == 0) ? kh : ray_hash_combine(ih, kh);
         }
-        if (idx_nmask) ih = ray_hash_combine(ih, ray_hash_i64(idx_nmask));
+        ih = pivot_hash_null_words(ih, idx_nwords, null_words);
 
         /* Open-addressed HT probe. On match, reuse; else insert. */
         uint32_t ix_row = UINT32_MAX;
@@ -512,9 +547,11 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
                         eq = (ekeys[k] == keys[k]);
                     }
                 }
-                int64_t ent_nmask;
-                memcpy(&ent_nmask, ix_entry_p + 8 + (size_t)n_idx * 8, 8);
-                if (eq && ent_nmask == idx_nmask) { ix_row = ent; break; }
+                if (eq) {
+                    const int64_t* ent_nwords = (const int64_t*)(ix_entry_p + 8 + (size_t)n_idx * 8);
+                    eq = (memcmp(ent_nwords, idx_nwords, (size_t)null_words * 8) == 0);
+                }
+                if (eq) { ix_row = ent; break; }
             }
             slot = (slot + 1) & ix_ht_mask;
         }
@@ -525,7 +562,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
                     ix_cap * ix_entry, new_cap * ix_entry);
                 if (!new_rows) {
                     scratch_free(map_hdr); scratch_free(ix_ht_hdr);
-                    scratch_free(pv_hdr); pivot_ingest_free(&pg);
+                    scratch_free(pv_hdr); pivot_ingest_free(&pg); ght_layout_free(&ly);
                     return ray_error("oom", NULL);
                 }
                 ix_rows = new_rows;
@@ -535,7 +572,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
             char* dst = ix_rows + (size_t)ix_row * ix_entry;
             *(uint64_t*)dst = ih;
             memcpy(dst + 8, keys, (size_t)n_idx * 8);
-            memcpy(dst + 8 + (size_t)n_idx * 8, &idx_nmask, 8);
+            memcpy(dst + 8 + (size_t)n_idx * 8, idx_nwords, (size_t)null_words * 8);
             ix_ht[slot] = ix_row;
         }
 
@@ -581,12 +618,17 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
         uint8_t esz = col_esz(idx_vecs[k]);
         int8_t kt = idx_vecs[k]->type;
         const char* src_base = idx_wide[k] ? (const char*)key_data[k] : NULL;
+        /* Word-indexed per the Task-3/4 convention: k is fixed in this outer
+         * scope, so hoist its word/bit out of the per-row loop below (as
+         * the seq emit loop in group.c does) rather than recomputing it
+         * ix_count times. */
+        const uint32_t null_kw  = k >> 6;
+        const int64_t  null_kbit = (int64_t)((uint64_t)1 << (k & 63));
         for (uint32_t r = 0; r < ix_count; r++) {
             const char* ix_entry_p = ix_rows + r * ix_entry;
             int64_t kv = ((const int64_t*)(ix_entry_p + 8))[k];
-            int64_t ent_nmask;
-            memcpy(&ent_nmask, ix_entry_p + 8 + (size_t)n_idx * 8, 8);
-            if (ent_nmask & ((int64_t)1 << k)) {
+            const int64_t* ent_nwords = (const int64_t*)(ix_entry_p + 8 + (size_t)n_idx * 8);
+            if (ent_nwords[null_kw] & null_kbit) {
                 ray_vec_set_null(new_col, (int64_t)r, true);
                 /* Fill the correct-width sentinel. */
                 switch (kt) {
@@ -811,7 +853,8 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     }
 
 pivot_cleanup:
-    ght_layout_free(&ly);   /* no-op: pivot layout is always inline (see above) */
+    ght_layout_free(&ly);   /* no-op when inline (n_keys <= 8); frees the
+                             * owned spill block otherwise (see above) */
     scratch_free(map_hdr);
     scratch_free(ix_ht_hdr);
     scratch_free(ix_hdr);

--- a/src/ops/pivot.c
+++ b/src/ops/pivot.c
@@ -375,11 +375,13 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
      * followed by the key-null bitmap written by group_rows_range. */
 
     /* SQL PIVOT treats a null pivot key as "no column" — drop those groups.
-     * Widened to int64_t to match the stored null-mask slot's width
-     * (nmask below is read as a full int64 from the group row): a uint8
-     * mask can't overflow while n_idx <= 7 (this cap), but truncating a
-     * shift into uint8 is the wrong-type idiom this codebase purges, and
-     * the cut-4 ght rework will widen n_idx past 7. */
+     * Read as a full int64 from the group row's first null-mask word.  The
+     * ght layout now carries ceil(n_keys/64) null words, but pivot's own
+     * n_idx <= 7 admission gate (n_keys = n_idx+1 <= 8, independent of the
+     * ght-path key gate this migration lifts) pins pivot at exactly one word,
+     * so every null bit here lives in word 0 and this single-word read stays
+     * correct.  Widening this to word-indexed is contingent on pivot's own
+     * index-column gate rising, not on the ght key gate. */
     const int64_t pvt_null_bit = ((int64_t)1 << n_idx);
 
     /* Collect distinct pivot values */
@@ -430,9 +432,9 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     uint32_t ix_cap = 256, ix_count = 0;
     ray_t* ix_hdr = NULL;
     size_t ix_entry = 8 + (size_t)n_idx * 8 + 8;
-    /* Widened to int64_t for the same reason as pvt_null_bit above:
-     * matches the 64-bit stored null-mask slot, avoids the uint8
-     * shift-truncate idiom. */
+    /* int64 for the same reason as pvt_null_bit above: pivot's n_idx <= 7 gate
+     * pins the null mask at one word, so the low n_idx bits (the index-key null
+     * flags, excluding the pivot key at bit n_idx) all live in word 0. */
     const int64_t idx_null_bits = (((int64_t)1 << n_idx) - 1);
     char* ix_rows = (char*)scratch_alloc(&ix_hdr, ix_cap * ix_entry);
     if (!ix_rows) { scratch_free(pv_hdr); pivot_ingest_free(&pg); return ray_error("oom", NULL); }

--- a/src/ops/pivot.c
+++ b/src/ops/pivot.c
@@ -344,7 +344,15 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     if (agg_op == OP_MIN) need_flags |= GHT_NEED_MIN;
     if (agg_op == OP_MAX) need_flags |= GHT_NEED_MAX;
 
-    ght_layout_t ly = ght_compute_layout(n_keys, 1, agg_vecs, need_flags, agg_ops, key_types);
+    /* n_keys ≤ 8 (gated above) and n_aggs == 1, so the layout is always
+     * inline (spill_hdr == NULL); ght_compute_layout can only fail on the
+     * uint16 key-stride budget, unreachable at ≤8 keys.  ly owns no spill;
+     * ght_layout_free(&ly) at pivot_cleanup is therefore a no-op (kept for
+     * hygiene / future gate lift).  The early-return paths below likewise
+     * free nothing. */
+    ght_layout_t ly;
+    if (!ght_compute_layout(&ly, n_keys, 1, agg_vecs, need_flags, agg_ops, key_types))
+        return ray_error("limit", "pivot: key stride budget exceeded");
 
     /* Hash-aggregate all rows via the shared radix pipeline — parallel
      * across thread-pool workers for n_scan ≥ RAY_PARALLEL_THRESHOLD,
@@ -786,6 +794,7 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
     }
 
 pivot_cleanup:
+    ght_layout_free(&ly);   /* no-op: pivot layout is always inline (see above) */
     scratch_free(map_hdr);
     scratch_free(ix_ht_hdr);
     scratch_free(ix_hdr);

--- a/src/ops/pivot.c
+++ b/src/ops/pivot.c
@@ -685,6 +685,10 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
                 uint32_t r = grp_ix[gi];
                 const char* row = ph->rows + (size_t)gi_local * pg.row_stride;
                 int64_t cnt = *(const int64_t*)(const void*)row;
+                /* nn = per-slot non-null count (nullable value column) or the
+                 * group row count (null-free — byte-identical to before). */
+                int64_t nn = ly.off_nn
+                    ? ((const int64_t*)(const void*)(row + ly.off_nn))[s] : cnt;
 
             if (out_agg_type == RAY_F64) {
                 double v;
@@ -694,18 +698,22 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
                                        : (double)ROW_RD_I64(row, ly.off_sum, s);
                         break;
                     case OP_AVG:
-                        v = val_is_f64 ? ROW_RD_F64(row, ly.off_sum, s) / cnt
-                                       : (double)ROW_RD_I64(row, ly.off_sum, s) / cnt;
+                        if (nn == 0) { v = NULL_F64; ray_vec_set_null(new_col, (int64_t)r, true); break; }
+                        v = val_is_f64 ? ROW_RD_F64(row, ly.off_sum, s) / nn
+                                       : (double)ROW_RD_I64(row, ly.off_sum, s) / nn;
                         break;
                     case OP_MIN:
+                        if (nn == 0) { v = NULL_F64; ray_vec_set_null(new_col, (int64_t)r, true); break; }
                         v = val_is_f64 ? ROW_RD_F64(row, ly.off_min, s)
                                        : (double)ROW_RD_I64(row, ly.off_min, s);
                         break;
                     case OP_MAX:
+                        if (nn == 0) { v = NULL_F64; ray_vec_set_null(new_col, (int64_t)r, true); break; }
                         v = val_is_f64 ? ROW_RD_F64(row, ly.off_max, s)
                                        : (double)ROW_RD_I64(row, ly.off_max, s);
                         break;
                     case OP_FIRST: case OP_LAST:
+                        if (nn == 0) { v = NULL_F64; ray_vec_set_null(new_col, (int64_t)r, true); break; }
                         v = val_is_f64 ? ROW_RD_F64(row, ly.off_sum, s)
                                        : (double)ROW_RD_I64(row, ly.off_sum, s);
                         break;
@@ -717,12 +725,19 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
                 ((double*)ray_data(new_col))[r] = ray_f64_fin(v);
             } else {
                 int64_t v;
+                int64_t int_null = agg_int_null_sentinel_for(out_agg_type);
                 switch (agg_op) {
                     case OP_SUM:   v = ROW_RD_I64(row, ly.off_sum, s); break;
                     case OP_COUNT: v = cnt; break;
-                    case OP_MIN:   v = ROW_RD_I64(row, ly.off_min, s); break;
-                    case OP_MAX:   v = ROW_RD_I64(row, ly.off_max, s); break;
-                    case OP_FIRST: case OP_LAST: v = ROW_RD_I64(row, ly.off_sum, s); break;
+                    case OP_MIN:
+                        if (nn == 0) { v = int_null; ray_vec_set_null(new_col, (int64_t)r, true); break; }
+                        v = ROW_RD_I64(row, ly.off_min, s); break;
+                    case OP_MAX:
+                        if (nn == 0) { v = int_null; ray_vec_set_null(new_col, (int64_t)r, true); break; }
+                        v = ROW_RD_I64(row, ly.off_max, s); break;
+                    case OP_FIRST: case OP_LAST:
+                        if (nn == 0) { v = int_null; ray_vec_set_null(new_col, (int64_t)r, true); break; }
+                        v = ROW_RD_I64(row, ly.off_sum, s); break;
                     default:       v = 0; break;
                 }
                     write_col_i64(ray_data(new_col), (int64_t)r, v, out_agg_type, new_col->attrs);

--- a/src/ops/tblop.c
+++ b/src/ops/tblop.c
@@ -110,21 +110,37 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
      * cells into runtime atoms (the Task-3 chokepoint), so the
      * ray_sym_str / ray_table_get_col calls below stay global.
      *
-     * Bound: 7 index columns, honestly matching exec_pivot's ght
-     * layout gate (pivot.c: n_keys = n_idx + 1 > 8 → error) — the
-     * true structural limit of the [8]-slot group layout.  This is a
-     * documented spec deviation: cut 3 lifts join/group/distinct key
-     * caps to unbounded, but pivot routes through the cut-4 ght
-     * rework's fixed [8] layout, so its cap stays put until then. */
-    int64_t idx_syms[8];
-    int64_t n_idx = 0;
+     * No count cap: pivot's index-column bound used to mirror exec_pivot's
+     * ght layout's fixed [8]-slot key array (pivot.c: n_keys = n_idx + 1 >
+     * 8 -> error), a documented spec deviation from cut 3's otherwise-
+     * unbounded join/group/distinct key caps.  The cut-4 ght rework widens
+     * that layout to spill past 8 keys (same mechanism group.c's
+     * exec_group_run relies on), so both this caller-side check and
+     * exec_pivot's own gate are gone — n_idx is sized from the real column
+     * count below, not compared against a cap. */
+    int64_t n_idx;
     if (index_arg->type == -RAY_SYM) {
-        idx_syms[0] = index_arg->i64;
         n_idx = 1;
     } else if (index_arg->type == RAY_LIST || ray_is_vec(index_arg)) {
-        int64_t len = ray_len(index_arg);
-        if (len > 7) return ray_error("limit", "pivot: too many index columns, max 7 (group layout bound, lifted in the ght rework)");
-        for (int64_t i = 0; i < len; i++) {
+        n_idx = ray_len(index_arg);
+    } else {
+        return ray_error("type", "pivot: index must be a symbol or list of symbols, got %s", ray_type_name(index_arg->type));
+    }
+
+    /* VLA, exact-size (mirrors group.c's exec_group_run driver arrays —
+     * key_vecs/key_data/key_types/key_attrs, cut-4 Task 4 — the established
+     * pattern for small per-index metadata scoped to one function call:
+     * every one of this function's many return points below frees it via
+     * ordinary C stack unwind, so there is no carve-then-forget-to-free
+     * hazard to track across those exits).  Floored at 1 to sidestep
+     * zero-length VLA UB (an empty index list is legal: pivot grouped by
+     * the pivot column alone). */
+    int64_t vla_idx = n_idx > 0 ? n_idx : 1;
+    int64_t idx_syms[vla_idx];
+    if (index_arg->type == -RAY_SYM) {
+        idx_syms[0] = index_arg->i64;
+    } else {
+        for (int64_t i = 0; i < n_idx; i++) {
             int alloc = 0;
             ray_t* elem = collection_elem(index_arg, i, &alloc);
             if (RAY_IS_ERR(elem)) return elem;
@@ -136,9 +152,6 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
             idx_syms[i] = elem->i64;
             if (alloc) ray_release(elem);
         }
-        n_idx = len;
-    } else {
-        return ray_error("type", "pivot: index must be a symbol or list of symbols, got %s", ray_type_name(index_arg->type));
     }
 
     /* Get pivot column, value column */
@@ -154,8 +167,8 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
     if (pcol->type == RAY_STR)
         return ray_error("nyi", "pivot: STR pivot column not supported as column names");
 
-    /* Get index columns */
-    ray_t* icols[8]; /* n_idx <= 7, see the bound comment above */
+    /* Get index columns (VLA, exact-size; see idx_syms above) */
+    ray_t* icols[vla_idx];
     for (int64_t i = 0; i < n_idx; i++) {
         icols[i] = ray_table_get_col(tbl, idx_syms[i]);
         if (!icols[i]) return ray_error("domain", "pivot: index column not found");
@@ -173,7 +186,7 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
     if (dag_ok) {
         ray_graph_t* g = ray_graph_new(tbl);
         if (!g) return ray_error("oom", NULL);
-        ray_op_t* idx_ops[8]; /* n_idx <= 7 */
+        ray_op_t* idx_ops[vla_idx]; /* VLA, exact-size; see idx_syms above */
         bool ok = true;
         for (int64_t i = 0; i < n_idx && ok; i++) {
             ray_t* s = ray_sym_str(idx_syms[i]);
@@ -202,8 +215,8 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
     ray_graph_t* g = ray_graph_new(tbl);
     if (!g) return ray_error("oom", NULL);
 
-    uint32_t n_keys = n_idx + 1;
-    ray_op_t* key_ops[8]; /* n_keys = n_idx + 1 <= 8 */
+    uint32_t n_keys = (uint32_t)n_idx + 1;
+    ray_op_t* key_ops[n_keys]; /* VLA, exact-size; n_keys = n_idx + 1 >= 1 always */
     bool ok = true;
     for (int64_t i = 0; i < n_idx && ok; i++) {
         ray_t* s = ray_sym_str(idx_syms[i]);
@@ -234,8 +247,8 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
      * Now for each group, gather the value column subset and apply agg_fn. */
     int64_t n_grps = ray_table_nrows(grouped);
 
-    /* Get grouped columns */
-    ray_t* g_icols[8]; /* n_idx <= 7 */
+    /* Get grouped columns (VLA, exact-size; see idx_syms above) */
+    ray_t* g_icols[vla_idx];
     for (int64_t i = 0; i < n_idx; i++)
         g_icols[i] = ray_table_get_col(grouped, idx_syms[i]);
     ray_t* g_pcol = ray_table_get_col(grouped, pivot_col_name->i64);

--- a/src/ops/tblop.c
+++ b/src/ops/tblop.c
@@ -127,26 +127,35 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
         return ray_error("type", "pivot: index must be a symbol or list of symbols, got %s", ray_type_name(index_arg->type));
     }
 
-    /* VLA, exact-size (mirrors group.c's exec_group_run driver arrays —
-     * key_vecs/key_data/key_types/key_attrs, cut-4 Task 4 — the established
-     * pattern for small per-index metadata scoped to one function call:
-     * every one of this function's many return points below frees it via
-     * ordinary C stack unwind, so there is no carve-then-forget-to-free
-     * hazard to track across those exits).  Floored at 1 to sidestep
-     * zero-length VLA UB (an empty index list is legal: pivot grouped by
-     * the pivot column alone). */
+    /* n_idx is a USER-SUPPLIED RUNTIME value — the index-arg's length, not
+     * an AST-bounded count (unlike group.c's exec_group_run driver arrays,
+     * whose element count is capped by query text) — so a caller can pass
+     * a multi-million-element index vector.  A stack VLA at that size is a
+     * stack-clash SIGSEGV where the old code returned a clean limit error;
+     * heap-carve instead.  One consolidated block holds idx_syms (column
+     * NAME ids) and icols (the resolved column pointers) — both survive to
+     * the very end of this function (the fb_cleanup result-building code
+     * below reads both) — so every one of this function's many return
+     * points must scratch_free(ic_hdr) exactly once.  Floored at 1 to
+     * sidestep zero-size alloc UB (an empty index list is legal: pivot
+     * grouped by the pivot column alone). */
     int64_t vla_idx = n_idx > 0 ? n_idx : 1;
-    int64_t idx_syms[vla_idx];
+    ray_t* ic_hdr = NULL;
+    int64_t* idx_syms = (int64_t*)scratch_alloc(&ic_hdr,
+            (size_t)vla_idx * (sizeof(int64_t) + sizeof(ray_t*)));
+    if (!idx_syms) return ray_error("oom", NULL);
+    ray_t** icols = (ray_t**)(idx_syms + vla_idx);
     if (index_arg->type == -RAY_SYM) {
         idx_syms[0] = index_arg->i64;
     } else {
         for (int64_t i = 0; i < n_idx; i++) {
             int alloc = 0;
             ray_t* elem = collection_elem(index_arg, i, &alloc);
-            if (RAY_IS_ERR(elem)) return elem;
+            if (RAY_IS_ERR(elem)) { scratch_free(ic_hdr); return elem; }
             if (elem->type != -RAY_SYM) {
                 int8_t et = elem->type;
                 if (alloc) ray_release(elem);
+                scratch_free(ic_hdr);
                 return ray_error("type", "pivot: index columns must be symbols, got %s", ray_type_name(et));
             }
             idx_syms[i] = elem->i64;
@@ -156,26 +165,27 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
 
     /* Get pivot column, value column */
     ray_t* pcol = ray_table_get_col(tbl, pivot_col_name->i64);
-    if (!pcol) return ray_error("domain", "pivot: pivot column not found");
+    if (!pcol) { scratch_free(ic_hdr); return ray_error("domain", "pivot: pivot column not found"); }
     ray_t* vcol = ray_table_get_col(tbl, value_col_name->i64);
-    if (!vcol) return ray_error("domain", "pivot: value column not found");
+    if (!vcol) { scratch_free(ic_hdr); return ray_error("domain", "pivot: value column not found"); }
 
     /* The pivot column's distinct values become output column NAMES (syms);
      * a STR pivot column cannot supply names.  (STR *index* columns ARE now
      * supported — they group via the wide-key path; this restriction is
      * specific to the pivot column, whose values name the unstacked columns.) */
-    if (pcol->type == RAY_STR)
+    if (pcol->type == RAY_STR) {
+        scratch_free(ic_hdr);
         return ray_error("nyi", "pivot: STR pivot column not supported as column names");
+    }
 
-    /* Get index columns (VLA, exact-size; see idx_syms above) */
-    ray_t* icols[vla_idx];
+    /* Get index columns (icols carved together with idx_syms above) */
     for (int64_t i = 0; i < n_idx; i++) {
         icols[i] = ray_table_get_col(tbl, idx_syms[i]);
-        if (!icols[i]) return ray_error("domain", "pivot: index column not found");
+        if (!icols[i]) { scratch_free(ic_hdr); return ray_error("domain", "pivot: index column not found"); }
     }
 
     int64_t nrows = ray_table_nrows(tbl);
-    if (nrows == 0) return ray_table_new(0);
+    if (nrows == 0) { scratch_free(ic_hdr); return ray_table_new(0); }
 
     /* DAG fast path: known agg builtins on hashable columns → OP_PIVOT */
     uint16_t agg_op = pivot_fn_to_agg_op(agg_fn);
@@ -185,25 +195,59 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
 
     if (dag_ok) {
         ray_graph_t* g = ray_graph_new(tbl);
-        if (!g) return ray_error("oom", NULL);
-        ray_op_t* idx_ops[vla_idx]; /* VLA, exact-size; see idx_syms above */
+        if (!g) { scratch_free(ic_hdr); return ray_error("oom", NULL); }
+        /* Same user-length hazard as idx_syms/icols above: heap-carve.
+         *
+         * SECOND, independent hazard uncovered by lifting the index-count
+         * cap: ray_scan() appends a node to `g`, which grows g->nodes via
+         * realloc once node_count crosses node_cap (GRAPH_INIT_CAP=4096,
+         * doubling) — moving the whole array.  Any ray_op_t* returned by an
+         * EARLIER ray_scan() call in the loop below is a pointer into the
+         * OLD (now freed) g->nodes block once a LATER call in the same
+         * loop crosses that boundary — exactly the hazard op_node's own
+         * contract warns about ("never store [a node pointer] across a
+         * node allocation; re-resolve from the id instead").  n_idx used
+         * to be capped well under 4096, so this was unreachable; a 5000+
+         * duplicated-index pivot now reaches it and segfaults inside
+         * exec_group on a garbage node id read through the stale pointer.
+         * Fix: collect each scan's stable ->id through every ray_scan call
+         * in this block, and only resolve id -> pointer in ONE pass after
+         * the LAST scan call (v_op below) — that resolve reads the FINAL
+         * g->nodes block, and nothing after it grows the graph again
+         * before ray_pivot_op consumes the pointers. */
+        ray_t* iids_hdr = NULL;
+        ray_op_t** idx_ops = (ray_op_t**)scratch_alloc(&iids_hdr,
+                (size_t)vla_idx * (sizeof(ray_op_t*) + sizeof(uint32_t)));
+        if (!idx_ops) { ray_graph_free(g); scratch_free(ic_hdr); return ray_error("oom", NULL); }
+        uint32_t* idx_ids = (uint32_t*)(idx_ops + vla_idx);
         bool ok = true;
         for (int64_t i = 0; i < n_idx && ok; i++) {
             ray_t* s = ray_sym_str(idx_syms[i]);
-            idx_ops[i] = s ? ray_scan(g, ray_str_ptr(s)) : NULL;
-            if (!idx_ops[i]) ok = false;
+            ray_op_t* op = s ? ray_scan(g, ray_str_ptr(s)) : NULL;
+            if (!op) { ok = false; break; }
+            idx_ids[i] = op->id;
         }
         ray_t* ps = ray_sym_str(pivot_col_name->i64);
+        ray_op_t* p_scan = (ps && ok) ? ray_scan(g, ray_str_ptr(ps)) : NULL;
+        uint32_t p_id = p_scan ? p_scan->id : RAY_OP_NONE;
         ray_t* vs = ray_sym_str(value_col_name->i64);
-        ray_op_t* p_op = (ps && ok) ? ray_scan(g, ray_str_ptr(ps)) : NULL;
-        ray_op_t* v_op = (vs && p_op) ? ray_scan(g, ray_str_ptr(vs)) : NULL;
+        ray_op_t* v_op = (vs && p_scan) ? ray_scan(g, ray_str_ptr(vs)) : NULL;
         if (v_op) {
+            /* Resolve now: v_op (the LAST scan call above) is still fresh;
+             * idx_ops/p_op must be re-read from their ids (see comment
+             * above — their own earlier pointers may already be stale). */
+            for (int64_t i = 0; i < n_idx; i++) idx_ops[i] = op_node(g, idx_ids[i]);
+            ray_op_t* p_op = op_node(g, p_id);
             ray_op_t* root = ray_pivot_op(g, idx_ops, (uint32_t)n_idx, p_op, v_op, agg_op);
+            scratch_free(iids_hdr);
             if (root) {
                 ray_t* result = ray_execute(g, root);
                 ray_graph_free(g);
+                scratch_free(ic_hdr);
                 return result;
             }
+        } else {
+            scratch_free(iids_hdr);
         }
         ray_graph_free(g);
     }
@@ -213,42 +257,59 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
 
     /* Build GROUP BY (idx0, ..., idxN-1, pivot_col) with COUNT agg via DAG */
     ray_graph_t* g = ray_graph_new(tbl);
-    if (!g) return ray_error("oom", NULL);
+    if (!g) { scratch_free(ic_hdr); return ray_error("oom", NULL); }
 
     uint32_t n_keys = (uint32_t)n_idx + 1;
-    ray_op_t* key_ops[n_keys]; /* VLA, exact-size; n_keys = n_idx + 1 >= 1 always */
+    /* Same two hazards as the DAG fast path above (user-length heap-carve
+     * + stale ray_op_t* across a reallocating ray_scan loop): collect ids
+     * through every scan call, resolve to pointers in one pass right
+     * before ray_group — val_scan below is the LAST scan call in this
+     * function, so it stays fresh without needing the id round-trip. */
+    ray_t* kids_hdr = NULL;
+    ray_op_t** key_ops = (ray_op_t**)scratch_alloc(&kids_hdr,
+            (size_t)n_keys * (sizeof(ray_op_t*) + sizeof(uint32_t)));
+    if (!key_ops) { ray_graph_free(g); scratch_free(ic_hdr); return ray_error("oom", NULL); }
+    uint32_t* key_ids = (uint32_t*)(key_ops + n_keys);
     bool ok = true;
     for (int64_t i = 0; i < n_idx && ok; i++) {
         ray_t* s = ray_sym_str(idx_syms[i]);
-        key_ops[i] = s ? ray_scan(g, ray_str_ptr(s)) : NULL;
-        if (!key_ops[i]) ok = false;
+        ray_op_t* op = s ? ray_scan(g, ray_str_ptr(s)) : NULL;
+        if (!op) { ok = false; break; }
+        key_ids[i] = op->id;
     }
     {
         ray_t* ps = ray_sym_str(pivot_col_name->i64);
-        key_ops[n_idx] = (ps && ok) ? ray_scan(g, ray_str_ptr(ps)) : NULL;
-        if (!key_ops[n_idx]) ok = false;
+        ray_op_t* op = (ps && ok) ? ray_scan(g, ray_str_ptr(ps)) : NULL;
+        if (op) key_ids[n_idx] = op->id; else ok = false;
     }
     /* Value column scan for COUNT (just need a column ref for group) */
     ray_t* vs = ray_sym_str(value_col_name->i64);
     ray_op_t* val_scan = (vs && ok) ? ray_scan(g, ray_str_ptr(vs)) : NULL;
-    if (!val_scan) { ray_graph_free(g); return ray_error("domain", "pivot: failed to build DAG"); }
+    if (!val_scan) { scratch_free(kids_hdr); ray_graph_free(g); scratch_free(ic_hdr); return ray_error("domain", "pivot: failed to build DAG"); }
+    for (uint32_t i = 0; i < n_keys; i++) key_ops[i] = op_node(g, key_ids[i]);
 
     uint16_t grp_agg_ops[1] = { OP_COUNT };
     ray_op_t* grp_agg_ins[1] = { val_scan };
     ray_op_t* grp_root = ray_group(g, key_ops, n_keys, grp_agg_ops, grp_agg_ins, 1);
-    if (!grp_root) { ray_graph_free(g); return ray_error("oom", NULL); }
+    scratch_free(kids_hdr);
+    if (!grp_root) { ray_graph_free(g); scratch_free(ic_hdr); return ray_error("oom", NULL); }
 
     ray_t* grouped = ray_execute(g, grp_root);
     ray_graph_free(g);
-    if (!grouped || RAY_IS_ERR(grouped)) return grouped;
+    if (!grouped || RAY_IS_ERR(grouped)) { scratch_free(ic_hdr); return grouped; }
 
     /* `grouped` is a table: (idx0, ..., idxN-1, pivot_col, _count).
      * Each row is one (index, pivot) combination.
      * Now for each group, gather the value column subset and apply agg_fn. */
     int64_t n_grps = ray_table_nrows(grouped);
 
-    /* Get grouped columns (VLA, exact-size; see idx_syms above) */
-    ray_t* g_icols[vla_idx];
+    /* Same user-length hazard as idx_syms/icols: heap-carve.  Lives until
+     * the unstack loop below finishes using it (last read is inside the
+     * "Find or insert index key" loop over ix_list), then freed there —
+     * every return between here and that point must also free it. */
+    ray_t* g_icols_hdr = NULL;
+    ray_t** g_icols = (ray_t**)scratch_alloc(&g_icols_hdr, (size_t)vla_idx * sizeof(ray_t*));
+    if (!g_icols) { ray_release(grouped); scratch_free(ic_hdr); return ray_error("oom", NULL); }
     for (int64_t i = 0; i < n_idx; i++)
         g_icols[i] = ray_table_get_col(grouped, idx_syms[i]);
     ray_t* g_pcol = ray_table_get_col(grouped, pivot_col_name->i64);
@@ -259,10 +320,13 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
     ray_retain(g_pcol);
     ray_t* dvals = ray_distinct_fn(g_pcol);
     ray_release(g_pcol);
-    if (RAY_IS_ERR(dvals)) { ray_release(grouped); return dvals; }
+    if (RAY_IS_ERR(dvals)) { scratch_free(g_icols_hdr); ray_release(grouped); scratch_free(ic_hdr); return dvals; }
     if (ray_is_lazy(dvals)) {
         dvals = ray_lazy_materialize(dvals);
-        if (!dvals || RAY_IS_ERR(dvals)) { ray_release(grouped); return dvals ? dvals : ray_error("oom", NULL); }
+        if (!dvals || RAY_IS_ERR(dvals)) {
+            scratch_free(g_icols_hdr); ray_release(grouped); scratch_free(ic_hdr);
+            return dvals ? dvals : ray_error("oom", NULL);
+        }
     }
     int64_t n_pv = ray_len(dvals);
 
@@ -312,7 +376,10 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
     uint32_t gid_cap = 256;
     while (gid_cap < (uint32_t)n_grps * 2 && gid_cap < (1u << 30)) gid_cap <<= 1;
     ray_t* gid_ht_hdr = ray_alloc((size_t)gid_cap * sizeof(uint32_t));
-    if (!gid_ht_hdr) { ray_release(dvals); ray_release(grouped); return ray_error("oom", NULL); }
+    if (!gid_ht_hdr) {
+        scratch_free(g_icols_hdr); ray_release(dvals); ray_release(grouped); scratch_free(ic_hdr);
+        return ray_error("oom", NULL);
+    }
     uint32_t* gid_ht = (uint32_t*)ray_data(gid_ht_hdr);
     memset(gid_ht, 0xFF, gid_cap * sizeof(uint32_t));
     uint32_t gid_mask = gid_cap - 1;
@@ -328,7 +395,8 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
 
     ray_t* gid_vec = ray_vec_new(RAY_I64, nrows);
     if (!gid_vec || RAY_IS_ERR(gid_vec)) {
-        ray_free(gid_ht_hdr); ray_release(dvals); ray_release(grouped);
+        ray_free(gid_ht_hdr); scratch_free(g_icols_hdr); ray_release(dvals); ray_release(grouped);
+        scratch_free(ic_hdr);
         return ray_error("oom", NULL);
     }
     gid_vec->len = nrows;
@@ -371,7 +439,11 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
      * Slots are NULL-initialised so error paths can free agg_results even
      * before all slots are populated. */
     ray_t* agg_results = ray_alloc(n_grps * sizeof(ray_t*));
-    if (!agg_results) { ray_release(gid_vec); ray_release(dvals); ray_release(grouped); return ray_error("oom", NULL); }
+    if (!agg_results) {
+        scratch_free(g_icols_hdr); ray_release(gid_vec); ray_release(dvals); ray_release(grouped);
+        scratch_free(ic_hdr);
+        return ray_error("oom", NULL);
+    }
     agg_results->type = RAY_LIST;
     agg_results->len = n_grps;
     ray_t** ar = (ray_t**)ray_data(agg_results);
@@ -381,7 +453,8 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
      * O(nrows * n_grps) double-scan per group. */
     ray_t* off_hdr = ray_alloc((size_t)(n_grps + 1) * sizeof(int64_t));
     if (!off_hdr) {
-        ray_free(agg_results); ray_release(gid_vec); ray_release(dvals); ray_release(grouped);
+        ray_free(agg_results); scratch_free(g_icols_hdr); ray_release(gid_vec); ray_release(dvals); ray_release(grouped);
+        scratch_free(ic_hdr);
         return ray_error("oom", NULL);
     }
     int64_t* offs = (int64_t*)ray_data(off_hdr);
@@ -395,7 +468,8 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
     ray_t* sorted_hdr = ray_alloc((size_t)nrows * sizeof(int64_t));
     if (!sorted_hdr) {
         ray_free(off_hdr);
-        ray_free(agg_results); ray_release(gid_vec); ray_release(dvals); ray_release(grouped);
+        ray_free(agg_results); scratch_free(g_icols_hdr); ray_release(gid_vec); ray_release(dvals); ray_release(grouped);
+        scratch_free(ic_hdr);
         return ray_error("oom", NULL);
     }
     int64_t* sorted = (int64_t*)ray_data(sorted_hdr);
@@ -403,7 +477,8 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
     ray_t* wcur_hdr = ray_alloc((size_t)n_grps * sizeof(int64_t));
     if (!wcur_hdr) {
         ray_free(sorted_hdr); ray_free(off_hdr);
-        ray_free(agg_results); ray_release(gid_vec); ray_release(dvals); ray_release(grouped);
+        ray_free(agg_results); scratch_free(g_icols_hdr); ray_release(gid_vec); ray_release(dvals); ray_release(grouped);
+        scratch_free(ic_hdr);
         return ray_error("oom", NULL);
     }
     int64_t* wcur = (int64_t*)ray_data(wcur_hdr);
@@ -419,7 +494,8 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
         ray_t* subset = gather_by_idx(vcol, sorted + offs[gi], cnt);
         if (RAY_IS_ERR(subset)) {
             ray_free(sorted_hdr); ray_free(off_hdr);
-            ray_free(agg_results); ray_release(gid_vec); ray_release(dvals); ray_release(grouped);
+            ray_free(agg_results); scratch_free(g_icols_hdr); ray_release(gid_vec); ray_release(dvals); ray_release(grouped);
+            scratch_free(ic_hdr);
             return subset;
         }
         ray_t* agg_val = call_fn1(agg_fn, subset);
@@ -431,7 +507,8 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
             agg_val = ray_lazy_materialize(agg_val);
         if (RAY_IS_ERR(agg_val)) {
             ray_free(sorted_hdr); ray_free(off_hdr);
-            ray_free(agg_results); ray_release(gid_vec); ray_release(dvals); ray_release(grouped);
+            ray_free(agg_results); scratch_free(g_icols_hdr); ray_release(gid_vec); ray_release(dvals); ray_release(grouped);
+            scratch_free(ic_hdr);
             return agg_val;
         }
         ar[gi] = agg_val;
@@ -490,6 +567,7 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
             ray_release(tup);
         }
     }
+    scratch_free(g_icols_hdr); /* last use of g_icols was inside this loop */
 
     int64_t n_ix = ray_len(ix_list);
 
@@ -575,6 +653,8 @@ fb_cleanup:
     ray_free(agg_results);
     ray_release(dvals);
     ray_release(grouped);
+    scratch_free(ic_hdr); /* idx_syms/icols consolidated carve — last read
+                            * just above (icols[ci]->type / idx_syms[ci]) */
     return result;
 }
 

--- a/test/rfl/group/group_radix_narrow_int_emit.rfl
+++ b/test/rfl/group/group_radix_narrow_int_emit.rfl
@@ -1,0 +1,55 @@
+;; ════════════════════════════════════════════════════════════════════
+;; group_radix_narrow_int_emit.rfl — width-correct parallel radix emit
+;; (radix_phase3_fn, src/ops/group.c) for narrow-int MIN/MAX/PROD/FIRST/LAST
+;; output columns.
+;;
+;; MIN/MAX/PROD/FIRST/LAST keep out_type == the source agg column's type
+;; (unlike SUM/AVG, which widen to I64/F64), so their result column can be a
+;; narrow I32/I16 vector.  radix_phase3_fn's final emit used a fixed 8-byte
+;; `((int64_t*)ao->dst)[di] = v` store regardless of ao->out_type — every
+;; group past di==0 in a narrow-int output column overshoots its 4-/2-byte
+;; slot, corrupting neighboring groups and eventually running off the
+;; allocation entirely (heap overflow / SIGSEGV).  The serial emit (~line
+;; 4586) and the pivot finalizer (~line 10679) already used the width-correct
+;; topk_write_i64(dst, di, v, ray_sym_elem_size(out_type, attrs)) idiom;
+;; radix_phase3_fn (the parallel partitioned emit) did not.
+;;
+;; This was latent for a long time because a width guard kept the row-layout
+;; ght path (and its parallel radix_phase3_fn variant) from ever being
+;; reached by narrow-int aggregates in practice; the unbounded-slots cut-4
+;; guard lift (055b4446 / 99dc4ead / 0b1b6e0f) admits them, making the crash
+;; trivially reachable.
+;;
+;; Trigger conditions (both required to reach radix_phase3_fn, not DA):
+;;   - key range > DA_MAX_COMPOSITE_SLOTS (262144)   -> DA declined
+;;   - nrows >= RAY_PARALLEL_THRESHOLD (65536)        -> parallel radix, not
+;;                                                        the serial ght loop
+;;
+;; til(300000): 300000 distinct keys (range 299999 > 262144) and 300000 rows
+;; (>= 65536) -> every group is a singleton, so MIN/MAX/PROD/FIRST/LAST of
+;; the group is trivially the row's own (provable) value — safe from PROD
+;; overflow since each "product" is a single factor.
+;; ════════════════════════════════════════════════════════════════════
+
+;; ---------- I32 out_type: the review's exact repro (MIN) ----------
+(set Tw32 (table [k v] (list (til 300000) (as 'I32 (% (til 300000) 97)))))
+(set Rw32 (select {mn:(min v) mx:(max v) pr:(prod v) fi:(first v) la:(last v) from: Tw32 by: k}))
+(count Rw32) -- 300000
+(at (at (select {x: mn from: Rw32 where: (== k 0)}) 'x) 0) -- 0
+(at (at (select {x: mn from: Rw32 where: (== k 150000)}) 'x) 0) -- 38
+(at (at (select {x: mn from: Rw32 where: (== k 299999)}) 'x) 0) -- 75
+(at (at (select {x: mx from: Rw32 where: (== k 150000)}) 'x) 0) -- 38
+(at (at (select {x: pr from: Rw32 where: (== k 150000)}) 'x) 0) -- 38
+(at (at (select {x: fi from: Rw32 where: (== k 299999)}) 'x) 0) -- 75
+(at (at (select {x: la from: Rw32 where: (== k 299999)}) 'x) 0) -- 75
+;; Whole-column oracle: singleton groups means {mn} is a permutation of {v}.
+(sum (at Rw32 'mn)) -- (sum (at Tw32 'v))
+
+;; ---------- I16 out_type: same shape, narrower width ----------
+(set Tw16 (table [k v] (list (til 300000) (as 'I16 (% (til 300000) 251)))))
+(set Rw16 (select {mn:(min v) mx:(max v) from: Tw16 by: k}))
+(count Rw16) -- 300000
+(at (at (select {x: mn from: Rw16 where: (== k 0)}) 'x) 0) -- 0
+(at (at (select {x: mn from: Rw16 where: (== k 150000)}) 'x) 0) -- 153
+(at (at (select {x: mx from: Rw16 where: (== k 299999)}) 'x) 0) -- 54
+(sum (at Rw16 'mn)) -- (sum (at Tw16 'v))

--- a/test/rfl/group/multiword_null_mask.rfl
+++ b/test/rfl/group/multiword_null_mask.rfl
@@ -1,0 +1,68 @@
+;; Task 3 — multi-word entry null mask (key region carries ceil(nk/64) words)
+;;
+;; The legacy group HT entry tracked key-nullness in ONE int64 word at
+;; key_off[n_keys].  It now carries ceil(n_keys/64) null-mask words (bit k =
+;; word k>>6, bit k&63).  For every reachable (<=8-key) shape null_words==1, so
+;; grouping must stay byte-identical — this file is the frozen-behavior net.
+;;
+;; The discriminating property throughout: a NULL key forms a DISTINCT group
+;; from a real 0 key (the null-mask bit is what separates them), in every key
+;; slot.  If NULL and 0 ever collapsed, the group counts below would shrink.
+
+;; ── A. Single I64 key: NULL vs 0 are distinct groups ──
+(set A (table [k v] (list (as 'I64 [0 0N 0 0N 5 0N]) (as 'I64 [1 2 3 4 5 6]))))
+(set RA (select {s: (sum v) c: (count v) from: A by: k}))
+;; k=0 (rows 0,2 -> 1+3=4), null (rows 1,3,5 -> 2+4+6=12), k=5 (row 4 -> 5)
+(count RA) -- 3
+(sum (at RA 's)) -- 21
+(sum (at RA 'c)) -- 6
+
+;; ── B. F64 key: NULL (NaN-encoded) vs 0.0 distinct ──
+(set B (table [k v] (list (as 'F64 [0.0 0N 0.0 0N 2.5]) (as 'I64 [1 2 3 4 5]))))
+(set RB (select {s: (sum v) from: B by: k}))
+;; k=0.0 (rows 0,2 -> 4), null (rows 1,3 -> 6), k=2.5 (row 4 -> 5)
+(count RB) -- 3
+(sum (at RB 's)) -- 15
+
+;; ── C. Two keys: all four (null,zero) combinations are distinct ──
+(set C (table [a b v] (list (as 'I64 [0 0 0N 0N 0 0N]) (as 'I64 [0 0N 0 0N 0 0N]) (as 'I64 [10 20 30 40 1 2]))))
+(set RC (select {s: (sum v) from: C by: [a b]}))
+;; (0,0):r0,r4->11  (0,N):r1->20  (N,0):r2->30  (N,N):r3,r5->42
+(count RC) -- 4
+(sum (at RC 's)) -- 103
+
+;; ── D. Eight keys: a null in each distinct slot forms its own group ──
+;; 9 rows: row 0 is all-zero (null mask 0); row j (1..8) sets key (j-1) null.
+;; Every row carries a distinct null-mask (0, then one bit per slot) over an
+;; otherwise byte-identical all-zero key region -> 9 groups of 1 row each.
+;; Exercises the widest reachable shape (n_keys == 8).
+(set D (table [k0 k1 k2 k3 k4 k5 k6 k7 v] (list (as 'I64 [0 0N 0 0 0 0 0 0 0]) (as 'I64 [0 0 0N 0 0 0 0 0 0]) (as 'I64 [0 0 0 0N 0 0 0 0 0]) (as 'I64 [0 0 0 0 0N 0 0 0 0]) (as 'I64 [0 0 0 0 0 0N 0 0 0]) (as 'I64 [0 0 0 0 0 0 0N 0 0]) (as 'I64 [0 0 0 0 0 0 0 0N 0]) (as 'I64 [0 0 0 0 0 0 0 0 0N]) (as 'I64 [1 2 3 4 5 6 7 8 9]))))
+(set RD (select {s: (sum v) c: (count v) from: D by: [k0 k1 k2 k3 k4 k5 k6 k7]}))
+(count RD) -- 9
+(sum (at RD 's)) -- 45
+(max (at RD 'c)) -- 1
+(min (at RD 'c)) -- 1
+
+;; ── E. All-null-key rows collapse to a single group ──
+(set E (table [a b v] (list (as 'I64 [0N 0N 0N]) (as 'I64 [0N 0N 0N]) (as 'I64 [10 20 30]))))
+(set RE (select {s: (sum v) c: (count v) from: E by: [a b]}))
+(count RE) -- 1
+(at (at RE 's) 0) -- 60
+(at (at RE 'c) 0) -- 3
+
+;; ── F. Narrow (I32) key: 0, null, and a nonzero value all distinct ──
+(set F (table [k v] (list (as 'I32 [0 0N 7 0 0N 7]) (as 'I64 [1 2 3 4 5 6]))))
+(set RF (select {c: (count v) from: F by: k}))
+;; k=0 (r0,r3), null (r1,r4), k=7 (r2,r5) -> 3 groups, 2 rows each
+(count RF) -- 3
+(min (at RF 'c)) -- 2
+(max (at RF 'c)) -- 2
+
+;; ── G. Radix (parallel) path: large null-bearing key, NULL vs 0 held ──
+;; take cycles the pattern; the two null slots collapse to ONE null group.
+(set NG 100000)
+(set G (table [k v] (list (take (as 'I64 [0 0N 1 0N 2]) NG) (as 'I64 (til NG)))))
+(set RG (select {c: (count v) from: G by: k}))
+;; distinct keys {0, null, 1, 2} -> 4 groups; count includes every row.
+(count RG) -- 4
+(sum (at RG 'c)) -- 100000

--- a/test/rfl/integration/slice_group.rfl
+++ b/test/rfl/integration/slice_group.rfl
@@ -112,3 +112,23 @@
 (set QDP (select {sv: (sum v) from: TP by: s where: (in s ['aa 'bb 'cc 'dd]) desc: sv take: 2}))
 (count QDI) -- 2
 (min (== (at QDI 'sv) (at QDP 'sv))) -- true
+
+;; ── sg 16-agg gate: unchanged by cut 4 (regression pin, not a lift) ──
+;; sg_shape_eligible's OWN cap (ext->n_aggs > 16 -> false, group.c ~6690) is
+;; a fixed-array [16] bound unrelated to the unbounded-slots cut-4 width
+;; guards this file otherwise exercises — cut 4 does not touch it.  A
+;; 17-agg query in this exact fused shape (FILTER(in on grouped SYM col) +
+;; GROUP by that col) must decline the slice path and fall back to whatever
+;; serves it next (here: v2, since all 17 aggs are plain SUM/COUNT scans,
+;; group_limit==0, no emit-filter armed) with results identical to the
+;; plain-table (non-indexed) run — same equivalence idiom as every other
+;; cell above, just past the sg agg-count boundary instead of the width
+;; guards.
+(set Q10I (select {a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) a17: (count v) from: TI by: s where: (in s ['aa 'cc])}))
+(set Q10P (select {a01: (sum v) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) a17: (count v) from: TP by: s where: (in s ['aa 'cc])}))
+(at (meta Q10I) 'len) -- 18
+(min (== (at Q10I 'a01) (at Q10P 'a01))) -- true
+(min (== (at Q10I 'a17) (at Q10P 'a17))) -- true
+(min (== (at Q10I 's) (at Q10P 's))) -- true
+(at (at Q10I 'a01) 0) -- 998000
+(at (at Q10I 'a17) 0) -- 500

--- a/test/rfl/null/grouped_agg_null_ght.rfl
+++ b/test/rfl/null/grouped_agg_null_ght.rfl
@@ -1,0 +1,118 @@
+;; Null handling on the legacy ght (hash) group-by path.
+;;
+;; The DA, scalar, and v2 engines all skip nulls in aggregates, but the
+;; row-layout ght accumulators (init_accum_from_entry / accum_from_entry in
+;; src/ops/group.c) historically summed / compared the F64 NaN and NULL_I*
+;; sentinels as ordinary values — a live wrong-answer bug for any
+;; high-cardinality or multi-key SUM/MIN/MAX/AVG/PROD/FIRST/LAST/STDDEV that
+;; declined DA (slot-budget) and v2 (nullable) and fell to the hash path.
+;;
+;; A key range > the DA composite-slot budget (262144) forces the ght path.
+;; Keys {0, 10000000} do that; each group then holds a null + a value, and a
+;; post-group WHERE on the RESULT table pins the group without compacting the
+;; key range (which would re-admit DA).  Group k=0 = rows [null, 3]; group
+;; k=10000000 = rows [5, 8].
+
+;; ---------- I32 SUM: the review's exact repro ----------
+;; Pre-fix this emitted [-2147483645, 13] (3 + NULL_I32 summed as a value).
+(set Ti (table [k v] (list [0 10000000 0 10000000] (as 'I32 [0N 5 3 8]))))
+(set Ri (select {s:(sum v) mn:(min v) mx:(max v) av:(avg v) fi:(first v) la:(last v) pr:(prod v) ct:(count v) from: Ti by: k}))
+(at (at (select {x: s  from: Ri where: (== k 0)}) 'x) 0) -- 3
+(at (at (select {x: s  from: Ri where: (== k 10000000)}) 'x) 0) -- 13
+;; MIN skips the NULL_I32 sentinel (pre-fix it won the compare → 0Ni).
+(at (at (select {x: mn from: Ri where: (== k 0)}) 'x) 0) -- 3
+(at (at (select {x: mx from: Ri where: (== k 0)}) 'x) 0) -- 3
+;; AVG divides by the NON-NULL count (1), not the row count (2).
+(at (at (select {x: av from: Ri where: (== k 0)}) 'x) 0) -- 3.0
+(at (at (select {x: av from: Ri where: (== k 10000000)}) 'x) 0) -- 6.5
+;; FIRST skips the null prefix; PROD skips the null factor.
+(at (at (select {x: fi from: Ri where: (== k 0)}) 'x) 0) -- 3
+(at (at (select {x: la from: Ri where: (== k 0)}) 'x) 0) -- 3
+(at (at (select {x: pr from: Ri where: (== k 0)}) 'x) 0) -- 3
+;; COUNT still tallies ALL rows (nulls included).
+(at (at (select {x: ct from: Ri where: (== k 0)}) 'x) 0) -- 2
+
+;; ---------- I16 (narrow, NULL_I16) ----------
+(set Th (table [k v] (list [0 10000000 0 10000000] (as 'I16 [0N 5 3 8]))))
+(set Rh (select {s:(sum v) mn:(min v) pr:(prod v) from: Th by: k}))
+(at (at (select {x: s  from: Rh where: (== k 0)}) 'x) 0) -- 3
+(at (at (select {x: mn from: Rh where: (== k 0)}) 'x) 0) -- 3
+(at (at (select {x: pr from: Rh where: (== k 0)}) 'x) 0) -- 3
+
+;; ---------- I64 (NULL_I64) in a mixed-op query (forced to ght by MIN) ----------
+(set Tl (table [k v] (list [0 10000000 0 10000000] (as 'I64 [0N 5 3 8]))))
+(set Rl (select {s:(sum v) mn:(min v) mx:(max v) from: Tl by: k}))
+(at (at (select {x: s  from: Rl where: (== k 0)}) 'x) 0) -- 3
+(at (at (select {x: mn from: Rl where: (== k 0)}) 'x) 0) -- 3
+
+;; ---------- TIMESTAMP MIN/MAX (I64-backed sentinel) ----------
+(set Tt (table [k v] (list [0 10000000 0 10000000] (as 'TIMESTAMP [0N 5 3 8]))))
+(set Rt (select {mn:(min v) mx:(max v) from: Tt by: k}))
+(at (at (select {x: mn from: Rt where: (== k 0)}) 'x) 0) -- 2000.01.01D00:00:00.000000003
+(nil? (at (at (select {x: mx from: Rt where: (== k 0)}) 'x) 0)) -- false
+
+;; ---------- F64 (NaN-encoded null) forced to ght by MIN ----------
+;; Pre-fix ght summed NaN → whole group went null; MIN kept the NaN seed.
+(set Tf (table [k v] (list [0 10000000 0 10000000] (as 'F64 [0N 5.0 3.0 8.0]))))
+(set Rf (select {s:(sum v) mn:(min v) mx:(max v) av:(avg v) fi:(first v) pr:(prod v) from: Tf by: k}))
+(at (at (select {x: s  from: Rf where: (== k 0)}) 'x) 0) -- 3.0
+(at (at (select {x: mn from: Rf where: (== k 0)}) 'x) 0) -- 3.0
+(at (at (select {x: av from: Rf where: (== k 0)}) 'x) 0) -- 3.0
+(at (at (select {x: fi from: Rf where: (== k 0)}) 'x) 0) -- 3.0
+(at (at (select {x: pr from: Rf where: (== k 0)}) 'x) 0) -- 3.0
+
+;; ---------- ALL-NULL group: SUM = 0, everything else typed null ----------
+;; Group k=0 = [null, null]; group k=10000000 = [5, 8].
+(set Ta (table [k v] (list [0 10000000 0 10000000] (as 'I32 [0N 5 0N 8]))))
+(set Ra (select {s:(sum v) mn:(min v) mx:(max v) av:(avg v) pr:(prod v) ct:(count v) sd:(stddev v) from: Ta by: k}))
+;; SUM of an all-null group is the additive identity 0 (NOT null).
+(at (at (select {x: s  from: Ra where: (== k 0)}) 'x) 0) -- 0
+(nil? (at (at (select {x: s  from: Ra where: (== k 0)}) 'x) 0)) -- false
+;; MIN/MAX/AVG/PROD/STDDEV of an all-null group are typed nulls.
+(nil? (at (at (select {x: mn from: Ra where: (== k 0)}) 'x) 0)) -- true
+(nil? (at (at (select {x: mx from: Ra where: (== k 0)}) 'x) 0)) -- true
+(nil? (at (at (select {x: av from: Ra where: (== k 0)}) 'x) 0)) -- true
+(nil? (at (at (select {x: pr from: Ra where: (== k 0)}) 'x) 0)) -- true
+(nil? (at (at (select {x: sd from: Ra where: (== k 0)}) 'x) 0)) -- true
+;; COUNT still tallies the two null rows.
+(at (at (select {x: ct from: Ra where: (== k 0)}) 'x) 0) -- 2
+;; The live group is unaffected.
+(at (at (select {x: s  from: Ra where: (== k 10000000)}) 'x) 0) -- 13
+;; STDDEV needs >= 2 non-null; the live group has exactly 2 -> defined.
+(nil? (at (at (select {x: sd from: Ra where: (== k 10000000)}) 'x) 0)) -- false
+
+;; ---------- ght (high-card key) vs DA (low-card key) oracle: identical ----------
+;; Same value column and grouping structure; only the key VALUES differ, so
+;; DA serves the low-card table and ght serves the high-card one.  Every
+;; aggregate must agree cell-for-cell.
+(set Vv (as 'I32 [0N 5 3 8 0N 0N 7 2]))
+(set Gght (select {s:(sum v) mn:(min v) mx:(max v) av:(avg v) pr:(prod v) ct:(count v) from: (table [k v] (list [0 10000000 0 10000000 0 10000000 0 10000000] Vv)) by: k}))
+(set Gda  (select {s:(sum v) mn:(min v) mx:(max v) av:(avg v) pr:(prod v) ct:(count v) from: (table [k v] (list [0 1 0 1 0 1 0 1] Vv)) by: k}))
+(at (at (select {x: s  from: Gght where: (== k 0)}) 'x) 0) -- 10
+(at (at (select {x: s  from: Gda  where: (== k 0)}) 'x) 0) -- 10
+(at (at (select {x: av from: Gght where: (== k 0)}) 'x) 0) -- (at (at (select {x: av from: Gda where: (== k 0)}) 'x) 0)
+(at (at (select {x: mn from: Gght where: (== k 0)}) 'x) 0) -- (at (at (select {x: mn from: Gda where: (== k 0)}) 'x) 0)
+;; k=10000000 (ght) and k=1 (DA) are the same logical group (odd indices).
+(at (at (select {x: pr from: Gght where: (== k 10000000)}) 'x) 0) -- (at (at (select {x: pr from: Gda where: (== k 1)}) 'x) 0)
+
+;; ---------- multi-key DA-ineligible variant ----------
+;; Two high-card keys -> composite budget blown -> ght; nulls still skipped.
+(set Tm (table [k1 k2 v] (list [0 10000000 0 10000000] [0 5000000 0 5000000] (as 'I32 [0N 5 3 8]))))
+(set Rm (select {s:(sum v) mn:(min v) from: Tm by: [k1 k2]}))
+(at (at (select {x: s  from: Rm where: (== k1 0)}) 'x) 0) -- 3
+(at (at (select {x: mn from: Rm where: (== k1 0)}) 'x) 0) -- 3
+
+;; ---------- parallel ght path (N above the parallel threshold) ----------
+;; N = 600000 >= 64*8192 forces the partitioned radix (radix_phase3_fn).
+;; Values tile [null 5 null 8 3 null 7 null]; row i lands in group i%2.
+;; Even rows -> {null,null,3,7}, odd rows -> {5,8,null,null}.
+(set Np 600000)
+(set Vp (take (as 'I64 [0N 5 0N 8 3 0N 7 0N]) Np))
+(set Rp (select {s:(sum v) mn:(min v) mx:(max v) av:(avg v) ct:(count v) from: (table [k v] (list (take [0 10000000] Np) Vp)) by: k}))
+(at (at (select {x: s  from: Rp where: (== k 0)}) 'x) 0) -- 750000
+(at (at (select {x: mn from: Rp where: (== k 0)}) 'x) 0) -- 3
+(at (at (select {x: mx from: Rp where: (== k 0)}) 'x) 0) -- 7
+(at (at (select {x: av from: Rp where: (== k 0)}) 'x) 0) -- 5.0
+(at (at (select {x: ct from: Rp where: (== k 0)}) 'x) 0) -- 300000
+(at (at (select {x: s  from: Rp where: (== k 10000000)}) 'x) 0) -- 975000
+(at (at (select {x: av from: Rp where: (== k 10000000)}) 'x) 0) -- 6.5

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -828,9 +828,10 @@
 ;; fired; `da_path:` also fired first since da_eligible is only cleared
 ;; partway through that block, but da_fits ends up false and control falls
 ;; through to ht_path, which returns the result).
-;; FIRST is defined by original ROW INDEX, not iteration/thread order (the HT
-;; and DA paths both track first_row/last_row per group and keep the
-;; smallest/largest index across per-worker merges — group.c ~8283-8325), so
+;; FIRST is defined by original ROW INDEX, not iteration/thread order.  v is a
+;; wide (STR) column, so its first(v) is resolved holistically by the post-radix
+;; per-group pass (wide_winner_row), which keeps the smallest winning row index
+;; across per-worker merges — NOT the DA min/max-index block; so
 ;; first(v) is deterministic here regardless of scheduling: k=[1 1 2 2] means
 ;; group1 = rows 0,1 (first row 0), group2 = rows 2,3 (first row 2).
 ;; a=[2 3 4 5] b=[5 6 7 8] w=[10 20 30 40]: a*b=[10 18 28 40] ->
@@ -871,6 +872,29 @@
 (at wm_r256 's) -- [10 30]
 (at wm_r256 'k255) -- [1 2]
 
+;; ── 256-key PARALLEL emit (65536 rows forces the radix path): the sequential
+;; cell above never reaches radix_phase3_fn, whose ctx carried the key/agg
+;; counts in uint8 — 256 wrapped to (uint8)256==0, so the phase-3 key SCATTER
+;; loop ran zero iterations and the emitted key columns kept their zero-fill.
+;; COUNT and SUMS come from phase1/2 grouping and stay correct; only the key
+;; VALUES were silently zeroed — a wrong answer with no error.  F64 k000 forces
+;; legacy; k255 = [1 2 1 2 ...] (even rows -> group with k255=1, odd -> k255=2).
+;; v = til 65536: even-row sum = 2*(0+..+32767) = 1073709056; odd-row sum =
+;; 2147450880 - 1073709056 = 1073741824.  Order-independent discriminators
+;; (radix emits in partition order, not value order): sum of the k255 column ==
+;; 1+2 == 3 (pre-fix all-zero -> 0), and sum of the F64 k000 column == 2.0
+;; (pre-fix -> 0.0).  Grouping proof: count == 2, total sum preserved. ──
+(set wm_k000p (take [1.0] 65536))
+(set wm_kintp (take [1] 65536))
+(set wm_kdisp (+ 1 (% (til 65536) 2)))
+(set wm_kvp (til 65536))
+(set wm_tp256 (table [k000 k001 k002 k003 k004 k005 k006 k007 k008 k009 k010 k011 k012 k013 k014 k015 k016 k017 k018 k019 k020 k021 k022 k023 k024 k025 k026 k027 k028 k029 k030 k031 k032 k033 k034 k035 k036 k037 k038 k039 k040 k041 k042 k043 k044 k045 k046 k047 k048 k049 k050 k051 k052 k053 k054 k055 k056 k057 k058 k059 k060 k061 k062 k063 k064 k065 k066 k067 k068 k069 k070 k071 k072 k073 k074 k075 k076 k077 k078 k079 k080 k081 k082 k083 k084 k085 k086 k087 k088 k089 k090 k091 k092 k093 k094 k095 k096 k097 k098 k099 k100 k101 k102 k103 k104 k105 k106 k107 k108 k109 k110 k111 k112 k113 k114 k115 k116 k117 k118 k119 k120 k121 k122 k123 k124 k125 k126 k127 k128 k129 k130 k131 k132 k133 k134 k135 k136 k137 k138 k139 k140 k141 k142 k143 k144 k145 k146 k147 k148 k149 k150 k151 k152 k153 k154 k155 k156 k157 k158 k159 k160 k161 k162 k163 k164 k165 k166 k167 k168 k169 k170 k171 k172 k173 k174 k175 k176 k177 k178 k179 k180 k181 k182 k183 k184 k185 k186 k187 k188 k189 k190 k191 k192 k193 k194 k195 k196 k197 k198 k199 k200 k201 k202 k203 k204 k205 k206 k207 k208 k209 k210 k211 k212 k213 k214 k215 k216 k217 k218 k219 k220 k221 k222 k223 k224 k225 k226 k227 k228 k229 k230 k231 k232 k233 k234 k235 k236 k237 k238 k239 k240 k241 k242 k243 k244 k245 k246 k247 k248 k249 k250 k251 k252 k253 k254 k255 v] (concat (list wm_k000p) (concat (take (list wm_kintp) 254) (list wm_kdisp wm_kvp)))))
+(set wm_rp256 (select {from: wm_tp256 s: (sum v) by: ['k000 'k001 'k002 'k003 'k004 'k005 'k006 'k007 'k008 'k009 'k010 'k011 'k012 'k013 'k014 'k015 'k016 'k017 'k018 'k019 'k020 'k021 'k022 'k023 'k024 'k025 'k026 'k027 'k028 'k029 'k030 'k031 'k032 'k033 'k034 'k035 'k036 'k037 'k038 'k039 'k040 'k041 'k042 'k043 'k044 'k045 'k046 'k047 'k048 'k049 'k050 'k051 'k052 'k053 'k054 'k055 'k056 'k057 'k058 'k059 'k060 'k061 'k062 'k063 'k064 'k065 'k066 'k067 'k068 'k069 'k070 'k071 'k072 'k073 'k074 'k075 'k076 'k077 'k078 'k079 'k080 'k081 'k082 'k083 'k084 'k085 'k086 'k087 'k088 'k089 'k090 'k091 'k092 'k093 'k094 'k095 'k096 'k097 'k098 'k099 'k100 'k101 'k102 'k103 'k104 'k105 'k106 'k107 'k108 'k109 'k110 'k111 'k112 'k113 'k114 'k115 'k116 'k117 'k118 'k119 'k120 'k121 'k122 'k123 'k124 'k125 'k126 'k127 'k128 'k129 'k130 'k131 'k132 'k133 'k134 'k135 'k136 'k137 'k138 'k139 'k140 'k141 'k142 'k143 'k144 'k145 'k146 'k147 'k148 'k149 'k150 'k151 'k152 'k153 'k154 'k155 'k156 'k157 'k158 'k159 'k160 'k161 'k162 'k163 'k164 'k165 'k166 'k167 'k168 'k169 'k170 'k171 'k172 'k173 'k174 'k175 'k176 'k177 'k178 'k179 'k180 'k181 'k182 'k183 'k184 'k185 'k186 'k187 'k188 'k189 'k190 'k191 'k192 'k193 'k194 'k195 'k196 'k197 'k198 'k199 'k200 'k201 'k202 'k203 'k204 'k205 'k206 'k207 'k208 'k209 'k210 'k211 'k212 'k213 'k214 'k215 'k216 'k217 'k218 'k219 'k220 'k221 'k222 'k223 'k224 'k225 'k226 'k227 'k228 'k229 'k230 'k231 'k232 'k233 'k234 'k235 'k236 'k237 'k238 'k239 'k240 'k241 'k242 'k243 'k244 'k245 'k246 'k247 'k248 'k249 'k250 'k251 'k252 'k253 'k254 'k255]}))
+(count (at wm_rp256 'k255)) -- 2
+(sum (at wm_rp256 's)) -- 2147450880
+(sum (at wm_rp256 'k255)) -- 3
+(sum (at wm_rp256 'k000)) -- 2.0
+
 ;; ── 9-key group with a group emit-filter (desc/take) — v2 and v2-exprs are
 ;; both skipped when a group emit-filter is armed, so this stays on the legacy
 ;; ght path, which the width-guard lift now serves at 9 keys.  F64 k0 gives 3
@@ -899,16 +923,29 @@
 
 ;; ── 9-key PLAIN-STR (non-dict) group: the width-guard lift means this shape
 ;; no longer `nyi`s and the legacy ght inline-STR scatter groups it correctly
-;; (verified: identical key tuples hash-collide and merge in group_ht).  It is
-;; NOT asserted for grouped VALUES here because a PRE-EXISTING, cut-4-orthogonal
-;; bug in the query-layer routing sends any select with >=2 STR/wide key
-;; columns AND >=3 total keys to an eval path that fails to merge groups
-;; (repro: 2 STR + 1 int keys returns one group per row; 1 STR + 2 int keys is
-;; correct — reproduces on master, independent of the >8 width guards).  The
-;; correct STR-key width path is covered by the dict-STR cell above; this cell
-;; pins only that the 9-key plain-STR shape is now SERVED (a table, no nyi). ──
+;; (identical key tuples hash-collide and merge in group_ht).  Value-asserted:
+;; the pre-existing query-layer multi-STR misroute (>=2 STR/wide key cols AND
+;; >=3 total keys -> one group per row) that once masked this shape no longer
+;; reproduces at HEAD — the branch fixed it as a side effect (base-vs-HEAD
+;; verified in review; base@3b6ff13e gave 4 groups, HEAD merges to 2).
+;; k0..k8 STR ["a" "a" "b" "b"], v=[10 20 30 40] -> 2 groups: {rows0,1}="a"
+;; sum 30, {rows2,3}="b" sum 70. ──
 (set wm_ps (table [k0 k1 k2 k3 k4 k5 k6 k7 k8 v] (list ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] [10 20 30 40])))
-(at (meta (select {from: wm_ps s: (sum v) by: {k0: k0 k1: k1 k2: k2 k3: k3 k4: k4 k5: k5 k6: k6 k7: k7 k8: k8}})) 'len) -- 10
+(set wm_rps (select {from: wm_ps s: (sum v) by: {k0: k0 k1: k1 k2: k2 k3: k3 k4: k4 k5: k5 k6: k6 k7: k7 k8: k8}}))
+(at (meta wm_rps) 'len) -- 10
+(at wm_rps 'k0) -- ["a" "b"]
+(at wm_rps 's) -- [30 70]
+
+;; ── 3-key 2-STR + 1-int merge pin: the exact shape the pre-existing query-layer
+;; misroute mangled on base (2 STR keys + >=3 total keys -> one group per row).
+;; Fixed on-branch as a side effect (see above); the identical (k0,k1,k2) tuples
+;; now merge.  k0=k1 STR ["a" "a" "b" "b"], k2 int [1 1 2 2], v=[10 20 30 40] ->
+;; 2 groups {rows0,1} sum 30, {rows2,3} sum 70. ──
+(set wm_p2s (table [k0 k1 k2 v] (list ["a" "a" "b" "b"] ["a" "a" "b" "b"] [1 1 2 2] [10 20 30 40])))
+(set wm_rp2s (select {from: wm_p2s s: (sum v) by: {k0: k0 k1: k1 k2: k2}}))
+(at (meta wm_rp2s) 'len) -- 4
+(at wm_rp2s 'k0) -- ["a" "b"]
+(at wm_rp2s 's) -- [30 70]
 
 ;; ── 1 plain-STR key + N int keys, 70000 rows forcing the PARALLEL radix_v2
 ;; path (>= RAY_PARALLEL_THRESHOLD = 64*1024 = 65536).  Review Critical:

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -898,3 +898,126 @@
 (set wm_xr (select {from: wm_xt sm: (sum v) by: {k0: k0 k1: k1 k2: k2 k3: k3 k4: k4 k5: k5 k6: k6 k7: k7 k8: k8 k9: k9}}))
 (at wm_xr 'k0) -- ["a" "b"]
 (at wm_xr 'sm) -- [1224965000 1225000000]
+
+;; ══════════════════════════════════════════════════════════════════
+;; Task 5 (unbounded-slots cut 4): DA/sp-path per-agg bitmasks widened
+;; uint32_t -> uint64_t (da_ctx_t agg_f64_mask/agg_int_null_mask; the
+;; independent agg_f64_mask in the single-key sparse (sp) macro path).
+;; Post-Task-4 the legacy group path serves any n_aggs at all, so the
+;; DA path (n_keys<=8, admitted at group.c da_eligible) could for the
+;; first time see n_aggs > 32 — a uint32_t bitmask's bit `a` for a>=32
+;; is a variable shift-by->=32, which x86 hardware evaluates modulo 32
+;; (SHL/SHR only ever use the low 5 bits of the count register), so bit
+;; 32 silently aliases bit 0, bit 33 aliases bit 1, etc.  This section
+;; gates admission at n_aggs<=64 (the width of the new uint64_t masks)
+;; and pins three shapes: the exact historical alias point (33 aggs,
+;; bit 32 vs bit 0), the new upper boundary (64 aggs, bit 63), and one
+;; past it (65 aggs, forced to the hash/ht_path — ght_layout_t's
+;; per-agg metadata is per-element flag BYTES, not a bitmask, so it has
+;; no width cap to alias against).
+;;
+;; Shared fixture, single I64 key, two groups (k=1 rows 0-1, k=2 rows
+;; 2-3):
+;;   wm5_va (I32, no nulls): row0 is 2147483647i + 1i, which WRAPS to
+;;     -2147483648 (INT32_MIN) — a real, non-null data value per the
+;;     documented I16/I32 wraparound exception (src/vec/validate.c
+;;     invariant 16.4: narrow-int sentinels are NOT reserved because
+;;     modulo arithmetic legitimately produces them; see also
+;;     test/rfl/expr/narrow_binary.rfl's `(+ [2147483647i] [1i]) --
+;;     [-2147483648]`).  It is chosen because it exactly equals
+;;     NULL_I32 — the value da_ctx_t's int-null sentinel check compares
+;;     against — so if agg 0's mask bit is ever wrongly turned on by an
+;;     unrelated agg's alias, this row is wrongly dropped from the sum.
+;;     Row1 = 100 (untainted control value); rows2-3 = 10, 20 for the
+;;     second group (no wraparound there, plain control values).
+;;   wm5_vf (I32, no nulls): filler agg input, DISTINCT per group
+;;     (7,7 / 3,3) so any cross-group corruption is visible too.
+;;   wm5_vn (I32, WITH a genuine null): 0Ni at the first row of each
+;;     group, a real value at the second — placed at the boundary agg
+;;     position in the 33-agg and 64-agg tests below (both admitted to
+;;     the DA path, which correctly int-null-skips), so its own mask
+;;     bit is legitimately set from real HAS_NULLS.  NOT used at the
+;;     65-agg boundary — see wm5_vd below and the comment at that test.
+;;   wm5_vd (F64, no nulls): used only by the 65-agg test's boundary
+;;     position, in place of wm5_vn — see that test's comment for why.
+;;
+;; Group k=1 (rows 0,1): a01 (wm5_va) correct sum = -2147483648 + 100 =
+;;   -2147483548; buggy (bit-32-aliased-to-0) sum = 100 (row0 wrongly
+;;   treated as null and dropped).  Filler sum = 7+7 = 14.  wm5_vn
+;;   correct sum = 5 (row0 null skipped).  wm5_vd sum = 1.5+2.5 = 4.0.
+;; Group k=2 (rows 2,3): a01 sum = 10+20 = 30 (no wraparound row, so
+;;   this group is unaffected by the alias either way — a control).
+;;   Filler sum = 3+3 = 6.  wm5_vn sum = 8.  wm5_vd sum = 10.5+20.5=31.0.
+;; ══════════════════════════════════════════════════════════════════
+
+(set wm5_va (+ [2147483647i 99i 10i 20i] [1i 1i 0i 0i]))
+;; The vector itself carries no HAS_NULLS (the wraparound row is a real
+;; value, not a null) even though extracting it as a bare scalar via
+;; `at` renders as `0Ni` — nil?/format on an ATOM re-derives nullness
+;; from the sentinel bit pattern alone (an atom has no attrs byte to
+;; carry HAS_NULLS), so that quirk is scalar-context-only and does NOT
+;; reflect how the vector's own consumers (sum, the DA accumulator)
+;; treat it: they gate on the VECTOR's HAS_NULLS attribute first, which
+;; is correctly unset here.
+(nil? wm5_va) -- false
+(sum wm5_va) -- -2147483518
+(at wm5_va 1) -- 100
+(set wm5_vf [7i 7i 3i 3i])
+(set wm5_vn [0Ni 5i 0Ni 8i])
+(set wm5_t (table [k va vf vn] (list [1 1 2 2] wm5_va wm5_vf wm5_vn)))
+
+;; ── 33 aggs: pins the exact historical alias point.  a33 (agg index
+;; 32) is the nulls column — bit 32 of a uint32_t mask aliases bit 0
+;; (a01's).  Pre-Task-5 this would corrupt a01's group-1 sum to 100;
+;; post-Task-5 (uint64_t masks) bits 0 and 32 are independent. ──
+(set wm5_r33 (select {from: wm5_t a01: (sum wm5_va) a02: (sum wm5_vf) a03: (sum wm5_vf) a04: (sum wm5_vf) a05: (sum wm5_vf) a06: (sum wm5_vf) a07: (sum wm5_vf) a08: (sum wm5_vf) a09: (sum wm5_vf) a10: (sum wm5_vf) a11: (sum wm5_vf) a12: (sum wm5_vf) a13: (sum wm5_vf) a14: (sum wm5_vf) a15: (sum wm5_vf) a16: (sum wm5_vf) a17: (sum wm5_vf) a18: (sum wm5_vf) a19: (sum wm5_vf) a20: (sum wm5_vf) a21: (sum wm5_vf) a22: (sum wm5_vf) a23: (sum wm5_vf) a24: (sum wm5_vf) a25: (sum wm5_vf) a26: (sum wm5_vf) a27: (sum wm5_vf) a28: (sum wm5_vf) a29: (sum wm5_vf) a30: (sum wm5_vf) a31: (sum wm5_vf) a32: (sum wm5_vf) a33: (sum wm5_vn) by: {gk: k}}))
+(at (meta wm5_r33) 'len) -- 34
+(at wm5_r33 'gk) -- [1 2]
+(at wm5_r33 'a01) -- [-2147483548 30]
+(at wm5_r33 'a02) -- [14 6]
+(at wm5_r33 'a32) -- [14 6]
+(at wm5_r33 'a33) -- [5 8]
+
+;; ── 64 aggs: upper boundary of the new uint64_t mask width.  a64 (agg
+;; index 63, the top bit) is the nulls column — this pins that the full
+;; widened range 33..64 is admitted to the DA path and computed
+;; correctly, not just the head of the range. ──
+(set wm5_r64 (select {from: wm5_t a01: (sum wm5_va) a02: (sum wm5_vf) a03: (sum wm5_vf) a04: (sum wm5_vf) a05: (sum wm5_vf) a06: (sum wm5_vf) a07: (sum wm5_vf) a08: (sum wm5_vf) a09: (sum wm5_vf) a10: (sum wm5_vf) a11: (sum wm5_vf) a12: (sum wm5_vf) a13: (sum wm5_vf) a14: (sum wm5_vf) a15: (sum wm5_vf) a16: (sum wm5_vf) a17: (sum wm5_vf) a18: (sum wm5_vf) a19: (sum wm5_vf) a20: (sum wm5_vf) a21: (sum wm5_vf) a22: (sum wm5_vf) a23: (sum wm5_vf) a24: (sum wm5_vf) a25: (sum wm5_vf) a26: (sum wm5_vf) a27: (sum wm5_vf) a28: (sum wm5_vf) a29: (sum wm5_vf) a30: (sum wm5_vf) a31: (sum wm5_vf) a32: (sum wm5_vf) a33: (sum wm5_vf) a34: (sum wm5_vf) a35: (sum wm5_vf) a36: (sum wm5_vf) a37: (sum wm5_vf) a38: (sum wm5_vf) a39: (sum wm5_vf) a40: (sum wm5_vf) a41: (sum wm5_vf) a42: (sum wm5_vf) a43: (sum wm5_vf) a44: (sum wm5_vf) a45: (sum wm5_vf) a46: (sum wm5_vf) a47: (sum wm5_vf) a48: (sum wm5_vf) a49: (sum wm5_vf) a50: (sum wm5_vf) a51: (sum wm5_vf) a52: (sum wm5_vf) a53: (sum wm5_vf) a54: (sum wm5_vf) a55: (sum wm5_vf) a56: (sum wm5_vf) a57: (sum wm5_vf) a58: (sum wm5_vf) a59: (sum wm5_vf) a60: (sum wm5_vf) a61: (sum wm5_vf) a62: (sum wm5_vf) a63: (sum wm5_vf) a64: (sum wm5_vn) by: {gk: k}}))
+(at (meta wm5_r64) 'len) -- 65
+(at wm5_r64 'gk) -- [1 2]
+(at wm5_r64 'a01) -- [-2147483548 30]
+(at wm5_r64 'a02) -- [14 6]
+(at wm5_r64 'a63) -- [14 6]
+(at wm5_r64 'a64) -- [5 8]
+
+;; ── 65 aggs: one past the mask width.  n_aggs=65 fails both
+;; da_eligible's and sp_eligible's `n_aggs <= 64` gate (group.c, added
+;; this task), so this shape is forced onto the legacy ht_path — a
+;; completely different mechanism (ght_layout_t's agg_flags[a] is a
+;; per-element uint8_t array, not a bitmask, per src/ops/internal.h) —
+;; not exercised by this task's fix at all.
+;;
+;; a65 (agg index 64) is wm5_vd, an F64 column with NO nulls — chosen
+;; instead of reusing wm5_vn's int-null trick because the legacy
+;; ht_path's accum_from_entry has no int-null-sentinel skip at all for
+;; narrow-int SUM (a separate, pre-existing gap, confirmed independently
+;; via a 9-key/1-agg repro that is orthogonal to this task's masks — see
+;; task report); an F64 agg with no nulls sidesteps that gap entirely
+;; while still exercising the alias position. Bit 64 does not exist in
+;; a uint64_t (the shift itself is UB), so agg index 64 is exactly what
+;; a future regression that loosened the 64 cap without further
+;; widening da_ctx_t's agg_f64_mask would corrupt the SAME way a33 was
+;; corrupted above: index 64 mod 64 = index 0 (a01's slot), so a01 (an
+;; I32, non-F64 agg) would be wrongly reinterpreted as F64 raw bits —
+;; a drastically wrong number, not a subtle one. Correct results here
+;; both confirm the hash-path fallback is right AND stand as a
+;; regression guard on the gate itself. ──
+(set wm5_vd [1.5 2.5 10.5 20.5])
+(set wm5_r65 (select {from: wm5_t a01: (sum wm5_va) a02: (sum wm5_vf) a03: (sum wm5_vf) a04: (sum wm5_vf) a05: (sum wm5_vf) a06: (sum wm5_vf) a07: (sum wm5_vf) a08: (sum wm5_vf) a09: (sum wm5_vf) a10: (sum wm5_vf) a11: (sum wm5_vf) a12: (sum wm5_vf) a13: (sum wm5_vf) a14: (sum wm5_vf) a15: (sum wm5_vf) a16: (sum wm5_vf) a17: (sum wm5_vf) a18: (sum wm5_vf) a19: (sum wm5_vf) a20: (sum wm5_vf) a21: (sum wm5_vf) a22: (sum wm5_vf) a23: (sum wm5_vf) a24: (sum wm5_vf) a25: (sum wm5_vf) a26: (sum wm5_vf) a27: (sum wm5_vf) a28: (sum wm5_vf) a29: (sum wm5_vf) a30: (sum wm5_vf) a31: (sum wm5_vf) a32: (sum wm5_vf) a33: (sum wm5_vf) a34: (sum wm5_vf) a35: (sum wm5_vf) a36: (sum wm5_vf) a37: (sum wm5_vf) a38: (sum wm5_vf) a39: (sum wm5_vf) a40: (sum wm5_vf) a41: (sum wm5_vf) a42: (sum wm5_vf) a43: (sum wm5_vf) a44: (sum wm5_vf) a45: (sum wm5_vf) a46: (sum wm5_vf) a47: (sum wm5_vf) a48: (sum wm5_vf) a49: (sum wm5_vf) a50: (sum wm5_vf) a51: (sum wm5_vf) a52: (sum wm5_vf) a53: (sum wm5_vf) a54: (sum wm5_vf) a55: (sum wm5_vf) a56: (sum wm5_vf) a57: (sum wm5_vf) a58: (sum wm5_vf) a59: (sum wm5_vf) a60: (sum wm5_vf) a61: (sum wm5_vf) a62: (sum wm5_vf) a63: (sum wm5_vf) a64: (sum wm5_vf) a65: (sum wm5_vd) by: {gk: k}}))
+(at (meta wm5_r65) 'len) -- 66
+(at wm5_r65 'gk) -- [1 2]
+(at wm5_r65 'a01) -- [-2147483548 30]
+(at wm5_r65 'a02) -- [14 6]
+(at wm5_r65 'a64) -- [14 6]
+(at wm5_r65 'a65) -- [4.0 31.0]
+

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -800,6 +800,25 @@
 (set wm_re (select {from: wm_te sm: (sum (* a b)) by: ['k00 'k01 'k02 'k03 'k04 'k05 'k06 'k07 'k08 'k09 'k10 'k11 'k12 'k13 'k14 'k15 'k16]}))
 (at wm_re 'sm) -- [28 28]
 
+;; ── 1-key group with 17 total aggs, ONE of which is an expression-input
+;; agg (sum(a*b)) — the >16-AGG twin of the >16-KEY cell above.  v2 declines
+;; on the expr-input agg alone (agg_v2_can_handle decline i); v2-exprs also
+;; declines, but on ITS OWN n_aggs>16 gate (group.c ~6430, unrelated to the
+;; >8 width guard) since 17 > 16; the group then falls all the way to the
+;; `6744` nyi guard (n_keys>0 && n_aggs>8), now width-lifted, and is served
+;; by the legacy ht_path, which materializes sum(a*b) via the generic
+;; expr_compile/exec_node fallback (~group.c:7349-7376) — the same
+;; machinery that handles ANY agg input shape, not just OP_SCAN.
+;; k=[1 1 2 2] a=[2 3 4 5] b=[5 6 7 8] v=[10 20 30 40]: a*b=[10 18 28 40] ->
+;; group1(rows0,1) sum=28, group2(rows2,3) sum=68; sum(v) group1=30 group2=70. ──
+(set wm_tg (table [k a b v] (list [1 1 2 2] [2 3 4 5] [5 6 7 8] [10 20 30 40])))
+(set wm_rg (select {from: wm_tg a01: (sum (* a b)) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) a17: (sum v) by: {k: k}}))
+(at (meta wm_rg) 'len) -- 18
+(at wm_rg 'k) -- [1 2]
+(at wm_rg 'a01) -- [28 68]
+(at wm_rg 'a02) -- [30 70]
+(at wm_rg 'a17) -- [30 70]
+
 ;; ── 65-key group (F64 key forces legacy; 65 keys -> ceil(65/64)=2 null-mask
 ;; words) with nulls in key 0 (word 0) and key 64 (word 1) — proves per-key
 ;; null tracking PAST word 0.  k00 F64 [1.0 1.0 0Nf 1.0] (null at row 2);

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -864,3 +864,37 @@
 ;; pins only that the 9-key plain-STR shape is now SERVED (a table, no nyi). ──
 (set wm_ps (table [k0 k1 k2 k3 k4 k5 k6 k7 k8 v] (list ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] [10 20 30 40])))
 (at (meta (select {from: wm_ps s: (sum v) by: {k0: k0 k1: k1 k2: k2 k3: k3 k4: k4 k5: k5 k6: k6 k7: k7 k8: k8}})) 'len) -- 10
+
+;; ── 1 plain-STR key + N int keys, 70000 rows forcing the PARALLEL radix_v2
+;; path (>= RAY_PARALLEL_THRESHOLD = 64*1024 = 65536).  Review Critical:
+;; radix_v2_phase2_ctx_t's key_pool was left a fixed `const void* key_pool[8]`
+;; while every sibling ctx was widened to a carved `const void**`;
+;; derive_key_pool writes out[k] for ALL k < n_keys, so any_wide_key (the STR
+;; key) + >8 total keys overflows the [8] at exec_group_run's v2p2 setup
+;; (~9338).  Two cells pin the two failure modes (both ASan-verified pre-fix):
+;;   * 9 keys (1 STR + 8 int): out[8] lands on the adjacent _Atomic oom field
+;;     — an INTRA-struct overflow ASan cannot see; silent corruption boundary.
+;;   * 10 keys (1 STR + 9 int): out[9] crosses the struct end into the stack
+;;     redzone — ASan stack-buffer-overflow WRITE in derive_key_pool via
+;;     exec_group_run (verified crashing pre-fix, passing post-fix).
+;; Only 1 wide/STR key is used (k0) — a second wide key would hit the
+;; separate, pre-existing, cut-4-orthogonal eval-misroute bug noted above and
+;; is deliberately avoided here.  k0 STR cycles ["a" "b"] non-splayed (stays
+;; PLAIN, not RAY_IDX_DICT — dict conversion is a splayed-storage attribute);
+;; the int keys are all constant 0 so grouping is solely by k0 -> exactly 2
+;; groups.  v = til 70000.  Group "a" = even indices 0,2,..,69998: sum =
+;; 2*(0+1+..+34999) = 34999*35000 = 1224965000.  Group "b" = odd indices:
+;; sum(til 70000) - 1224965000 = 69999*70000/2 - 1224965000 =
+;; 2449965000 - 1224965000 = 1225000000. ──
+(set wm_wk (take ["a" "b"] 70000))
+(set wm_wz (take [0] 70000))
+(set wm_wt (table [k0 k1 k2 k3 k4 k5 k6 k7 k8 v] (list wm_wk wm_wz wm_wz wm_wz wm_wz wm_wz wm_wz wm_wz wm_wz (til 70000))))
+(set wm_wr (select {from: wm_wt sm: (sum v) by: {k0: k0 k1: k1 k2: k2 k3: k3 k4: k4 k5: k5 k6: k6 k7: k7 k8: k8}}))
+(at wm_wr 'k0) -- ["a" "b"]
+(at wm_wr 'sm) -- [1224965000 1225000000]
+
+;; 10-key variant: the ASan-visible redzone crossing (crashed pre-fix).
+(set wm_xt (table [k0 k1 k2 k3 k4 k5 k6 k7 k8 k9 v] (list wm_wk wm_wz wm_wz wm_wz wm_wz wm_wz wm_wz wm_wz wm_wz wm_wz (til 70000))))
+(set wm_xr (select {from: wm_xt sm: (sum v) by: {k0: k0 k1: k1 k2: k2 k3: k3 k4: k4 k5: k5 k6: k6 k7: k7 k8: k8 k9: k9}}))
+(at wm_xr 'k0) -- ["a" "b"]
+(at wm_xr 'sm) -- [1224965000 1225000000]

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -742,3 +742,125 @@
 (count (at rd300 'k299)) -- 2
 (at rd300 'k000) -- [1 1]
 (at rd300 'k299) -- [1 2]
+
+;; ══════════════════════════════════════════════════════════════════
+;; cut-4: LEGACY group path serves ANY key/agg count — width guards retired
+;; The exec_group_run width guard (n_keys>8 || (n_keys>0 && n_aggs>8)), the
+;; ht_path keyless n_aggs>8 guard, the exec_group dict-STR wrapper n_keys>8
+;; bail, and the exec_group_v2_exprs >16 caps are all removed.  Every entry-
+;; staging buffer on the legacy path is layout-sized (stack when it fits, one
+;; per-call/per-worker heap block when wider); per-key null tracking uses
+;; ceil(n_keys/64) mask words.  These shapes all `nyi`d before this cut.
+;; ══════════════════════════════════════════════════════════════════
+
+;; ── 9-key group with an F64 key (v2-ineligible: F64 keys decline the v2
+;; engine, forcing the legacy ght path) + sum agg.  k0 is F64 [1.0 1.0 2.0 2.0],
+;; k1..k8 int, all rows share the group discriminator so there are exactly 2
+;; groups: (1.0,...) over rows 0,1 -> sum 10+20=30; (2.0,...) over rows 2,3 ->
+;; sum 30+40=70.  Exercises the 9-key legacy scatter (key_region 80 > the old
+;; 8-key stack; group_ht wide-table spill carve at n_keys>8). ──
+(set wm_f9 (table [k0 k1 k2 k3 k4 k5 k6 k7 k8 v] (list [1.0 1.0 2.0 2.0] [1 1 2 2] [1 1 2 2] [1 1 2 2] [1 1 2 2] [1 1 2 2] [1 1 2 2] [1 1 2 2] [1 1 2 2] [10 20 30 40])))
+(set wm_rf9 (select {from: wm_f9 s: (sum v) by: {k0: k0 k1: k1 k2: k2 k3: k3 k4: k4 k5: k5 k6: k6 k7: k7 k8: k8}}))
+(at wm_rf9 'k0) -- [1.0 2.0]
+(at wm_rf9 's) -- [30 70]
+
+;; ── 2-key group with 9 aggs including FIRST and LAST (both v2-ineligible —
+;; not in the agg_resolve registry — so the whole group drops to legacy, and
+;; n_aggs>8 with n_keys>0 was the second guard clause).  Fixture k=[1 1 2 2]
+;; g=[5 5 6 6] v=[10 20 30 40]: group (1,5) rows 0,1; group (2,6) rows 2,3.
+;; first v = first row's v per group = [10 30]; last v = [20 40];
+;; sum=[30 70] count=[2 2] min=[10 30] max=[20 40] avg=[15.0 35.0]. ──
+(set wm_fl (table [k g v] (list [1 1 2 2] [5 5 6 6] [10 20 30 40])))
+(set wm_rfl (select {from: wm_fl a1: (sum v) a2: (count v) a3: (min v) a4: (max v) a5: (avg v) a6: (sum v) a7: (min v) a8: (first v) a9: (last v) by: {k: k g: g}}))
+(at (meta wm_rfl) 'len) -- 11
+(at wm_rfl 'a8) -- [10 30]
+(at wm_rfl 'a9) -- [20 40]
+(at wm_rfl 'a1) -- [30 70]
+(at wm_rfl 'a5) -- [15.0 35.0]
+
+;; ── keyless group with pearson_corr + 8 other aggs (9 total).  Keyless groups
+;; always decline v2; a PEARSON_CORR agg sets sc_has_binary so the scalar
+;; fast path is skipped and it lands on ht_path, whose n_aggs>8 guard is now
+;; retired.  x=[1..5] y=[2 4 6 8 10]=2x: pearson=1.0 (perfect positive);
+;; sum(x)=15 min(x)=1 max(x)=5 count(x)=5 sum(y)=30 min(y)=2 max(y)=10 avg(y)=6.0 ──
+(set wm_tp (table [x y] (list [1.0 2.0 3.0 4.0 5.0] [2.0 4.0 6.0 8.0 10.0])))
+(set wm_rp (select {from: wm_tp c: (pearson_corr x y) a1: (sum x) a2: (min x) a3: (max x) a4: (count x) a5: (sum y) a6: (min y) a7: (max y) a8: (avg y)}))
+(at (meta wm_rp) 'len) -- 9
+(at wm_rp 'c) -- [1.0]
+(at wm_rp 'a1) -- [15.0]
+(at wm_rp 'a5) -- [30.0]
+(at wm_rp 'a8) -- [6.0]
+
+;; ── 17-key group with an expression-input agg (sum(a*b)).  The expression
+;; input routes to exec_group_v2_exprs, whose n_keys>16 cap is retired (its
+;; [16] scratch is now VLA-sized).  17 identical key columns [1 1 2] -> 2
+;; groups (rows 0,1 key 1; row 2 key 2).  a=[2 3 4] b=[5 6 7] a*b=[10 18 28]:
+;; group1 (rows 0,1) sum=10+18=28; group2 (row 2) sum=28.  So sm=[28 28]. ──
+(set wm_te (table [k00 k01 k02 k03 k04 k05 k06 k07 k08 k09 k10 k11 k12 k13 k14 k15 k16 a b] (list [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [1 1 2] [2 3 4] [5 6 7])))
+(set wm_re (select {from: wm_te sm: (sum (* a b)) by: ['k00 'k01 'k02 'k03 'k04 'k05 'k06 'k07 'k08 'k09 'k10 'k11 'k12 'k13 'k14 'k15 'k16]}))
+(at wm_re 'sm) -- [28 28]
+
+;; ── 65-key group (F64 key forces legacy; 65 keys -> ceil(65/64)=2 null-mask
+;; words) with nulls in key 0 (word 0) and key 64 (word 1) — proves per-key
+;; null tracking PAST word 0.  k00 F64 [1.0 1.0 0Nf 1.0] (null at row 2);
+;; k01..k63 all 0; k64 int [0 0N 0 0] (null at row 1); v=[10 20 30 40].
+;; Tuples: row0=(1.0, 0*63, 0); row1=(1.0, 0*63, NULL@k64); row2=(NULL@k00,
+;; 0*63, 0); row3==row0.  Distinct groups: {0,3}, {1}, {2} = 3.  If the
+;; word-1 null bit for k64 were dropped, row1 would merge into row0 -> 2
+;; groups; the k00 null (word 0) splits row2.  count==3 pins both null words;
+;; sum over all group sums = 10+40 + 20 + 30 = 100 (every row counted once). ──
+(set wm_t65 (table [k00 k01 k02 k03 k04 k05 k06 k07 k08 k09 k10 k11 k12 k13 k14 k15 k16 k17 k18 k19 k20 k21 k22 k23 k24 k25 k26 k27 k28 k29 k30 k31 k32 k33 k34 k35 k36 k37 k38 k39 k40 k41 k42 k43 k44 k45 k46 k47 k48 k49 k50 k51 k52 k53 k54 k55 k56 k57 k58 k59 k60 k61 k62 k63 k64 v] (concat (list [1.0 1.0 0Nf 1.0]) (concat (take (list [0 0 0 0]) 63) (list [0 0N 0 0] [10 20 30 40])))))
+(set wm_r65 (select {from: wm_t65 s: (sum v) by: ['k00 'k01 'k02 'k03 'k04 'k05 'k06 'k07 'k08 'k09 'k10 'k11 'k12 'k13 'k14 'k15 'k16 'k17 'k18 'k19 'k20 'k21 'k22 'k23 'k24 'k25 'k26 'k27 'k28 'k29 'k30 'k31 'k32 'k33 'k34 'k35 'k36 'k37 'k38 'k39 'k40 'k41 'k42 'k43 'k44 'k45 'k46 'k47 'k48 'k49 'k50 'k51 'k52 'k53 'k54 'k55 'k56 'k57 'k58 'k59 'k60 'k61 'k62 'k63 'k64]}))
+(count (at wm_r65 'k00)) -- 3
+(sum (at wm_r65 's)) -- 100
+
+;; ── 256-key sentinel on the legacy path (F64 key k000 forces legacy;
+;; k001..k254 constant int; k255 the discriminator [1 2]).  256 keys -> 4
+;; null-mask words, and key index 255 exercises the k&63==63 shift bits (now
+;; unsigned-safe).  The two rows differ ONLY in k255, so there are 2 groups;
+;; a mod-256 truncation of the key count (256 -> 0) would collapse both rows
+;; into one and drop k255 -> count 1.  count==2, s=[10 30], k255=[1 2]. ──
+(set wm_t256 (table [k000 k001 k002 k003 k004 k005 k006 k007 k008 k009 k010 k011 k012 k013 k014 k015 k016 k017 k018 k019 k020 k021 k022 k023 k024 k025 k026 k027 k028 k029 k030 k031 k032 k033 k034 k035 k036 k037 k038 k039 k040 k041 k042 k043 k044 k045 k046 k047 k048 k049 k050 k051 k052 k053 k054 k055 k056 k057 k058 k059 k060 k061 k062 k063 k064 k065 k066 k067 k068 k069 k070 k071 k072 k073 k074 k075 k076 k077 k078 k079 k080 k081 k082 k083 k084 k085 k086 k087 k088 k089 k090 k091 k092 k093 k094 k095 k096 k097 k098 k099 k100 k101 k102 k103 k104 k105 k106 k107 k108 k109 k110 k111 k112 k113 k114 k115 k116 k117 k118 k119 k120 k121 k122 k123 k124 k125 k126 k127 k128 k129 k130 k131 k132 k133 k134 k135 k136 k137 k138 k139 k140 k141 k142 k143 k144 k145 k146 k147 k148 k149 k150 k151 k152 k153 k154 k155 k156 k157 k158 k159 k160 k161 k162 k163 k164 k165 k166 k167 k168 k169 k170 k171 k172 k173 k174 k175 k176 k177 k178 k179 k180 k181 k182 k183 k184 k185 k186 k187 k188 k189 k190 k191 k192 k193 k194 k195 k196 k197 k198 k199 k200 k201 k202 k203 k204 k205 k206 k207 k208 k209 k210 k211 k212 k213 k214 k215 k216 k217 k218 k219 k220 k221 k222 k223 k224 k225 k226 k227 k228 k229 k230 k231 k232 k233 k234 k235 k236 k237 k238 k239 k240 k241 k242 k243 k244 k245 k246 k247 k248 k249 k250 k251 k252 k253 k254 k255 v] (concat (list [1.0 1.0]) (concat (take (list [1 1]) 254) (list [1 2] [10 30])))))
+(set wm_r256 (select {from: wm_t256 s: (sum v) by: ['k000 'k001 'k002 'k003 'k004 'k005 'k006 'k007 'k008 'k009 'k010 'k011 'k012 'k013 'k014 'k015 'k016 'k017 'k018 'k019 'k020 'k021 'k022 'k023 'k024 'k025 'k026 'k027 'k028 'k029 'k030 'k031 'k032 'k033 'k034 'k035 'k036 'k037 'k038 'k039 'k040 'k041 'k042 'k043 'k044 'k045 'k046 'k047 'k048 'k049 'k050 'k051 'k052 'k053 'k054 'k055 'k056 'k057 'k058 'k059 'k060 'k061 'k062 'k063 'k064 'k065 'k066 'k067 'k068 'k069 'k070 'k071 'k072 'k073 'k074 'k075 'k076 'k077 'k078 'k079 'k080 'k081 'k082 'k083 'k084 'k085 'k086 'k087 'k088 'k089 'k090 'k091 'k092 'k093 'k094 'k095 'k096 'k097 'k098 'k099 'k100 'k101 'k102 'k103 'k104 'k105 'k106 'k107 'k108 'k109 'k110 'k111 'k112 'k113 'k114 'k115 'k116 'k117 'k118 'k119 'k120 'k121 'k122 'k123 'k124 'k125 'k126 'k127 'k128 'k129 'k130 'k131 'k132 'k133 'k134 'k135 'k136 'k137 'k138 'k139 'k140 'k141 'k142 'k143 'k144 'k145 'k146 'k147 'k148 'k149 'k150 'k151 'k152 'k153 'k154 'k155 'k156 'k157 'k158 'k159 'k160 'k161 'k162 'k163 'k164 'k165 'k166 'k167 'k168 'k169 'k170 'k171 'k172 'k173 'k174 'k175 'k176 'k177 'k178 'k179 'k180 'k181 'k182 'k183 'k184 'k185 'k186 'k187 'k188 'k189 'k190 'k191 'k192 'k193 'k194 'k195 'k196 'k197 'k198 'k199 'k200 'k201 'k202 'k203 'k204 'k205 'k206 'k207 'k208 'k209 'k210 'k211 'k212 'k213 'k214 'k215 'k216 'k217 'k218 'k219 'k220 'k221 'k222 'k223 'k224 'k225 'k226 'k227 'k228 'k229 'k230 'k231 'k232 'k233 'k234 'k235 'k236 'k237 'k238 'k239 'k240 'k241 'k242 'k243 'k244 'k245 'k246 'k247 'k248 'k249 'k250 'k251 'k252 'k253 'k254 'k255]}))
+(count (at wm_r256 'k255)) -- 2
+(at wm_r256 's) -- [10 30]
+(at wm_r256 'k255) -- [1 2]
+
+;; ── 9-key group with a group emit-filter (desc/take) — v2 and v2-exprs are
+;; both skipped when a group emit-filter is armed, so this stays on the legacy
+;; ght path, which the width-guard lift now serves at 9 keys.  F64 k0 gives 3
+;; groups (k0=1.0 sum 30, k0=2.0 sum 70, k0=3.0 sum 50); desc: s take: 2 keeps
+;; the two largest sums -> [70 50]. ──
+(set wm_tf (table [k0 k1 k2 k3 k4 k5 k6 k7 k8 v] (list [1.0 1.0 2.0 2.0 3.0] [1 1 2 2 3] [1 1 2 2 3] [1 1 2 2 3] [1 1 2 2 3] [1 1 2 2 3] [1 1 2 2 3] [1 1 2 2 3] [1 1 2 2 3] [10 20 30 40 50])))
+(set wm_ref (select {from: wm_tf s: (sum v) by: {k0: k0 k1: k1 k2: k2 k3: k3 k4: k4 k5: k5 k6: k6 k7: k7 k8: k8} desc: s take: 2}))
+(count (at wm_ref 's)) -- 2
+(at wm_ref 's) -- [70 50]
+
+;; ── 9-key DICT-STR group (the exec_group wrapper shape; n_keys>8 bail
+;; retired).  Splayed STR columns >= 65536 rows carry a RAY_IDX_DICT, so the
+;; wrapper substitutes each key's int32 code vector and the rewritten integer
+;; group is served by v2 at 9 keys.  s = repeated ["a" "b"] over 70000 rows:
+;; even rows "a", odd rows "b"; v = til 70000.  Group "a" = even indices
+;; 0,2,..,69998: sum = 2*(0+1+..+34999) = 34999*35000 = 1224965000.
+;; Group "b" = odd indices: sum(til 70000) - 1224965000 = 2449965000 -
+;; 1224965000 = 1225000000.  Dict codes "a"->0 "b"->1 so groups emit [a b]. ──
+(set wm_ds (take ["a" "b"] 70000))
+(set wm_dt (table [k0 k1 k2 k3 k4 k5 k6 k7 k8 v] (list wm_ds wm_ds wm_ds wm_ds wm_ds wm_ds wm_ds wm_ds wm_ds (til 70000))))
+(.db.splayed.set "/tmp/rfl_wm_dict9/t/" wm_dt)
+(set wm_dg (.db.splayed.get "/tmp/rfl_wm_dict9/t/"))
+(set wm_rd (select {from: wm_dg sm: (sum v) by: {k0: k0 k1: k1 k2: k2 k3: k3 k4: k4 k5: k5 k6: k6 k7: k7 k8: k8}}))
+(at wm_rd 'k0) -- ["a" "b"]
+(at wm_rd 'sm) -- [1224965000 1225000000]
+
+;; ── 9-key PLAIN-STR (non-dict) group: the width-guard lift means this shape
+;; no longer `nyi`s and the legacy ght inline-STR scatter groups it correctly
+;; (verified: identical key tuples hash-collide and merge in group_ht).  It is
+;; NOT asserted for grouped VALUES here because a PRE-EXISTING, cut-4-orthogonal
+;; bug in the query-layer routing sends any select with >=2 STR/wide key
+;; columns AND >=3 total keys to an eval path that fails to merge groups
+;; (repro: 2 STR + 1 int keys returns one group per row; 1 STR + 2 int keys is
+;; correct — reproduces on master, independent of the >8 width guards).  The
+;; correct STR-key width path is covered by the dict-STR cell above; this cell
+;; pins only that the 9-key plain-STR shape is now SERVED (a table, no nyi). ──
+(set wm_ps (table [k0 k1 k2 k3 k4 k5 k6 k7 k8 v] (list ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] ["a" "a" "b" "b"] [10 20 30 40])))
+(at (meta (select {from: wm_ps s: (sum v) by: {k0: k0 k1: k1 k2: k2 k3: k3 k4: k4 k5: k5 k6: k6 k7: k7 k8: k8}})) 'len) -- 10

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -800,24 +800,50 @@
 (set wm_re (select {from: wm_te sm: (sum (* a b)) by: ['k00 'k01 'k02 'k03 'k04 'k05 'k06 'k07 'k08 'k09 'k10 'k11 'k12 'k13 'k14 'k15 'k16]}))
 (at wm_re 'sm) -- [28 28]
 
-;; ── 1-key group with 17 total aggs, ONE of which is an expression-input
-;; agg (sum(a*b)) — the >16-AGG twin of the >16-KEY cell above.  v2 declines
-;; on the expr-input agg alone (agg_v2_can_handle decline i); v2-exprs also
-;; declines, but on ITS OWN n_aggs>16 gate (group.c ~6430, unrelated to the
-;; >8 width guard) since 17 > 16; the group then falls all the way to the
-;; `6744` nyi guard (n_keys>0 && n_aggs>8), now width-lifted, and is served
-;; by the legacy ht_path, which materializes sum(a*b) via the generic
-;; expr_compile/exec_node fallback (~group.c:7349-7376) — the same
-;; machinery that handles ANY agg input shape, not just OP_SCAN.
-;; k=[1 1 2 2] a=[2 3 4 5] b=[5 6 7 8] v=[10 20 30 40]: a*b=[10 18 28 40] ->
-;; group1(rows0,1) sum=28, group2(rows2,3) sum=68; sum(v) group1=30 group2=70. ──
-(set wm_tg (table [k a b v] (list [1 1 2 2] [2 3 4 5] [5 6 7 8] [10 20 30 40])))
-(set wm_rg (select {from: wm_tg a01: (sum (* a b)) a02: (sum v) a03: (sum v) a04: (sum v) a05: (sum v) a06: (sum v) a07: (sum v) a08: (sum v) a09: (sum v) a10: (sum v) a11: (sum v) a12: (sum v) a13: (sum v) a14: (sum v) a15: (sum v) a16: (sum v) a17: (sum v) by: {k: k}}))
+;; ── 1-key group with 17 total aggs, mixing an expression-input agg
+;; (sum(a*b)) with a v2-ineligible agg (first(v)) — genuinely legacy-routed,
+;; unlike the naive "sum(a*b) + 16 plain sums" shape this cell used to test.
+;; That all-SUM shape was checked by runtime trace (temporary fprintf at
+;; exec_group_v2_exprs's success return + at the `da_path:`/`ht_path:` labels
+;; in exec_group_run, group.c, debug rebuild, removed after) and turned out
+;; to be served by v2 end to end, NOT legacy: v2 declines directly on the
+;; expr-input agg (agg_v2_can_handle requires OP_SCAN inputs), but
+;; exec_group_v2_exprs materializes a*b into a synthetic `_e0` column and
+;; rebuilds a shadow GROUP node of 17 plain-scan SUMs — every one of which
+;; `agg_resolve` supports — so its own agg_v2_can_handle(op2, sub) admits it
+;; and v2 runs the shadow.  The stale comment claiming "legacy ht_path" here
+;; was false on this branch (the v2-exprs >16-agg cap it cited was already
+;; retired, group.c ~6892).
+;;
+;; Adding first(v) — OP_FIRST is not in agg_resolve at all, so no scan-input
+;; shape admits it — forces BOTH declines: the direct v2 check now fails on
+;; two counts, and the shadow node's own agg_v2_can_handle(op2, sub) fails
+;; too (the FIRST persists into the shadow unchanged), so v2-exprs returns
+;; NULL and exec_group_run falls through to its post-v2 body.  Making v
+;; (first's input) STR — a wide element type — additionally disqualifies the
+;; DA direct-index fast path (group.c ~7910: wide-type FIRST/LAST forces the
+;; HT row-layout, which tracks the winning min/max ROW INDEX instead of
+;; truncating to a byte) so the shape reaches ht_path specifically, not just
+;; "legacy" generically — confirmed by the same trace technique (`ht_path:`
+;; fired; `da_path:` also fired first since da_eligible is only cleared
+;; partway through that block, but da_fits ends up false and control falls
+;; through to ht_path, which returns the result).
+;; FIRST is defined by original ROW INDEX, not iteration/thread order (the HT
+;; and DA paths both track first_row/last_row per group and keep the
+;; smallest/largest index across per-worker merges — group.c ~8283-8325), so
+;; first(v) is deterministic here regardless of scheduling: k=[1 1 2 2] means
+;; group1 = rows 0,1 (first row 0), group2 = rows 2,3 (first row 2).
+;; a=[2 3 4 5] b=[5 6 7 8] w=[10 20 30 40]: a*b=[10 18 28 40] ->
+;; group1(rows0,1) sum=28, group2(rows2,3) sum=68; sum(w) group1=30 group2=70;
+;; v=["p" "q" "r" "s"]: first(v) group1="p" (row0), group2="r" (row2). ──
+(set wm_tg (table [k a b v w] (list [1 1 2 2] [2 3 4 5] [5 6 7 8] ["p" "q" "r" "s"] [10 20 30 40])))
+(set wm_rg (select {from: wm_tg a01: (sum (* a b)) f01: (first v) a02: (sum w) a03: (sum w) a04: (sum w) a05: (sum w) a06: (sum w) a07: (sum w) a08: (sum w) a09: (sum w) a10: (sum w) a11: (sum w) a12: (sum w) a13: (sum w) a14: (sum w) a15: (sum w) a16: (sum w) by: {k: k}}))
 (at (meta wm_rg) 'len) -- 18
 (at wm_rg 'k) -- [1 2]
 (at wm_rg 'a01) -- [28 68]
+(at wm_rg 'f01) -- ["p" "r"]
 (at wm_rg 'a02) -- [30 70]
-(at wm_rg 'a17) -- [30 70]
+(at wm_rg 'a16) -- [30 70]
 
 ;; ── 65-key group (F64 key forces legacy; 65 keys -> ceil(65/64)=2 null-mask
 ;; words) with nulls in key 0 (word 0) and key 64 (word 1) — proves per-key
@@ -1039,4 +1065,22 @@
 (at wm5_r65 'a02) -- [14 6]
 (at wm5_r65 'a64) -- [14 6]
 (at wm5_r65 'a65) -- [4.0 31.0]
+
+;; ── keyless, EMPTY table (0 rows), 9 total aggs — n_keys==0 so the DA
+;; path's `n_keys > 0` gate excludes it outright and the scalar fast path's
+;; own `nrows > 0` guard (group.c ~7503, the same guard the `wm_tp`
+;; PEARSON_CORR cell above skips via `sc_has_binary` instead) also excludes
+;; it here since nrows==0 — both routes decline for the SAME reason nrows
+;; gives them nothing to scan, landing on ht_path unconditionally, same as
+;; every other keyless shape in this file. Verified today's deterministic
+;; behavior is a 9-column, 0-ROW result (not a 1-row all-null/zero scalar
+;; row) — identical in shape to the always-legal 2-agg keyless-empty case,
+;; just wider; a mix of SUM/COUNT/MIN/MAX/AVG confirms the shape holds
+;; across agg kinds, not just one. ──
+(set wm_e0 (table [x] (list (take [1] 0))))
+(count (at wm_e0 'x)) -- 0
+(set wm_e0_r9 (select {from: wm_e0 a01: (sum x) a02: (count x) a03: (min x) a04: (max x) a05: (avg x) a06: (sum x) a07: (min x) a08: (max x) a09: (count x)}))
+(at (meta wm_e0_r9) 'len) -- 9
+(count (at wm_e0_r9 'a01)) -- 0
+(count (at wm_e0_r9 'a09)) -- 0
 

--- a/test/rfl/table/tblop_branch_cov.rfl
+++ b/test/rfl/table/tblop_branch_cov.rfl
@@ -9,7 +9,8 @@
 ;;
 ;; Reachable branches targeted:
 ;;   L85   — ray_is_vec(index_arg) true (SYM vec index arg, lambda agg)
-;;   L87   — len > 7 index columns guard (honest cut-3 bound, was 16)
+;;   (was L87: len > 7 index columns guard — REMOVED, task 6; pivot's
+;;    index-column count is unbounded now.  See Section 8/8c below.)
 ;;   L124  — STR index column forces dag_ok=false (tested via !- nyi)
 ;;   L253  — gid_cap while-loop for large n_grps
 ;;   L265  — hash collision during grouped-HT insert
@@ -150,41 +151,58 @@
 (at (at Pmk_fb 'q) 1) -- 20
 
 ;; ══════════════════════════════════════════════════════════════════
-;; Section 8: pivot index-column cap → L119 ("too many index columns"
-;;            error)
+;; Section 8: pivot index-column cap LIFTED (task 6, ght rework complete)
 ;;
-;;            Cut-3 honesty fix: the cap is now 7 (not 16) — pivot's
-;;            true structural bound is exec_pivot's ght layout, which
-;;            groups (index_cols + pivot_col) through a fixed [8]-slot
-;;            key array (pivot.c: n_keys = n_idx + 1 > 8 -> error).
-;;            Lifting tblop.c's caller-side check alone used to just
-;;            move the error from tblop.c to pivot.c at 17 index cols;
-;;            now both layers agree at 7.  (Full lift to unbounded
-;;            index columns is deferred to the cut-4 ght rework.)
+;;            Both the honest cut-3 boundary (7 index columns, tblop.c's
+;;            caller-side check) and exec_pivot's own n_keys > 8 gate are
+;;            gone: index_vecs/idx_wide/key_data/key_types/key_attrs/
+;;            key_vecs (pivot.c) and idx_syms/icols/idx_ops/key_ops/g_icols
+;;            (tblop.c) are all exact-size carves now, and
+;;            ght_compute_layout spills to an owned heap block whenever
+;;            n_keys exceeds its GHT_INLINE (8) inline capacity — the same
+;;            mechanism group.c's exec_group_run already relies on.  The
+;;            8- and 17-index cells that used to `!- limit` under the old
+;;            (and, before that, the even-older 16-column) cap now FLIP to
+;;            SUCCESS with hand-derived oracles: one shared 8-/17-tuple
+;;            index key across two rows differing only in (pv, val), so
+;;            exec_pivot groups them into a single index row with two
+;;            distinct pivot-value columns — no row-order ambiguity.
 ;; ══════════════════════════════════════════════════════════════════
 
-;; Any table with enough named columns would work; the error fires during
-;; index-arg parsing (a length check) before the table is examined, so the
-;; index list may repeat names freely.
-(set T17 (table [a b c pv val] (list [1] [1] [1] ['x] [42])))
+;; 8 index columns -> n_keys = 9, one past the historical [8]-slot inline
+;; capacity -> first shape that must exercise the ght layout's heap SPILL
+;; (ght_compute_layout / ly.spill_hdr), not just the inline fast path.
+(set T8 (table [j1 j2 j3 j4 j5 j6 j7 j8 pv val] (list [1 1] [2 2] [3 3] [4 4] [5 5] [6 6] [7 7] [8 8] ['x 'y] [10 20])))
+(set P8 (pivot T8 ['j1 'j2 'j3 'j4 'j5 'j6 'j7 'j8] 'pv 'val sum))
+(count P8) -- 1
+(count (key P8)) -- 10
+(at (at P8 'j1) 0) -- 1
+(at (at P8 'j8) 0) -- 8
+(at (at P8 'x) 0) -- 10
+(at (at P8 'y) 0) -- 20
 
-;; 8 index columns -> one past the honest bound -> !- limit (was previously
-;; accepted under the old, dishonest 16-column cap; pins the new boundary).
-(pivot T17 (list 'a 'b 'c 'a 'b 'c 'a 'b) 'pv 'val sum) !- limit
-
-;; 17 index columns -> still over the bound either way (regression pin: the
-;; pre-existing assertion below must keep passing under the new cap, same
-;; error tag, just a different exact-max reason).
-(pivot T17 (list 'a 'b 'c 'a 'b 'c 'a 'b 'c 'a 'b 'c 'a 'b 'c 'a 'b) 'pv 'val sum) !- limit
+;; 17 index columns -> n_keys = 18, well past the old 16-column AND 7-column
+;; caps alike (regression pin: both historical limits are gone, not just
+;; moved to a new number).
+(set T17w (table [m1 m2 m3 m4 m5 m6 m7 m8 m9 m10 m11 m12 m13 m14 m15 m16 m17 pv val] (list [1 1] [2 2] [3 3] [4 4] [5 5] [6 6] [7 7] [8 8] [9 9] [10 10] [11 11] [12 12] [13 13] [14 14] [15 15] [16 16] [17 17] ['x 'y] [10 20])))
+(set P17 (pivot T17w ['m1 'm2 'm3 'm4 'm5 'm6 'm7 'm8 'm9 'm10 'm11 'm12 'm13 'm14 'm15 'm16 'm17] 'pv 'val sum))
+(count P17) -- 1
+(count (key P17)) -- 19
+(at (at P17 'm1) 0) -- 1
+(at (at P17 'm17) 0) -- 17
+(at (at P17 'x) 0) -- 10
+(at (at P17 'y) 0) -- 20
 
 ;; ══════════════════════════════════════════════════════════════════
-;; Section 8b: pivot at exactly 7 index columns -> SUCCESS (the honest
-;;             bound is inclusive: n_idx = 7 -> n_keys = n_idx + 1 = 8,
-;;             which is exactly the ght layout's [8]-slot capacity, not
-;;             one past it).  Exercises the DAG fast path (sum is a known
-;;             agg builtin, all columns are non-STR) straight into
-;;             exec_pivot, i.e. the exact pivot.c code this task widened
-;;             (pvt_null_bit/idx_null_bits/the 1<<k null-mask read).
+;; Section 8b: pivot at exactly 7 index columns -> SUCCESS (small-index
+;;             boundary companion to the 8-/17-index cells above: n_idx =
+;;             7 -> n_keys = 8 is exactly the historical [8]-slot INLINE
+;;             capacity, not the heap-spill path 8b's neighbors exercise).
+;;             Exercises the DAG fast path (sum is a known agg builtin,
+;;             all columns are non-STR) straight into exec_pivot, i.e.
+;;             the exact pivot.c code this task widened
+;;             (pvt_null_bit / the null-word read / the 1<<k null-mask
+;;             read, all now word-indexed).
 ;;
 ;;             Oracle derivation: both rows share the same 7-tuple index
 ;;             key (1,2,3,4,5,6,7), so exec_pivot groups them into a
@@ -204,6 +222,51 @@
 (at (at P7 'k7) 0) -- 7
 (at (at P7 'x) 0) -- 10
 (at (at P7 'y) 0) -- 20
+
+;; ══════════════════════════════════════════════════════════════════
+;; Section 8c: 65-index pivot — the REQUIRED null-word conflation detector
+;;             (Task-3 review carryover, binding for this task).  Before
+;;             this task, pivot's ix-dedupe entry stored/compared/hashed
+;;             ONE int64 null word (word 0, bits 0-63) no matter how many
+;;             keys existed — pvt_null_bit/idx_null_bits were UB past
+;;             n_idx>=64 (1<<n_idx with n_idx>=64) and the entry's null
+;;             region could never see bit 64+ at all.  65 index columns
+;;             (k00..k64) -> n_keys = 66 -> ceil(66/64) = 2 null-mask
+;;             words: word 0 covers index keys 0-63, word 1 covers index
+;;             key 64 (bit 64) and the pivot key itself (bit 65).
+;;
+;;             Fixture: k00 = NULL for BOTH rows (so word 0's null bit
+;;             pattern is IDENTICAL between the two rows: bit 0 set,
+;;             bits 1-63 clear in both, since k01..k63 = 0 for both).
+;;             k64 differs: row A = 0 (not null), row B = 0N (null) — the
+;;             ONLY difference lives in word 1.  Both rows share pv='x
+;;             (not null, so neither is dropped by the pivot-null check)
+;;             with distinct val 10/20.  A word-0-only implementation
+;;             would see identical dedupe keys for A and B (word 0 ties,
+;;             word 1 never compared) and wrongly conflate them into ONE
+;;             index row; the fixed, word-indexed implementation must
+;;             keep them as TWO distinct index rows.
+;; ══════════════════════════════════════════════════════════════════
+
+(set T65 (table [k00 k01 k02 k03 k04 k05 k06 k07 k08 k09 k10 k11 k12 k13 k14 k15 k16 k17 k18 k19 k20 k21 k22 k23 k24 k25 k26 k27 k28 k29 k30 k31 k32 k33 k34 k35 k36 k37 k38 k39 k40 k41 k42 k43 k44 k45 k46 k47 k48 k49 k50 k51 k52 k53 k54 k55 k56 k57 k58 k59 k60 k61 k62 k63 k64 pv val] (concat (list [0N 0N]) (concat (take (list [0 0]) 63) (list [0 0N] ['x 'x] [10 20])))))
+(set P65 (pivot T65 ['k00 'k01 'k02 'k03 'k04 'k05 'k06 'k07 'k08 'k09 'k10 'k11 'k12 'k13 'k14 'k15 'k16 'k17 'k18 'k19 'k20 'k21 'k22 'k23 'k24 'k25 'k26 'k27 'k28 'k29 'k30 'k31 'k32 'k33 'k34 'k35 'k36 'k37 'k38 'k39 'k40 'k41 'k42 'k43 'k44 'k45 'k46 'k47 'k48 'k49 'k50 'k51 'k52 'k53 'k54 'k55 'k56 'k57 'k58 'k59 'k60 'k61 'k62 'k63 'k64] 'pv 'val sum))
+
+;; The conflation detector: count==2 proves A and B stayed DISTINCT index
+;; rows (a word-0-only dedupe would collapse both into one, count==1).
+(count P65) -- 2
+(count (key P65)) -- 66
+;; Both source rows contribute (no data loss / silent drop): 10+20 = 30,
+;; order-independent (single pivot value 'x', so this is a straight sum
+;; over the two output rows).
+(sum (at P65 'x)) -- 30
+;; k00 reads back NULL on both output rows (word-0 null bit correctly
+;; propagated to the emitted index column, order-independent).
+(sum (map nil? (at P65 'k00))) -- 2
+;; k64 reads back NULL on EXACTLY ONE output row — the word-1 null bit
+;; correctly isolated to the row that carried it (order-independent: if
+;; the emit read were still word-0-only, k64 would never read null at
+;; all, giving 0 here instead of 1).
+(sum (map nil? (at P65 'k64))) -- 1
 
 ;; ══════════════════════════════════════════════════════════════════
 ;; Section 9: Larger pivot to exercise HT probe walks past non-matching

--- a/test/rfl/table/tblop_branch_cov.rfl
+++ b/test/rfl/table/tblop_branch_cov.rfl
@@ -552,6 +552,56 @@ Lset -- (list 'a 'b 'Z 'd)
 (at (at Pf64v 'y) 1) -- 4.5
 
 ;; ══════════════════════════════════════════════════════════════════
+;; Section 29: pivot — USER-LENGTH index arg no longer a stack VLA
+;;             (rayforce-audit finding, unbounded-slots cut 4).  n_idx =
+;;             ray_len(index_arg) is a RUNTIME value the caller controls
+;;             directly (index_arg is just a vector of column-name syms —
+;;             nothing requires it to be short, or even to name distinct
+;;             columns).  Before this fix, tblop.c's idx_syms/icols/
+;;             idx_ops/key_ops/g_icols and pivot.c's idx_vecs/idx_wide/
+;;             key_data/key_types/key_attrs/key_vecs were STACK VLAs sized
+;;             by n_idx.  Confirmed (pre-fix, via git stash, default 8 MiB
+;;             ulimit -s): 8200 copies of the valid column sym 'k SIGSEGV'd
+;;             with the fault inside ray_pivot_op's `index_cols[i]->id`
+;;             read (graph.c) — idx_ops, the STACK VLA holding those
+;;             pointers, corrupted by the stack-clash — instead of a clean
+;;             error.  All eleven arrays across both functions are heap
+;;             scratch-carves now, so this either runs or fails cleanly —
+;;             never crashes.
+;;
+;;             A SECOND, independent hazard surfaced while pinning this:
+;;             ray_scan() grows g->nodes (realloc) as scan nodes are
+;;             appended, so a ray_op_t* returned by an early ray_scan call
+;;             in tblop.c's idx_ops/key_ops fill loops went stale once a
+;;             later call in the same loop crossed a capacity boundary
+;;             (GRAPH_INIT_CAP=4096) — unreachable pre-cut-4 (n_idx capped
+;;             well under 4096), reachable now.  Fixed alongside the VLA
+;;             carve: both loops collect each scan's stable ->id and
+;;             resolve id -> pointer in one pass after the LAST scan call,
+;;             per op_node's own contract ("never store a node pointer
+;;             across a node allocation; re-resolve from the id instead").
+;;
+;;             Oracle: 8200 index columns (all the same 'k, repeated —
+;;             pivot does not require distinct index-column names) plus
+;;             the pivot column gives n_keys = 8201, past
+;;             ght_compute_layout's uint16 byte-offset stride budget
+;;             (~8192 plain 8-byte keys before the offset accumulator
+;;             would overflow UINT16_MAX) — so this must fail with the
+;;             SAME clean "limit" domain error ght_compute_layout already
+;;             returns for any over-budget key set, not crash and not
+;;             silently truncate.  (A much larger n_idx, e.g. 200000, also
+;;             fails cleanly but is excluded here on runtime grounds: a
+;;             separate, pre-existing O(n^2) exec_pivot cost — repeated
+;;             find_ext() linear scans over the DAG's ext-node list, one
+;;             per index column — makes it minutes slow rather than a
+;;             fast, deterministic test cell; that algorithmic-complexity
+;;             issue is out of scope for this memory-safety fix.) ──
+;; ══════════════════════════════════════════════════════════════════
+
+(set Tbig29 (table [k p v] (list [1 2] ['x 'y] [10 20])))
+(pivot Tbig29 (take ['k] 8200) 'p 'v sum) !- limit
+
+;; ══════════════════════════════════════════════════════════════════
 ;; Unreachable branches documentation (OOM guards, internal-only):
 ;;
 ;; L128  — ray_graph_new returns NULL (OOM in DAG fast path)

--- a/test/test_group_extra.c
+++ b/test/test_group_extra.c
@@ -2334,6 +2334,9 @@ static test_result_t test_ght_layout_copy_depth_invariance(void) {
     TEST_ASSERT_EQ_PTR(b1.wide_key_esz, master.wide_key_esz);
     TEST_ASSERT_EQ_PTR(b1.agg_flags2,       master.agg_flags2);
     TEST_ASSERT_EQ_PTR(b1.agg_null_sentinel, master.agg_null_sentinel);
+    TEST_ASSERT_EQ_PTR(b1.agg_dom,          master.agg_dom);
+    TEST_ASSERT_EQ_PTR(b1.key_flags,        master.key_flags);
+    TEST_ASSERT_EQ_PTR(b1.wide_key_type,    master.wide_key_type);
 
     /* The bug: copying FROM a borrower.  b1.spill_hdr == NULL looks
      * identical to a true-inline layout to the old (fixed) spill_hdr-based
@@ -2348,6 +2351,9 @@ static test_result_t test_ght_layout_copy_depth_invariance(void) {
     TEST_ASSERT_EQ_PTR(b2.wide_key_esz, master.wide_key_esz);
     TEST_ASSERT_EQ_PTR(b2.agg_flags2,       master.agg_flags2);
     TEST_ASSERT_EQ_PTR(b2.agg_null_sentinel, master.agg_null_sentinel);
+    TEST_ASSERT_EQ_PTR(b2.agg_dom,          master.agg_dom);
+    TEST_ASSERT_EQ_PTR(b2.key_flags,        master.key_flags);
+    TEST_ASSERT_EQ_PTR(b2.wide_key_type,    master.wide_key_type);
     /* The failure signature the bug would produce, explicitly ruled out:
      * b2 re-pointed at its own inline storage instead of the spill. */
     TEST_ASSERT_FALSE(b2.agg_val_slot == b2.agg_val_slot_in);
@@ -2364,6 +2370,23 @@ static test_result_t test_ght_layout_copy_depth_invariance(void) {
         TEST_ASSERT_EQ_I(master.key_off[k], b1.key_off[k]);
         TEST_ASSERT_EQ_I(master.key_off[k], b2.key_off[k]);
     }
+
+    /* Inline leg of the copy dispatch: a true-inline (≤ GHT_INLINE) source
+     * must have its copy RE-POINTED at the destination's own inline arrays,
+     * never left aliasing the source's — the mirror of the spill leg above. */
+    ght_layout_t inl;
+    TEST_ASSERT_TRUE(ght_compute_layout(&inl, 2, 2, agg_vecs,
+                                        GHT_NEED_SUM, agg_ops, key_types));
+    TEST_ASSERT_NULL(inl.spill_hdr);
+    TEST_ASSERT_TRUE(inl.agg_val_slot == inl.agg_val_slot_in);
+    ght_layout_t ic;
+    ght_layout_copy(&ic, &inl);
+    TEST_ASSERT_NULL(ic.spill_hdr);
+    TEST_ASSERT_TRUE(ic.agg_val_slot == ic.agg_val_slot_in);   /* its OWN inline */
+    TEST_ASSERT_FALSE(ic.agg_val_slot == inl.agg_val_slot);    /* not the source's */
+    TEST_ASSERT_TRUE(ic.key_off == ic.key_off_in);
+    ght_layout_free(&ic);
+    ght_layout_free(&inl);
 
     /* Free order: borrowers first (no-ops — dst->spill_hdr is NULL for
      * both), the owning master last (actually frees the block). Freeing

--- a/test/test_group_extra.c
+++ b/test/test_group_extra.c
@@ -2332,6 +2332,8 @@ static test_result_t test_ght_layout_copy_depth_invariance(void) {
     TEST_ASSERT_EQ_PTR(b1.key_off,      master.key_off);
     TEST_ASSERT_EQ_PTR(b1.agg_flags,    master.agg_flags);
     TEST_ASSERT_EQ_PTR(b1.wide_key_esz, master.wide_key_esz);
+    TEST_ASSERT_EQ_PTR(b1.agg_flags2,       master.agg_flags2);
+    TEST_ASSERT_EQ_PTR(b1.agg_null_sentinel, master.agg_null_sentinel);
 
     /* The bug: copying FROM a borrower.  b1.spill_hdr == NULL looks
      * identical to a true-inline layout to the old (fixed) spill_hdr-based
@@ -2344,6 +2346,8 @@ static test_result_t test_ght_layout_copy_depth_invariance(void) {
     TEST_ASSERT_EQ_PTR(b2.key_off,      master.key_off);
     TEST_ASSERT_EQ_PTR(b2.agg_flags,    master.agg_flags);
     TEST_ASSERT_EQ_PTR(b2.wide_key_esz, master.wide_key_esz);
+    TEST_ASSERT_EQ_PTR(b2.agg_flags2,       master.agg_flags2);
+    TEST_ASSERT_EQ_PTR(b2.agg_null_sentinel, master.agg_null_sentinel);
     /* The failure signature the bug would produce, explicitly ruled out:
      * b2 re-pointed at its own inline storage instead of the spill. */
     TEST_ASSERT_FALSE(b2.agg_val_slot == b2.agg_val_slot_in);

--- a/test/test_group_extra.c
+++ b/test/test_group_extra.c
@@ -2273,6 +2273,111 @@ static test_result_t test_hll_merge_edges(void) {
 }
 
 /* --------------------------------------------------------------------------
+ * Test: ght_layout_copy depth-invariance (review fix, unbounded-slots cut 4)
+ *
+ * ght_compute_layout carves ONE owned heap spill block when n_keys or
+ * n_aggs exceeds GHT_INLINE (8); ght_layout_copy re-points a copy's base
+ * pointers at either the copy's own inline arrays (inline src) or the
+ * shared spill block (spilled src, borrowed read-only).
+ *
+ * The defect this test targets: a BORROWER (a copy of a spilled master)
+ * has spill_hdr == NULL too — that's how "borrow, don't own" is encoded —
+ * so a naive `src->spill_hdr == NULL` test in ght_layout_copy cannot tell
+ * a true-inline source from a borrower source.  Copying FROM a borrower
+ * (master -> b1 -> b2, exactly the group_ht_init_sized(&c->part_hts[p],
+ * ..., &c->layout, ...) / group_ht_init_sized(&my_hts[p], ..., ly, ...)
+ * shape used for per-partition HTs) would take the wrong branch and
+ * re-point b2's bases at b2's own zeroed size-8 *_in arrays — silently
+ * truncating any layout with > 8 keys/aggs two copies deep.
+ *
+ * The fix dispatches on STORAGE identity (src->agg_val_slot ==
+ * src->agg_val_slot_in) instead of ownership (spill_hdr == NULL), which is
+ * depth-invariant: this test builds a 10-key/10-agg (> GHT_INLINE) layout
+ * directly via ght_compute_layout, copies it twice (master -> b1 -> b2),
+ * and asserts b2's bases are pointer-identical to the master's spill bases
+ * (not b2's own inline arrays) and that master/b1/b2 read identical values
+ * through those bases.  Free order: borrowers (no-ops) then the owning
+ * master last.
+ * -------------------------------------------------------------------------- */
+static test_result_t test_ght_layout_copy_depth_invariance(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    enum { NK = 10, NA = 10 };  /* both > GHT_INLINE (8): forces the spill path */
+
+    int8_t key_types[NK];
+    for (int i = 0; i < NK; i++) key_types[i] = RAY_I64;  /* narrow keys, no wide-key path */
+
+    uint16_t agg_ops[NA];
+    ray_t* agg_vecs[NA];
+    for (int i = 0; i < NA; i++) {
+        agg_ops[i] = OP_SUM;
+        agg_vecs[i] = ray_vec_new(RAY_F64, 1);
+        TEST_ASSERT_NOT_NULL(agg_vecs[i]);
+        agg_vecs[i]->len = 1;
+        ((double*)ray_data(agg_vecs[i]))[0] = 0.0;
+    }
+
+    ght_layout_t master;
+    TEST_ASSERT_TRUE(ght_compute_layout(&master, NK, NA, agg_vecs,
+                                        GHT_NEED_SUM, agg_ops, key_types));
+    /* > GHT_INLINE on both axes: this must be a real, owned spill block. */
+    TEST_ASSERT_NOT_NULL(master.spill_hdr);
+    TEST_ASSERT_FALSE(master.agg_val_slot == master.agg_val_slot_in);
+
+    ght_layout_t b1;
+    ght_layout_copy(&b1, &master);
+    TEST_ASSERT_NULL(b1.spill_hdr);                          /* borrows, doesn't own */
+    TEST_ASSERT_EQ_PTR(b1.agg_val_slot, master.agg_val_slot); /* shares master's spill */
+    TEST_ASSERT_EQ_PTR(b1.key_off,      master.key_off);
+    TEST_ASSERT_EQ_PTR(b1.agg_flags,    master.agg_flags);
+    TEST_ASSERT_EQ_PTR(b1.wide_key_esz, master.wide_key_esz);
+
+    /* The bug: copying FROM a borrower.  b1.spill_hdr == NULL looks
+     * identical to a true-inline layout to the old (fixed) spill_hdr-based
+     * test, so the buggy branch would re-point b2 at b2's OWN inline
+     * arrays instead of the shared spill block. */
+    ght_layout_t b2;
+    ght_layout_copy(&b2, &b1);
+    TEST_ASSERT_NULL(b2.spill_hdr);
+    TEST_ASSERT_EQ_PTR(b2.agg_val_slot, master.agg_val_slot);
+    TEST_ASSERT_EQ_PTR(b2.key_off,      master.key_off);
+    TEST_ASSERT_EQ_PTR(b2.agg_flags,    master.agg_flags);
+    TEST_ASSERT_EQ_PTR(b2.wide_key_esz, master.wide_key_esz);
+    /* The failure signature the bug would produce, explicitly ruled out:
+     * b2 re-pointed at its own inline storage instead of the spill. */
+    TEST_ASSERT_FALSE(b2.agg_val_slot == b2.agg_val_slot_in);
+    TEST_ASSERT_FALSE(b2.key_off == b2.key_off_in);
+
+    /* All three read identical values through their (possibly distinct
+     * struct, but pointer-identical base) views. */
+    for (int a = 0; a < NA; a++) {
+        TEST_ASSERT_EQ_I(master.agg_val_slot[a], b1.agg_val_slot[a]);
+        TEST_ASSERT_EQ_I(master.agg_val_slot[a], b2.agg_val_slot[a]);
+        TEST_ASSERT_EQ_I(master.agg_flags[a],    b2.agg_flags[a]);
+    }
+    for (int k = 0; k <= NK; k++) {
+        TEST_ASSERT_EQ_I(master.key_off[k], b1.key_off[k]);
+        TEST_ASSERT_EQ_I(master.key_off[k], b2.key_off[k]);
+    }
+
+    /* Free order: borrowers first (no-ops — dst->spill_hdr is NULL for
+     * both), the owning master last (actually frees the block). Freeing
+     * a borrower must never touch the master's block. */
+    ght_layout_free(&b2);
+    ght_layout_free(&b1);
+    TEST_ASSERT_NOT_NULL(master.spill_hdr);  /* untouched by borrower frees */
+    ght_layout_free(&master);
+    TEST_ASSERT_NULL(master.spill_hdr);
+
+    for (int i = 0; i < NA; i++) ray_release(agg_vecs[i]);
+
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* --------------------------------------------------------------------------
  * Test registry
  * -------------------------------------------------------------------------- */
 
@@ -2300,5 +2405,6 @@ const test_entry_t group_extra_entries[] = {
     { "group_extra/hll_count_distinct_approx_pg_buf_direct", test_hll_count_distinct_approx_pg_buf_direct, NULL, NULL },
     { "group_extra/hll_count_distinct_approx_pg_stream_types", test_hll_count_distinct_approx_pg_stream_types, NULL, NULL },
     { "group_extra/hll_merge_edges",               test_hll_merge_edges,               NULL, NULL },
+    { "group_extra/ght_layout_copy_depth_invariance", test_ght_layout_copy_depth_invariance, NULL, NULL },
     { NULL, NULL, NULL, NULL },
 };


### PR DESCRIPTION
## Summary

The final cut of the four-cut unbounded-slots migration (cuts 1-3 = PRs #300/#303/#304). The legacy group hash-table's `[8]` layout family retires; the engine's **last compile-time width errors are gone**. Group-by on the legacy fallback path (v2-ineligible keys/aggs) and pivot index columns are now memory-limited only, with every remaining representational bound (stride/slot budgets) refusing loudly instead of wrapping silently.

### Mechanism (documented deviation from the spec's flexible-array block)
`ght_layout_t` stays fixed-size and by-value-embeddable: **inline-or-spill** — base pointers aim at inline `[8]` storage for widths ≤8 (identical cache behavior to the old fixed fields) or one owned heap spill for wider, chosen once at layout build; copies are depth-invariant by storage identity (pinned by a C unit test across all nine arrays); hot loops read via hoisted const bases per the register-promotion discipline cut 3 established. The uint8 per-agg/per-key bitmasks became flag-byte arrays; the entry null mask generalized to `ceil(n_keys/64)` words inside the key region (memcmp/hash generalize by width, single-word case hash-identical).

### What the lift unlocked (and the sentinels that guard it)
Pivot at any index count (8/17/65-index cells — the 65 one detects >64-key null-pattern conflation); >8-key groups with v2-ineligible keys (F64/STR/dict-STR) or aggs (FIRST/LAST/PROD, narrow-int SUM); keyless pearson+8; >16-key/agg expr-input shapes; 65-key (two null words) and 256-key (parallel-emit) boundary cells.

### Bugs fixed along the way (each verified pre-fix, each pinned)
1. **Live wrong answer on dev** (owner-approved scope add): the ght accumulators had no null handling — grouped SUM/MIN/MAX/AVG/PROD/FIRST/LAST/STDDEV/VAR over nullable columns (F64-NaN + every sentinel width) summed sentinels / leaked seeds on all-null groups. Fixed with per-slot non-null counts; all-null semantics pinned against the DA path; no-null workloads gated to the unchanged path.
2. Guard-lift-exposed: uint8 `nullable_mask` dropping nulls at keys ≥8; signed-shift UB at k≡63; the phase-3 narrow-int emit SIGSEGV (8-byte stores into I16/I32 columns); the phase-2 wide-key pool `[8]` overflow (parallel STR+8-int shape); the phase-3 ctx uint8 counts (256-key parallel emit zeroed key columns — caught by the final review past the boundary cells).
3. Side effect: the pre-existing multi-STR-key query misroute no longer reproduces at HEAD (value-pinned).
4. Three OOM-path leaks on the new carves (LSan-verified frees).

### Bench record (owner-adjudicated; full tables + RCA in-branch scratch)
- **Wins**: q34 −13.9%, q33 −14.4%, q28 −10.5% (recovers cut-1's accepted residual) — the DA count hot path extracted from the 3.7k-line monolith whose growth had degraded register allocation (+5.5% spill instructions).
- **Accepted residuals**: TAQ idx45 +9.3%/idx46 +2.7% — the price of CORRECT null handling (baseline was wrong-answer-fast); q15/q35/S2 +2-5% — entry-build generalization, with a **proven recovery patch** parked on the TU-split ticket (it helps all targets but pays placement collateral in the monolith).
- Two fix rounds honestly reverted on measurement (accumulator mask forms; the phase-1 fast form); one measurement artifact identified (allocator-trajectory coupling between serially-run bench shapes).
- Correctness byte-identical throughout; agg_v2 checksums 11/11; new wide-shape reference numbers recorded (no dev baseline exists — dev errors on those shapes).

### Follow-up tickets (consolidated)
1. **TU split** of the DA/sp hot region (three cuts' placement evidence + FIX D's recovery patch + the nv uint16 nit).
2. **v2 nullable-agg admission** via off_nn merge in group_merge_row (recovers idx45/46).
3. **NEW pre-existing**: keyless PEARSON + integer SUM/AVG siblings emit 0 (verified on dev base; F64/keyed variants correct).
4. Multi-STR misroute: re-verify/close (fixed as a side effect here, pinned).
5. Pre-existing OOM/cancel leak family; per-partition >8 widening (perf-only); >255-index pivot untested (impractical fixture); streaming-DAG stack overflow at 8MB stacks; static-analysis baseline; wj eargs leaks.

Suite: 3545/3545 (ASan/UBSan) at every commit; gcc + clang release `-O3 -Werror` green throughout.

**This completes the unbounded-slots program**: RAY_GROUP_MAX_SLOTS (cut 1) → graph uint32 + dict view (cut 2) → key-count API limits (cut 3) → the ght layout (cut 4).