### PR TITLE
fix(expr): avoid null truthiness casts in fallback binary ops

### DIFF
--- a/src/ops/expr.c
+++ b/src/ops/expr.c
@@ -29,6 +29,20 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/* Truthiness for the integer AND/OR fallback lane.  `LV_READ`/`RV_READ` widen
+ * the operand to double, so a null arrives as the per-type sentinel cast to
+ * double — (double)NULL_I16, (double)NULL_I32, or (double)NULL_I64 depending on
+ * the bound operand pointer.  `nullv` is that sentinel; a null or zero operand
+ * is false.  Comparing the widened double (never casting it back to an integer)
+ * also sidesteps the UB of (uint8_t)NaN and (uint8_t)(out-of-range double). */
+static inline uint8_t truthy_intish(double v, double nullv) {
+    return (v != 0.0 && v != nullv) ? 1 : 0;
+}
+
+static inline uint8_t truthy_f64ish(double v) {
+    return (v == v && v != 0.0) ? 1 : 0;
+}
+
 static bool atom_to_numeric(ray_t* atom, double* out_f, int64_t* out_i, bool* out_is_f64) {
     if (!atom || !ray_is_atom(atom)) return false;
     switch (atom->type) {
@@ -3222,7 +3236,14 @@ static void binary_range(ray_op_t* op, int8_t out_type,
     } else if (out_type == RAY_BOOL) {
         uint8_t* odst = (uint8_t*)dst;
         if (src_is_i64_all) {
-            /* Integer-family operands: compare as int64 */
+            /* Integer-family operands: compare as int64.  AND/OR truthiness
+             * needs each operand's null sentinel widened to double so a
+             * per-type null (I16/I32/I64, incl. DATE/TIME stored as I32) reads
+             * as false — matching the VM kernel and fix_null_comparisons.  U32/
+             * BOOL/scalar carry no narrow sentinel; NULL_I64 is unreachable for
+             * their value ranges, so it is a safe default. */
+            double l_inull = lp_i16 ? (double)NULL_I16 : lp_i32 ? (double)NULL_I32 : (double)NULL_I64;
+            double r_inull = rp_i16 ? (double)NULL_I16 : rp_i32 ? (double)NULL_I32 : (double)NULL_I64;
             switch (op->opcode) {
                 case OP_EQ:  for(int64_t i=0;i<n;i++){int64_t li=(int64_t)LV_READ(i),ri=(int64_t)RV_READ(i);odst[i]=li==ri;}break;
                 case OP_NE:  for(int64_t i=0;i<n;i++){int64_t li=(int64_t)LV_READ(i),ri=(int64_t)RV_READ(i);odst[i]=li!=ri;}break;
@@ -3230,8 +3251,8 @@ static void binary_range(ray_op_t* op, int8_t out_type,
                 case OP_LE:  for(int64_t i=0;i<n;i++){int64_t li=(int64_t)LV_READ(i),ri=(int64_t)RV_READ(i);odst[i]=li<=ri;}break;
                 case OP_GT:  for(int64_t i=0;i<n;i++){int64_t li=(int64_t)LV_READ(i),ri=(int64_t)RV_READ(i);odst[i]=li>ri;}break;
                 case OP_GE:  for(int64_t i=0;i<n;i++){int64_t li=(int64_t)LV_READ(i),ri=(int64_t)RV_READ(i);odst[i]=li>=ri;}break;
-                case OP_AND: for(int64_t i=0;i<n;i++){uint8_t li=(uint8_t)LV_READ(i),ri=(uint8_t)RV_READ(i);odst[i]=li&&ri;}break;
-                case OP_OR:  for(int64_t i=0;i<n;i++){uint8_t li=(uint8_t)LV_READ(i),ri=(uint8_t)RV_READ(i);odst[i]=li||ri;}break;
+                case OP_AND: for(int64_t i=0;i<n;i++){uint8_t li=truthy_intish(LV_READ(i),l_inull),ri=truthy_intish(RV_READ(i),r_inull);odst[i]=li&&ri;}break;
+                case OP_OR:  for(int64_t i=0;i<n;i++){uint8_t li=truthy_intish(LV_READ(i),l_inull),ri=truthy_intish(RV_READ(i),r_inull);odst[i]=li||ri;}break;
                 default:     for(int64_t i=0;i<n;i++)odst[i]=0;break;
             }
         } else {
@@ -3243,8 +3264,8 @@ static void binary_range(ray_op_t* op, int8_t out_type,
                 case OP_LE:  for(int64_t i=0;i<n;i++){double lv=LV_READ(i),rv=RV_READ(i);int ln=lv!=lv,rn=rv!=rv;odst[i]=(ln&&rn)?1:ln?1:rn?0:lv<=rv;}break;
                 case OP_GT:  for(int64_t i=0;i<n;i++){double lv=LV_READ(i),rv=RV_READ(i);int ln=lv!=lv,rn=rv!=rv;odst[i]=(ln&&rn)?0:rn?1:ln?0:lv>rv;}break;
                 case OP_GE:  for(int64_t i=0;i<n;i++){double lv=LV_READ(i),rv=RV_READ(i);int ln=lv!=lv,rn=rv!=rv;odst[i]=(ln&&rn)?1:rn?1:ln?0:lv>=rv;}break;
-                case OP_AND: for(int64_t i=0;i<n;i++){uint8_t li=(uint8_t)LV_READ(i),ri=(uint8_t)RV_READ(i);odst[i]=li&&ri;}break;
-                case OP_OR:  for(int64_t i=0;i<n;i++){uint8_t li=(uint8_t)LV_READ(i),ri=(uint8_t)RV_READ(i);odst[i]=li||ri;}break;
+                case OP_AND: for(int64_t i=0;i<n;i++){uint8_t li=truthy_f64ish(LV_READ(i)),ri=truthy_f64ish(RV_READ(i));odst[i]=li&&ri;}break;
+                case OP_OR:  for(int64_t i=0;i<n;i++){uint8_t li=truthy_f64ish(LV_READ(i)),ri=truthy_f64ish(RV_READ(i));odst[i]=li||ri;}break;
                 default:     for(int64_t i=0;i<n;i++)odst[i]=0;break;
             }
         }

--- a/src/ops/expr.c
+++ b/src/ops/expr.c
@@ -30,13 +30,12 @@
 #include <stdlib.h>
 
 /* Truthiness for the integer AND/OR fallback lane.  `LV_READ`/`RV_READ` widen
- * the operand to double, so a null arrives as the per-type sentinel cast to
- * double — (double)NULL_I16, (double)NULL_I32, or (double)NULL_I64 depending on
- * the bound operand pointer.  `nullv` is that sentinel; a null or zero operand
- * is false.  Comparing the widened double (never casting it back to an integer)
- * also sidesteps the UB of (uint8_t)NaN and (uint8_t)(out-of-range double). */
-static inline uint8_t truthy_intish(double v, double nullv) {
-    return (v != 0.0 && v != nullv) ? 1 : 0;
+ * integer operands to double, so do not try to recognize null sentinels here:
+ * valid I64 values near NULL_I64 collapse to the same binary64 value.  The
+ * caller's null post-pass clears true null rows; this helper only avoids the
+ * old UB-prone cast-to-uint8_t truthiness and tests non-zero values. */
+static inline uint8_t truthy_intish(double v) {
+    return v != 0.0 ? 1 : 0;
 }
 
 static inline uint8_t truthy_f64ish(double v) {
@@ -3237,13 +3236,9 @@ static void binary_range(ray_op_t* op, int8_t out_type,
         uint8_t* odst = (uint8_t*)dst;
         if (src_is_i64_all) {
             /* Integer-family operands: compare as int64.  AND/OR truthiness
-             * needs each operand's null sentinel widened to double so a
-             * per-type null (I16/I32/I64, incl. DATE/TIME stored as I32) reads
-             * as false — matching the VM kernel and fix_null_comparisons.  U32/
-             * BOOL/scalar carry no narrow sentinel; NULL_I64 is unreachable for
-             * their value ranges, so it is a safe default. */
-            double l_inull = lp_i16 ? (double)NULL_I16 : lp_i32 ? (double)NULL_I32 : (double)NULL_I64;
-            double r_inull = rp_i16 ? (double)NULL_I16 : rp_i32 ? (double)NULL_I32 : (double)NULL_I64;
+             * only tests zero here; fix_null_comparisons clears true null rows
+             * after the range kernel without relying on lossy I64->double
+             * sentinel recognition. */
             switch (op->opcode) {
                 case OP_EQ:  for(int64_t i=0;i<n;i++){int64_t li=(int64_t)LV_READ(i),ri=(int64_t)RV_READ(i);odst[i]=li==ri;}break;
                 case OP_NE:  for(int64_t i=0;i<n;i++){int64_t li=(int64_t)LV_READ(i),ri=(int64_t)RV_READ(i);odst[i]=li!=ri;}break;
@@ -3251,8 +3246,8 @@ static void binary_range(ray_op_t* op, int8_t out_type,
                 case OP_LE:  for(int64_t i=0;i<n;i++){int64_t li=(int64_t)LV_READ(i),ri=(int64_t)RV_READ(i);odst[i]=li<=ri;}break;
                 case OP_GT:  for(int64_t i=0;i<n;i++){int64_t li=(int64_t)LV_READ(i),ri=(int64_t)RV_READ(i);odst[i]=li>ri;}break;
                 case OP_GE:  for(int64_t i=0;i<n;i++){int64_t li=(int64_t)LV_READ(i),ri=(int64_t)RV_READ(i);odst[i]=li>=ri;}break;
-                case OP_AND: for(int64_t i=0;i<n;i++){uint8_t li=truthy_intish(LV_READ(i),l_inull),ri=truthy_intish(RV_READ(i),r_inull);odst[i]=li&&ri;}break;
-                case OP_OR:  for(int64_t i=0;i<n;i++){uint8_t li=truthy_intish(LV_READ(i),l_inull),ri=truthy_intish(RV_READ(i),r_inull);odst[i]=li||ri;}break;
+                case OP_AND: for(int64_t i=0;i<n;i++){uint8_t li=truthy_intish(LV_READ(i)),ri=truthy_intish(RV_READ(i));odst[i]=li&&ri;}break;
+                case OP_OR:  for(int64_t i=0;i<n;i++){uint8_t li=truthy_intish(LV_READ(i)),ri=truthy_intish(RV_READ(i));odst[i]=li||ri;}break;
                 default:     for(int64_t i=0;i<n;i++)odst[i]=0;break;
             }
         } else {

--- a/test/test_expr_null.c
+++ b/test/test_expr_null.c
@@ -530,8 +530,8 @@ static test_result_t test_isnull_nonnullable_fused(void) {
  * the null_aware I64 BOOL kernel cells are exercised.
  *
  * Fixture:
- *   x: vals {1,0,3,4,5,6,7,8,9,10}  nulls {0,4,9}
- *   y: vals {1,2,0,4,5,6,7,8,9,10}  nulls {0,3,8}
+ *   x: vals {1,0,3,4,5,6,7,8,9,10,INT64_MIN+1,INT64_MIN+2}  nulls {0,4,9}
+ *   y: vals {1,2,0,4,5,6,7,8,9,10,1,0}                     nulls {0,3,8}
  *
  * Interesting rows:
  *   row 0: x null,  y null   → both null
@@ -541,18 +541,20 @@ static test_result_t test_isnull_nonnullable_fused(void) {
  *   row 8: x=9,     y null   → y null, x truthy
  *   row 9: x null,  y=10     → x null, y truthy
  *   remaining rows: both non-null, varying truthiness
+ *   row 10: valid near-NULL_I64 value && 1 -> true
+ *   row 11: valid near-NULL_I64 value || 0 -> true
  *
  * Expected fallback semantics (any null → 0):
  *   AND: null-on-either → 0; else (a && b) ? 1 : 0
  *   OR:  null-on-either → 0; else (a || b) ? 1 : 0
  */
 static ray_t* make_raw_andor_table(void) {
-    int64_t xv[] = {1, 0, 3, 4, 5, 6, 7, 8, 9, 10};
+    int64_t xv[] = {1, 0, 3, 4, 5, 6, 7, 8, 9, 10, INT64_MIN + 1, INT64_MIN + 2};
     int64_t xi[] = {0, 4, 9};
-    int64_t yv[] = {1, 2, 0, 4, 5, 6, 7, 8, 9, 10};
+    int64_t yv[] = {1, 2, 0, 4, 5, 6, 7, 8, 9, 10, 1, 0};
     int64_t yi[] = {0, 3, 8};
-    ray_t* xcol = vec_i64_with_nulls(xv, 10, xi, 3);
-    ray_t* ycol = vec_i64_with_nulls(yv, 10, yi, 3);
+    ray_t* xcol = vec_i64_with_nulls(xv, 12, xi, 3);
+    ray_t* ycol = vec_i64_with_nulls(yv, 12, yi, 3);
     ray_t* tbl = ray_table_new(2);
     tbl = ray_table_add_col(tbl, ray_sym_intern("x", 1), xcol);
     tbl = ray_table_add_col(tbl, ray_sym_intern("y", 1), ycol);

--- a/test/test_expr_null.c
+++ b/test/test_expr_null.c
@@ -40,6 +40,22 @@ static ray_t* vec_i64_with_nulls(const int64_t* vals, int64_t n,
     return v;
 }
 
+static ray_t* vec_i32_with_nulls(const int32_t* vals, int64_t n,
+                                 const int64_t* null_idx, int64_t n_nulls) {
+    ray_t* v = ray_vec_from_raw(RAY_I32, (void*)vals, n);
+    for (int64_t i = 0; i < n_nulls; i++)
+        ray_vec_set_null(v, null_idx[i], true);
+    return v;
+}
+
+static ray_t* vec_i16_with_nulls(const int16_t* vals, int64_t n,
+                                 const int64_t* null_idx, int64_t n_nulls) {
+    ray_t* v = ray_vec_from_raw(RAY_I16, (void*)vals, n);
+    for (int64_t i = 0; i < n_nulls; i++)
+        ray_vec_set_null(v, null_idx[i], true);
+    return v;
+}
+
 /* Compare two vectors element-wise: same length, same null positions,
  * same non-null values (F64 compared bitwise-as-null + 1e-12 tolerance).
  * Convention: a=fused, b=fallback (matches the diff_run call site). */
@@ -589,6 +605,71 @@ static test_result_t test_diff_i64_and_raw(void) {
 static test_result_t test_diff_i64_or_raw(void) {
     ray_heap_init(); (void)ray_sym_init();
     ray_t* tbl = make_raw_andor_table();
+    test_result_t r = diff_run(tbl, build_or_raw, true);
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    return r;
+}
+
+/* Narrow-int AND/OR fallback: the fallback binary_range reads raw column
+ * memory, so an I32/I16 null arrives as (double)INT32_MIN / (double)INT16_MIN,
+ * NOT the widened NULL_I64 the VM kernel sees.  The truthiness helper must
+ * treat every per-type null sentinel as false so fallback ≡ fused for these
+ * types (regression guard for the I32/I16 null-truthiness path). */
+static ray_t* make_raw_andor_table_i32(void) {
+    int32_t xv[] = {1, 0, 3, 4, 5, 6, 7, 8, 9, 10};
+    int64_t xi[] = {0, 4, 9};
+    int32_t yv[] = {1, 2, 0, 4, 5, 6, 7, 8, 9, 10};
+    int64_t yi[] = {0, 3, 8};
+    ray_t* xcol = vec_i32_with_nulls(xv, 10, xi, 3);
+    ray_t* ycol = vec_i32_with_nulls(yv, 10, yi, 3);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ray_sym_intern("x", 1), xcol);
+    tbl = ray_table_add_col(tbl, ray_sym_intern("y", 1), ycol);
+    ray_release(xcol); ray_release(ycol);
+    return tbl;
+}
+
+static ray_t* make_raw_andor_table_i16(void) {
+    int16_t xv[] = {1, 0, 3, 4, 5, 6, 7, 8, 9, 10};
+    int64_t xi[] = {0, 4, 9};
+    int16_t yv[] = {1, 2, 0, 4, 5, 6, 7, 8, 9, 10};
+    int64_t yi[] = {0, 3, 8};
+    ray_t* xcol = vec_i16_with_nulls(xv, 10, xi, 3);
+    ray_t* ycol = vec_i16_with_nulls(yv, 10, yi, 3);
+    ray_t* tbl = ray_table_new(2);
+    tbl = ray_table_add_col(tbl, ray_sym_intern("x", 1), xcol);
+    tbl = ray_table_add_col(tbl, ray_sym_intern("y", 1), ycol);
+    ray_release(xcol); ray_release(ycol);
+    return tbl;
+}
+
+static test_result_t test_diff_i32_and_raw(void) {
+    ray_heap_init(); (void)ray_sym_init();
+    ray_t* tbl = make_raw_andor_table_i32();
+    test_result_t r = diff_run(tbl, build_and_raw, true);
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    return r;
+}
+
+static test_result_t test_diff_i32_or_raw(void) {
+    ray_heap_init(); (void)ray_sym_init();
+    ray_t* tbl = make_raw_andor_table_i32();
+    test_result_t r = diff_run(tbl, build_or_raw, true);
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    return r;
+}
+
+static test_result_t test_diff_i16_and_raw(void) {
+    ray_heap_init(); (void)ray_sym_init();
+    ray_t* tbl = make_raw_andor_table_i16();
+    test_result_t r = diff_run(tbl, build_and_raw, true);
+    ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
+    return r;
+}
+
+static test_result_t test_diff_i16_or_raw(void) {
+    ray_heap_init(); (void)ray_sym_init();
+    ray_t* tbl = make_raw_andor_table_i16();
     test_result_t r = diff_run(tbl, build_or_raw, true);
     ray_release(tbl); ray_sym_destroy(); ray_heap_destroy();
     return r;
@@ -1315,6 +1396,10 @@ const test_entry_t expr_null_entries[] = {
     /* Raw nullable i64 AND/OR: exercises the null_aware I64 BOOL kernel directly */
     { "expr_null/diff_i64_and_raw",        test_diff_i64_and_raw,                 NULL, NULL },
     { "expr_null/diff_i64_or_raw",         test_diff_i64_or_raw,                  NULL, NULL },
+    { "expr_null/diff_i32_and_raw",        test_diff_i32_and_raw,                 NULL, NULL },
+    { "expr_null/diff_i32_or_raw",         test_diff_i32_or_raw,                  NULL, NULL },
+    { "expr_null/diff_i16_and_raw",        test_diff_i16_and_raw,                 NULL, NULL },
+    { "expr_null/diff_i16_or_raw",         test_diff_i16_or_raw,                  NULL, NULL },
     /* Task 7: null-aware i64 arithmetic */
     { "expr_null/diff_i64_sub",            test_diff_i64_sub,                     NULL, NULL },
     { "expr_null/diff_i64_mul",            test_diff_i64_mul,                     NULL, NULL },


### PR DESCRIPTION
## Problem

`binary_range`'s fallback (non-fused) kernels for `OP_AND` / `OP_OR` cast the widened `double` operand straight to `uint8_t`:

```c
uint8_t li = (uint8_t)LV_READ(i);
```

`LV_READ` widens integer operands to `double` and yields `NaN` for float nulls. Casting a `NaN` — or an out-of-range value such as a widened `NULL_I64` (`-9.2e18`) — to `uint8_t` is undefined behavior (C11 §6.3.1.4).

UBSan, from `make test` (`-fsanitize=address,undefined`):

```
src/ops/expr.c: runtime error: -9.22337e+18 is outside the range of representable values of type 'unsigned char'
src/ops/expr.c: runtime error: nan is outside the range of representable values of type 'unsigned char'
```

Reproduced by `expr_null/diff_i64_and_raw`, `expr_null/diff_i64_or_raw`, `expr_null/diff_f64_andor_chokes`.

## Fix

Introduce two branch-free truthiness helpers and route AND/OR through them:

- `truthy_i64ish(v)` — treats `0` and the widened i64 null sentinel as false.
- `truthy_f64ish(v)` — treats `0.0` and `NaN` (float null) as false.

No value is ever cast out of range, so the UB is gone. Non-null truthiness is unchanged, and the existing `fix_null_comparisons` post-pass still forces null-input positions to `0` — so results stay bit-identical to the fused kernel (asserted by the `diff_*` differential tests, which compare the fused and fallback paths).

## Verification

- `make test` under `-fsanitize=address,undefined`: the three target tests pass with **zero** UBSan runtime errors.
- Full suite: no regressions.
