### PR TITLE
group: size v2 radix group-state arrays by distinct-group count via grow-on-demand

### DIFF
--- a/src/ops/agg_engine.c
+++ b/src/ops/agg_engine.c
@@ -2136,14 +2136,18 @@ static void agg_radix_group_fn(void* vctx, uint32_t wid, int64_t start, int64_t 
         uint64_t htmask = (uint64_t)htcap - 1;
         int32_t* ht        = ray_alloc_raw((size_t)htcap * sizeof(int32_t));
         uint8_t* ht_salt   = ray_alloc_raw((size_t)htcap);  /* parallel salt fingerprint per slot */
+        /* Group-state arrays sized to the distinct-group count (grow-on-
+         * demand) instead of `total` rows. gid/gv/gy stay row-sized. */
+        int64_t gcap = total < 256 ? total : 256;
+        if (gcap < 16) gcap = 16;
         /* first_row is only populated when a row-dependent agg needs it. */
-        int64_t* first_row = c->needs_row ? ray_alloc_raw((size_t)total * sizeof(int64_t)) : NULL;
-        char*    states    = ray_alloc_raw((size_t)total * c->block);
-        const int64_t** keyp = ray_alloc_raw((size_t)total * sizeof(int64_t*)); /* gid -> packed keys */
+        int64_t* first_row = c->needs_row ? ray_alloc_raw((size_t)gcap * sizeof(int64_t)) : NULL;
+        char*    states    = ray_alloc_raw((size_t)gcap * c->block);
+        const int64_t** keyp = ray_alloc_raw((size_t)gcap * sizeof(int64_t*)); /* gid -> packed keys */
         uint32_t* gid      = ray_alloc_raw((size_t)total * sizeof(uint32_t));/* row i -> local gid */
         /* Persist each group's packed keys (build order) so Phase 3 emits the
          * key columns by sequential un-pack rather than scattered gather. */
-        int64_t* gkeys     = ray_alloc_raw((size_t)total * (size_t)(n_keys ? n_keys : 1) * sizeof(int64_t));
+        int64_t* gkeys     = ray_alloc_raw((size_t)gcap * (size_t)(n_keys ? n_keys : 1) * sizeof(int64_t));
         if (!ht || !ht_salt || (c->needs_row && !first_row) || !states || !keyp || !gid || !gkeys) {
             ray_free_raw(ht); ray_free_raw(ht_salt); ray_free_raw(first_row); ray_free_raw(states); ray_free_raw(keyp); ray_free_raw(gid); ray_free_raw(gkeys);
             pr->oom = 1; return;
@@ -2199,6 +2203,29 @@ static void agg_radix_group_fn(void* vctx, uint32_t wid, int64_t start, int64_t 
                 for (;;) {
                     int32_t gp = ht[slot];
                     if (gp < 0) {                       /* new group */
+                        if ((int64_t)ng >= gcap) {      /* grow group-state arrays (sized to distinct groups, not rows) */
+                            int64_t ncap = gcap * 2;
+                            /* Assign each realloc result back before the next so
+                             * a mid-sequence failure leaves only valid pointers
+                             * for the oom: cleanup (realloc frees the old block
+                             * on success, so the pre-realloc pointer must never
+                             * survive into cleanup). */
+                            void* ns = ray_realloc_raw(states, (size_t)ncap * c->block);
+                            if (!ns) goto oom;
+                            states = ns;
+                            void* nk = ray_realloc_raw((void*)keyp, (size_t)ncap * sizeof(int64_t*));
+                            if (!nk) goto oom;
+                            keyp = nk;
+                            void* ngk = ray_realloc_raw(gkeys, (size_t)ncap * (size_t)(n_keys ? n_keys : 1) * sizeof(int64_t));
+                            if (!ngk) goto oom;
+                            gkeys = ngk;
+                            if (c->needs_row) {
+                                void* nf = ray_realloc_raw(first_row, (size_t)ncap * sizeof(int64_t));
+                                if (!nf) goto oom;
+                                first_row = nf;
+                            }
+                            gcap = ncap;
+                        }
                         gg = (int32_t)ng;
                         ht[slot] = gg;
                         ht_salt[slot] = salt;

--- a/test/rfl/group/group_radix_rightsize.rfl
+++ b/test/rfl/group/group_radix_rightsize.rfl
@@ -1,0 +1,35 @@
+;; group_radix_rightsize.rfl — exercises the grow-on-demand group-state
+;; arrays in agg_radix_group_fn (src/ops/agg_engine.c).  The v2 parallel
+;; radix kernel sizes states/keyp/gkeys/first_row to the distinct-group
+;; count (initial gcap=256, doubled on new-group creation) rather than the
+;; partition row count; correctness of the grown arrays is the assertion.
+;;
+;; Routing note: the radix strategy is reached only for a PARALLEL
+;; (nrows >= 65536) int-keyed group-by whose keys are too SPARSE for the v2
+;; dense direct-index plan (which would exceed its 8MB/worker budget).  A
+;; contiguous `til N` key stays dense and never reaches radix — the keys are
+;; spread with `* 1000003` so the dense plan bails and radix runs.  With
+;; 200000 distinct keys / 256 radix partitions ~= 781 groups per partition,
+;; the initial gcap of 256 is crossed and the realloc growth path fires
+;; (~512 growth events observed; verified via a temporary marker).
+
+;; ── all-distinct sparse keys: one group per row, grow fires ──────────────
+(set N 200000)
+(set Tg (table [k v] (list (as 'I64 (* 1000003 (til N))) (as 'I64 (til N)))))
+(set Rg (select {c: (count v) by: k from: Tg}))
+(count Rg) -- 200000
+;; every key distinct → each group has exactly one row.
+(== (sum (at Rg 'c)) 200000) -- true
+(== (max (at Rg 'c)) 1) -- true
+
+;; ── moderate duplication: groups << rows (the right-sizing win case) ─────
+;; 100000 distinct sparse keys over 300000 rows (each appears 3x); grow still
+;; fires (100000/256 ~= 391 groups/partition > 256) and the group-state
+;; arrays are genuinely smaller than the row count.
+(set M 300000)
+(set Td (table [k v] (list (as 'I64 (* 1000003 (% (til M) 100000))) (as 'I64 (til M)))))
+(set Rd (select {c: (count v) by: k from: Td}))
+(count Rd) -- 100000
+(== (sum (at Rd 'c)) 300000) -- true
+(== (max (at Rd 'c)) 3) -- true
+(== (min (at Rd 'c)) 3) -- true


### PR DESCRIPTION
Right-sizes the v2 radix group kernel's per-partition group-state arrays to the distinct-group count instead of the partition row count, cutting the memory peak of high-cardinality group-bys with no latency cost.

## What

`agg_radix_group_fn` (the v2 parallel radix aggregation kernel) allocated its per-partition `states` (group aggregate state), `keyp` (per-group packed-key pointers), `gkeys` (per-group key values) and `first_row` arrays sized to the partition **row** count. But only the distinct-**group** count is ever written or read. For a high-duplication group-by — e.g. 8M groups from 120M rows — this over-allocates the group-state block by the duplication ratio.

The change sizes those four arrays to a small initial capacity (256, matching the codebase's other open-addressing tables) and doubles them (realloc) on new-group creation. `gid` (per-row → group id), `gv`/`gy` (per-row value staging) and `ht`/`ht_salt` (hash slots) stay row-sized — they are genuinely per-row.

## Why it's safe

- The grow check lives only in the new-group branch, never the per-row probe/hit path — the hot loop is unchanged.
- Realloc-failure handling assigns each new pointer back before attempting the next and `goto oom` on failure, so the `oom:` cleanup always sees exactly one valid pointer per array on every partial-failure ordering (no double-free / leak / use-after-free).
- Growth is standard amortized doubling; the near-unique (groups ≈ rows) worst case adds ~one extra buffer copy, which measures neutral.

## Measured

- **−31% anon-peak** on a 120M-row / 8M-group int-keyed group-by (5.95 → 4.11 GB); the arrays grow to the true per-partition group count instead of the row count.
- **ClickBench group-by latency: neutral** (same-box A/B on the group-heavy queries; some marginally faster, none regressed). Only `agg_radix_group_fn` changed, so non-group queries are provably unaffected.
- Suite **3613/3613** (ASan/UBSan); release `-O3 -Werror` clean.

## Scope

Helps high-cardinality int/SYM-keyed group-bys that route through the v2 radix strategy (large data — the out-of-core / options scale). Legacy-engine shapes (STR/F64 keys, some multi-agg rowforms) route elsewhere and are unaffected — a separate follow-up if their peaks matter.

## Test

`group_radix_rightsize.rfl` — a parallel sparse-int-keyed group-by that routes to the radix kernel and crosses the initial capacity, exercising the realloc growth path (dense contiguous keys stay on the dense plan and never reach radix, so the keys are deliberately spread; grow-path firing verified during development via a temporary marker).
