### PR TITLE
fix(store): surface FlushFileBuffers failure in journal SYNC mode

### DIFF
--- a/src/store/journal.c
+++ b/src/store/journal.c
@@ -173,7 +173,11 @@ ray_err_t ray_journal_write_bytes(const ray_ipc_header_t* hdr,
 #ifndef RAY_OS_WINDOWS
         if (fsync(fileno(g_journal.fp)) != 0) return RAY_ERR_IO;
 #else
-        FlushFileBuffers((HANDLE)_get_osfhandle(_fileno(g_journal.fp)));
+        /* FlushFileBuffers returns 0 (FALSE) on failure — surface it as an I/O
+         * error like the fsync path above, so SYNC mode's durability guarantee
+         * isn't silently dropped on Windows. */
+        if (!FlushFileBuffers((HANDLE)_get_osfhandle(_fileno(g_journal.fp))))
+            return RAY_ERR_IO;
 #endif
     }
     return RAY_OK;


### PR DESCRIPTION
## What & why

In `RAY_JOURNAL_SYNC` mode, `ray_journal_write_bytes` (`src/store/journal.c`) is
meant to guarantee each write reaches disk before returning — that is the whole
point of SYNC mode (crash recovery). The POSIX branch enforces this by checking
`fsync`'s return and failing with `RAY_ERR_IO`; the Windows branch called
`FlushFileBuffers` but **ignored its return**. A failed flush was silently
swallowed, so the function returned `RAY_OK` while the data may not have reached
disk — dropping the durability guarantee the mode exists to provide.

The fix checks `FlushFileBuffers` (returns 0 / `FALSE` on failure) and returns
`RAY_ERR_IO`, mirroring the adjacent `fsync` check.

### Verification & scope

This branch is Windows-only. The project's CI matrix is `ubuntu-latest` +
`macos-latest` (no Windows leg), so the changed line is not compiled by CI and
not reproducible locally on macOS. It is a one-line symmetry fix that uses only
symbols already present in the original Windows branch, verified by inspection
against the `fsync` path two lines above.

No test is added: the flush-failure path is not unit-testable (a successful
`FlushFileBuffers` / `fsync` can't be made to fail on demand), which is also why
the equivalent POSIX `fsync`-failure path is untested. The existing SYNC-mode
write test (`test_journal.c`, case 4f) still covers the success path. The full
macOS debug (ASan + UBSan) suite builds clean and passes:
`3631 of 3632 passed (1 skipped, 0 failed)`.

## Checklist

- [x] PR targets `dev` (not `master`)
- [x] Commits follow Conventional Commits (`fix:`)
- [x] `make` builds cleanly (no new warnings)
- [x] `make test` passes (no unit test added — the Windows-only flush-failure
      path is not testable on demand; see Verification & scope)
