### PR TITLE
fix(builtins): reject malformed strings in TIMESTAMP cast

### DIFF
--- a/src/ops/builtins.c
+++ b/src/ops/builtins.c
@@ -1628,34 +1628,92 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
             int64_t days = val->i32;
             return ray_timestamp(days * 24LL * 60 * 60 * 1000000000LL);
         }
-        /* ISO string -> timestamp: "YYYY-MM-DD[T ]HH:MM:SS[.nnn...]" or "YYYY.MM.DDDHH:MM:SS.nnn..." */
+        /* ISO string -> timestamp.  Parse the whole value with a bounded
+         * cursor and require it to reach the end of the string.  A partial
+         * or trailing-garbage match must be REJECTED — otherwise malformed
+         * input is silently cast to a valid-but-wrong timestamp, the exact
+         * data-corruption class this parser guards against.  Grammar:
+         *   YYYY<sep>MM<sep>DD [ (T|' '|D) HH:MM[:SS][.frac] [Z|(+|-)HH[:]?MM] ]
+         * where <sep> is '-' or '.' and is consistent within the date. */
         if (val->type == -RAY_STR) {
             const char* sp = ray_str_ptr(val);
             size_t sl = ray_str_len(val);
-            if (sl < 10) return ray_error("domain", "as: cannot parse str as timestamp, too short, got %lld chars", (long long)sl);
-            int y, m, d, hh = 0, mm = 0, ss = 0;
-            long long frac = 0;
-            /* Try both formats: YYYY-MM-DD and YYYY.MM.DD */
-            int parsed = sscanf(sp, "%d-%d-%d", &y, &m, &d);
-            /* parse date: try YYYY-MM-DD then YYYY.MM.DD */
-            if (parsed != 3) {
-                parsed = sscanf(sp, "%d.%d.%d", &y, &m, &d);
-                /* YYYY.MM.DD format */
-            }
-            if (parsed != 3) return ray_error("domain", "as: cannot parse str as timestamp, expected YYYY-MM-DD or YYYY.MM.DD");
-            /* Parse optional time part */
-            if (sl > 10 && (sp[10] == 'T' || sp[10] == ' ' || sp[10] == 'D')) {
-                sscanf(sp + 11, "%d:%d:%d", &hh, &mm, &ss);
-                /* Parse fractional seconds */
-                const char* dot = memchr(sp + 11, '.', sl - 11);
-                if (dot) {
-                    dot++;
+            size_t i = 0;
+            int y = 0, m = 0, d = 0, hh = 0, mm = 0, ss = 0;
+            long long frac = 0, tz_ns = 0;
+
+            /* Read exactly `w` digits (0-9) into `out`, or fail. */
+            #define TS_DIGITS(w, out) do {                                                     \
+                (out) = 0;                                                                     \
+                for (int _k = 0; _k < (w); _k++) {                                             \
+                    if (i >= sl || sp[i] < '0' || sp[i] > '9')                                 \
+                        return ray_error("domain", "as: cannot parse str as timestamp, expected %d-digit field at offset %lld", (w), (long long)i); \
+                    (out) = (out) * 10 + (sp[i] - '0'); i++;                                   \
+                }                                                                             \
+            } while (0)
+
+            TS_DIGITS(4, y);
+            if (i >= sl || (sp[i] != '-' && sp[i] != '.'))
+                return ray_error("domain", "as: cannot parse str as timestamp, expected '-' or '.' date separator");
+            char dsep = sp[i]; i++;
+            TS_DIGITS(2, m);
+            if (i >= sl || sp[i] != dsep)
+                return ray_error("domain", "as: cannot parse str as timestamp, inconsistent date separator");
+            i++;
+            TS_DIGITS(2, d);
+            if (m < 1 || m > 12 || d < 1 || d > 31)
+                return ray_error("domain", "as: cannot parse str as timestamp, date component out of range");
+
+            if (i < sl) {
+                /* date/time separator: T, space, or D (kdb literal form) */
+                if (sp[i] != 'T' && sp[i] != ' ' && sp[i] != 'D')
+                    return ray_error("domain", "as: cannot parse str as timestamp, expected 'T', ' ', or 'D' between date and time");
+                i++;
+                TS_DIGITS(2, hh);
+                if (i >= sl || sp[i] != ':')
+                    return ray_error("domain", "as: cannot parse str as timestamp, expected ':' after hour");
+                i++;
+                TS_DIGITS(2, mm);
+                if (i < sl && sp[i] == ':') { i++; TS_DIGITS(2, ss); }
+                if (hh > 23 || mm > 59 || ss > 59)
+                    return ray_error("domain", "as: cannot parse str as timestamp, time component out of range");
+                /* optional fractional seconds: at least one digit; up to 9
+                 * are kept (right-padded), any beyond are consumed. */
+                if (i < sl && sp[i] == '.') {
+                    i++;
+                    if (i >= sl || sp[i] < '0' || sp[i] > '9')
+                        return ray_error("domain", "as: cannot parse str as timestamp, expected fractional digits after '.'");
                     char fbuf[10] = "000000000";
                     int fi = 0;
-                    while (*dot >= '0' && *dot <= '9' && fi < 9) fbuf[fi++] = *dot++;
+                    while (i < sl && sp[i] >= '0' && sp[i] <= '9') {
+                        if (fi < 9) fbuf[fi++] = sp[i];
+                        i++;
+                    }
                     frac = strtoll(fbuf, NULL, 10);
                 }
+                /* optional timezone: Z | (+|-)HH[:]?MM */
+                if (i < sl) {
+                    if (sp[i] == 'Z' || sp[i] == 'z') {
+                        i++;
+                    } else if (sp[i] == '+' || sp[i] == '-') {
+                        int tz_sign = (sp[i] == '+') ? 1 : -1; i++;
+                        int tz_hh = 0, tz_mm = 0;
+                        TS_DIGITS(2, tz_hh);
+                        if (i < sl && sp[i] == ':') i++;   /* optional ':' */
+                        if (i < sl) TS_DIGITS(2, tz_mm);
+                        if (tz_hh > 23 || tz_mm > 59)
+                            return ray_error("domain", "as: cannot parse str as timestamp, timezone offset out of range");
+                        tz_ns = (long long)tz_sign *
+                                ((long long)tz_hh * 3600 + (long long)tz_mm * 60) * 1000000000LL;
+                    } else {
+                        return ray_error("domain", "as: cannot parse str as timestamp, unexpected trailing characters");
+                    }
+                }
             }
+            if (i != sl)
+                return ray_error("domain", "as: cannot parse str as timestamp, unexpected trailing characters");
+            #undef TS_DIGITS
+
             /* Convert to days since 2000-01-01 */
             int64_t days = 0;
             { int ty;
@@ -1669,32 +1727,8 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
             }
             int64_t ns = days * 86400000000000LL + (int64_t)hh * 3600000000000LL +
                          (int64_t)mm * 60000000000LL + (int64_t)ss * 1000000000LL + frac;
-            /* Handle timezone offset: Z, +HH:MM, -HH:MM, +HHMM, -HHMM */
-            if (sl > 19) {
-                const char* tz = sp + 19; /* after YYYY-MM-DDTHH:MM:SS */
-                /* Skip fractional seconds */
-                if (tz < sp + sl && *tz == '.') {
-                    tz++;
-                    while (tz < sp + sl && *tz >= '0' && *tz <= '9') tz++;
-                }
-                if (tz < sp + sl) {
-                    if (*tz == 'Z') {
-                        /* UTC, no adjustment */
-                    } else if (*tz == '+' || *tz == '-') {
-                        int tz_sign = (*tz == '+') ? 1 : -1;
-                        int tz_hh = 0, tz_mm = 0;
-                        tz++;
-                        /* Parse HH:MM or HHMM */
-                        if (tz + 4 < sp + sl && tz[2] == ':') {
-                            sscanf(tz, "%2d:%2d", &tz_hh, &tz_mm);
-                        } else {
-                            sscanf(tz, "%2d%2d", &tz_hh, &tz_mm);
-                        }
-                        int64_t tz_ns = ((int64_t)tz_hh * 3600 + (int64_t)tz_mm * 60) * 1000000000LL;
-                        ns -= tz_sign * tz_ns;
-                    }
-                }
-            }
+            /* Timezone offset converts local wall-clock to UTC. */
+            ns -= tz_ns;
             return ray_timestamp(ns);
         }
         /* Vector cast */

--- a/src/ops/builtins.c
+++ b/src/ops/builtins.c
@@ -1661,7 +1661,12 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
                 return ray_error("domain", "as: cannot parse str as timestamp, inconsistent date separator");
             i++;
             TS_DIGITS(2, d);
-            if (m < 1 || m > 12 || d < 1 || d > 31)
+            if (m < 1 || m > 12 || d < 1)
+                return ray_error("domain", "as: cannot parse str as timestamp, date component out of range");
+            static const int ts_md[] = {0,31,28,31,30,31,30,31,31,30,31,30,31};
+            int leap = (y % 4 == 0 && (y % 100 != 0 || y % 400 == 0));
+            int mdays = ts_md[m] + (m == 2 && leap ? 1 : 0);
+            if (d > mdays)
                 return ray_error("domain", "as: cannot parse str as timestamp, date component out of range");
 
             if (i < sl) {
@@ -1700,7 +1705,7 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
                         int tz_hh = 0, tz_mm = 0;
                         TS_DIGITS(2, tz_hh);
                         if (i < sl && sp[i] == ':') i++;   /* optional ':' */
-                        if (i < sl) TS_DIGITS(2, tz_mm);
+                        TS_DIGITS(2, tz_mm);
                         if (tz_hh > 23 || tz_mm > 59)
                             return ray_error("domain", "as: cannot parse str as timestamp, timezone offset out of range");
                         tz_ns = (long long)tz_sign *
@@ -1720,14 +1725,24 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
               for (ty = 2000; ty < y; ty++) days += (ty % 4 == 0 && (ty % 100 != 0 || ty % 400 == 0)) ? 366 : 365;
               for (ty = y; ty < 2000; ty++) days -= (ty % 4 == 0 && (ty % 100 != 0 || ty % 400 == 0)) ? 366 : 365;
             }
-            { static const int md[] = {0,31,28,31,30,31,30,31,31,30,31,30,31};
-              int leap = (y % 4 == 0 && (y % 100 != 0 || y % 400 == 0));
-              for (int mi = 1; mi < m; mi++) days += md[mi] + (mi == 2 && leap ? 1 : 0);
+            {
+              for (int mi = 1; mi < m; mi++) days += ts_md[mi] + (mi == 2 && leap ? 1 : 0);
               days += d - 1;
             }
-            int64_t ns = days * 86400000000000LL + (int64_t)hh * 3600000000000LL +
-                         (int64_t)mm * 60000000000LL + (int64_t)ss * 1000000000LL + frac;
+            const int64_t ns_per_day = 86400000000000LL;
+            if (days > INT64_MAX / ns_per_day || days < INT64_MIN / ns_per_day)
+                return ray_error("domain", "as: timestamp out of int64 nanosecond range");
+            int64_t day_ns = days * ns_per_day;
+            int64_t tod_ns = (int64_t)hh * 3600000000000LL +
+                             (int64_t)mm * 60000000000LL + (int64_t)ss * 1000000000LL + frac;
+            if (day_ns > INT64_MAX - tod_ns)
+                return ray_error("domain", "as: timestamp out of int64 nanosecond range");
+            int64_t ns = day_ns + tod_ns;
             /* Timezone offset converts local wall-clock to UTC. */
+            if (tz_ns > 0 && ns < INT64_MIN + tz_ns)
+                return ray_error("domain", "as: timestamp out of int64 nanosecond range");
+            if (tz_ns < 0 && ns > INT64_MAX + tz_ns)
+                return ray_error("domain", "as: timestamp out of int64 nanosecond range");
             ns -= tz_ns;
             return ray_timestamp(ns);
         }

--- a/test/rfl/ops/builtins_branch_cov.rfl
+++ b/test/rfl/ops/builtins_branch_cov.rfl
@@ -325,6 +325,37 @@
 (type (as 'TIMESTAMP "2024.01.15D12:30:45.000000000")) -- 'timestamp
 (as 'TIMESTAMP "2024.01.15D12:30:45.000000000") -- 2024.01.15D12:30:45.000000000
 
+;; TIMESTAMP STR malformed input must be REJECTED, not silently normalized.
+;; The parser walks a bounded cursor over
+;;   YYYY<sep>MM<sep>DD [ (T| |D) HH:MM[:SS][.frac] [Z|(+|-)HH[:]?MM] ]
+;; and must consume the whole string — a partial match or trailing garbage
+;; that used to be ignored silently corrupts the value.
+;; Bad date/time separator (dropped the time, returned midnight):
+(as 'TIMESTAMP "2024-01-02x01:02:03") !- domain
+(as 'TIMESTAMP "2024-01-02abc") !- domain
+;; Out-of-range time component (used to roll into the next day):
+(as 'TIMESTAMP "2024-01-02T25:02:03") !- domain
+(as 'TIMESTAMP "2024-01-02T12:99:03") !- domain
+;; Trailing garbage after HH:MM / HH:MM:SS / fraction / 'Z':
+(as 'TIMESTAMP "2024-01-02T12:34junk") !- domain
+(as 'TIMESTAMP "2024-01-02T12:34:03junk") !- domain
+(as 'TIMESTAMP "2024-01-02T12:34:03Zjunk") !- domain
+(as 'TIMESTAMP "2024-01-02T12:34:03.5junk") !- domain
+;; Partial / dangling component:
+(as 'TIMESTAMP "2024-01-02T12:34:") !- domain
+(as 'TIMESTAMP "2024-01-02T12:34:03.") !- domain
+;; Out-of-range timezone offset:
+(as 'TIMESTAMP "2024-01-02T12:34:03+99:99") !- domain
+;; Inconsistent / malformed date separator and short fields:
+(as 'TIMESTAMP "2024-01.02T00:00:00") !- domain
+(as 'TIMESTAMP "2024-1-2T00:00:00") !- domain
+;; Bare date (no time) is valid and yields midnight.
+(as 'TIMESTAMP "2024-01-02") -- 2024.01.02D00:00:00.000000000
+;; Space separator, HH:MM without seconds, and a tz offset are all accepted.
+(as 'TIMESTAMP "2024-01-02 01:02:03") -- 2024.01.02D01:02:03.000000000
+(as 'TIMESTAMP "2024-01-02T12:34") -- 2024.01.02D12:34:00.000000000
+(as 'TIMESTAMP "2004-10-21 12:00:00.010-23:00") -- 2004.10.22D11:00:00.010000000
+
 ;; --- Cast to GUID ---
 (type (as 'GUID "01234567-89ab-cdef-0123-456789abcdef")) -- 'guid
 (as 'STR (as 'GUID "01234567-89ab-cdef-0123-456789abcdef")) -- "01234567-89ab-cdef-0123-456789abcdef"

--- a/test/rfl/ops/builtins_branch_cov.rfl
+++ b/test/rfl/ops/builtins_branch_cov.rfl
@@ -346,11 +346,21 @@
 (as 'TIMESTAMP "2024-01-02T12:34:03.") !- domain
 ;; Out-of-range timezone offset:
 (as 'TIMESTAMP "2024-01-02T12:34:03+99:99") !- domain
+;; Timezone minutes are mandatory: grammar is HH[:]?MM, not bare HH.
+(as 'TIMESTAMP "2024-01-02T12:34:03+12") !- domain
+(as 'TIMESTAMP "2024-01-02T12:34:03+12:") !- domain
 ;; Inconsistent / malformed date separator and short fields:
 (as 'TIMESTAMP "2024-01.02T00:00:00") !- domain
 (as 'TIMESTAMP "2024-1-2T00:00:00") !- domain
+;; Calendar dates must be valid for the selected month/leap year.
+(as 'TIMESTAMP "2024-02-31") !- domain
+(as 'TIMESTAMP "2023-02-29") !- domain
+(as 'TIMESTAMP "2024-04-31") !- domain
+;; Reject values outside int64 nanosecond timestamp range before overflow.
+(as 'TIMESTAMP "9999-12-31") !- domain
 ;; Bare date (no time) is valid and yields midnight.
 (as 'TIMESTAMP "2024-01-02") -- 2024.01.02D00:00:00.000000000
+(as 'TIMESTAMP "2024-02-29") -- 2024.02.29D00:00:00.000000000
 ;; Space separator, HH:MM without seconds, and a tz offset are all accepted.
 (as 'TIMESTAMP "2024-01-02 01:02:03") -- 2024.01.02D01:02:03.000000000
 (as 'TIMESTAMP "2024-01-02T12:34") -- 2024.01.02D12:34:00.000000000


### PR DESCRIPTION
## Problem

`(as 'TIMESTAMP str)` silently accepted several malformed inputs instead of returning a `domain` error, producing valid-looking but wrong values — a data-integrity issue, since the corruption is invisible at the call site.

| Input | Before (wrong) | After |
|---|---|---|
| `"2024-01-02x01:02:03"` | `2024.01.02D00:00:00` (time dropped) | `domain` error |
| `"2024-01-02abc"` | `2024.01.02D00:00:00` | `domain` error |
| `"2024-01-02T25:02:03"` | `2024.01.03D01:02:03` (rolled to next day) | `domain` error |
| `"2024-01-02T12:99:03"` | `2024.01.02D13:39:03` | `domain` error |

Root cause: the time part was only parsed when the character at index 10 was `T`/`' '`/`D`; any other character silently skipped the entire time component and returned midnight. Out-of-range hour/minute/second values were normalized (carried into the following day) instead of rejected.

## Fix

- Require a recognized date/time separator (`T`, `' '`, or `D`) before a time part — otherwise `domain` error.
- Require the time to parse at least `HH:MM`.
- Reject out-of-range hour/minute/second components.

This matches the strict behavior of the `DATE` string cast.

## Compatibility

All previously accepted valid forms continue to round-trip: bare date (→ midnight), space/`T`/`D` separators, fractional seconds, and `Z` / `+HH:MM` / `-HHMM` timezone suffixes. Covered by the existing goldens in `ops/builtins_branch_cov.rfl`, which this PR extends with the rejection cases plus the bare-date and space-separator forms.

Full `make test` suite passes (0 failed) under the default ASan/UBSan build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)