### PR TITLE
ci: fix/suppress new-cppcheck findings across dev

### DIFF
--- a/src/app/term.c
+++ b/src/app/term.c
@@ -715,6 +715,7 @@ int32_t ray_term_find_matching_paren(const char* buf, int32_t buf_len,
             str_map[i] = (uint8_t)s;
         }
         for (int32_t i = cursor_pos; i >= 0; i--) {
+            // cppcheck-suppress uninitvar // entry guard ensures cursor_pos < buf_len, so the fill loop above covered [0, cursor_pos]
             if (str_map[i]) continue;
             if (buf[i] == c) depth++;
             else if (buf[i] == target) {

--- a/src/lang/compile.c
+++ b/src/lang/compile.c
@@ -187,7 +187,7 @@ static void patch_jump(compiler_t *c, int32_t pos) {
     int32_t raw = c->code_len - pos - 2;
     if (raw > 32767 || raw < -32768) { c->error = true; return; }
     int16_t offset = (int16_t)raw;
-    c->code[pos]     = (uint8_t)(offset >> 8);
+    c->code[pos]     = (uint8_t)((uint16_t)offset >> 8);
     c->code[pos + 1] = (uint8_t)(offset & 0xFF);
 }
 

--- a/src/lang/format.c
+++ b/src/lang/format.c
@@ -272,7 +272,7 @@ static void fmt_sym(fmt_buf_t* b, int64_t sym_id) {
 #include "lang/cal.h"
 
 static void time_to_hms(int32_t ms, int* h, int* min, int* s, int* ms_out) {
-    int32_t mask = ms >> 31;
+    int32_t mask = -(int32_t)((uint32_t)ms >> 31);  /* 0 or -1, without the impl-defined signed shift */
     int32_t val  = (mask ^ ms) - mask;  /* absolute value */
 
     int32_t secs = val / 1000;

--- a/src/ops/exec.c
+++ b/src/ops/exec.c
@@ -1518,7 +1518,7 @@ static const char* prof_op_label(uint16_t opc) {
         const char* up = ray_opcode_name(opc);
         if (!up) return NULL;
         size_t i = 0;
-        for (; up[i] && i < sizeof(lc[0]) - 1; i++) {
+        for (; i < sizeof(lc[0]) - 1 && up[i]; i++) {
             char c = up[i];
             if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
             else if (c == '_')        c = ' ';

--- a/src/ops/expr.c
+++ b/src/ops/expr.c
@@ -988,14 +988,14 @@ static void expr_exec_binary(uint8_t opcode, uint8_t null_aware, int8_t dt, void
                  * then zero-divisor pass marks null — same observable result). */
                 case OP_DIV: for (int64_t j=0;j<n;j++) {
                     if (I64_ISN(a[j])||I64_ISN(b[j])) { d[j]=NULL_I64; continue; }
-                    if (b[j]==0||(b[j]==-1&&a[j]==((int64_t)1<<63))) { d[j]=NULL_I64; continue; }
+                    if (b[j]==0||(b[j]==-1&&a[j]==INT64_MIN)) { d[j]=NULL_I64; continue; }
                     int64_t q=a[j]/b[j];
                     if ((a[j]^b[j])<0&&q*b[j]!=a[j]) q--;
                     d[j]=q;
                 } break;
                 case OP_MOD: for (int64_t j=0;j<n;j++) {
                     if (I64_ISN(a[j])||I64_ISN(b[j])) { d[j]=NULL_I64; continue; }
-                    if (b[j]==0||(b[j]==-1&&a[j]==((int64_t)1<<63))) { d[j]=NULL_I64; continue; }
+                    if (b[j]==0||(b[j]==-1&&a[j]==INT64_MIN)) { d[j]=NULL_I64; continue; }
                     int64_t m=a[j]%b[j];
                     if (m&&(m^b[j])<0) m+=b[j];
                     d[j]=m;
@@ -1014,13 +1014,13 @@ static void expr_exec_binary(uint8_t opcode, uint8_t null_aware, int8_t dt, void
                 case OP_SUB: for (int64_t j = 0; j < n; j++) d[j] = (int64_t)((uint64_t)a[j] - (uint64_t)b[j]); break;
                 case OP_MUL: for (int64_t j = 0; j < n; j++) d[j] = (int64_t)((uint64_t)a[j] * (uint64_t)b[j]); break;
                 case OP_DIV: for (int64_t j = 0; j < n; j++) {
-                    if (b[j]==0 || (b[j]==-1 && a[j]==((int64_t)1<<63))) { d[j]=0; continue; }
+                    if (b[j]==0 || (b[j]==-1 && a[j]==INT64_MIN)) { d[j]=0; continue; }
                     int64_t q = a[j]/b[j];
                     if ((a[j]^b[j])<0 && q*b[j]!=a[j]) q--;
                     d[j] = q;
                 } break;
                 case OP_MOD: for (int64_t j = 0; j < n; j++) {
-                    if (b[j]==0 || (b[j]==-1 && a[j]==((int64_t)1<<63))) { d[j]=0; continue; }
+                    if (b[j]==0 || (b[j]==-1 && a[j]==INT64_MIN)) { d[j]=0; continue; }
                     int64_t m = a[j]%b[j];
                     if (m && (m^b[j])<0) m+=b[j];
                     d[j] = m;
@@ -1042,13 +1042,13 @@ static void expr_exec_binary(uint8_t opcode, uint8_t null_aware, int8_t dt, void
             case OP_SUB: for (int64_t j = 0; j < n; j++) d[j] = (int32_t)((uint32_t)a[j] - (uint32_t)b[j]); break;
             case OP_MUL: for (int64_t j = 0; j < n; j++) d[j] = (int32_t)((uint32_t)a[j] * (uint32_t)b[j]); break;
             case OP_DIV: for (int64_t j = 0; j < n; j++) {
-                if (b[j]==0 || (b[j]==-1 && a[j]==((int32_t)1<<31))) { d[j]=0; continue; }
+                if (b[j]==0 || (b[j]==-1 && a[j]==INT32_MIN)) { d[j]=0; continue; }
                 int32_t q = a[j]/b[j];
                 if ((a[j]^b[j])<0 && q*b[j]!=a[j]) q--;
                 d[j] = q;
             } break;
             case OP_MOD: for (int64_t j = 0; j < n; j++) {
-                if (b[j]==0 || (b[j]==-1 && a[j]==((int32_t)1<<31))) { d[j]=0; continue; }
+                if (b[j]==0 || (b[j]==-1 && a[j]==INT32_MIN)) { d[j]=0; continue; }
                 int32_t m = a[j]%b[j];
                 if (m && (m^b[j])<0) m+=b[j];
                 d[j] = m;
@@ -2244,7 +2244,7 @@ ray_t* exec_elementwise_unary(ray_graph_t* g, ray_op_t* op, ray_t* input) {
         while (ray_morsel_next(&m)) {
             int64_t n = m.morsel_len;
             double* src = (double*)m.morsel_ptr;
-            double* dst = (double*)((char*)ray_data(result) + out_off * sizeof(double));
+            double* dst = (double*)ray_data(result) + out_off;
             switch (opc) {
                 /* Single-null float model: SQRT/LOG/EXP can map finite→non-finite
                  * → canonicalize to NULL_F64 (HAS_NULLS via post-scan below).
@@ -2296,7 +2296,7 @@ ray_t* exec_elementwise_unary(ray_graph_t* g, ray_op_t* op, ray_t* input) {
         while (ray_morsel_next(&m)) {
             int64_t n = m.morsel_len;
             int64_t* src = (int64_t*)m.morsel_ptr;
-            double* dst = (double*)((char*)ray_data(result) + out_off * sizeof(double));
+            double* dst = (double*)ray_data(result) + out_off;
             switch (opc) {
                 case OP_NEG:  for (int64_t i=0;i<n;i++) dst[i]=-(double)src[i]; break;
                 case OP_SQRT: for (int64_t i=0;i<n;i++) dst[i]=ray_f64_fin(sqrt((double)src[i])); break;
@@ -2353,7 +2353,7 @@ ray_t* exec_elementwise_unary(ray_graph_t* g, ray_op_t* op, ray_t* input) {
                 while (ray_morsel_next(&m)) {
                     int64_t n = m.morsel_len;
                     int32_t* src = (int32_t*)m.morsel_ptr;
-                    double* dst = (double*)((char*)ray_data(result) + out_off * sizeof(double));
+                    double* dst = (double*)ray_data(result) + out_off;
                     for (int64_t i = 0; i < n; i++) dst[i] = (double)src[i];
                     out_off += n;
                 }
@@ -2371,7 +2371,7 @@ ray_t* exec_elementwise_unary(ray_graph_t* g, ray_op_t* op, ray_t* input) {
                 while (ray_morsel_next(&m)) {
                     int64_t n = m.morsel_len;
                     int16_t* src = (int16_t*)m.morsel_ptr;
-                    double* dst = (double*)((char*)ray_data(result) + out_off * sizeof(double));
+                    double* dst = (double*)ray_data(result) + out_off;
                     for (int64_t i = 0; i < n; i++) dst[i] = (double)src[i];
                     out_off += n;
                 }
@@ -2389,7 +2389,7 @@ ray_t* exec_elementwise_unary(ray_graph_t* g, ray_op_t* op, ray_t* input) {
                 while (ray_morsel_next(&m)) {
                     int64_t n = m.morsel_len;
                     uint8_t* src = (uint8_t*)m.morsel_ptr;
-                    double* dst = (double*)((char*)ray_data(result) + out_off * sizeof(double));
+                    double* dst = (double*)ray_data(result) + out_off;
                     for (int64_t i = 0; i < n; i++) dst[i] = (double)src[i];
                     out_off += n;
                 }
@@ -2872,7 +2872,7 @@ static void binary_range(ray_op_t* op, int8_t out_type,
             /* OP_DIV omitted — ray_binop hard-codes F64 for OP_DIV, so
              * narrow-output OP_DIV is unreachable through any caller. */
             case OP_IDIV:for(int64_t i=0;i<n;i++){double lv=LV_READ(i),rv=RV_READ(i);odst[i]=rv!=0.0?(int32_t)floor(lv/rv):0;}break;
-            case OP_MOD: for(int64_t i=0;i<n;i++){int32_t li=(int32_t)LV_READ(i),ri=(int32_t)RV_READ(i);int32_t r;if(ri==0||(ri==-1&&li==((int32_t)1<<31))){r=0;}else{r=li%ri;if(r&&(r^ri)<0)r+=ri;}odst[i]=r;}break;
+            case OP_MOD: for(int64_t i=0;i<n;i++){int32_t li=(int32_t)LV_READ(i),ri=(int32_t)RV_READ(i);int32_t r;if(ri==0||(ri==-1&&li==INT32_MIN)){r=0;}else{r=li%ri;if(r&&(r^ri)<0)r+=ri;}odst[i]=r;}break;
             case OP_MIN2:for(int64_t i=0;i<n;i++){int32_t li=(int32_t)LV_READ(i),ri=(int32_t)RV_READ(i);odst[i]=li<ri?li:ri;}break;
             case OP_MAX2:for(int64_t i=0;i<n;i++){int32_t li=(int32_t)LV_READ(i),ri=(int32_t)RV_READ(i);odst[i]=li>ri?li:ri;}break;
             default:     for(int64_t i=0;i<n;i++)odst[i]=0;break;

--- a/src/ops/fused_topk.c
+++ b/src/ops/fused_topk.c
@@ -403,11 +403,14 @@ ray_t* ray_fused_topk_select(ray_t* tbl,
         int64_t* hidx = &ctx.heap_idx[(size_t)w * (size_t)k];
         for (int32_t i = 0; i < hn; i++) {
             if (global_n < (int32_t)k) {
+                // cppcheck-suppress objectIndex // heap_idx is an nw*k scratch buffer and hn <= k; cppcheck misreads ray_data's inline payload as a scalar
                 global_idx[global_n++] = hidx[i];
                 if (global_n == (int32_t)k)
                     fpk_heapify(&ctx, global_idx, global_n);
             } else {
+                // cppcheck-suppress objectIndex // same nw*k buffer as above
                 if (fpk_cmp(&ctx, hidx[i], global_idx[0]) >= 0) continue;
+                // cppcheck-suppress objectIndex // same nw*k buffer as above
                 global_idx[0] = hidx[i];
                 fpk_sift_down(&ctx, global_idx, global_n, 0);
             }

--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -4133,6 +4133,7 @@ static inline uint32_t group_merge_row(group_ht_t* ht,
                         if (aflags[a] & GHT_AF_F64) {
                             double sv_f;
                             memcpy(&sv_f, src_row + off, 8);
+                            // cppcheck-suppress invalidPointerCast // GHT rows are 8-byte aligned and off_sum/s*8 are multiples of 8
                             *(double*)(row + off) += sv_f;
                         } else {
                             int64_t sv_i;
@@ -7555,7 +7556,7 @@ static ray_t* exec_group_run(ray_graph_t* g, ray_op_t* op, ray_t* tbl,
                             int64_t agg_name = ray_sym_intern("_agg", 4);
                             if (n_aggs > 1) {
                                 char buf[16];
-                                int n = snprintf(buf, sizeof(buf), "_agg%d", a);
+                                int n = snprintf(buf, sizeof(buf), "_agg%u", a);
                                 agg_name = ray_sym_intern(buf, (size_t)n);
                             }
                             tmp_r = ray_table_add_col(result, agg_name, cnt_col);

--- a/src/ops/hash.h
+++ b/src/ops/hash.h
@@ -162,7 +162,12 @@ static inline uint64_t ray_hash_bytes(const void *data, size_t len) {
     uint64_t a, b;
     if (RAY_HASH_LIKELY(len <= 16)) {
         if (RAY_HASH_LIKELY(len >= 4)) {
+            /* Upstream wyhash tail reads: every access stays inside [p, p+len)
+             * for any valid (ptr, len) pair; cppcheck's valueflow misjudges the
+             * intermediate offsets at some call sites. */
+            // cppcheck-suppress pointerOutOfBoundsCond // (len>>3)<<2 is 8 only when len==16, so the 4-byte read ends at p+12
             a = (ray__wyr4(p) << 32) | ray__wyr4(p + ((len >> 3) << 2));
+            // cppcheck-suppress pointerOutOfBoundsCond // p+len is at most one-past-end before the -4 rewind
             b = (ray__wyr4(p + len - 4) << 32) | ray__wyr4(p + len - 4 - ((len >> 3) << 2));
         } else if (RAY_HASH_LIKELY(len > 0)) {
             a = ray__wyr3(p, len);
@@ -184,11 +189,15 @@ static inline uint64_t ray_hash_bytes(const void *data, size_t len) {
             seed ^= see1 ^ see2;
         }
         while (RAY_HASH_UNLIKELY(i > 16)) {
+            // cppcheck-suppress pointerOutOfBounds // loop guard i > 16 leaves >= 17 readable bytes at p
             seed = ray__wymix(ray__wyr8(p) ^ ray__wyp[1], ray__wyr8(p + 8) ^ seed);
             i -= 16;
             p += 16;
         }
+        /* p+i == one-past-end here; both reads rewind first (i in [1,16], len > 16). */
+        // cppcheck-suppress pointerOutOfBoundsCond // reads [end-16, end-8)
         a = ray__wyr8(p + i - 16);
+        // cppcheck-suppress pointerOutOfBoundsCond // reads [end-8, end)
         b = ray__wyr8(p + i - 8);
     }
     a ^= ray__wyp[1];

--- a/src/ops/idxop.c
+++ b/src/ops/idxop.c
@@ -106,7 +106,7 @@ static bool vec_is_ascending(const ray_t* v) {
         for (int64_t i = 0; i < n; i++)
             if (ray_vec_is_null((ray_t*)v, i)) return false;
     }
-    const uint8_t* b = (const uint8_t*)ray_data((ray_t*)v);
+    const void* b = ray_data((ray_t*)v);
     switch (v->type) {
     case RAY_BOOL: case RAY_U8: {
         const uint8_t* p = b;

--- a/src/ops/pivot.c
+++ b/src/ops/pivot.c
@@ -534,7 +534,9 @@ ray_t* exec_pivot(ray_graph_t* g, ray_op_t* op, ray_t* tbl) {
                 const char* base = (const char*)key_data[k];
                 kh = ray_hash_bytes(base + (size_t)keys[k] * 16, 16);
             } else if (key_types[k] == RAY_F64) {
-                kh = ray_hash_f64(*(const double*)&keys[k]);
+                double kd;                          /* F64 key bits live in the i64 slot; */
+                memcpy(&kd, &keys[k], sizeof kd);   /* memcpy bit-cast is aliasing-safe   */
+                kh = ray_hash_f64(kd);
             } else {
                 kh = ray_hash_i64(keys[k]);
             }

--- a/src/store/fileio.c
+++ b/src/store/fileio.c
@@ -258,6 +258,7 @@ ray_err_t ray_mkdir_p(const char* path) {
     // cppcheck-suppress arrayIndexOutOfBoundsCond // buf is RAY_PATH_MAX (>=4096) bytes and len < sizeof(buf); cppcheck misjudges the extent when PATH_MAX is unresolved
     while (len > 1 && buf[len - 1] == '/') buf[--len] = '\0';
     for (size_t i = 1; i < len; i++) {
+        // cppcheck-suppress arrayIndexOutOfBounds // same FP as above: PATH_MAX unresolved => cppcheck 2.13 guesses buf as size 1; i < len < sizeof(buf)
         if (buf[i] == '/') {
             buf[i] = '\0';
             if (mkdir(buf, 0755) != 0 && errno != EEXIST) return RAY_ERR_IO;

--- a/src/store/fileio.c
+++ b/src/store/fileio.c
@@ -255,6 +255,7 @@ ray_err_t ray_mkdir_p(const char* path) {
     if (len >= sizeof(buf)) return RAY_ERR_IO;
     memcpy(buf, path, len + 1);
     /* Strip trailing slash so the final mkdir creates `buf` itself. */
+    // cppcheck-suppress arrayIndexOutOfBoundsCond // buf is RAY_PATH_MAX (>=4096) bytes and len < sizeof(buf); cppcheck misjudges the extent when PATH_MAX is unresolved
     while (len > 1 && buf[len - 1] == '/') buf[--len] = '\0';
     for (size_t i = 1; i < len; i++) {
         if (buf[i] == '/') {


### PR DESCRIPTION
## Why

The GitHub Actions runner image update (2026-07-06) bumped the apt cppcheck on ubuntu-latest to **2.13.0**, and `make cppcheck` now fails on baseline dev. This is why the static-analysis job on PR #307 is red (none of its findings touch that PR's changes), and the dev Nightly is red for the same reason.

## Triage

| File | Finding | Verdict | Note |
|---|---|---|---|
| `src/lang/compile.c:190` | shiftNegativeLHS | **bug fixed** | `patch_jump` right-shifted a possibly negative `int16_t` (technically UB); shift as `uint16_t`, same emitted bytes |
| `src/lang/format.c:275` | shiftTooManyBitsSigned | **bug fixed** | `ms >> 31` impl-defined for negative `ms`; mask now derived from an unsigned shift (`0` or `-1`, same values) |
| `src/ops/expr.c:991-1051, 2875` | shiftTooManyBitsSigned (x7) | **bug fixed** | `((int64_t)1<<63)` / `((int32_t)1<<31)` shift into the sign bit (UB); replaced with `INT64_MIN` / `INT32_MIN` |
| `src/ops/expr.c:2247-2392` | invalidPointerCast (x5) | **fixed (refactor)** | `(double*)((char*)ray_data(r) + off*sizeof(double))` → `(double*)ray_data(r) + off`; identical address, no byte-pointer cast |
| `src/ops/exec.c:1522` | arrayIndexThenCheck | **fixed (refactor)** | single-line operand swap: bound check before `up[i]`; deliberately minimal — another in-flight branch edits this file |
| `src/ops/group.c:7558` | invalidPrintfArgType_sint | **bug fixed** | `%d` with a `uint32_t` arg → `%u` |
| `src/ops/pivot.c:537` | invalidPointerCast | **fixed (refactor)** | F64 key bits were read by aliasing the i64 key slot as `double*`; now a `memcpy` bit-cast (aliasing-safe, same codegen) |
| `src/ops/idxop.c:132,138` | invalidPointerCast (x2) | **fixed (refactor)** | vector base pointer typed `const void*` instead of `const uint8_t*`; per-type casts unchanged |
| `src/app/term.c:718` | uninitvar | **FP suppressed** | entry guard ensures `cursor_pos < buf_len`, so the forward fill loop covers `[0, cursor_pos]`; cppcheck can't correlate the two loop bounds |
| `src/ops/fused_topk.c:406,410,411` | objectIndex (x3) | **FP suppressed** | `heap_idx` is an `nw*k` scratch buffer and `hn <= k` is enforced by the fill loop; cppcheck misreads `ray_data`'s inline payload as a scalar |
| `src/ops/group.c:4136` | invalidPointerCast | **FP suppressed** | GHT rows are 8-byte aligned; `off_sum` and `s*8` are multiples of 8 |
| `src/ops/hash.h:165,166,187,191,192` | pointerOutOfBounds(Cond) (x5) | **FP suppressed** | upstream wyhash final4.2 tail reads — every access stays inside `[p, p+len)` for valid `(ptr, len)`; valueflow misjudges intermediate offsets |
| `src/store/fileio.c:258` | arrayIndexOutOfBoundsCond | **FP suppressed** | `buf` is `RAY_PATH_MAX` (>=4096) bytes with a `len < sizeof(buf)` guard; cppcheck misjudges the extent when `PATH_MAX` is unresolved |

## Validation

- `make lib` compiles clean (`-Wall -Wextra -Werror`).
- Verified locally with cppcheck **2.21.0** (Homebrew): every finding from the CI list that 2.21 reproduces is gone after this change. Three findings (exec.c arrayIndexThenCheck, fused_topk.c objectIndex, fileio.c arrayIndexOutOfBoundsCond) are 2.13-only and can't be reproduced locally — verified by reading; **CI is the arbiter** for those. Unmatched inline suppressions are harmless under the Makefile flags (no `--enable=information`).
- cppcheck 2.21 also reports ~12 additional findings on dev that 2.13/CI does not (eval.c, parse.c, builtins.c, collection.c, datalog.c, lftj.c, expr.c UnionZeroInit); left out of scope to keep this PR matched to the CI breakage.
- `make test` intentionally not run here: it is long-running and currently flaky due to the unrelated exec.c stack-overflow being fixed on a concurrent branch. No behavioral change is expected from this diff (all fixes are representation-identical rewrites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)