### PR TITLE
fix(ipc): preserve boxed data list args

### DIFF
--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -59,6 +59,16 @@
 #include "lang/internal.h"
 #include "table/sym.h"
 
+static void mark_ipc_literal_fallbacks(ray_t* obj) {
+    if (!obj || RAY_IS_ERR(obj) || obj->type != RAY_LIST)
+        return;
+
+    obj->attrs |= RAY_EVAL_LITERAL_FALLBACK;
+    ray_t** elems = (ray_t**)ray_data(obj);
+    for (int64_t i = 0; i < ray_len(obj); i++)
+        mark_ipc_literal_fallbacks(elems[i]);
+}
+
 /* ===== Compression (delta + RLE) ===== */
 
 size_t ray_ipc_compress(const uint8_t* src, size_t len,
@@ -506,6 +516,12 @@ static ray_t* eval_payload_core(uint8_t* payload, size_t payload_len,
 
     ray_t* result = NULL;
     if (msg && !RAY_IS_ERR(msg)) {
+        if (msg->type == RAY_LIST) {
+            ray_t** elems = (ray_t**)ray_data(msg);
+            for (int64_t i = 1; i < ray_len(msg); i++)
+                mark_ipc_literal_fallbacks(elems[i]);
+        }
+
         /* Dispatch through `.ipc.on.sync` / `.ipc.on.async` hook if
          * installed; otherwise fall back to v1's inline-eval default.
          * The hook receives the raw deserialised payload — same shape

--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -3609,8 +3609,17 @@ ray_t* ray_eval(ray_t* obj) {
 
     /* List: evaluate first element, dispatch by type */
     ray_t** elems = (ray_t**)ray_data(obj);
+    int literal_fallback = (obj->attrs & RAY_EVAL_LITERAL_FALLBACK) != 0;
     ray_t* head = ray_eval(elems[0]);
-    if (RAY_IS_ERR(head)) { ret = head; goto out; }
+    if (RAY_IS_ERR(head)) {
+        const char* code = ray_err_code(head);
+        if (literal_fallback && code && strcmp(code, "name") == 0) {
+            ray_error_free(head);
+            ray_retain(obj);
+            ret = obj; goto out;
+        }
+        ret = head; goto out;
+    }
 
     /* A symbol in functional position names the function to apply.  A name
      * head (e.g. from `(quote f)`) already resolved during head-eval above;
@@ -3619,6 +3628,11 @@ ray_t* ray_eval(ray_t* obj) {
     if (head->type == -RAY_SYM) {
         ray_t* fn = ray_env_resolve(head->i64);
         if (!fn) {
+            if (literal_fallback) {
+                ray_release(head);
+                ray_retain(obj);
+                ret = obj; goto out;
+            }
             ray_t* ns = ray_sym_str(head->i64);
             if (ns) {
                 ret = ray_error("name", "'%.*s' undefined",
@@ -3632,7 +3646,16 @@ ray_t* ray_eval(ray_t* obj) {
         }
         /* env_resolve may also surface a real error (e.g. nyi from a
          * dotted-target deref) — propagate it directly. */
-        if (RAY_IS_ERR(fn)) { ray_release(head); ret = fn; goto out; }
+        if (RAY_IS_ERR(fn)) {
+            const char* code = ray_err_code(fn);
+            if (literal_fallback && code && strcmp(code, "name") == 0) {
+                ray_release(head);
+                ray_error_free(fn);
+                ray_retain(obj);
+                ret = obj; goto out;
+            }
+            ray_release(head); ret = fn; goto out;
+        }
         ray_release(head);
         head = fn;   /* env_resolve hands back an owned ref; no extra retain. */
     }
@@ -3827,6 +3850,10 @@ ray_t* ray_eval(ray_t* obj) {
         default: {
             int8_t head_type = head->type;
             ray_release(head);
+            if (obj->attrs & RAY_EVAL_LITERAL_FALLBACK) {
+                ray_retain(obj);
+                ret = obj; goto out;
+            }
             ret = ray_error("type", "eval: head of list is not callable, got %s", ray_type_name(head_type)); goto out;
         }
     }

--- a/src/lang/eval.h
+++ b/src/lang/eval.h
@@ -46,6 +46,11 @@
 #define ATTR_QUOTED  0x20  /* -RAY_SYM atom with this flag SET = quoted/literal symbol;
                               CLEAR (default) = name reference, resolved at eval. */
 
+/* Internal eval flag for RAY_LIST values carried as nested IPC arguments.
+ * The evaluator still runs callable lists normally; this only makes a
+ * non-callable list head fall back to returning the list as data. */
+#define RAY_EVAL_LITERAL_FALLBACK 0x04
+
 /* Function type signatures */
 typedef ray_t* (*ray_unary_fn)(ray_t*);
 typedef ray_t* (*ray_binary_fn)(ray_t*, ray_t*);

--- a/test/test_ipc.c
+++ b/test/test_ipc.c
@@ -485,6 +485,129 @@ static test_result_t test_ipc_send_compiled_lambda_msg(void) {
     PASS();
 }
 
+static test_result_t test_ipc_send_list_dict_arg_literal(void) {
+    ray_ipc_server_t srv;
+    ray_err_t err = ray_ipc_server_init(&srv, 0);
+    TEST_ASSERT_EQ_I(err, RAY_OK);
+
+    uint16_t port = get_listen_port(srv.listen_fd);
+    TEST_ASSERT((port) > (0), "port > 0");
+
+    ray_vm_t* srv_vm = make_server_vm();
+    TEST_ASSERT_NOT_NULL(srv_vm);
+
+    ipc_thread_ctx_t ctx = { .srv = &srv, .vm = srv_vm };
+    ray_thread_t tid;
+    ray_thread_create(&tid, server_thread_fn, &ctx);
+
+    int64_t h = ray_ipc_connect("127.0.0.1", port, NULL, NULL, 0);
+    TEST_ASSERT((h) >= (0), "h >= 0");
+
+    ray_t* setup_msg = ray_str("(set echo (fn [x] x))", strlen("(set echo (fn [x] x))"));
+    ray_t* setup = ray_ipc_send(h, setup_msg);
+    ray_release(setup_msg);
+    TEST_ASSERT_NOT_NULL(setup);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(setup));
+    ray_release(setup);
+
+    ray_t* msg = ray_eval_str("(list 'echo (list {lo: 0 hi: 10} {lo: 10 hi: 20}))");
+    TEST_ASSERT_NOT_NULL(msg);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(msg));
+
+    ray_t* result = ray_ipc_send(h, msg);
+    ray_release(msg);
+
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(result->type, RAY_LIST);
+    TEST_ASSERT_EQ_I(result->len, 2);
+
+    ray_t** rows = (ray_t**)ray_data(result);
+    TEST_ASSERT_EQ_I(rows[0]->type, RAY_DICT);
+    TEST_ASSERT_EQ_I(rows[1]->type, RAY_DICT);
+
+    ray_t* lo_key = ray_sym(ray_sym_intern("lo", 2));
+    ray_t* hi_key = ray_sym(ray_sym_intern("hi", 2));
+    TEST_ASSERT_NOT_NULL(lo_key);
+    TEST_ASSERT_NOT_NULL(hi_key);
+
+    ray_t* lo0 = ray_dict_get(rows[0], lo_key);
+    ray_t* hi0 = ray_dict_get(rows[0], hi_key);
+    ray_t* lo1 = ray_dict_get(rows[1], lo_key);
+    ray_t* hi1 = ray_dict_get(rows[1], hi_key);
+    TEST_ASSERT_NOT_NULL(lo0);
+    TEST_ASSERT_NOT_NULL(hi0);
+    TEST_ASSERT_NOT_NULL(lo1);
+    TEST_ASSERT_NOT_NULL(hi1);
+    TEST_ASSERT_EQ_I(lo0->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(hi0->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(lo1->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(hi1->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(lo0->i64, 0);
+    TEST_ASSERT_EQ_I(hi0->i64, 10);
+    TEST_ASSERT_EQ_I(lo1->i64, 10);
+    TEST_ASSERT_EQ_I(hi1->i64, 20);
+
+    ray_release(lo0);
+    ray_release(hi0);
+    ray_release(lo1);
+    ray_release(hi1);
+    ray_release(lo_key);
+    ray_release(hi_key);
+    ray_release(result);
+
+    ray_t* hook_msg = ray_str("(set .ipc.on.sync (fn [m] (eval m)))",
+                              strlen("(set .ipc.on.sync (fn [m] (eval m)))"));
+    ray_t* hook = ray_ipc_send(h, hook_msg);
+    ray_release(hook_msg);
+    TEST_ASSERT_NOT_NULL(hook);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(hook));
+    ray_release(hook);
+
+    ray_t* msg2 = ray_eval_str("(list 'echo (list {lo: 0 hi: 10} {lo: 10 hi: 20}))");
+    TEST_ASSERT_NOT_NULL(msg2);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(msg2));
+
+    ray_t* result2 = ray_ipc_send(h, msg2);
+    ray_release(msg2);
+
+    TEST_ASSERT_NOT_NULL(result2);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result2));
+    TEST_ASSERT_EQ_I(result2->type, RAY_LIST);
+    TEST_ASSERT_EQ_I(result2->len, 2);
+
+    ray_t** hook_rows = (ray_t**)ray_data(result2);
+    TEST_ASSERT_EQ_I(hook_rows[0]->type, RAY_DICT);
+    TEST_ASSERT_EQ_I(hook_rows[1]->type, RAY_DICT);
+
+    ray_t* hook_lo_key = ray_sym(ray_sym_intern("lo", 2));
+    ray_t* hook_hi_key = ray_sym(ray_sym_intern("hi", 2));
+    TEST_ASSERT_NOT_NULL(hook_lo_key);
+    TEST_ASSERT_NOT_NULL(hook_hi_key);
+
+    ray_t* hook_lo0 = ray_dict_get(hook_rows[0], hook_lo_key);
+    ray_t* hook_hi1 = ray_dict_get(hook_rows[1], hook_hi_key);
+    TEST_ASSERT_NOT_NULL(hook_lo0);
+    TEST_ASSERT_NOT_NULL(hook_hi1);
+    TEST_ASSERT_EQ_I(hook_lo0->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(hook_hi1->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(hook_lo0->i64, 0);
+    TEST_ASSERT_EQ_I(hook_hi1->i64, 20);
+
+    ray_release(hook_lo0);
+    ray_release(hook_hi1);
+    ray_release(hook_lo_key);
+    ray_release(hook_hi_key);
+    ray_release(result2);
+
+    ray_ipc_close(h);
+    srv.running = false;
+    ray_thread_join(tid);
+    ray_ipc_server_destroy(&srv);
+    ray_sys_free(srv_vm);
+    PASS();
+}
+
 /* ---- test_ipc_connect_fail_no_server ------------------------------------ */
 /*
  * ray_ipc_connect to a port with nothing listening must return -1.
@@ -1945,6 +2068,7 @@ const test_entry_t ipc_entries[] = {
     { "ipc/eval_non_string_msg",        test_ipc_eval_non_string_msg,            ipc_setup, ipc_teardown },
     { "ipc/send_list_select_msg",       test_ipc_send_list_select_msg,           ipc_setup, ipc_teardown },
     { "ipc/send_compiled_lambda_msg",   test_ipc_send_compiled_lambda_msg,       ipc_setup, ipc_teardown },
+    { "ipc/send_list_dict_arg_literal", test_ipc_send_list_dict_arg_literal,     ipc_setup, ipc_teardown },
     { "ipc/connect_fail_no_server",      test_ipc_connect_fail_no_server,         ipc_setup, ipc_teardown },
     { "ipc/connect_auth_no_user",       test_ipc_connect_auth_no_user,           ipc_setup, ipc_teardown },
     { "ipc/close_invalid_handle",       test_ipc_close_invalid_handle,           ipc_setup, ipc_teardown },

--- a/test/test_lang.c
+++ b/test/test_lang.c
@@ -411,6 +411,90 @@ static test_result_t test_eval_symbol_head_applies(void) {
     PASS();
 }
 
+static test_result_t test_eval_literal_fallback_preserves_boxed_data(void) {
+    ray_t* setup = ray_eval_str("(set echo (fn [x] x))");
+    TEST_ASSERT_NOT_NULL(setup);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(setup));
+    ray_release(setup);
+
+    ray_t* msg = ray_eval_str("(list 'echo (list {lo: 0 hi: 10} {lo: 10 hi: 20}))");
+    TEST_ASSERT_NOT_NULL(msg);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(msg));
+    TEST_ASSERT_EQ_I(msg->type, RAY_LIST);
+
+    ray_t** msg_elems = (ray_t**)ray_data(msg);
+    msg_elems[1]->attrs |= RAY_EVAL_LITERAL_FALLBACK;
+
+    ray_t* result = ray_eval(msg);
+    ray_release(msg);
+
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(result->type, RAY_LIST);
+    TEST_ASSERT_EQ_I(result->len, 2);
+
+    ray_t** rows = (ray_t**)ray_data(result);
+    TEST_ASSERT_EQ_I(rows[0]->type, RAY_DICT);
+    TEST_ASSERT_EQ_I(rows[1]->type, RAY_DICT);
+
+    ray_t* lo_key = ray_sym(ray_sym_intern("lo", 2));
+    ray_t* hi_key = ray_sym(ray_sym_intern("hi", 2));
+    TEST_ASSERT_NOT_NULL(lo_key);
+    TEST_ASSERT_NOT_NULL(hi_key);
+
+    ray_t* lo0 = ray_dict_get(rows[0], lo_key);
+    ray_t* hi1 = ray_dict_get(rows[1], hi_key);
+    TEST_ASSERT_NOT_NULL(lo0);
+    TEST_ASSERT_NOT_NULL(hi1);
+    TEST_ASSERT_EQ_I(lo0->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(hi1->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(lo0->i64, 0);
+    TEST_ASSERT_EQ_I(hi1->i64, 20);
+
+    ray_release(lo0);
+    ray_release(hi1);
+    ray_release(lo_key);
+    ray_release(hi_key);
+    ray_release(result);
+
+    ray_t* sym_msg = ray_eval_str("(list 'echo (list 'ipc_data_tag 1))");
+    TEST_ASSERT_NOT_NULL(sym_msg);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(sym_msg));
+    TEST_ASSERT_EQ_I(sym_msg->type, RAY_LIST);
+
+    ray_t** sym_elems = (ray_t**)ray_data(sym_msg);
+    sym_elems[1]->attrs |= RAY_EVAL_LITERAL_FALLBACK;
+
+    ray_t* sym_result = ray_eval(sym_msg);
+    ray_release(sym_msg);
+    TEST_ASSERT_NOT_NULL(sym_result);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(sym_result));
+    TEST_ASSERT_EQ_I(sym_result->type, RAY_LIST);
+    TEST_ASSERT_EQ_I(sym_result->len, 2);
+    ray_t** sym_rows = (ray_t**)ray_data(sym_result);
+    TEST_ASSERT_EQ_I(sym_rows[0]->type, -RAY_SYM);
+    TEST_ASSERT_EQ_I(sym_rows[1]->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(sym_rows[1]->i64, 1);
+    ray_release(sym_result);
+
+    ray_t* expr_msg = ray_eval_str("(list 'echo (list + 1 2))");
+    TEST_ASSERT_NOT_NULL(expr_msg);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(expr_msg));
+    TEST_ASSERT_EQ_I(expr_msg->type, RAY_LIST);
+
+    ray_t** expr_elems = (ray_t**)ray_data(expr_msg);
+    expr_elems[1]->attrs |= RAY_EVAL_LITERAL_FALLBACK;
+
+    ray_t* expr_result = ray_eval(expr_msg);
+    ray_release(expr_msg);
+    TEST_ASSERT_NOT_NULL(expr_result);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(expr_result));
+    TEST_ASSERT_EQ_I(expr_result->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(expr_result->i64, 3);
+    ray_release(expr_result);
+    PASS();
+}
+
 /* ---- Test: eval if true ---- */
 static test_result_t test_eval_if_true(void) {
     ray_t* result = ray_eval_str("(if true 1 2)");
@@ -8439,6 +8523,7 @@ const test_entry_t lang_entries[] = {
     { "lang/eval/cmp", test_eval_cmp, lang_setup, lang_teardown },
     { "lang/eval/set", test_eval_set, lang_setup, lang_teardown },
     { "lang/eval/symbol_head_applies", test_eval_symbol_head_applies, lang_setup, lang_teardown },
+    { "lang/eval/literal_fallback_preserves_boxed_data", test_eval_literal_fallback_preserves_boxed_data, lang_setup, lang_teardown },
     { "lang/eval/if_true", test_eval_if_true, lang_setup, lang_teardown },
     { "lang/eval/if_false", test_eval_if_false, lang_setup, lang_teardown },
     { "lang/eval/let", test_eval_let, lang_setup, lang_teardown },


### PR DESCRIPTION
## Summary
- mark nested list arguments in non-string IPC calls with a literal fallback
- preserve boxed data lists, including list-of-dicts payloads, when their head is not callable
- keep callable nested lists evaluated normally, preserving expression-style IPC messages

## Tests
- RAYFORCE_CORES=2 ./rayforce.test -f lang/eval/literal_fallback_preserves_boxed_data
- RAYFORCE_CORES=2 ./rayforce.test -f lang/eval/symbol_head_applies
- RAYFORCE_CORES=2 ./rayforce.test -f rfl/hof/eval_coverage2

Note: socket-backed IPC regression RAYFORCE_CORES=2 ./rayforce.test -f ipc/send_list_dict_arg_literal fails locally before exercising the change: ray_ipc_server_init returns RAY_ERR_IO, matching the existing local IPC/listen failures.