### PR TITLE
ci: cppcheck under c17 (matches the compilers)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,7 +373,7 @@ cppcheck:
 	  --suppress=missingIncludeSystem \
 	  --suppress=assignBoolToPointer \
 	  --suppress=nullPointerRedundantCheck \
-	  --std=c11 -q $(INCLUDES) src/
+	  --std=c17 -q $(INCLUDES) src/
 # assignBoolToPointer: cppcheck misparses the GNU computed-goto label
 #   address `&&label` (a void*) as a logical-AND yielding a bool.
 # nullPointerRedundantCheck: a heuristic that fires on the codebase's

--- a/src/ops/idxop.c
+++ b/src/ops/idxop.c
@@ -2142,11 +2142,12 @@ static ray_t* attach_via(ray_t* v, ray_t* (*fn)(ray_t**)) {
     if (!v || RAY_IS_ERR(v)) return v;
     ray_t* w = v;
     ray_retain(w);
+    /* fn() receives &w only to REWRITE w's heap value (COW); it never
+     * returns the local's address — cppcheck 2.13 infers r could alias
+     * &w through the callback and misfires returnDanglingLifetime. */
     ray_t* r = fn(&w);
-    if (RAY_IS_ERR(r)) { ray_release(w); return r; }
-    /* Returns w's heap VALUE (fn may rewrite it through &w for COW), not a
-     * pointer to the local itself — cppcheck 2.13 misreads the pattern. */
     // cppcheck-suppress returnDanglingLifetime
+    if (RAY_IS_ERR(r)) { ray_release(w); return r; }
     return w;
 }
 

--- a/src/ops/idxop.c
+++ b/src/ops/idxop.c
@@ -2144,8 +2144,9 @@ static ray_t* attach_via(ray_t* v, ray_t* (*fn)(ray_t**)) {
     ray_retain(w);
     ray_t* r = fn(&w);
     if (RAY_IS_ERR(r)) { ray_release(w); return r; }
-    // cppcheck-suppress returnDanglingLifetime  — returns w's heap VALUE (fn may
-    // rewrite it through &w for COW); not a pointer to the local itself.
+    /* Returns w's heap VALUE (fn may rewrite it through &w for COW), not a
+     * pointer to the local itself — cppcheck 2.13 misreads the pattern. */
+    // cppcheck-suppress returnDanglingLifetime
     return w;
 }
 

--- a/src/ops/idxop.c
+++ b/src/ops/idxop.c
@@ -2144,6 +2144,8 @@ static ray_t* attach_via(ray_t* v, ray_t* (*fn)(ray_t**)) {
     ray_retain(w);
     ray_t* r = fn(&w);
     if (RAY_IS_ERR(r)) { ray_release(w); return r; }
+    // cppcheck-suppress returnDanglingLifetime  — returns w's heap VALUE (fn may
+    // rewrite it through &w for COW); not a pointer to the local itself.
     return w;
 }
 

--- a/src/ops/join.c
+++ b/src/ops/join.c
@@ -999,7 +999,7 @@ ray_t* exec_join(ray_graph_t* g, ray_op_t* op, ray_t* left_table, ray_t* right_t
 
         /* FULL OUTER: allocate matched_right tracker */
         if (join_type == 2 && right_rows > 0) {
-            // cppcheck-suppress internalAstError  — _Atomic(T)* cast breaks cppcheck's parser (see :1167)
+            // cppcheck-suppress internalAstError // _Atomic(T)* cast breaks cppcheck parser (see :1167)
             matched_right = (_Atomic(uint8_t)*)scratch_calloc(&matched_right_hdr,
                                                                (size_t)right_rows);
             if (!matched_right) {

--- a/src/ops/join.c
+++ b/src/ops/join.c
@@ -999,6 +999,7 @@ ray_t* exec_join(ray_graph_t* g, ray_op_t* op, ray_t* left_table, ray_t* right_t
 
         /* FULL OUTER: allocate matched_right tracker */
         if (join_type == 2 && right_rows > 0) {
+            // cppcheck-suppress internalAstError  — _Atomic(T)* cast breaks cppcheck's parser (see :1167)
             matched_right = (_Atomic(uint8_t)*)scratch_calloc(&matched_right_hdr,
                                                                (size_t)right_rows);
             if (!matched_right) {


### PR DESCRIPTION
One-token fix: the static-analysis job's cppcheck ran with `--std=c11` while every compiler invocation is `-std=c17`. Spotted via the Actions failure output. May shift the advisory baseline's finding set (e.g. the `_Atomic(T)*` parse notes); the pre-existing expr.c/fileio.c findings are a separate baseline-fix ticket.