### PR TITLE
fix(arith): reject float temporal operands

### DIFF
--- a/src/ops/arith.c
+++ b/src/ops/arith.c
@@ -145,6 +145,14 @@ ray_t* ray_sub_fn(ray_t* a, ray_t* b) {
     if ((a && RAY_IS_PARTED(a->type)) || (b && RAY_IS_PARTED(b->type)))
         return atomic_map_binary_op(ray_sub_fn, OP_SUB, a, b);
 
+    /* Match add: temporal offsets must be integer typed.  Without this,
+     * DATE/TIME/TIMESTAMP - F64 reads the float payload through as_i64() and
+     * either truncates semantics or uses raw union bits. */
+    if (((a->type == -RAY_F64 || a->type == -RAY_F32) && is_temporal(b)) ||
+        (is_temporal(a) && (b->type == -RAY_F64 || b->type == -RAY_F32)))
+        return ray_error("type", "subtract: temporal arithmetic requires integer offsets, got %s and %s",
+                         ray_type_name(a->type), ray_type_name(b->type));
+
     /* Temporal - int null propagation (both operands) */
     if (is_temporal(a) && is_numeric(b)) {
         if (RAY_ATOM_IS_NULL(a) || RAY_ATOM_IS_NULL(b))
@@ -218,6 +226,11 @@ ray_t* ray_sub_fn(ray_t* a, ray_t* b) {
 ray_t* ray_mul_fn(ray_t* a, ray_t* b) {
     if ((a && RAY_IS_PARTED(a->type)) || (b && RAY_IS_PARTED(b->type)))
         return atomic_map_binary_op(ray_mul_fn, OP_MUL, a, b);
+
+    if (((a->type == -RAY_F64 || a->type == -RAY_F32) && b->type == -RAY_TIME) ||
+        (a->type == -RAY_TIME && (b->type == -RAY_F64 || b->type == -RAY_F32)))
+        return ray_error("type", "multiply: temporal arithmetic requires integer factors, got %s and %s",
+                         ray_type_name(a->type), ray_type_name(b->type));
 
     /* int * TIME → TIME, TIME * int → TIME */
     if (is_numeric(a) && b->type == -RAY_TIME) {

--- a/test/rfl/arith/mul.rfl
+++ b/test/rfl/arith/mul.rfl
@@ -110,6 +110,12 @@
 (type (* 3 (as 'TIME 1000))) -- 'time
 (* (as 'TIME 1000) 3) -- 00:00:03.000
 (type (* (as 'TIME 1000) 3)) -- 'time
+;; TIME scaling only admits integer factors; float factors used to read raw
+;; F64 union bits as i64 and trip signed-overflow UBSan.
+(* (as 'TIME 1000) 1.5) !- type
+(* 1.5 (as 'TIME 1000)) !- type
+(* (as 'TIME [1000 2000]) 1.5) !- type
+(* (as 'TIME 1000) 0Nf) !- type
 
 ;; null-int * TIME → null TIME (line 174 path)
 (nil? (* 0Ni (as 'TIME 1000))) -- true

--- a/test/rfl/arith/sub.rfl
+++ b/test/rfl/arith/sub.rfl
@@ -115,6 +115,12 @@
 (- (as 'DATE 7305) (as 'I32 30)) -- 2019.12.02
 ;; DATE - I16
 (- (as 'DATE 7305) (as 'I16 5)) -- 2019.12.27
+;; DATE/TIME/TIMESTAMP offsets must be integer typed; float offsets are type errors.
+(- (as 'DATE 7305) 1.5) !- type
+(- (as 'TIME 5000) 1.5) !- type
+(- (as 'TIMESTAMP 5000) 1.5) !- type
+(- (as 'DATE [7305 7306]) 1.5) !- type
+(- (as 'DATE 7305) 0Nf) !- type
 
 ;; DATE - DATE → I32 (days)
 (- (as 'DATE 7310) (as 'DATE 7305)) -- 5


### PR DESCRIPTION
## Summary
- reject float operands for temporal subtraction before temporal paths call as_i64()
- reject float factors for TIME multiplication to avoid reading F64 payload bits as integers
- add Rayfall coverage for DATE/TIME/TIMESTAMP minus float and TIME times float cases

## Tests
- make test TEST_CORES=2