### PR TITLE
test(system): connect-retry window on log_journal_advanced ipc opens

### DIFF
--- a/test/rfl/system/log_journal_advanced.rfl
+++ b/test/rfl/system/log_journal_advanced.rfl
@@ -1,6 +1,10 @@
 ;; Journal feature — invariants the basic test (log_journal.rfl) does
 ;; not cover.  Each phase uses a distinct base + port so a phase
 ;; failing mid-run doesn't pollute the next one's state.
+;; The `.ipc.open` calls carry a 5s connect-retry window: the readiness
+;; probe confirms the spawned server is listening, but on loaded CI runners
+;; (esp. macOS) the connect can still race a momentarily-busy accept queue —
+;; retrying instead of one-shot-failing removes the flake (was intermittent io).
 ;;
 ;; Phase A: -L sync mode survives kill -9 (durability promise of -L)
 ;; Phase B: user override of a builtin survives snapshot/restart
@@ -24,7 +28,7 @@
 (.sys.exec "./rayforce -L /tmp/rftest_jdura -p 19991 </dev/null >/dev/null 2>&1 &")
 (.sys.exec "for i in $(seq 30); do bash -c '(echo > /dev/tcp/127.0.0.1/19991) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
 
-(set hA (.ipc.open "127.0.0.1:19991"))
+(set hA (.ipc.open "127.0.0.1:19991" 5000))
 (.ipc.send hA "(set durable_a 7)") -- 7
 (.ipc.send hA "(set durable_b \"survived\")") -- "survived"
 (.ipc.close hA)
@@ -38,7 +42,7 @@
 (.sys.exec "./rayforce -L /tmp/rftest_jdura -p 19991 </dev/null >/dev/null 2>&1 &")
 (.sys.exec "for i in $(seq 30); do bash -c '(echo > /dev/tcp/127.0.0.1/19991) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
 
-(set hA2 (.ipc.open "127.0.0.1:19991"))
+(set hA2 (.ipc.open "127.0.0.1:19991" 5000))
 (.ipc.send hA2 "durable_a") -- 7
 (.ipc.send hA2 "durable_b") -- "survived"
 (.ipc.close hA2)
@@ -60,7 +64,7 @@
 (.sys.exec "./rayforce -l /tmp/rftest_jovr -p 19992 </dev/null >/dev/null 2>&1 &")
 (.sys.exec "for i in $(seq 30); do bash -c '(echo > /dev/tcp/127.0.0.1/19992) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
 
-(set hB (.ipc.open "127.0.0.1:19992"))
+(set hB (.ipc.open "127.0.0.1:19992" 5000))
 ;; Override the `+` builtin with a sentinel integer, then snapshot.
 ;; The snapshot's .qdb must contain `+` -> 42 so phase-B-restart can
 ;; load it from .qdb (not from log replay, which is also rolled).
@@ -74,7 +78,7 @@
 (.sys.exec "./rayforce -l /tmp/rftest_jovr -p 19992 </dev/null >/dev/null 2>&1 &")
 (.sys.exec "for i in $(seq 30); do bash -c '(echo > /dev/tcp/127.0.0.1/19992) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
 
-(set hB2 (.ipc.open "127.0.0.1:19992"))
+(set hB2 (.ipc.open "127.0.0.1:19992" 5000))
 ;; The override must have survived the .qdb roundtrip.
 (.ipc.send hB2 "+") -- 42
 (.ipc.close hB2)
@@ -95,7 +99,7 @@
 (.sys.exec "./rayforce -l /tmp/rftest_jerr -p 19993 </dev/null >/dev/null 2>&1 &")
 (.sys.exec "for i in $(seq 30); do bash -c '(echo > /dev/tcp/127.0.0.1/19993) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
 
-(set hC (.ipc.open "127.0.0.1:19993"))
+(set hC (.ipc.open "127.0.0.1:19993" 5000))
 (.ipc.send hC "(set c1 100)") -- 100
 ;; This one errors on the server (undefined `not_a_thing`) — the
 ;; .ipc.send returns an error response, but the inbound message was
@@ -109,7 +113,7 @@
 (.sys.exec "./rayforce -l /tmp/rftest_jerr -p 19993 </dev/null >/dev/null 2>&1 &")
 (.sys.exec "for i in $(seq 30); do bash -c '(echo > /dev/tcp/127.0.0.1/19993) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
 
-(set hC2 (.ipc.open "127.0.0.1:19993"))
+(set hC2 (.ipc.open "127.0.0.1:19993" 5000))
 (.ipc.send hC2 "c1") -- 100
 ;; c2 is expected to be undefined (the bad replay entry was warn-
 ;; skipped, not applied).  Use try to catch the undefined-name error.
@@ -131,7 +135,7 @@
 (.sys.exec "./rayforce -l /tmp/rftest_jwr -p 19994 </dev/null >/dev/null 2>&1 &")
 (.sys.exec "for i in $(seq 30); do bash -c '(echo > /dev/tcp/127.0.0.1/19994) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
 
-(set hD (.ipc.open "127.0.0.1:19994"))
+(set hD (.ipc.open "127.0.0.1:19994" 5000))
 ;; Journal a string-eval entry manually.  On replay this string will
 ;; be re-evaluated (string payloads go through ray_eval_str), binding d1.
 (.ipc.send hD "(.log.write \"(set d1 999)\")")
@@ -142,7 +146,7 @@
 (.sys.exec "./rayforce -l /tmp/rftest_jwr -p 19994 </dev/null >/dev/null 2>&1 &")
 (.sys.exec "for i in $(seq 30); do bash -c '(echo > /dev/tcp/127.0.0.1/19994) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
 
-(set hD2 (.ipc.open "127.0.0.1:19994"))
+(set hD2 (.ipc.open "127.0.0.1:19994" 5000))
 (.ipc.send hD2 "d1") -- 999
 (.ipc.close hD2)
 (.sys.exec "pkill -KILL -f '[r]ayforce -l /tmp/rftest_jwr' 2>/dev/null; true")


### PR DESCRIPTION
The 8 `.ipc.open` calls in this test connect to a just-spawned server with no retry; on loaded CI runners the connect races a momentarily-busy accept queue and returns `io` (intermittent macos-debug failures, e.g. blocking the v2.3.0 release run). Adds the existing `.ipc.open` connect-timeout arg (5s retry window) to all 8 — near-zero cost once the server is up. Suite 3568/3568 locally.