### PR TITLE
fix(null): avoid f64 null casts to integers

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -50,15 +50,23 @@ static inline int64_t ray_cast_f64_to_i64_null(double v) {
 }
 
 static inline int32_t ray_cast_f64_to_i32_null(double v) {
-    return (v != v) ? NULL_I32 : (int32_t)v;
+    if (v != v) return NULL_I32;
+    if (v >= (double)INT32_MAX) return INT32_MAX;
+    if (v <= (double)INT32_MIN) return INT32_MIN + 1;
+    return (int32_t)v;
 }
 
 static inline int16_t ray_cast_f64_to_i16_null(double v) {
-    return (v != v) ? NULL_I16 : (int16_t)v;
+    if (v != v) return NULL_I16;
+    if (v >= (double)INT16_MAX) return INT16_MAX;
+    if (v <= (double)INT16_MIN) return INT16_MIN + 1;
+    return (int16_t)v;
 }
 
 static inline uint8_t ray_cast_f64_to_u8_null(double v) {
-    return (v != v) ? 0 : (uint8_t)v;
+    if (v != v || v <= 0.0) return 0;
+    if (v >= (double)UINT8_MAX) return UINT8_MAX;
+    return (uint8_t)v;
 }
 
 static inline uint8_t ray_cast_f64_to_bool_null(double v) {

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -42,4 +42,27 @@ extern const uint8_t ray_type_sizes[256];
 /* Element size for a given type tag */
 #define ray_elem_size(t)  (ray_type_sizes[(t)])
 
+static inline int64_t ray_cast_f64_to_i64_null(double v) {
+    if (v != v) return NULL_I64;
+    if (v >= (double)INT64_MAX) return INT64_MAX;
+    if (v <= (double)INT64_MIN) return INT64_MIN + 1;
+    return (int64_t)v;
+}
+
+static inline int32_t ray_cast_f64_to_i32_null(double v) {
+    return (v != v) ? NULL_I32 : (int32_t)v;
+}
+
+static inline int16_t ray_cast_f64_to_i16_null(double v) {
+    return (v != v) ? NULL_I16 : (int16_t)v;
+}
+
+static inline uint8_t ray_cast_f64_to_u8_null(double v) {
+    return (v != v) ? 0 : (uint8_t)v;
+}
+
+static inline uint8_t ray_cast_f64_to_bool_null(double v) {
+    return (v == v && v != 0.0) ? 1 : 0;
+}
+
 #endif /* RAY_TYPES_H */

--- a/src/ops/builtins.c
+++ b/src/ops/builtins.c
@@ -953,7 +953,7 @@ static bool cast_range_worker(const void* _src_p, void* _dst_p,
         case RAY_I16:   CL(int16_t,  int64_t, (int64_t)_v);
         case RAY_I32: case RAY_DATE: case RAY_TIME:
                         CL(int32_t,  int64_t, (int64_t)_v);
-        case RAY_F64:   CL(double,   int64_t, (int64_t)_v);
+        case RAY_F64:   CL(double,   int64_t, ray_cast_f64_to_i64_null(_v));
         }
         break;
     case RAY_I32: case RAY_DATE: case RAY_TIME:
@@ -963,7 +963,7 @@ static bool cast_range_worker(const void* _src_p, void* _dst_p,
         case RAY_I16:   CL(int16_t,  int32_t, (int32_t)_v);
         case RAY_I64: case RAY_TIMESTAMP:
                         CL(int64_t,  int32_t, (int32_t)_v);
-        case RAY_F64:   CL(double,   int32_t, (int32_t)_v);
+        case RAY_F64:   CL(double,   int32_t, ray_cast_f64_to_i32_null(_v));
         }
         break;
     case RAY_I16:
@@ -974,7 +974,7 @@ static bool cast_range_worker(const void* _src_p, void* _dst_p,
                         CL(int32_t,  int16_t, (int16_t)_v);
         case RAY_I64: case RAY_TIMESTAMP:
                         CL(int64_t,  int16_t, (int16_t)_v);
-        case RAY_F64:   CL(double,   int16_t, (int16_t)_v);
+        case RAY_F64:   CL(double,   int16_t, ray_cast_f64_to_i16_null(_v));
         }
         break;
     case RAY_U8:
@@ -985,7 +985,7 @@ static bool cast_range_worker(const void* _src_p, void* _dst_p,
                         CL(int32_t,  uint8_t, (uint8_t)_v);
         case RAY_I64: case RAY_TIMESTAMP:
                         CL(int64_t,  uint8_t, (uint8_t)_v);
-        case RAY_F64:   CL(double,   uint8_t, (uint8_t)_v);
+        case RAY_F64:   CL(double,   uint8_t, ray_cast_f64_to_u8_null(_v));
         }
         break;
     case RAY_F64:
@@ -1007,7 +1007,7 @@ static bool cast_range_worker(const void* _src_p, void* _dst_p,
                         CL(int32_t,  uint8_t, _v != 0 ? 1 : 0);
         case RAY_I64: case RAY_TIMESTAMP:
                         CL(int64_t,  uint8_t, _v != 0 ? 1 : 0);
-        case RAY_F64:   CL(double,   uint8_t, _v != 0.0 ? 1 : 0);
+        case RAY_F64:   CL(double,   uint8_t, ray_cast_f64_to_bool_null(_v));
         }
         break;
     }

--- a/src/ops/expr.c
+++ b/src/ops/expr.c
@@ -34,12 +34,12 @@ static bool atom_to_numeric(ray_t* atom, double* out_f, int64_t* out_i, bool* ou
     switch (atom->type) {
         case -RAY_F64:
             *out_f = atom->f64;
-            *out_i = (int64_t)atom->f64;
+            *out_i = ray_cast_f64_to_i64_null(atom->f64);
             *out_is_f64 = true;
             return true;
         case -RAY_F32:
             *out_f = (double)(float)atom->f64;
-            *out_i = (int64_t)(float)atom->f64;
+            *out_i = ray_cast_f64_to_i64_null((double)(float)atom->f64);
             *out_is_f64 = true;
             return true;
         case -RAY_I64:
@@ -132,7 +132,7 @@ static bool eval_const_numeric_expr(ray_graph_t* g, ray_op_t* op,
         }
         r = ray_f64_fin(r);
         *out_f = r;
-        *out_i = (int64_t)r;
+        *out_i = ray_cast_f64_to_i64_null(r);
         *out_is_f64 = true;
         return true;
     }
@@ -168,7 +168,7 @@ static bool eval_const_numeric_expr(ray_graph_t* g, ray_op_t* op,
          * (div/mod by zero → NaN, overflow → ±Inf) canonicalizes to NULL_F64. */
         r = ray_f64_fin(r);
         *out_f = r;
-        *out_i = (int64_t)r;
+        *out_i = ray_cast_f64_to_i64_null(r);
         *out_is_f64 = true;
         return true;
     }
@@ -1358,15 +1358,10 @@ static void expr_exec_unary(uint8_t opcode, uint8_t null_aware, int8_t dt, void*
              * non-null i64 — so a saturated cast stays a real value. */
             if (null_aware)
                 for (int64_t j = 0; j < n; j++)
-                    d[j] = (a[j] != a[j]) ? NULL_I64
-                         : (a[j] >= (double)INT64_MAX) ? INT64_MAX
-                         : (a[j] <= (double)INT64_MIN) ? (INT64_MIN + 1)
-                         : (int64_t)a[j];
+                    d[j] = ray_cast_f64_to_i64_null(a[j]);
             else
                 for (int64_t j = 0; j < n; j++)
-                    d[j] = (a[j] >= (double)INT64_MAX) ? INT64_MAX
-                         : (a[j] <= (double)INT64_MIN) ? (INT64_MIN + 1)
-                         : (int64_t)a[j];
+                    d[j] = ray_cast_f64_to_i64_null(a[j]);
         }
     } else if (dt == RAY_BOOL) {
         uint8_t* d = (uint8_t*)dp;
@@ -1431,9 +1426,9 @@ static void expr_exec_unary(uint8_t opcode, uint8_t null_aware, int8_t dt, void*
             const double* a = (const double*)ap;
             if (null_aware)
                 for (int64_t j = 0; j < n; j++)
-                    d[j] = (a[j] != a[j]) ? NULL_I32 : (int32_t)a[j];
+                    d[j] = ray_cast_f64_to_i32_null(a[j]);
             else
-                for (int64_t j = 0; j < n; j++) d[j] = (int32_t)a[j];
+                for (int64_t j = 0; j < n; j++) d[j] = ray_cast_f64_to_i32_null(a[j]);
         } else {
             const int64_t* a = (const int64_t*)ap;
             if (null_aware)
@@ -1457,9 +1452,9 @@ static void expr_exec_unary(uint8_t opcode, uint8_t null_aware, int8_t dt, void*
             const double* a = (const double*)ap;
             if (null_aware)
                 for (int64_t j = 0; j < n; j++)
-                    d[j] = (a[j] != a[j]) ? NULL_I16 : (int16_t)a[j];
+                    d[j] = ray_cast_f64_to_i16_null(a[j]);
             else
-                for (int64_t j = 0; j < n; j++) d[j] = (int16_t)a[j];
+                for (int64_t j = 0; j < n; j++) d[j] = ray_cast_f64_to_i16_null(a[j]);
         } else {
             const int64_t* a = (const int64_t*)ap;
             if (null_aware)
@@ -1472,7 +1467,7 @@ static void expr_exec_unary(uint8_t opcode, uint8_t null_aware, int8_t dt, void*
         uint8_t* d = (uint8_t*)dp;
         if (t1 == RAY_F64) {
             const double* a = (const double*)ap;
-            for (int64_t j = 0; j < n; j++) d[j] = (uint8_t)a[j];
+            for (int64_t j = 0; j < n; j++) d[j] = ray_cast_f64_to_u8_null(a[j]);
         } else {
             const int64_t* a = (const int64_t*)ap;
             for (int64_t j = 0; j < n; j++) d[j] = (uint8_t)a[j];
@@ -2720,7 +2715,7 @@ ray_t* exec_elementwise_unary(ray_graph_t* g, ray_op_t* op, ray_t* input) {
                     int64_t n = m.morsel_len;
                     double* src = (double*)m.morsel_ptr;
                     int32_t* dst = (int32_t*)((char*)ray_data(result) + out_off * sizeof(int32_t));
-                    for (int64_t i = 0; i < n; i++) dst[i] = (int32_t)src[i];
+                    for (int64_t i = 0; i < n; i++) dst[i] = ray_cast_f64_to_i32_null(src[i]);
                     out_off += n;
                 }
             } else if (out_type == RAY_I16) {
@@ -2728,7 +2723,7 @@ ray_t* exec_elementwise_unary(ray_graph_t* g, ray_op_t* op, ray_t* input) {
                     int64_t n = m.morsel_len;
                     double* src = (double*)m.morsel_ptr;
                     int16_t* dst = (int16_t*)((char*)ray_data(result) + out_off * sizeof(int16_t));
-                    for (int64_t i = 0; i < n; i++) dst[i] = (int16_t)src[i];
+                    for (int64_t i = 0; i < n; i++) dst[i] = ray_cast_f64_to_i16_null(src[i]);
                     out_off += n;
                 }
             } else if (out_type == RAY_U8 || out_type == RAY_BOOL) {
@@ -2741,9 +2736,9 @@ ray_t* exec_elementwise_unary(ray_graph_t* g, ray_op_t* op, ray_t* input) {
                          * `NaN != 0.0` is true so add an explicit
                          * `src[i] == src[i]` to filter NaN to false. */
                         for (int64_t i = 0; i < n; i++)
-                            dst[i] = (src[i] != 0.0 && src[i] == src[i]) ? 1 : 0;
+                            dst[i] = ray_cast_f64_to_bool_null(src[i]);
                     else
-                        for (int64_t i = 0; i < n; i++) dst[i] = (uint8_t)src[i];
+                        for (int64_t i = 0; i < n; i++) dst[i] = ray_cast_f64_to_u8_null(src[i]);
                     out_off += n;
                 }
             }

--- a/src/ops/expr.c
+++ b/src/ops/expr.c
@@ -2504,7 +2504,7 @@ ray_t* exec_elementwise_unary(ray_graph_t* g, ray_op_t* op, ray_t* input) {
                 case OP_CEIL:  for (int64_t i=0;i<n;i++) dst[i] = (int64_t)ceil(src[i]); break;
                 case OP_FLOOR: for (int64_t i=0;i<n;i++) dst[i] = (int64_t)floor(src[i]); break;
                 case OP_ROUND: for (int64_t i=0;i<n;i++) dst[i] = (int64_t)round(src[i]); break;
-                default:       for (int64_t i=0;i<n;i++) dst[i] = (int64_t)src[i]; break;
+                default:       for (int64_t i=0;i<n;i++) dst[i] = ray_cast_f64_to_i64_null(src[i]); break;
             }
             out_off += n;
         }

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -11380,9 +11380,9 @@ ray_t* ray_update(ray_t** args, int64_t n) {
                     for (int64_t r = 0; r < nrows; r++) {
                         if (!mask[r]) continue;
                         if (ct == RAY_I64 && expr_type == RAY_F64)
-                            ((int64_t*)ray_data(new_col))[r] = (int64_t)((double*)ray_data(expr_vec))[r];
+                            ((int64_t*)ray_data(new_col))[r] = ray_cast_f64_to_i64_null(((double*)ray_data(expr_vec))[r]);
                         else if (ct == RAY_I32 && expr_type == RAY_F64)
-                            ((int32_t*)ray_data(new_col))[r] = (int32_t)((double*)ray_data(expr_vec))[r];
+                            ((int32_t*)ray_data(new_col))[r] = ray_cast_f64_to_i32_null(((double*)ray_data(expr_vec))[r]);
                         else if (ct == RAY_F64 && expr_type == RAY_I64)
                             ((double*)ray_data(new_col))[r] = (double)((int64_t*)ray_data(expr_vec))[r];
                     }

--- a/test/test_expr_null.c
+++ b/test/test_expr_null.c
@@ -24,10 +24,12 @@
 /* test/test_expr_null.c — null-aware fused expression tests */
 #include "test.h"
 #include <rayforce.h>
+#include "core/types.h"
 #include "ops/ops.h"
 #include "ops/internal.h"
 #include "mem/heap.h"
 #include "table/sym.h"
+#include <limits.h>
 #include <string.h>
 #include <math.h>
 
@@ -950,6 +952,19 @@ static test_result_t test_diff_cast_f64_to_i32(void) {
     return r;
 }
 
+static test_result_t test_cast_f64_narrow_saturates(void) {
+    TEST_ASSERT(ray_cast_f64_to_i32_null(NAN) == NULL_I32, "i32 NaN -> null");
+    TEST_ASSERT(ray_cast_f64_to_i32_null(1e300) == INT32_MAX, "i32 overflow clamps high");
+    TEST_ASSERT(ray_cast_f64_to_i32_null(-1e300) == INT32_MIN + 1, "i32 overflow preserves null sentinel");
+    TEST_ASSERT(ray_cast_f64_to_i16_null(NAN) == NULL_I16, "i16 NaN -> null");
+    TEST_ASSERT(ray_cast_f64_to_i16_null(1e300) == INT16_MAX, "i16 overflow clamps high");
+    TEST_ASSERT(ray_cast_f64_to_i16_null(-1e300) == INT16_MIN + 1, "i16 overflow preserves null sentinel");
+    TEST_ASSERT(ray_cast_f64_to_u8_null(NAN) == 0, "u8 NaN -> false/nullish");
+    TEST_ASSERT(ray_cast_f64_to_u8_null(1e300) == UINT8_MAX, "u8 overflow clamps high");
+    TEST_ASSERT(ray_cast_f64_to_u8_null(-1e300) == 0, "u8 underflow clamps low");
+    PASS();
+}
+
 /* ---- Task 9: fused agg input — attr propagation gates sentinel-aware aggregation ----
  *
  * Table: k=[1,1,2,2] (group key), x=[10,20,NULL,NULL] (values).
@@ -1334,6 +1349,7 @@ const test_entry_t expr_null_entries[] = {
     { "expr_null/diff_cast_i32",           test_diff_cast_i32,                    NULL, NULL },
     { "expr_null/diff_cast_i16",           test_diff_cast_i16,                    NULL, NULL },
     { "expr_null/diff_cast_f64_to_i32",    test_diff_cast_f64_to_i32,             NULL, NULL },
+    { "expr_null/cast_f64_narrow_saturates", test_cast_f64_narrow_saturates,      NULL, NULL },
     /* Task 9: fused agg inputs — all-null group finalizes to NULL */
     { "expr_null/fused_agg_allnull_group", test_fused_agg_input_allnull_group,    NULL, NULL },
     /* Task 10: parted nullable columns through the fused path */


### PR DESCRIPTION
## Problem

Several paths cast an F64 value straight to an integer type. When the F64 holds a null — encoded as `NaN` (`NULL_F64`) — the cast is undefined behavior (C11 §6.3.1.4: `NaN` / out-of-range float → integer is UB).

UBSan, from `make test` (`-fsanitize=address,undefined`):

```
src/ops/builtins.c: runtime error: nan is outside the range of representable values of type 'long long'
src/ops/expr.c:     runtime error: nan is outside the range of representable values of type 'int'
src/ops/query.c:    runtime error: nan is outside the range of representable values of type 'long long'
```

Reproduced by `expr_null/diff_cast_f64_to_i32`, `rfl/null/cast`, `rfl/expr/const_expr`, `compile/update_promo_f64_to_i64_null_slot_is_sentinel`.

## Fix

Add null-aware cast helpers in `core/types.h` and use them at the affected sites (`builtins.c` cast worker, `expr.c` const-fold + unary/elementwise casts, `query.c` update promotion):

- `ray_cast_f64_to_i64_null` — `NaN` → `NULL_I64`, plus saturation so out-of-range finite values never land on the sentinel.
- `ray_cast_f64_to_i32_null` / `_i16_null` — `NaN` → `NULL_I32` / `NULL_I16`.
- `ray_cast_f64_to_u8_null` / `_bool_null` — `NaN` → `0` (U8 / BOOL are non-nullable).

Final values are unchanged (null positions were already sentinel-masked); this removes the UB and writes the canonical null sentinel in-buffer.

## Verification

- `make test` under `-fsanitize=address,undefined`: the four target tests pass with **zero** UBSan runtime errors.
- Full suite: no regressions.
