### PR TITLE
prof: drop the per-operator serialized-size bandwidth stat (O(data) under -t)

### DIFF
--- a/src/app/repl.c
+++ b/src/app/repl.c
@@ -249,15 +249,13 @@ static int32_t profile_print_tree(int32_t idx, int32_t indent,
                     fprintf(stdout, " self=%.3f ms", (double)self / 1e6);
                 if (total_ns > 0)
                     fprintf(stdout, " %.0f%%", (double)wall * 100.0 / (double)total_ns);
-                /* Append the captured per-operator payload: result rows and
-                 * footprint, net allocation, and parallelism (worker count and
-                 * effective parallelism = worker busy time / wall time). Only
-                 * heavy operators carry a payload; phase spans stay bare. */
+                /* Append the captured per-operator payload: result rows, net
+                 * allocation, and parallelism (worker count and effective
+                 * parallelism = worker busy time / wall time). Only heavy
+                 * operators carry a payload; phase spans stay bare. */
                 int64_t dmem = ep->sys_cur - sp->sys_cur;
                 if (ep->rows_out > 0 || ep->qs_workers > 0 || dmem != 0) {
                     fprintf(stdout, "  rows=%lld", (long long)ep->rows_out);
-                    if (ep->bytes_out > 0)
-                        fprintf(stdout, " out=%.1fKB", (double)ep->bytes_out / 1024.0);
                     if (dmem != 0)
                         fprintf(stdout, " mem=%+.1fKB", (double)dmem / 1024.0);
                     if (ep->qs_workers > 0) {

--- a/src/core/profile.h
+++ b/src/core/profile.h
@@ -64,7 +64,6 @@ typedef struct {
      * fields carry no cost when inactive — the span is simply not created. */
     int64_t  sys_cur;     /* process bytes in use (ray_sys) at this instant */
     int64_t  rows_out;    /* result element/row count (END spans)            */
-    int64_t  bytes_out;   /* result serialized footprint (END spans)         */
     uint64_t qs_rows;     /* cumulative qstats rows_done at this instant      */
     uint64_t qs_busy_ns;  /* cumulative qstats worker busy-ns at this instant */
     uint64_t qs_tasks;    /* cumulative qstats tasks_run at this instant      */

--- a/src/core/qlog.c
+++ b/src/core/qlog.c
@@ -11,7 +11,6 @@
 #include <rayforce.h>
 #include "core/qlog.h"
 #include "core/qstats.h"   /* ray_qstats_agg */
-#include "store/serde.h"   /* ray_serde_size */
 
 /* Single global instance.  Zero-initialised: disabled, empty ring. */
 ray_qlog_t g_qlog;
@@ -37,15 +36,12 @@ void ray_qlog_end(const ray_qlog_ctx_t* c, const char* src, size_t src_len,
         const char* code = ray_err_code(result);
         status = code ? code : "error";
         row->result_rows = 0;
-        row->output_kib  = 0.0;
     } else if (!result || RAY_IS_NULL(result)) {
         row->result_rows = 0;
-        row->output_kib  = 0.0;
     } else {
         row->result_rows = (result->type == RAY_TABLE) ? ray_table_nrows(result)
                          : ray_is_atom(result)         ? 1
                          :                                (int64_t)ray_len(result);
-        row->output_kib  = (double)ray_serde_size(result) / 1024.0;
     }
 
     /* Parallelism from the query-scoped qstats aggregate (ray_eval resets the
@@ -79,14 +75,13 @@ ray_t* ray_qlog_table(void) {
     ray_t* c_time = ray_vec_new(RAY_TIMESTAMP, n);
     ray_t* c_dur  = ray_vec_new(RAY_F64, n);
     ray_t* c_rows = ray_vec_new(RAY_I64, n);
-    ray_t* c_out  = ray_vec_new(RAY_F64, n);
     ray_t* c_mem  = ray_vec_new(RAY_F64, n);
     ray_t* c_wrk  = ray_vec_new(RAY_I64, n);
     ray_t* c_par  = ray_vec_new(RAY_F64, n);
     ray_t* c_stat = ray_vec_new(RAY_SYM, n);
     ray_t* c_qry  = ray_vec_new(RAY_STR, n);
-    ray_t* fixed[] = { c_time, c_dur, c_rows, c_out, c_mem, c_wrk, c_par, c_stat };
-    ray_t* all[]   = { c_time, c_dur, c_rows, c_out, c_mem, c_wrk, c_par, c_stat, c_qry };
+    ray_t* fixed[] = { c_time, c_dur, c_rows, c_mem, c_wrk, c_par, c_stat };
+    ray_t* all[]   = { c_time, c_dur, c_rows, c_mem, c_wrk, c_par, c_stat, c_qry };
     for (size_t i = 0; i < sizeof(all)/sizeof(all[0]); i++)
         if (!all[i] || RAY_IS_ERR(all[i])) {
             for (size_t j = 0; j < sizeof(all)/sizeof(all[0]); j++)
@@ -97,7 +92,6 @@ ray_t* ray_qlog_table(void) {
     int64_t* times = (int64_t*)ray_data(c_time);
     double*  durs  = (double*)ray_data(c_dur);
     int64_t* rows  = (int64_t*)ray_data(c_rows);
-    double*  outs  = (double*)ray_data(c_out);
     double*  mems  = (double*)ray_data(c_mem);
     int64_t* wrks  = (int64_t*)ray_data(c_wrk);
     double*  pars  = (double*)ray_data(c_par);
@@ -109,7 +103,6 @@ ray_t* ray_qlog_table(void) {
         times[i] = r->time_ns;
         durs[i]  = r->duration_ms;
         rows[i]  = r->result_rows;
-        outs[i]  = r->output_kib;
         mems[i]  = r->memory_kib;
         wrks[i]  = r->workers;
         pars[i]  = r->parallelism;
@@ -124,10 +117,10 @@ ray_t* ray_qlog_table(void) {
         fixed[i]->len = n;
 
     static const char* names[] = { "time", "duration-ms", "result-rows",
-                                   "output-kib", "memory-kib", "workers",
+                                   "memory-kib", "workers",
                                    "parallelism", "status", "query" };
-    ray_t* cols[] = { c_time, c_dur, c_rows, c_out, c_mem, c_wrk, c_par, c_stat, c_qry };
-    ray_t* tbl = ray_table_new(9);
+    ray_t* cols[] = { c_time, c_dur, c_rows, c_mem, c_wrk, c_par, c_stat, c_qry };
+    ray_t* tbl = ray_table_new(8);
     if (!tbl || RAY_IS_ERR(tbl)) {
         for (size_t i = 0; i < sizeof(cols)/sizeof(cols[0]); i++) ray_release(cols[i]);
         return tbl ? tbl : ray_error("oom", "sys.querylog: table");

--- a/src/core/qlog.h
+++ b/src/core/qlog.h
@@ -42,7 +42,6 @@ typedef struct {
     int64_t  time_ns;       /* wall-clock finish time (RAY_TIMESTAMP units)  */
     double   duration_ms;   /* total wall time                               */
     int64_t  result_rows;   /* rows in the result (atom => 1)                */
-    double   output_kib;    /* serialized result footprint                   */
     double   memory_kib;    /* net system-allocation delta over the query    */
     double   parallelism;   /* qstats busy_ns / wall                         */
     int32_t  workers;       /* qstats distinct workers                       */

--- a/src/core/qstats.h
+++ b/src/core/qstats.h
@@ -8,8 +8,7 @@
  *   writes only to its own cache-line-padded slot, and the main thread
  *   sums the slots after a dispatch barrier (or samples them on its wait
  *   path).  It is the shared foundation for two features:
- *     - per-query statistics (parallelism / bandwidth payloads on profile
- *       spans), and
+ *     - per-query statistics (parallelism payloads on profile spans), and
  *     - long-query progress reporting.
  *
  *   Zero cost when disabled: a worker reads the global `mode` once per

--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -3388,11 +3388,11 @@ void ray_lang_destroy(void) {
  * Tree-walking evaluator
  * ══════════════════════════════════════════ */
 
-/* Fill a profiler span's payload — memory (sys_cur), bandwidth (bytes_out),
- * and parallelism (qstats) — from the live counters.  Mirrors exec_node's
- * capture so direct-builtin ops (arithmetic, aggregation, generators that
- * run OUTSIDE the DAG) report the same columns as DAG operators.  `result`
- * is NULL at span START (no footprint to size yet). */
+/* Fill a profiler span's payload — memory (sys_cur) and parallelism (qstats)
+ * — from the live counters.  Mirrors exec_node's capture so direct-builtin
+ * ops (arithmetic, aggregation, generators that run OUTSIDE the DAG) report
+ * the same columns as DAG operators.  `result` is NULL at span START (no
+ * row count to size yet). */
 static inline void eval_span_payload(ray_prof_span_t* s, ray_t* result) {
     if (!s) return;
     int64_t cur = 0; ray_sys_get_stat(&cur, NULL);
@@ -3409,7 +3409,6 @@ static inline void eval_span_payload(ray_prof_span_t* s, ray_t* result) {
         s->rows_out  = (result->type == RAY_TABLE) ? ray_table_nrows(result)
                      : ray_is_atom(result)         ? 1
                      :                                (int64_t)ray_len(result);
-        s->bytes_out = ray_serde_size(result);
     }
 }
 

--- a/src/ops/exec.c
+++ b/src/ops/exec.c
@@ -30,7 +30,6 @@
 #include "mem/heap.h"
 #include "mem/sys.h"
 #include "core/qstats.h"   /* per-worker parallelism stats for profile spans */
-#include "store/serde.h"   /* ray_serde_size — result footprint for spans */
 #include "core/runtime.h"  /* __VM — filter-compaction projection keep-set */
 
 /* Global profiler instance (zero-initialized = inactive) */
@@ -1582,15 +1581,13 @@ ray_t* exec_node(ray_graph_t* g, ray_op_t* op) {
             ray_qstats_agg(&used, &sum, &mx);
             ep->qs_busy_ns = sum;
             ep->qs_workers = used;
-            /* Result footprint — rows and serialized byte size, a proxy for
-             * the bandwidth this operator produced. */
+            /* Result footprint — rows this operator produced. */
             if (_prof_result && !RAY_IS_ERR(_prof_result) && !RAY_IS_NULL(_prof_result)) {
                 /* Scalar atoms alias their value into the len field, so
                  * ray_len would report the value, not a row count. */
                 ep->rows_out  = (_prof_result->type == RAY_TABLE) ? ray_table_nrows(_prof_result)
                               : ray_is_atom(_prof_result)         ? 1
                               :                                      (int64_t)ray_len(_prof_result);
-                ep->bytes_out = ray_serde_size(_prof_result);
             }
         }
     }

--- a/src/ops/system.c
+++ b/src/ops/system.c
@@ -756,7 +756,6 @@ ray_t* ray_memstat_fn(ray_t** args, int64_t n) {
  *   exclusive-ms   self time — this span minus its children
  *   percent        share of total query time (exclusive-based, sums to ~100)
  *   rows           result element/row count (operator spans)
- *   output-kib     result serialized footprint, KiB (operator spans)
  *   allocated-kib  net process bytes allocated across the span, KiB
  *   workers        worker threads that ran a task for this span
  *   busy-ms        summed worker busy time, ms (parallelism)
@@ -787,13 +786,12 @@ ray_t* ray_prof_fn(ray_t** args, int64_t n) {
     ray_t* c_self  = ray_vec_new(RAY_F64, nrows);
     ray_t* c_pct   = ray_vec_new(RAY_F64, nrows);
     ray_t* c_rows  = ray_vec_new(RAY_I64, nrows);
-    ray_t* c_kb    = ray_vec_new(RAY_F64, nrows);
     ray_t* c_alloc = ray_vec_new(RAY_F64, nrows);
     ray_t* c_wrk   = ray_vec_new(RAY_I64, nrows);
     ray_t* c_busy  = ray_vec_new(RAY_F64, nrows);
     ray_t* c_par   = ray_vec_new(RAY_F64, nrows);
     ray_t* cols[] = { c_op, c_depth, c_dur, c_self, c_pct,
-                      c_rows, c_kb, c_alloc, c_wrk, c_busy, c_par };
+                      c_rows, c_alloc, c_wrk, c_busy, c_par };
     for (size_t i = 0; i < sizeof(cols)/sizeof(cols[0]); i++)
         if (!cols[i] || RAY_IS_ERR(cols[i])) {
             for (size_t j = 0; j < sizeof(cols)/sizeof(cols[0]); j++)
@@ -807,7 +805,6 @@ ray_t* ray_prof_fn(ray_t** args, int64_t n) {
     double*  selfs   = (double*)ray_data(c_self);
     double*  pcts    = (double*)ray_data(c_pct);
     int64_t* rows    = (int64_t*)ray_data(c_rows);
-    double*  kbs     = (double*)ray_data(c_kb);
     double*  allocs  = (double*)ray_data(c_alloc);
     int64_t* wrks    = (int64_t*)ray_data(c_wrk);
     double*  busys   = (double*)ray_data(c_busy);
@@ -850,7 +847,6 @@ ray_t* ray_prof_fn(ray_t** args, int64_t n) {
              * and sums to ~100% — a direct "where did time go" ranking. */
             pcts[r]   = total_ns > 0 ? (double)self * 100.0 / (double)total_ns : 0.0;
             rows[r]   = s->rows_out;
-            kbs[r]    = (double)s->bytes_out / 1024.0;
             allocs[r] = (double)(s->sys_cur - st->sys_cur) / 1024.0;
             wrks[r]   = (int64_t)s->qs_workers;
             busys[r]  = (double)busy / 1e6;
@@ -866,7 +862,7 @@ ray_t* ray_prof_fn(ray_t** args, int64_t n) {
             durs[r]   = (double)wall / 1e6;
             selfs[r]  = (double)wall / 1e6;
             pcts[r]   = total_ns > 0 ? (double)wall * 100.0 / (double)total_ns : 0.0;
-            rows[r]   = 0; kbs[r] = 0.0; allocs[r] = 0.0;
+            rows[r]   = 0; allocs[r] = 0.0;
             wrks[r]   = 0; busys[r] = 0.0; pars[r] = 0.0;
             r++;
         }
@@ -880,9 +876,9 @@ ray_t* ray_prof_fn(ray_t** args, int64_t n) {
 
     /* Assemble the table. */
     static const char* names[] = { "operator","depth","cumulative-ms","exclusive-ms",
-                                   "percent","rows","output-kib","allocated-kib",
+                                   "percent","rows","allocated-kib",
                                    "workers","busy-ms","parallelism" };
-    ray_t* tbl = ray_table_new(11);
+    ray_t* tbl = ray_table_new(10);
     if (!tbl || RAY_IS_ERR(tbl)) {
         for (size_t i = 0; i < sizeof(cols)/sizeof(cols[0]); i++) ray_release(cols[i]);
         return tbl ? tbl : ray_error("oom", "sys.prof: table");
@@ -908,7 +904,6 @@ ray_t* ray_prof_fn(ray_t** args, int64_t n) {
  *   time         wall-clock time the query finished (timestamp)
  *   duration-ms  total wall time
  *   result-rows  rows in the result (scalar => 1)
- *   output-kib   serialized result footprint, KiB
  *   memory-kib   net process allocation across the query, KiB
  *   workers      worker threads that ran a task
  *   parallelism  worker busy time / wall time

--- a/test/rfl/system/querylog.rfl
+++ b/test/rfl/system/querylog.rfl
@@ -9,9 +9,9 @@
 ;; It is a table.
 (type (.sys.querylog)) -- 'TABLE
 
-;; Nine fixed columns, in order.
-(count (key (.sys.querylog))) -- 9
-(key (.sys.querylog)) -- [time duration-ms result-rows output-kib memory-kib workers parallelism status query]
+;; Eight fixed columns, in order.
+(count (key (.sys.querylog))) -- 8
+(key (.sys.querylog)) -- [time duration-ms result-rows memory-kib workers parallelism status query]
 
 ;; Empty in the harness (logging capture never fires here).
 (count (.sys.querylog)) -- 0

--- a/test/rfl/system/sys_prof.rfl
+++ b/test/rfl/system/sys_prof.rfl
@@ -9,9 +9,9 @@
 ;; It is a table.
 (type (.sys.prof)) -- 'TABLE
 
-;; Eleven fixed columns, in order.
-(count (key (.sys.prof))) -- 11
-(key (.sys.prof)) -- [operator depth cumulative-ms exclusive-ms percent rows output-kib allocated-kib workers busy-ms parallelism]
+;; Ten fixed columns, in order.
+(count (key (.sys.prof))) -- 10
+(key (.sys.prof)) -- [operator depth cumulative-ms exclusive-ms percent rows allocated-kib workers busy-ms parallelism]
 
 ;; It is an ordinary table — queryable like any other, without error.
 ;; (The row count reflects whatever query last ran with profiling on, so we


### PR DESCRIPTION
## Root cause (bisected)

`eb58ada0` "detailed per-query statistics" computed `ray_serde_size(result)` — an **O(result-data)** traversal that walks every SYM/STR byte — on **every operator's result** at span-end whenever `-t`/timeit is active. On a large intermediate it dominates:

- **ClickBench q07** (10M-row × 105-col pre-projection filter): serde-sizing that intermediate costs **~2.2s**, so `-t`-measured timing went **4ms → 2200ms (550×)**.
- Bisected cleanly: `3b6ff13e` = 4.018ms (good) → `eb58ada0` = 2387ms (bad, its direct child). The unbounded-slots migration and the mem/heap wave are both exonerated — they merely inherited it.
- **Production is unaffected** (all of it is behind `if (profiling)`), but it made `-t` profiling and the `-t`-based ClickBench/TAQ harness useless on any query with a large intermediate, and the cost lands *inside* the measured number.

A second, independent offender: `b363892b`'s `.sys.querylog` ring (`qlog.c`) called `ray_serde_size` per query for its own `output_kib` — same class, removed too.

## Change

Removes the serialized-size bandwidth stat **entirely** (owner call — instrumentation must never do work proportional to the data it measures; the cheap timing/rows/parallelism stats stay):
- `ray_serde_size` per-op call in `exec.c` span-end and `eval.c` `eval_span_payload` (kept the O(1) `rows_out`).
- `bytes_out` field (`profile.h`) and the `output-kib` column from `.sys.prof` (11→10 cols).
- `output_kib` field + column from `.sys.querylog` (`qlog.c/.h`, 9→8 cols).
- The `-t` tree printer's `out=…KB` line (`repl.c`) and a stale doc mention (`qstats.h`).
- Tests: `sys_prof.rfl`, `querylog.rfl` updated to the new column shapes.

## Verification

- q07 under `-t 8`: **4.9 / 4.5 / 4.6 ms** (was ~2200ms).
- Suite **3554/3554** (ASan/UBSan); gcc + clang release `-O3 -Werror` clean.
- `grep bytes_out|output_kib|output-kib` across src+test → zero (IPC message-size `ray_serde_size` at system.c:1173/1187 correctly untouched).
- Profile/querylog tables verified index-aligned at the new column counts.

Unblocks trustworthy `-t`-based benchmarking.