### PR TITLE
fix(exec): evaluate deep elementwise chains iteratively, guard recursion depth

### DIFF
--- a/src/ops/exec.c
+++ b/src/ops/exec.c
@@ -1538,6 +1538,197 @@ static inline bool op_is_heavy(uint16_t opc) {
            (opc >= OP_EXPAND && opc <= OP_KNN_RERANK);
 }
 
+/* ── Deep-DAG stack discipline ──────────────────────────────────────
+ * exec_node/exec_node_inner recurse per child, and exec_node_inner's
+ * frame is the union of every case's locals (~35 KB under ASan), so a
+ * deep op chain overflows the 8 MB main stack around depth ~220 —
+ * worker/IPC threads with 512 KB stacks die far sooner.  Two defenses:
+ *
+ *  1. Elementwise chains — the one shape that gets arbitrarily deep in
+ *     practice (machine-generated arithmetic, the >1024-node streaming
+ *     DAG test) — are evaluated iteratively by exec_elementwise_tree
+ *     and consume no recursion depth.
+ *  2. Any other graph nesting past RAY_EXEC_MAX_DEPTH is pathological:
+ *     fail with a clean "limit" error instead of a stack overflow
+ *     (mirrors RAY_EVAL_MAX_DEPTH in lang/eval.c).  The counter is
+ *     per-thread; 64 levels of non-elementwise nesting stays within
+ *     ~2.5 MB even at ASan frame sizes. */
+#define RAY_EXEC_MAX_DEPTH 64
+static _Thread_local int32_t tl_exec_depth = 0;
+
+/* Opcodes handled by the elementwise case of exec_node_inner — must
+ * match its case labels (ROUND sits at 9, outside NEG..CAST; IDIV at
+ * 49, outside ADD..MAX2). */
+static inline bool op_is_elementwise(uint16_t o) {
+    return o == OP_ROUND || (o >= OP_NEG && o <= OP_CAST)
+        || (o >= OP_ADD && o <= OP_MAX2) || o == OP_IDIV;
+}
+
+/* Iterative post-order evaluation of an elementwise subtree.
+ *
+ * Replaces the recursive per-child fallback, which burned one
+ * exec_node+exec_node_inner frame pair per chain link.  The walk uses
+ * an explicit heap stack:
+ *
+ *  - elementwise children are evaluated exactly once (vals[] memo,
+ *    released when their last in-tree consumer has run);
+ *  - non-elementwise children (SCAN/CONST/aggregates/...) remain
+ *    exec_node calls, evaluated per reference like the recursion did,
+ *    and bounded by the depth guard;
+ *  - each node still gets an expr_compile attempt on descent, so
+ *    fuseable sub-windows (within the compiler's depth-64 DFS cap)
+ *    run the fused kernels exactly as before — only the spine above
+ *    them is interpreted node-by-node. */
+static ray_t* exec_elementwise_tree(ray_graph_t* g, ray_op_t* root) {
+    uint32_t nc = g->node_count;
+    int64_t  nr = g->table ? ray_table_nrows(g->table) : 0;
+
+    typedef struct { uint32_t id; uint8_t phase; } ew_ent_t;
+    enum { EW_NEW = 0, EW_PENDING = 1, EW_DONE = 2, EW_SEEN = 3 };
+
+    /* One carve for the id-indexed maps plus the walk stack.  Stack
+     * bound: one discover push per edge (≤ 2·nc) + one emit push per
+     * node (≤ nc).  The byte-wide state map goes last so every wider
+     * field stays naturally aligned. */
+    size_t vals_sz = (size_t)nc * sizeof(ray_t*);
+    size_t uses_sz = (size_t)nc * sizeof(uint32_t);
+    size_t stk_sz  = ((size_t)3 * nc + 2) * sizeof(ew_ent_t);
+    ray_t* hdr = NULL;
+    char* mem = (char*)scratch_calloc(&hdr, vals_sz + uses_sz + stk_sz + (size_t)nc);
+    if (!mem) return ray_error("oom", NULL);
+    ray_t**   vals  = (ray_t**)mem;
+    uint32_t* uses  = (uint32_t*)(mem + vals_sz);
+    ew_ent_t* stk   = (ew_ent_t*)(mem + vals_sz + uses_sz);
+    uint8_t*  state = (uint8_t*)(mem + vals_sz + uses_sz + stk_sz);
+
+    ray_t* result = NULL;
+    int64_t sp = 0;
+
+    /* Prepass: count each node's in-tree consumers (parent edges from
+     * elementwise nodes, +1 for the root's return reference) BEFORE
+     * evaluating anything.  Counting lazily during the walk is wrong
+     * for diamond sharing: the first parent to emit would see the
+     * shared child at 1 use, drop it to 0 and free the value while a
+     * later parent still needs it.  Marks nodes EW_SEEN, which the
+     * evaluation walk below treats as unvisited. */
+    uses[root->id] = 1;
+    stk[sp++] = (ew_ent_t){root->id, 0};
+    while (sp > 0) {
+        uint32_t id = stk[--sp].id;
+        if (state[id] != EW_NEW) continue;
+        state[id] = EW_SEEN;
+        ray_op_t* n = op_node(g, id);
+        if (!n) { result = ray_error("nyi", NULL); goto done; }
+        for (int k = 0; k < n->arity; k++) {
+            ray_op_t* c = op_child(g, n, k);
+            if (c && op_is_elementwise(c->opcode)) {
+                uses[c->id]++;                    /* one per edge */
+                stk[sp++] = (ew_ent_t){c->id, 0};
+            }
+        }
+    }
+
+    stk[sp++] = (ew_ent_t){root->id, 0};
+
+    while (sp > 0) {
+        ew_ent_t e = stk[--sp];
+        ray_op_t* n = op_node(g, e.id);
+        if (!n) { result = ray_error("nyi", NULL); goto done; }
+
+        if (e.phase == 0) {                       /* discover */
+            if (state[e.id] == EW_DONE)           /* shared node, evaluated */
+                continue;
+            if (state[e.id] == EW_PENDING) {
+                /* Re-discovering a node whose emit is still pending means
+                 * the node is its own ancestor — a cyclic graph.  Refuse
+                 * rather than read a missing value. */
+                result = ray_error("nyi", NULL);
+                goto done;
+            }
+            state[e.id] = EW_PENDING;
+
+            /* Fusion attempt on descent (root's was just done by the
+             * caller).  The recursion re-tried expr_compile at every
+             * level; keep that so the deepest fuseable window still
+             * runs compiled. */
+            if (n != root && g->table && nr > 0) {
+                ray_expr_t ex;
+                if (expr_compile(g, g->table, n, &ex)) {
+                    ray_t* vec = expr_eval_full(&ex, nr);
+                    if (vec && !RAY_IS_ERR(vec)) {
+                        vals[e.id]  = vec;
+                        state[e.id] = EW_DONE;
+                        continue;
+                    }
+                    ray_error_free(vec);   /* fall through to per-node eval */
+                }
+            }
+
+            stk[sp++] = (ew_ent_t){e.id, 1};
+            for (int k = 0; k < n->arity; k++) {
+                ray_op_t* c = op_child(g, n, k);
+                if (c && op_is_elementwise(c->opcode))
+                    stk[sp++] = (ew_ent_t){c->id, 0};
+                /* non-elementwise children evaluate at emit time */
+            }
+        } else {                                  /* emit */
+            ray_t* in[2]    = {NULL, NULL};
+            bool   owned[2] = {false, false};     /* boundary refs to release */
+            for (int k = 0; k < n->arity; k++) {
+                ray_op_t* c = op_child(g, n, k);
+                if (c && op_is_elementwise(c->opcode)) {
+                    in[k] = vals[c->id];
+                    if (!in[k]) { result = ray_error("nyi", NULL); goto emit_fail; }
+                } else {
+                    in[k] = exec_node(g, c);      /* may recurse; depth-guarded */
+                    owned[k] = true;
+                    if (!in[k] || RAY_IS_ERR(in[k])) {
+                        result = in[k];
+                        in[k] = NULL;
+                        goto emit_fail;
+                    }
+                }
+            }
+
+            ray_t* out = (n->arity == 1)
+                       ? exec_elementwise_unary(g, n, in[0])
+                       : exec_elementwise_binary(g, n, in[0], in[1]);
+
+            for (int k = 0; k < n->arity; k++) {
+                if (owned[k]) {
+                    ray_release(in[k]);
+                } else {
+                    uint32_t cid = op_child(g, n, k)->id;
+                    if (--uses[cid] == 0) {
+                        ray_release(vals[cid]);
+                        vals[cid] = NULL;
+                    }
+                }
+            }
+            if (!out || RAY_IS_ERR(out)) { result = out; goto done; }
+            vals[e.id]  = out;
+            state[e.id] = EW_DONE;
+            continue;
+
+        emit_fail:
+            for (int k = 0; k < n->arity; k++)
+                if (owned[k] && in[k]) ray_release(in[k]);
+            goto done;
+        }
+    }
+
+    result = vals[root->id];
+    vals[root->id] = NULL;
+
+done:
+    /* Release stragglers: partially-evaluated memo entries on the error
+     * path (the success path has drained all consumers already). */
+    for (uint32_t i = 0; i < nc; i++)
+        if (vals[i]) ray_release(vals[i]);
+    scratch_free(hdr);
+    return result;
+}
+
 ray_t* exec_node(ray_graph_t* g, ray_op_t* op) {
     if (!op) return ray_error("nyi", NULL);
 
@@ -1545,6 +1736,12 @@ ray_t* exec_node(ray_graph_t* g, ray_op_t* op) {
      * exec_node many times; this catches Ctrl-C between operators
      * without adding cost to the per-row hot path. */
     if (ray_interrupted()) return ray_error("cancel", "interrupted");
+
+    /* Recursion depth guard — see RAY_EXEC_MAX_DEPTH above. */
+    if (++tl_exec_depth > RAY_EXEC_MAX_DEPTH) {
+        tl_exec_depth--;
+        return ray_error("limit", "exec depth exceeded");
+    }
 
     bool heavy = op_is_heavy(op->opcode);
     bool profiling = g_ray_profile.active && heavy;
@@ -1570,6 +1767,7 @@ ray_t* exec_node(ray_graph_t* g, ray_op_t* op) {
     }
 
     ray_t* _prof_result = exec_node_inner(g, op);
+    tl_exec_depth--;
 
     if (profiling) {
         ray_prof_span_t* ep = ray_profile_span_end(oname);
@@ -1693,23 +1891,11 @@ static ray_t* exec_node_inner(ray_graph_t* g, ray_op_t* op) {
                     }
                 }
             }
-            /* Fallback: recursive per-node evaluation */
-            if (op->arity == 1) {
-                ray_t* input = exec_node(g, op_child(g, op, 0));
-                if (!input || RAY_IS_ERR(input)) return input;
-                ray_t* result = exec_elementwise_unary(g, op, input);
-                ray_release(input);
-                return result;
-            } else {
-                ray_t* lhs = exec_node(g, op_child(g, op, 0));
-                ray_t* rhs = exec_node(g, op_child(g, op, 1));
-                if (!lhs || RAY_IS_ERR(lhs)) { if (rhs && !RAY_IS_ERR(rhs)) ray_release(rhs); return lhs; }
-                if (!rhs || RAY_IS_ERR(rhs)) { ray_release(lhs); return rhs; }
-                ray_t* result = exec_elementwise_binary(g, op, lhs, rhs);
-                ray_release(lhs);
-                ray_release(rhs);
-                return result;
-            }
+            /* Fallback: iterative per-node evaluation.  Deep chains
+             * (>1024-node NEG spines, machine-generated arithmetic)
+             * previously recursed one exec_node frame pair per link
+             * and overflowed the stack — see exec_elementwise_tree. */
+            return exec_elementwise_tree(g, op);
         }
 
         /* Reductions */

--- a/src/ops/expr.c
+++ b/src/ops/expr.c
@@ -2220,13 +2220,27 @@ static void propagate_nulls_binary(ray_t* lhs, ray_t* rhs, ray_t* result,
  * Element-wise execution
  * ============================================================================ */
 
+/* Graph type-inference stamps elementwise nodes with the scanned
+ * column's raw STORAGE tag — RAY_PARTED_* / RAY_MAPCOMMON propagate
+ * verbatim through NEG/ABS/... and promote().  At exec time OP_SCAN
+ * always hands the kernels a flat vector (segment tables in streaming
+ * mode, the flatten cold path otherwise), so a storage-tagged out_type
+ * would make ray_vec_new reject the allocation ("type" error).
+ * Normalize to the runtime element type: parted → its base type,
+ * mapcommon → the materialized operand's type. */
+static inline int8_t ew_runtime_out_type(int8_t out_type, int8_t operand_type) {
+    if (RAY_IS_PARTED(out_type)) return (int8_t)RAY_PARTED_BASETYPE(out_type);
+    if (out_type == RAY_MAPCOMMON) return operand_type;
+    return out_type;
+}
+
 ray_t* exec_elementwise_unary(ray_graph_t* g, ray_op_t* op, ray_t* input) {
     (void)g;
     if (!input || RAY_IS_ERR(input)) return input;
     if (!ray_is_vec(input)) return ray_error("type", "expr eval: unary op expects a vector, got %s", ray_type_name(input->type));
     int64_t len = input->len;
     int8_t in_type = input->type;
-    int8_t out_type = op->out_type;
+    int8_t out_type = ew_runtime_out_type(op->out_type, in_type);
 
     ray_t* result = ray_vec_new(out_type, len);
     if (!result || RAY_IS_ERR(result)) return result;
@@ -3010,7 +3024,10 @@ ray_t* exec_elementwise_binary(ray_graph_t* g, ray_op_t* op, ray_t* lhs, ray_t* 
         len = lhs->len;
     }
 
-    int8_t out_type = op->out_type;
+    int8_t out_type = ew_runtime_out_type(op->out_type,
+                                          !l_scalar ? lhs->type
+                                        : !r_scalar ? rhs->type
+                                        : (int8_t)(lhs->type < 0 ? -lhs->type : lhs->type));
     ray_t* result = ray_vec_new(out_type, len);
     if (!result || RAY_IS_ERR(result)) return result;
     result->len = len;

--- a/test/test_exec.c
+++ b/test/test_exec.c
@@ -9016,11 +9016,23 @@ static test_result_t test_exec_streaming_large_dag(void) {
     /* node_count = 1026 after the loop      */
 
     ray_t* result = ray_execute(g, op);
-    if (result && !RAY_IS_ERR(result)) {
-        /* 1025 NEG ops = odd count → result is the negated column.
-         * Values: [-3, 1, 2, -5] (each negated 1025 times) */
-        ray_release(result);
+    /* 1025 NEG ops = odd count → result is the negated column.
+     * Values: [-3, 1, 2, -5] (each negated 1025 times).  Must be a real
+     * value, not an error: deep elementwise chains evaluate iteratively
+     * (exec_elementwise_tree), so neither the stack nor the exec depth
+     * guard bounds them. */
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_TRUE(!RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(result->type, RAY_I64);
+    TEST_ASSERT_EQ_I(result->len, 4);
+    {
+        const int64_t* rd = (const int64_t*)ray_data(result);
+        TEST_ASSERT_EQ_I(rd[0], -3);
+        TEST_ASSERT_EQ_I(rd[1],  1);
+        TEST_ASSERT_EQ_I(rd[2],  2);
+        TEST_ASSERT_EQ_I(rd[3], -5);
     }
+    ray_release(result);
 
     ray_graph_free(g);
     ray_release(tbl);
@@ -9030,6 +9042,126 @@ static test_result_t test_exec_streaming_large_dag(void) {
     ray_release(pcol);
     ray_release(seg0);
     ray_release(seg1);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* ---- deep binary elementwise chain: 1500 ADD(const) links.
+ *
+ * Exercises the binary arm of exec_elementwise_tree on a flat (non-
+ * streaming) table: each link's right child is a non-elementwise
+ * OP_CONST boundary evaluated at emit time.  Before the iterative
+ * fallback this recursed one exec_node+exec_node_inner frame pair per
+ * link (~35 KB each under ASan) and overflowed the 8 MB main stack. */
+static test_result_t test_exec_deep_binary_chain(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int64_t v_data[] = {3, -1, -2, 5};
+    int64_t col_v = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(1);
+    tbl = ray_table_add_col(tbl, col_v, ray_vec_from_raw(RAY_I64, v_data, 4));
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* op = ray_scan(g, "v");
+    for (int i = 0; i < 1500; i++)
+        op = ray_add(g, op, ray_const_i64(g, 1));
+
+    ray_t* result = ray_execute(g, op);
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_TRUE(!RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(result->type, RAY_I64);
+    TEST_ASSERT_EQ_I(result->len, 4);
+    {
+        const int64_t* rd = (const int64_t*)ray_data(result);
+        TEST_ASSERT_EQ_I(rd[0], 1503);
+        TEST_ASSERT_EQ_I(rd[1], 1499);
+        TEST_ASSERT_EQ_I(rd[2], 1498);
+        TEST_ASSERT_EQ_I(rd[3], 1505);
+    }
+    ray_release(result);
+
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* ---- deep DAG with a shared (diamond) elementwise node.
+ *
+ * root = ADD(NEG^100(D), D) with D = NEG(v): the chain is deep enough
+ * (>64) that expr_compile bails and exec_elementwise_tree interprets
+ * it, and D has two in-tree consumers — the chain bottom and root.
+ * Locks the prepass use-counting: with lazy counting the chain bottom
+ * would free D's value before root's emit read it. */
+static test_result_t test_exec_deep_shared_dag(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int64_t v_data[] = {3, -1, -2, 5};
+    int64_t col_v = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(1);
+    tbl = ray_table_add_col(tbl, col_v, ray_vec_from_raw(RAY_I64, v_data, 4));
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* d = ray_neg(g, ray_scan(g, "v"));   /* D = -v */
+    ray_op_t* chain = d;
+    for (int i = 0; i < 100; i++)                 /* NEG^100(D) = D */
+        chain = ray_neg(g, chain);
+    ray_op_t* root = ray_add(g, chain, d);        /* D + D = -2v */
+
+    ray_t* result = ray_execute(g, root);
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_TRUE(!RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(result->type, RAY_I64);
+    TEST_ASSERT_EQ_I(result->len, 4);
+    {
+        const int64_t* rd = (const int64_t*)ray_data(result);
+        TEST_ASSERT_EQ_I(rd[0],  -6);
+        TEST_ASSERT_EQ_I(rd[1],   2);
+        TEST_ASSERT_EQ_I(rd[2],   4);
+        TEST_ASSERT_EQ_I(rd[3], -10);
+    }
+    ray_release(result);
+
+    ray_graph_free(g);
+    ray_release(tbl);
+    ray_sym_destroy();
+    ray_heap_destroy();
+    PASS();
+}
+
+/* ---- exec depth guard: non-elementwise nesting past RAY_EXEC_MAX_DEPTH.
+ *
+ * Elementwise chains bypass the recursion entirely, but every other
+ * opcode still burns a frame pair per level; a 100-deep SUM tower must
+ * come back as a clean "limit" error (exec.c RAY_EXEC_MAX_DEPTH = 64),
+ * not a stack overflow. */
+static test_result_t test_exec_depth_guard_limit(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int64_t v_data[] = {1, 2, 3, 4};
+    int64_t col_v = ray_sym_intern("v", 1);
+    ray_t* tbl = ray_table_new(1);
+    tbl = ray_table_add_col(tbl, col_v, ray_vec_from_raw(RAY_I64, v_data, 4));
+
+    ray_graph_t* g = ray_graph_new(tbl);
+    ray_op_t* op = ray_scan(g, "v");
+    for (int i = 0; i < 100; i++)
+        op = ray_sum(g, op);
+
+    ray_t* result = ray_execute(g, op);
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(result->slen, 5);
+    TEST_ASSERT_TRUE(memcmp(result->sdata, "limit", 5) == 0);
+    ray_error_free(result);
+
+    ray_graph_free(g);
+    ray_release(tbl);
     ray_sym_destroy();
     ray_heap_destroy();
     PASS();
@@ -17391,6 +17523,9 @@ const test_entry_t exec_entries[] = {
     { "exec/head_filter_pred_error",           test_exec_head_filter_pred_error,           NULL, NULL },
     { "exec/select_expr_col_error",            test_exec_select_expr_col_error,            NULL, NULL },
     { "exec/streaming_large_dag",              test_exec_streaming_large_dag,              NULL, NULL },
+    { "exec/deep_binary_chain",                test_exec_deep_binary_chain,                NULL, NULL },
+    { "exec/deep_shared_dag",                  test_exec_deep_shared_dag,                  NULL, NULL },
+    { "exec/depth_guard_limit",                test_exec_depth_guard_limit,                NULL, NULL },
     { "exec/filter_group_parted_empty",        test_exec_filter_group_parted_empty,        NULL, NULL },
     { "exec/head_parted_sym_wrong_esz",        test_exec_head_parted_sym_wrong_esz,        NULL, NULL },
     { "exec/tail_parted_sym_wrong_esz",        test_exec_tail_parted_sym_wrong_esz,        NULL, NULL },


### PR DESCRIPTION
## What & why

`exec/streaming_large_dag` crashes with an ASan stack-overflow on `dev`: `exec_node` ↔ `exec_node_inner` recurse once per DAG link, and the inner frame is the union of every switch case's locals (~35 KB under ASan), so the test's 1026-node NEG chain overflows the 8 MB main stack around depth 220. It is stack-size dependent (passes at a 64 MB ulimit), which is why it surfaced intermittently across environments. expr fusion cannot absorb deep chains: `expr_compile` bails past its depth-64 DFS cap, landing exactly on the recursive fallback.

Fixing the crash exposed a second, latent bug the old test swallowed (it tolerated error results): graph type-inference propagates a scanned column's *storage* tag (`RAY_PARTED_*`/`RAY_MAPCOMMON`) through elementwise nodes, so the interpreter kernels asked `ray_vec_new` for a parted-typed output and got a `"type"` error. Fusion always masked this — segment tables are flat — and the interpreter path only ran on deep chains, which crashed first.

Changes:

- **`exec_elementwise_tree`** (exec.c): iterative post-order evaluation of elementwise subtrees with an explicit heap stack — zero recursion depth per chain link. A prepass counts each node's in-tree consumers so diamond-shared values are not freed while a later parent still needs them; per-descent `expr_compile` attempts are kept, so fuseable sub-windows still run the compiled kernels; non-elementwise children remain `exec_node` calls.
- **`RAY_EXEC_MAX_DEPTH` (64)** thread-local guard in `exec_node`: remaining non-elementwise nesting fails with a clean `"limit"` error instead of a stack overflow (mirrors `RAY_EVAL_MAX_DEPTH` in `lang/eval.c`). A continuation-thread ("heap continuation") approach was considered and rejected: per-thread heap arenas (`ray_tl_heap`) and `tl_group_emit_filter` span exec calls, so hopping threads risks silent wrong results and per-hop arena leaks.
- **`ew_runtime_out_type`** (expr.c): normalize the inferred `out_type` at the kernel boundary — parted → base type, mapcommon → the materialized operand's runtime type. OP_SCAN always hands kernels flat vectors, so this is the runtime truth.

Tests:

- `exec/streaming_large_dag` now asserts the computed values (`[-3, 1, 2, -5]`) instead of silently accepting errors — this is what surfaced the `"type"` bug.
- New `exec/deep_binary_chain` (1500 ADD links, binary arm + per-link CONST boundary), `exec/deep_shared_dag` (diamond-shared node under a >64-deep chain, locks the prepass use-counting), `exec/depth_guard_limit` (100-deep SUM tower → `"limit"` error).

Verification: full ASan+UBSan suite 3554/3555 (1 skipped, 0 failed); the previously-crashing repro passes 3/3 standalone and even at a 4 MB stack. Pre-existing on `dev` (reproduced at 631daf72), unrelated to #307.

## Checklist

- [x] PR targets `dev` (not `master`)
- [x] Commits follow Conventional Commits (`feat:` / `fix:` / `perf:` / `docs:` / …)
- [x] `make` builds cleanly (no new warnings)
- [x] `make test` passes; tests added/updated for behaviour changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)