### PR TITLE
chore: generic wording in profiling and querylog comments

### DIFF
--- a/src/app/repl.c
+++ b/src/app/repl.c
@@ -219,7 +219,7 @@ static void repl_query_progress_cb(const ray_progress_t* p, void* user) {
 /* Recursively print the span tree.  `total_ns` is the whole-query wall time
  * (for the %-of-total figure); `*level_ns` is set on return to the summed
  * wall time of the spans printed at THIS level, so a parent can subtract it
- * to get its own EXCLUSIVE (self) time — the DuckDB EXPLAIN-ANALYZE view of
+ * to get its own EXCLUSIVE (self) time — the per-operator self-time view of
  * where time actually went, since cumulative time hides it inside the root. */
 static int32_t profile_print_tree(int32_t idx, int32_t indent,
                                   int64_t total_ns, int64_t* level_ns) {

--- a/src/core/qlog.h
+++ b/src/core/qlog.h
@@ -6,7 +6,7 @@
  *
  *   Ambient, server-side per-query statistics: one summary row per completed
  *   query, held in a fixed-capacity ring and exposed as an ordinary table via
- *   `(.sys.querylog)`.  The model mirrors ClickHouse's system.query_log — the
+ *   `(.sys.querylog)`.  The model is a server-side query_log system table — the
  *   stats are read back with normal queries, no extra protocol — but in its
  *   simplest, durable-free form.  A later phase may flush the ring to a
  *   date-partitioned table; that is out of scope here.

--- a/src/ops/system.c
+++ b/src/ops/system.c
@@ -817,7 +817,7 @@ ray_t* ray_prof_fn(ray_t** args, int64_t n) {
     /* Walk the flat span log, pairing START/END via a depth stack.
      * child_ns[d] accumulates the wall time of the direct children of the
      * span currently open at depth d, so each span's EXCLUSIVE (self) time
-     * is its own wall minus that sum — mirroring DuckDB's per-operator
+     * is its own wall minus that sum — standard per-operator
      * exclusive timing (cumulative is derivable by summing the subtree). */
     int32_t stack[256];
     int64_t child_ns[256] = {0};
@@ -895,7 +895,7 @@ ray_t* ray_prof_fn(ray_t** args, int64_t n) {
 /* (.sys.querylog) — the in-memory query-statistics ring as a table.
  *
  * One row per completed query (oldest first), capped at the ring capacity.
- * Ambient server-side statistics à la ClickHouse's system.query_log: read
+ * Ambient server-side query-log statistics (a system query_log table): read
  * back with ordinary queries, no extra protocol.  Each call materializes a
  * fresh snapshot, so anything a caller does to the returned table (upsert,
  * delete) touches the copy, never the ring.  Empty until logging is enabled


### PR DESCRIPTION
Rewords 4 source comments in the per-query stats/profiling code to plain DB terminology ("per-operator self-time", "a server-side query_log system table"). Comment-only, no behaviour change. Surfaced by the v2.3.0 release audit; source is grep-zero for vendor product references.