### PR TITLE
ci: use portable march for fuzz jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
   # suite each run and cached so coverage accretes across runs.
   fuzz-smoke:
     runs-on: ubuntu-latest
+    env:
+      # Hosted runner `-march=native` can expose transient CPU features that
+      # clang promotes to -Werror diagnostics; fuzzing does not need native ISA.
+      RAY_MARCH: x86-64
     steps:
       - uses: actions/checkout@v4
       - name: Cache fuzz corpus

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,6 +45,9 @@ jobs:
 
   fuzz-long:
     runs-on: ubuntu-latest
+    env:
+      # Keep clang fuzz builds off hosted-runner native ISA quirks.
+      RAY_MARCH: x86-64
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- set RAY_MARCH=x86-64 for fuzz-smoke CI
- set the same portable march for nightly fuzz-long
- avoid hosted-runner clang -march=native AVX feature diagnostics becoming -Werror fuzz build failures

## Tests
- RAY_MARCH=x86-64 make -n build_fuzz/fuzz_parse
- git diff --check