### PR TITLE
fix(query): preserve temporal arithmetic semantics

### DIFF
--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -308,6 +308,19 @@ static bool dag_pow_type_admitted(int8_t t) {
     return dag_numeric_type_admitted(t);
 }
 
+static bool dag_type_is_temporal(int8_t t) {
+    if (t <= 0) return false;
+    if (RAY_IS_PARTED(t)) t = (int8_t)RAY_PARTED_BASETYPE(t);
+    return t == RAY_DATE || t == RAY_TIME || t == RAY_TIMESTAMP;
+}
+
+static bool dag_temporal_arith_needs_eval(const char* name, size_t len,
+                                          int8_t left_type, int8_t right_type) {
+    if (!dag_type_is_temporal(left_type) && !dag_type_is_temporal(right_type))
+        return false;
+    return len == 1 && (name[0] == '+' || name[0] == '-' || name[0] == '*');
+}
+
 static bool dag_unary_numeric_name(const char* name, size_t len) {
     if (len == 3)
         return memcmp(name, "sin", 3) == 0 ||
@@ -1567,6 +1580,10 @@ ray_op_t* compile_expr_dag(ray_graph_t* g, ray_t* expr) {
                 ray_op_t* right = compile_expr_dag(g, elems[2]);
                 if (!right) return NULL;
                 left = &g->nodes[left_id];
+                if (dag_temporal_arith_needs_eval(fname, fname_len,
+                                                  left->out_type,
+                                                  right->out_type))
+                    return NULL;
                 if (fname_len == 3 && memcmp(fname, "pow", 3) == 0 &&
                     (!dag_pow_type_admitted(left->out_type) ||
                      !dag_pow_type_admitted(right->out_type)))
@@ -4302,6 +4319,95 @@ static ray_t* atom_broadcast_vec(ray_t* a, int64_t n) {
             memset(v->aux, 0xFF, 16);
     }
     return v;
+}
+
+static ray_t* scalar_result_col(ray_t* value) {
+    if (!value || RAY_IS_ERR(value)) return value ? value : ray_error("domain", "select: scalar aggregate produced no result");
+
+    if (ray_is_atom(value)) {
+        ray_t* col = atom_broadcast_vec(value, 1);
+        if (col) return col;
+
+        ray_t* boxed = ray_alloc(sizeof(ray_t*));
+        if (!boxed) return ray_error("oom", NULL);
+        boxed->type = RAY_LIST;
+        boxed->len = 1;
+        ((ray_t**)ray_data(boxed))[0] = value;
+        ray_retain(value);
+        return boxed;
+    }
+
+    if (ray_len(value) != 1)
+        return ray_error("length", "select: scalar aggregate produced %lld rows", (long long)ray_len(value));
+    ray_retain(value);
+    return value;
+}
+
+static ray_t* eval_scalar_agg_outputs(ray_t** dict_elems, int64_t dict_n,
+                                      ray_t* tbl,
+                                      int64_t from_id, int64_t where_id,
+                                      int64_t by_id, int64_t take_id,
+                                      int64_t asc_id, int64_t desc_id,
+                                      int64_t nearest_id) {
+    ray_t* result = ray_table_new(0);
+    if (!result || RAY_IS_ERR(result))
+        return result ? result : ray_error("oom", NULL);
+
+    int64_t nrows = ray_table_nrows(tbl);
+    for (int64_t i = 0; i + 1 < dict_n; i += 2) {
+        int64_t kid = dict_elems[i]->i64;
+        if (kid == from_id || kid == where_id || kid == by_id ||
+            kid == take_id || kid == asc_id || kid == desc_id ||
+            kid == nearest_id) continue;
+
+        ray_t* val_expr = dict_elems[i + 1];
+        if (!is_agg_expr(val_expr)) {
+            ray_release(result);
+            return ray_error("domain", "select: scalar aggregate fallback saw non-aggregate output");
+        }
+
+        ray_t** agg_elems = (ray_t**)ray_data(val_expr);
+        if (ray_len(val_expr) != 2) {
+            ray_release(result);
+            return ray_error("domain", "select: scalar aggregate fallback only supports unary aggregates");
+        }
+
+        ray_t* fn_obj = ray_env_get(agg_elems[0]->i64);
+        if (!fn_obj || fn_obj->type != RAY_UNARY) {
+            ray_release(result);
+            return ray_error("type", "select: aggregate must be a unary function, got %s",
+                             fn_obj ? ray_type_name(fn_obj->type) : "null");
+        }
+
+        ray_t* src = eval_expr_per_row(agg_elems[1], tbl, nrows);
+        if (!src || RAY_IS_ERR(src)) {
+            ray_release(result);
+            return src ? src : ray_error("domain", "select: failed to evaluate aggregation source");
+        }
+
+        ray_unary_fn uf = (ray_unary_fn)(uintptr_t)fn_obj->i64;
+        ray_t* agg_value = uf(src);
+        ray_release(src);
+        if (agg_value && !RAY_IS_ERR(agg_value) && ray_is_lazy(agg_value))
+            agg_value = ray_lazy_materialize(agg_value);
+        if (!agg_value || RAY_IS_ERR(agg_value)) {
+            ray_release(result);
+            return agg_value ? agg_value : ray_error("domain", "select: scalar aggregate evaluation failed");
+        }
+
+        ray_t* col = scalar_result_col(agg_value);
+        ray_release(agg_value);
+        if (!col || RAY_IS_ERR(col)) {
+            ray_release(result);
+            return col ? col : ray_error("domain", "select: failed to materialize scalar aggregate");
+        }
+        result = ray_table_add_col(result, kid, col);
+        ray_release(col);
+        if (!result || RAY_IS_ERR(result))
+            return result ? result : ray_error("oom", NULL);
+    }
+
+    return result;
 }
 
 /* (select {from: t [where: pred] [by: key] [col: expr ...]})
@@ -9285,6 +9391,7 @@ by_dict_done:
             uint16_t*  s_agg_ops  = (uint16_t*)(s_agg_ins2 + s_max);
             int64_t    s_n_aggs = 0;
             int        s_has_binary = 0;
+            int        s_use_eval_fallback = 0;
             for (int64_t i = 0; i + 1 < dict_n; i += 2) {
                 int64_t kid = dict_elems[i]->i64;
                 if (kid == from_id || kid == where_id || kid == by_id ||
@@ -9296,13 +9403,8 @@ by_dict_done:
                 s_agg_ins[s_n_aggs] = compile_expr_dag(g, agg_elems[1]);
                 s_agg_ins2[s_n_aggs] = NULL;
                 if (!s_agg_ins[s_n_aggs]) {
-                    if (g->selection) {
-                        ray_release(g->selection);
-                        g->selection = NULL;
-                    }
-                    ray_graph_free(g); ray_release(tbl);
-                    scratch_free(sagg_hdr);
-                    scratch_free(sel_slots_hdr); DICT_VIEW_CLOSE(dv); return ray_error("domain", "select: failed to compile aggregation argument");
+                    s_use_eval_fallback = 1;
+                    break;
                 }
                 /* Canonical aggregand type-admission (same table as the scalar
                  * builtins): reject non-numeric (SYM/STR/GUID) and, for sum,
@@ -9325,10 +9427,8 @@ by_dict_done:
                     }
                     s_agg_ins2[s_n_aggs] = compile_expr_dag(g, agg_elems[2]);
                     if (!s_agg_ins2[s_n_aggs]) {
-                        if (g->selection) { ray_release(g->selection); g->selection = NULL; }
-                        ray_graph_free(g); ray_release(tbl);
-                        scratch_free(sagg_hdr);
-                        scratch_free(sel_slots_hdr); DICT_VIEW_CLOSE(dv); return ray_error("domain", "select: failed to compile binary aggregation second argument");
+                        s_use_eval_fallback = 1;
+                        break;
                     }
                     if (s_agg_ins2[s_n_aggs]->out_type > 0 &&
                         !agg_type_admitted(op, s_agg_ins2[s_n_aggs]->out_type)) {
@@ -9341,6 +9441,29 @@ by_dict_done:
                     s_has_binary = 1;
                 }
                 s_n_aggs++;
+            }
+            if (s_use_eval_fallback) {
+                ray_t* eval_tbl = tbl;
+                int release_eval_tbl = 0;
+                if (g->selection) {
+                    eval_tbl = sel_compact(g, tbl, g->selection, NULL, 0);
+                    if (!eval_tbl || RAY_IS_ERR(eval_tbl)) {
+                        if (g->selection) { ray_release(g->selection); g->selection = NULL; }
+                        ray_graph_free(g); ray_release(tbl);
+                        scratch_free(sagg_hdr);
+                        scratch_free(sel_slots_hdr); DICT_VIEW_CLOSE(dv); return eval_tbl ? eval_tbl : ray_error("oom", NULL);
+                    }
+                    release_eval_tbl = 1;
+                }
+                ray_t* result = eval_scalar_agg_outputs(dict_elems, dict_n, eval_tbl,
+                                                        from_id, where_id, by_id,
+                                                        take_id, asc_id, desc_id,
+                                                        nearest_id);
+                if (release_eval_tbl) ray_release(eval_tbl);
+                if (g->selection) { ray_release(g->selection); g->selection = NULL; }
+                ray_graph_free(g); ray_release(tbl);
+                scratch_free(sagg_hdr);
+                scratch_free(sel_slots_hdr); DICT_VIEW_CLOSE(dv); return result;
             }
             if (s_has_binary)
                 root = ray_group_build(g, NULL, 0, s_agg_ops, s_agg_ins,

--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -1853,6 +1853,8 @@ static int expr_contains_agg(ray_t* expr) {
 }
 
 static int is_group_dag_agg_expr(ray_t* expr);  /* defined below */
+static bool simplify_agg_idiom(ray_t* val_expr, ray_t* tbl,
+                               uint16_t* out_op, ray_t** out_arg);
 
 /* ── Arith-of-aggs decomposition ──────────────────────────────────────────
  * A select-by output like (/ (sum a) (as 'F64 (sum b))) is not itself a
@@ -2042,6 +2044,71 @@ static int is_group_dag_agg_expr(ray_t* expr) {
             return 0;
     }
     return !expr_contains_call_named(elems[1], "distinct", 8);
+}
+
+static bool expr_literal_is_temporal(ray_t* expr) {
+    if (!expr) return false;
+    int8_t t = expr->type < 0 ? (int8_t)-expr->type : expr->type;
+    return dag_type_is_temporal(t);
+}
+
+static bool expr_dag_result_is_temporal(ray_t* expr, ray_t* tbl) {
+    if (expr_literal_is_temporal(expr)) return true;
+
+    ray_graph_t* pg = ray_graph_new(tbl);
+    if (!pg) return false;
+
+    ray_op_t* op = compile_expr_dag(pg, expr);
+    bool temporal = op && dag_type_is_temporal(op->out_type);
+    ray_graph_free(pg);
+    return temporal;
+}
+
+static bool expr_contains_temporal_arith(ray_t* expr, ray_t* tbl) {
+    if (!expr || expr->type != RAY_LIST) return false;
+
+    ray_t** elems = (ray_t**)ray_data(expr);
+    int64_t n = ray_len(expr);
+    if (n >= 3 && elems[0] && elems[0]->type == -RAY_SYM) {
+        ray_t* name = ray_sym_str(elems[0]->i64);
+        size_t len = name ? ray_str_len(name) : 0;
+        const char* s = name ? ray_str_ptr(name) : NULL;
+        if (len == 1 && (s[0] == '+' || s[0] == '-' || s[0] == '*')) {
+            if (expr_dag_result_is_temporal(elems[1], tbl) ||
+                expr_dag_result_is_temporal(elems[2], tbl))
+                return true;
+        }
+    }
+
+    for (int64_t i = 0; i < n; i++)
+        if (expr_contains_temporal_arith(elems[i], tbl))
+            return true;
+    return false;
+}
+
+static int is_group_dag_agg_expr_dag_safe(ray_t* expr, ray_t* tbl) {
+    if (!is_group_dag_agg_expr(expr)) return 0;
+
+    ray_t** elems = (ray_t**)ray_data(expr);
+    uint16_t op = resolve_agg_opcode(elems[0]->i64);
+    ray_t* agg_arg = elems[1];
+    {
+        uint16_t new_op;
+        ray_t* new_arg;
+        if (simplify_agg_idiom(expr, tbl, &new_op, &new_arg)) {
+            op = new_op;
+            agg_arg = new_arg;
+        }
+    }
+
+    if (expr_contains_temporal_arith(agg_arg, tbl))
+        return 0;
+    if (agg_is_binary_agg(op)) {
+        if (ray_len(expr) < 3) return 1;
+        if (expr_contains_temporal_arith(elems[2], tbl))
+            return 0;
+    }
+    return 1;
 }
 
 static int is_single_group_key_projection(ray_t* by_expr, ray_t* val_expr) {
@@ -6297,7 +6364,7 @@ by_dict_done:
         (size_t)n_out_max * (3 * sizeof(int64_t) + 2 * sizeof(ray_t*)) +
         (size_t)hidden_max * (sizeof(ray_t*) + sizeof(int64_t)) +
         (size_t)nk_max * sizeof(ray_op_t*) +
-        (size_t)aggs_max * (2 * sizeof(ray_op_t*) + sizeof(int64_t) + sizeof(uint16_t)) +
+        (size_t)aggs_max * (2 * sizeof(ray_op_t*) + 2 * sizeof(int64_t) + sizeof(uint16_t)) +
         (size_t)2 * (size_t)n_dep_keys * sizeof(int64_t));
     if (!nonagg_names) {
         scratch_free(dep_src_hdr);
@@ -6314,7 +6381,8 @@ by_dict_done:
     ray_op_t** agg_ins        = key_ops + nk_max;
     ray_op_t** agg_ins2       = agg_ins + aggs_max;
     int64_t*   agg_k          = (int64_t*)(agg_ins2 + aggs_max);
-    dep_key_names             = agg_k + aggs_max;          /* [n_dep_keys] */
+    int64_t*   agg_names      = agg_k + aggs_max;
+    dep_key_names             = agg_names + aggs_max;      /* [n_dep_keys] */
     dep_key_biases            = dep_key_names + n_dep_keys; /* [n_dep_keys] */
     uint16_t*  agg_ops        = (uint16_t*)(dep_key_biases + n_dep_keys);
     /* Copy the bridged dependent-key names/biases into this block, then release
@@ -8324,7 +8392,7 @@ by_dict_done:
                 ray_t* expr = dict_elems[i + 1];
                 if (is_single_group_key_projection(by_expr, expr))
                     continue;
-                if (is_group_dag_agg_expr(expr)) {
+                if (is_group_dag_agg_expr_dag_safe(expr, tbl)) {
                     /* dag-aggs claim output slots in order.  Not a flat
                      * forcer. */
                     n_grp_agg_outputs++;
@@ -8566,7 +8634,7 @@ by_dict_done:
             if (kid == from_id || kid == where_id || kid == by_id || kid == take_id || kid == asc_id || kid == desc_id) continue;
 
             ray_t* val_expr = dict_elems[i + 1];
-            if (is_group_dag_agg_expr(val_expr)) {
+            if (is_group_dag_agg_expr_dag_safe(val_expr, tbl)) {
                 ray_t** agg_elems = (ray_t**)ray_data(val_expr);
                 uint16_t op = resolve_agg_opcode(agg_elems[0]->i64);
                 ray_t* agg_arg = agg_elems[1];
@@ -8585,6 +8653,7 @@ by_dict_done:
                 /* Compile the aggregation input (the column reference) */
                 agg_ins[n_aggs] = compile_expr_dag(g, agg_arg);
                 if (!agg_ins[n_aggs]) { ray_graph_free(g); ray_release(tbl); scratch_free(sel_slots_hdr); DICT_VIEW_CLOSE(dv); return ray_error("domain", "select by: failed to compile aggregation argument"); }
+                agg_names[n_aggs] = kid;
                 /* Canonical aggregand type-admission (matches the scalar
                  * builtins): reject non-numeric / absolute-temporal inputs so a
                  * by-group sum/avg/var never silently folds symbol ids etc. */
@@ -9845,23 +9914,9 @@ by_dict_done:
                         ray_table_set_col_name(result, k, aliases[k]);
                 }
                 /* Rename only the agg columns (positions after keys).
-                 * Non-agg LIST columns were named at scatter time. */
-                ray_t* aun_hdr = NULL;
-                int64_t* agg_user_names = (int64_t*)scratch_alloc(&aun_hdr,
-                        (size_t)n_out_max * sizeof(int64_t));
-                int64_t n_agg_user = 0;
-                if (agg_user_names) {
-                    for (int64_t i = 0; i + 1 < dict_n; i += 2) {
-                        int64_t kid = dict_elems[i]->i64;
-                        if (kid == from_id || kid == where_id || kid == by_id ||
-                            kid == take_id || kid == asc_id || kid == desc_id) continue;
-                        if (!is_group_dag_agg_expr(dict_elems[i + 1])) continue;
-                        if (n_agg_user < n_out_max) agg_user_names[n_agg_user++] = kid;
-                    }
-                    for (int64_t j = 0; j < n_agg_user && n_key_cols + j < ncols; j++)
-                        ray_table_set_col_name(result, n_key_cols + j, agg_user_names[j]);
-                }
-                scratch_free(aun_hdr);
+                 * Non-agg/fallback columns are named at scatter time. */
+                for (int64_t j = 0; j < n_aggs_real && n_key_cols + j < ncols; j++)
+                    ray_table_set_col_name(result, n_key_cols + j, agg_names[j]);
             } else {
                 /* Projection-only: columns are in dict order.  Rename each
                  * output column directly — a projection may have any number

--- a/test/rfl/expr/const_expr.rfl
+++ b/test/rfl/expr/const_expr.rfl
@@ -99,26 +99,14 @@
 (select {s: (sum (+ x 3.5)) from: Tce}) -- (table [s] (list [32.5]))
 
 ;; ===================================================================
-;; DATE constant in arithmetic → atom_to_numeric called with -RAY_DATE
-;; type (line 38: case -RAY_DATE → Branch(39:9) True).
-;; 2024.01.01 represents 8766 days; sum(x * 8766) = 15 * 8766 = 131490
+;; Temporal constants in arithmetic must follow builtin temporal rules.
+;; The query DAG used to demote them to raw integers; the eval fallback now
+;; preserves builtin results for valid pairs and type errors for invalid pairs.
 ;; ===================================================================
-(select {s: (sum (* x 2024.01.01)) from: Tce}) -- (table [s] (list [131490]))
-
-;; ===================================================================
-;; TIME constant in arithmetic → atom_to_numeric with -RAY_TIME
-;; (line 39: case -RAY_TIME → Branch(40:9) True).
-;; 12:00:00 = 43200000ms; sum(x * 43200000) = 15 * 43200000 = 648000000
-;; ===================================================================
-(select {s: (sum (* x 12:00:00)) from: Tce}) -- (table [s] (list [648000000]))
-
-;; ===================================================================
-;; TIMESTAMP constant in arithmetic → atom_to_numeric with -RAY_TIMESTAMP
-;; (line 40: case -RAY_TIMESTAMP → Branch(40:9) True).
-;; 2000.01.01D00:00:00.000000001 = 1 nanosecond since epoch.
-;; sum(x * 1) = 1+2+3+4+5 = 15
-;; ===================================================================
-(select {s: (sum (* x 2000.01.01D00:00:00.000000001)) from: Tce}) -- (table [s] (list [15]))
+(select {s: (sum (* x 2024.01.01)) from: Tce}) !- type
+(type (at (select {s: (sum (* x 12:00:00)) from: Tce}) 's)) -- 'TIME
+(as 'I32 (at (at (select {s: (sum (* x 12:00:00)) from: Tce}) 's) 0)) -- 648000000i
+(select {s: (sum (* x 2000.01.01D00:00:00.000000001)) from: Tce}) !- type
 
 ;; ===================================================================
 ;; F64 NEG constant → eval_const_numeric_expr NEG/ABS branch (line 83:25)

--- a/test/rfl/expr/narrow_binary.rfl
+++ b/test/rfl/expr/narrow_binary.rfl
@@ -168,17 +168,15 @@
 (set _Tu8 (table [x] (list (as 'U8 [4 5 6]))))
 (at (select {y: (* x 2.0) from: _Tu8}) 'y) -- [8.0 10.0 12.0]
 
-;; TIMESTAMP column → F64 scratch (line 625-628 I64/TIMESTAMP path)
+;; Temporal columns route to eval fallback so builtin temporal rules are preserved.
 (set _Tts (table [x] (list (as 'TIMESTAMP [1000 2000 3000]))))
-(at (select {y: (* x 2.0) from: _Tts}) 'y) -- [2000.0 4000.0 6000.0]
+(select {y: (* x 2.0) from: _Tts}) !- type
 
-;; DATE column → F64 scratch (line 633: DATE/TIME path via I32)
 (set _Td (table [x] (list (as 'DATE [0 1 2]))))
-(at (select {y: (* x 2.0) from: _Td}) 'y) -- [0.0 2.0 4.0]
+(select {y: (* x 2.0) from: _Td}) !- type
 
-;; TIME column → F64 scratch
 (set _Tt (table [x] (list (as 'TIME [100 200 300]))))
-(at (select {y: (* x 2.0) from: _Tt}) 'y) -- [200.0 400.0 600.0]
+(select {y: (* x 2.0) from: _Tt}) !- type
 
 ;; BOOL column → F64 scratch (line 637-640 U8/BOOL path)
 (set _Tb (table [x] (list (as 'BOOL [true false true]))))

--- a/test/rfl/integration/dag_binary_ops.rfl
+++ b/test/rfl/integration/dag_binary_ops.rfl
@@ -87,6 +87,18 @@
 (select {x: (- d1 1.5) from: Ttm}) !- type
 (select {x: (* t1 1.5) from: Ttm}) !- type
 
+;; Grouped aggregations use the same temporal fallback instead of failing
+;; compile or renaming mixed fallback/DAG outputs incorrectly.
+(set Ttmg (table [k d1 d2 t1 v] (list [a a b b] [2024.01.01 2024.01.02 2024.01.03 2024.01.04] [2024.01.11 2024.01.12 2024.01.13 2024.01.14] [00:00:01.000 00:00:02.000 00:00:03.000 00:00:04.000] [1 2 3 4])))
+(set Gspan (select {span: (avg (- d2 d1)) from: Ttmg by: k}))
+(at Gspan 'span) -- [10.0 10.0]
+(set Gtime (select {total: (sum (* t1 2)) from: Ttmg by: k}))
+(type (at Gtime 'total)) -- 'TIME
+(as 'I32 (at Gtime 'total)) -- [6000 14000]
+(set Gmix (select {span: (avg (- d2 d1)) qty: (sum v) from: Ttmg by: k}))
+(at Gmix 'span) -- [10.0 10.0]
+(at Gmix 'qty) -- [3 7]
+
 ;; ────────────── compound where: AND / OR with derived comparisons ──────────────
 (set Tw (table [a b] (list [1 2 3 4 5 6 7 8] [10 20 30 40 50 60 70 80])))
 (at (select {from: Tw where: (and (> a 2) (< b 60))}) 'a) -- [3 4 5]

--- a/test/rfl/integration/dag_binary_ops.rfl
+++ b/test/rfl/integration/dag_binary_ops.rfl
@@ -71,6 +71,22 @@
 (at (select {x: (<= a b) from: Tc}) 'x) -- [true true true false false]
 (sum (as 'I64 (at (select {x: (<= a b) from: Tc}) 'x))) -- 3
 
+;; ────────────── temporal arithmetic routes to eval fallback ──────────────
+;; The generic DAG treats temporal values as raw integers, which demotes
+;; special temporal semantics. Projection fallback must preserve the builtin
+;; rules instead: valid pairs keep their temporal/difference types, invalid
+;; pairs surface type errors.
+(set Ttm (table [d1 d2 t1 t2 p1 p2] (list (as 'DATE [10 20]) (as 'DATE [20 30]) (as 'TIME [1000 2000]) (as 'TIME [2000 3000]) (as 'TIMESTAMP [1000 2000]) (as 'TIMESTAMP [2000 3000]))))
+(type (at (select {x: (+ d1 2) from: Ttm}) 'x)) -- 'DATE
+(at (select {x: (+ t1 t2) from: Ttm}) 'x) -- [00:00:03.000 00:00:05.000]
+(type (at (select {x: (- d2 d1) from: Ttm}) 'x)) -- 'I32
+(at (select {x: (- d2 d1) from: Ttm}) 'x) -- [10 10]
+(type (at (select {x: (* t1 2) from: Ttm}) 'x)) -- 'TIME
+(select {x: (+ d1 d2) from: Ttm}) !- type
+(select {x: (+ p1 p2) from: Ttm}) !- type
+(select {x: (- d1 1.5) from: Ttm}) !- type
+(select {x: (* t1 1.5) from: Ttm}) !- type
+
 ;; ────────────── compound where: AND / OR with derived comparisons ──────────────
 (set Tw (table [a b] (list [1 2 3 4 5 6 7 8] [10 20 30 40 50 60 70 80])))
 (at (select {from: Tw where: (and (> a 2) (< b 60))}) 'a) -- [3 4 5]


### PR DESCRIPTION
## Summary
- make the query DAG decline +, -, and * when either operand is DATE/TIME/TIMESTAMP so eval fallback preserves builtin temporal semantics
- add scalar aggregate eval fallback when aggregate arguments cannot compile into the DAG
- update regression coverage for temporal projections and scalar aggregates

## Tests
- RAYFORCE_CORES=2 ./rayforce.test -f rfl/expr/const_expr
- RAYFORCE_CORES=2 ./rayforce.test -f rfl/expr/narrow_binary
- RAYFORCE_CORES=2 ./rayforce.test -f rfl/integration/dag_binary_ops
- make test TEST_CORES=2