### PR TITLE
fix(xbar): avoid narrow bucket truncation

### DIFF
--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -10825,6 +10825,14 @@ static void xbar_par_fn(void* vctx, uint32_t worker_id,
     }
 }
 
+static bool xbar_bucket_fits_vec_type(int8_t out_type, int64_t b) {
+    if (out_type == RAY_I32 || out_type == RAY_DATE || out_type == RAY_TIME)
+        return b >= INT32_MIN && b <= INT32_MAX;
+    if (out_type == RAY_I16)
+        return b >= INT16_MIN && b <= INT16_MAX;
+    return true;
+}
+
 ray_t* ray_xbar_fn(ray_t* col, ray_t* bucket) {
     /* Vectorised fast path for `(xbar VEC scalar_int)` on integer or
      * temporal columns.  The generic atomic_map_binary path was
@@ -10847,6 +10855,8 @@ ray_t* ray_xbar_fn(ray_t* col, ray_t* bucket) {
         !RAY_ATOM_IS_NULL(bucket)) {
         int64_t b = bucket->i64;
         if (b == 0) return ray_error("domain", "xbar: bucket size must be non-zero");
+        if (!xbar_bucket_fits_vec_type(col->type, b))
+            return atomic_map_binary(ray_xbar_fn, col, bucket);
         int64_t n = col->len;
         ray_t* out = ray_vec_new(col->type, n);
         if (!out || RAY_IS_ERR(out)) return out ? out : ray_error("oom", NULL);

--- a/test/rfl/arith/xbar.rfl
+++ b/test/rfl/arith/xbar.rfl
@@ -15,3 +15,10 @@
 ;; distance to bucket in [0, step)
 (set D (- V (xbar V 10)))
 (count V) -- (sum (and (>= D 0) (< D 10)))
+
+;; Narrow integer vectors with a wide I64 bucket must avoid truncating the
+;; bucket to zero in the vector fast path.
+(type (xbar (as 'I32 [10 20]) 4294967296)) -- 'I64
+(xbar (as 'I32 [-10 20]) 4294967296) -- [-4294967296 0]
+(type (xbar (as 'I16 [10 20]) 65536)) -- 'I64
+(xbar (as 'I16 [-10 20]) 65536) -- [-65536 0]


### PR DESCRIPTION
Summary:
- guard xbar vector fast path against I64 buckets that do not fit narrow integer/temporal vector storage
- fall back to generic atomic mapping so wide buckets produce widened I64 results instead of truncating to zero
- add Rayfall regression coverage for I32 and I16 wide buckets

Tests:
- make rayforce
- make test TEST_CORES=2
- git diff --check