### PR TITLE
fix(pivot): preserve generic missing cells as null

### DIFF
--- a/src/ops/tblop.c
+++ b/src/ops/tblop.c
@@ -596,11 +596,17 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
 
     /* Value columns */
     for (int64_t p = 0; p < n_pv; p++) {
+        int8_t agg_type = RAY_I64;
+        for (int64_t gi = 0; gi < n_grps; gi++) {
+            if (gm_pv[gi] != p) continue;
+            if (ar[gi]->type == -RAY_F64) { agg_type = RAY_F64; break; }
+        }
+
         ray_t* col_vals = ray_list_new((int32_t)n_ix);
         for (int64_t r = 0; r < n_ix; r++) {
-            ray_t* zero = ray_i64(0);
-            col_vals = ray_list_append(col_vals, zero);
-            ray_release(zero);
+            ray_t* nullv = ray_typed_null((int8_t)-agg_type);
+            col_vals = ray_list_append(col_vals, nullv);
+            ray_release(nullv);
         }
 
         for (int64_t gi = 0; gi < n_grps; gi++) {
@@ -611,11 +617,6 @@ static ray_t* pivot_fn_impl(ray_t* tbl, ray_t* index_arg, ray_t* pivot_col_name,
             cv[gm_ix[gi]] = ar[gi];
         }
 
-        int8_t agg_type = RAY_I64;
-        { ray_t** cv = (ray_t**)ray_data(col_vals);
-          for (int64_t r = 0; r < n_ix; r++)
-            if (cv[r]->type == -RAY_F64) { agg_type = RAY_F64; break; }
-        }
         ray_t* agg_vec = list_to_typed_vec(col_vals, agg_type);
         if (RAY_IS_ERR(agg_vec)) { ray_release(result); result = agg_vec; goto fb_cleanup; }
 

--- a/test/rfl/table/pivot.rfl
+++ b/test/rfl/table/pivot.rfl
@@ -158,6 +158,9 @@
 (nil? (at (at Pcs 'y) 1)) -- true
 ;; present cell that genuinely sums to a value stays a value (not nulled)
 (at (at Pcs 'x) 1) -- 3
+(set PcsFn (pivot Ts 'r 'c 'v (fn [xs] (sum xs))))
+(nil? (at (at PcsFn 'y) 1)) -- true
+(at (at PcsFn 'x) 1) -- 3
 (set Pcc (pivot Ts 'r 'c 'v count))
 (nil? (at (at Pcc 'y) 1)) -- true
 (at (at Pcc 'x) 1) -- 1

--- a/test/rfl/table/tblop.rfl
+++ b/test/rfl/table/tblop.rfl
@@ -95,11 +95,11 @@
 (set Pgmk (pivot Tgmk ['a 'b] 'c 'v (fn [xs] (sum xs))))
 (count Pgmk) -- 4
 ;; Index columns survive verbatim; pivot columns p/q carry the summed
-;; values with zero-fill where the (a,b,c) combination never occurred.
+;; values with null-fill where the (a,b,c) combination never occurred.
 (at Pgmk 'a) -- ['X 'X 'Y 'Y]
 (at Pgmk 'b) -- [1 2 1 2]
-(at Pgmk 'p) -- [10 0 30 0]
-(at Pgmk 'q) -- [0 20 0 40]
+(at Pgmk 'p) -- [10 0N 30 0N]
+(at Pgmk 'q) -- [0N 20 0N 40]
 
 ;; Pivot column = i64 vec, lambda agg → fallback path that snprintfs the
 ;; i64 value into a column name ("col10" / "col20" via the i64 branch).


### PR DESCRIPTION
Summary: Preserve generic pivot fallback missing cells as typed nulls instead of real zeroes, and update pivot/tblop coverage for custom aggregate missing cells. Tests: make test TEST_CORES=2 (3644 of 3645 passed, 1 skipped, 0 failed).