### PR TITLE
fix(group): avoid f64 null cast in DA reads

### DIFF
--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -5685,7 +5685,7 @@ static inline void da_read_val(const void* ptr, int8_t type, uint8_t attrs,
                                int64_t r, double* out_f64, int64_t* out_i64) {
     if (group_fp_type(type)) {
         *out_f64 = group_fp_at(ptr, type, r);
-        *out_i64 = ray_cast_f64_to_i64_null(*out_f64);
+        *out_i64 = NULL_I64;
     } else {
         *out_i64 = read_col_i64(ptr, r, type, attrs);
         *out_f64 = (double)*out_i64;


### PR DESCRIPTION
## Summary
- avoid casting F64 grouped DA reads through int64_t
- keep the F64 null/NaN payload in the floating output and use NULL_I64 only as the unused integer fallback
- fixes UBSan on grouped binary aggregate paths with nullable F64 data

## Tests
- RAYFORCE_CORES=2 ./rayforce.test -f rfl/agg/binary_group_null_paths
- git diff --check
- make test TEST_CORES=2 (fails locally on socket/listen-dependent tests and one stress self-check; targeted regression above passes cleanly)