### PR TITLE
fix(store): support nested column inserts and persistence

### DIFF
--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -11238,6 +11238,43 @@ static ray_t* append_atom_to_col(ray_t* col_vec, ray_t* atom) {
     }
 }
 
+/* Build a fresh boxed LIST column.  A table payload supplies a LIST column
+ * whose slots are rows and is therefore spliced; positional LIST/DICT rows
+ * append their value as one boxed cell.  Every copied pointer gets its own
+ * retain so source tables and returned snapshots remain independently owned. */
+static ray_t* append_boxed_table_col(ray_t* orig_col, ray_t* payload,
+                                     bool splice_payload) {
+    if (!orig_col || RAY_IS_ERR(orig_col) || orig_col->type != RAY_LIST)
+        return ray_error("type", "insert: boxed column source must be LIST");
+    if (splice_payload &&
+        (!payload || RAY_IS_ERR(payload) || payload->type != RAY_LIST))
+        return ray_error("type", "insert: table payload for a LIST column must be LIST");
+
+    int64_t tail = splice_payload ? payload->len : 1;
+    if (tail < 0 || orig_col->len > INT64_MAX - tail)
+        return ray_error("oom", NULL);
+    ray_t* out = ray_list_new(orig_col->len + tail);
+    if (!out || RAY_IS_ERR(out)) return out ? out : ray_error("oom", NULL);
+    ray_t** dst = (ray_t**)ray_data(out);
+    ray_t** src = (ray_t**)ray_data(orig_col);
+    for (int64_t r = 0; r < orig_col->len; r++) {
+        dst[r] = src[r];
+        if (dst[r]) ray_retain(dst[r]);
+    }
+    if (splice_payload) {
+        ray_t** cells = (ray_t**)ray_data(payload);
+        for (int64_t r = 0; r < tail; r++) {
+            dst[orig_col->len + r] = cells[r];
+            if (cells[r]) ray_retain(cells[r]);
+        }
+    } else {
+        dst[orig_col->len] = payload;
+        if (payload) ray_retain(payload);
+    }
+    out->len = orig_col->len + tail;
+    return out;
+}
+
 /* (update {col: expr ... from: t [where: pred]})
  * Special form — receives unevaluated dict arg.
  * For rows matching where (or all if no where), evaluate column expressions
@@ -12192,7 +12229,9 @@ static int parted_key_atom_cmp(ray_t* key, ray_t* keys, int64_t cell,
 }
 
 static bool parted_segment_attrs_valid(int8_t base, uint8_t attrs) {
-    uint8_t allowed = RAY_ATTR_HAS_INDEX | RAY_ATTR_SORTED;
+    uint8_t allowed = base == RAY_LIST
+                    ? 0
+                    : (RAY_ATTR_HAS_INDEX | RAY_ATTR_SORTED);
     if (base == RAY_SYM) allowed |= RAY_SYM_W_MASK;
     if (base == RAY_I32 || base == RAY_I64)
         allowed |= RAY_ATTR_HAS_LINK;
@@ -12291,7 +12330,7 @@ static ray_t* validate_parted_insert_target(ray_t* tbl,
             wrapper->len != nparts || wrapper->attrs != 0)
             return ray_error("corrupt", "insert: physical column %lld is not a canonical PARTED wrapper", (long long)(c - 1));
         int8_t base = (int8_t)RAY_PARTED_BASETYPE(wrapper->type);
-        if (base < RAY_BOOL || base > RAY_STR)
+        if (base != RAY_LIST && (base < RAY_BOOL || base > RAY_STR))
             return ray_error("type", "insert: unsupported parted base type in physical column %lld", (long long)(c - 1));
 
         ray_t** segs = (ray_t**)ray_data(wrapper);
@@ -12408,7 +12447,22 @@ static ray_t* normalize_parted_insert_rows(ray_t* tbl,
         }
         ray_t** items = (ray_t**)ray_data(rows);
         for (int64_t c = 0; c < v->ndata; c++) {
-            vals = parted_values_append(vals, items[c], false);
+            ray_t* wrapper = ray_table_get_col_idx(tbl, c + 1);
+            if (RAY_PARTED_BASETYPE(wrapper->type) == RAY_LIST) {
+                ray_t* one = ray_list_new(1);
+                if (!one || RAY_IS_ERR(one)) {
+                    ray_release(vals);
+                    return one ? one : ray_error("oom", NULL);
+                }
+                one = ray_list_append(one, items[c]);
+                if (!one || RAY_IS_ERR(one)) {
+                    ray_release(vals);
+                    return one ? one : ray_error("oom", NULL);
+                }
+                vals = parted_values_append(vals, one, true);
+            } else {
+                vals = parted_values_append(vals, items[c], false);
+            }
             if (!vals || RAY_IS_ERR(vals)) return vals;
         }
         return vals;
@@ -12472,7 +12526,23 @@ static ray_t* normalize_parted_insert_rows(ray_t* tbl,
         }
         if (dvals->type == RAY_LIST) {
             ray_t* item = ((ray_t**)ray_data(dvals))[found];
-            vals = parted_values_append(vals, item, false);
+            ray_t* wrapper = ray_table_get_col_idx(tbl, c);
+            if (RAY_PARTED_BASETYPE(wrapper->type) == RAY_LIST &&
+                item && item->type == RAY_LIST) {
+                ray_t* one = ray_list_new(1);
+                if (!one || RAY_IS_ERR(one)) {
+                    ray_release(vals);
+                    return one ? one : ray_error("oom", NULL);
+                }
+                one = ray_list_append(one, item);
+                if (!one || RAY_IS_ERR(one)) {
+                    ray_release(vals);
+                    return one ? one : ray_error("oom", NULL);
+                }
+                vals = parted_values_append(vals, one, true);
+            } else {
+                vals = parted_values_append(vals, item, false);
+            }
         } else {
             int owned = 0;
             ray_t* item = collection_elem(dvals, found, &owned);
@@ -12484,7 +12554,8 @@ static ray_t* normalize_parted_insert_rows(ray_t* tbl,
 }
 
 static bool parted_value_is_scalar(ray_t* v) {
-    return v && !RAY_IS_ERR(v) && (RAY_IS_NULL(v) || v->type < 0);
+    return v && !RAY_IS_ERR(v) &&
+           (RAY_IS_NULL(v) || (v->type != RAY_LIST && !ray_is_vec(v)));
 }
 
 static bool parted_source_vec_compatible(int8_t dst, int8_t src) {
@@ -12540,7 +12611,8 @@ static ray_t* validate_parted_payloads(ray_t* tbl,
     for (int64_t c = 0; c < v->ndata; c++) {
         ray_t* payload = pv[c];
         if (parted_value_is_scalar(payload)) continue;
-        if (!payload || RAY_IS_ERR(payload) || !ray_is_vec(payload))
+        if (!payload || RAY_IS_ERR(payload) ||
+            (payload->type != RAY_LIST && !ray_is_vec(payload)))
             return ray_error("type", "insert: physical column %lld payload must be an atom or an exactly typed vector",
                              (long long)c);
         if (payload->len < 0)
@@ -12555,6 +12627,12 @@ static ray_t* validate_parted_payloads(ray_t* tbl,
         ray_t* wrapper = ray_table_get_col_idx(tbl, c + 1);
         int8_t dst = (int8_t)RAY_PARTED_BASETYPE(wrapper->type);
         ray_t* payload = pv[c];
+        if (dst == RAY_LIST) {
+            if (!parted_value_is_scalar(payload) && payload->type != RAY_LIST)
+                return ray_error("type", "insert: physical column %lld LIST payload must contain boxed rows",
+                                 (long long)c);
+            continue;
+        }
         if (!parted_value_is_scalar(payload) &&
             !parted_source_vec_compatible(dst, payload->type))
             return ray_error("type", "insert: physical column %lld vector type must exactly match %s",
@@ -12740,6 +12818,38 @@ static ray_t* build_parted_nonsym_segment(int8_t base,
         result->link_target = metadata_seg->link_target;
     }
     return result;
+}
+
+static ray_t* build_parted_list_segment(ray_t* old_seg, int64_t old_len,
+                                        ray_t* payload, int64_t batch) {
+    if (old_len > INT64_MAX - batch) return ray_error("oom", NULL);
+    ray_t* out = ray_list_new(old_len + batch);
+    if (!out || RAY_IS_ERR(out)) return out ? out : ray_error("oom", NULL);
+    ray_t** dst = (ray_t**)ray_data(out);
+    if (old_seg) {
+        ray_t** src = (ray_t**)ray_data(old_seg);
+        for (int64_t r = 0; r < old_len; r++) {
+            dst[r] = src[r];
+            if (dst[r]) ray_retain(dst[r]);
+        }
+    } else {
+        memset(dst, 0, (size_t)old_len * sizeof(ray_t*));
+    }
+
+    if (payload->type == RAY_LIST) {
+        ray_t** cells = (ray_t**)ray_data(payload);
+        for (int64_t r = 0; r < batch; r++) {
+            dst[old_len + r] = cells[r];
+            if (cells[r]) ray_retain(cells[r]);
+        }
+    } else {
+        for (int64_t r = 0; r < batch; r++) {
+            dst[old_len + r] = payload;
+            ray_retain(payload);
+        }
+    }
+    out->len = old_len + batch;
+    return out;
 }
 
 /* Allocate and copy the old prefix of a W64 FILE-domain SYM segment. Appended
@@ -13008,7 +13118,9 @@ static ray_t* insert_parted_rows(ray_t* tbl, ray_t* key, ray_t* rows) {
         ray_t** segs = (ray_t**)ray_data(wrapper);
         int8_t base = (int8_t)RAY_PARTED_BASETYPE(wrapper->type);
         ray_t* old_seg = new_partition ? NULL : segs[v.nparts - 1];
-        ray_t* new_seg = base == RAY_SYM
+        ray_t* new_seg = base == RAY_LIST
+            ? build_parted_list_segment(old_seg, old_len, pv[c], batch)
+            : base == RAY_SYM
             ? build_parted_sym_skeleton(&v, old_seg, old_len, batch)
             : build_parted_nonsym_segment(base, old_seg, old_len,
                                            parted_wrapper_metadata(wrapper, active),
@@ -13493,6 +13605,19 @@ ray_t* ray_insert(ray_t** args, int64_t n) {
          * derived type drives the new column's storage. */
         if (ct == RAY_LIST && ray_len(orig_col) == 0)
             ct = typeless_col_type(row_elems[c]);
+
+        if (ct == RAY_LIST) {
+            ray_t* new_col = append_boxed_table_col(
+                orig_col, row_elems[c], tbl_row_list != NULL);
+            if (!new_col || RAY_IS_ERR(new_col)) {
+                ray_release(result);
+                return new_col ? new_col : ray_error("oom", NULL);
+            }
+            result = ray_table_add_col(result, col_name, new_col);
+            ray_release(new_col);
+            if (!result || RAY_IS_ERR(result)) return result;
+            continue;
+        }
 
         ray_t* new_col = ray_vec_new(ct, nrows + 1);
         if (RAY_IS_ERR(new_col)) { ray_release(result); return new_col; }

--- a/src/store/col.c
+++ b/src/store/col.c
@@ -28,6 +28,7 @@
 #include "store/fileio.h"
 #include "table/sym.h"
 #include "table/domain.h"
+#include "table/dict.h"
 #include "ops/idxop.h"
 #include "vec/str.h"
 #include "lang/format.h"
@@ -153,6 +154,52 @@ static bool is_serializable_type(int8_t t) {
     default:
         return false;
     }
+}
+
+/* Mirror col_write_recursive without touching a FILE.  This is deliberately
+ * structural rather than size-estimating: the save path can still report I/O
+ * or OOM later, but deterministic unsupported/corrupt object graphs are
+ * rejected before a splayed overwrite replaces any live column. */
+static ray_err_t col_preflight_recursive(ray_t* obj) {
+    if (!obj || RAY_IS_ERR(obj)) return RAY_ERR_TYPE;
+    int8_t type = obj->type;
+    if (type < 0 || is_serializable_type(type)) return RAY_OK;
+
+    if (type == RAY_LIST) {
+        ray_t** slots = (ray_t**)ray_data(obj);
+        for (int64_t i = 0; i < obj->len; i++) {
+            ray_err_t err = col_preflight_recursive(slots[i]);
+            if (err != RAY_OK) return err;
+        }
+        return RAY_OK;
+    }
+
+    if (type == RAY_TABLE) {
+        int64_t ncols = ray_table_ncols(obj);
+        for (int64_t c = 0; c < ncols; c++) {
+            ray_err_t err = col_preflight_recursive(
+                ray_table_get_col_idx(obj, c));
+            if (err != RAY_OK) return err;
+        }
+        return RAY_OK;
+    }
+
+    if (type == RAY_DICT) {
+        ray_t* keys = ray_dict_keys(obj);
+        ray_t* vals = ray_dict_vals(obj);
+        ray_err_t err = col_preflight_recursive(keys);
+        return err == RAY_OK ? col_preflight_recursive(vals) : err;
+    }
+
+    return RAY_ERR_NYI;
+}
+
+ray_err_t ray_col_save_preflight(ray_t* vec) {
+    if (!vec || RAY_IS_ERR(vec)) return RAY_ERR_TYPE;
+    if (is_serializable_type(vec->type)) return RAY_OK;
+    if (vec->type == RAY_LIST || vec->type == RAY_TABLE)
+        return col_preflight_recursive(vec);
+    return RAY_ERR_NYI;
 }
 
 /* --------------------------------------------------------------------------
@@ -359,6 +406,13 @@ static ray_err_t col_write_recursive(ray_t* obj, FILE* f) {
         return RAY_OK;
     }
 
+    if (type == RAY_DICT) {
+        ray_t* keys = ray_dict_keys(obj);
+        ray_t* vals = ray_dict_vals(obj);
+        ray_err_t err = col_write_recursive(keys, f);
+        return err == RAY_OK ? col_write_recursive(vals, f) : err;
+    }
+
     return RAY_ERR_NYI;
 }
 
@@ -536,6 +590,17 @@ static ray_t* col_read_recursive(const uint8_t** pp, size_t* remaining) {
             if (!tbl || RAY_IS_ERR(tbl)) return tbl;
         }
         return tbl;
+    }
+
+    if (type == RAY_DICT) {
+        ray_t* keys = col_read_recursive(pp, remaining);
+        if (!keys || RAY_IS_ERR(keys)) return keys;
+        ray_t* vals = col_read_recursive(pp, remaining);
+        if (!vals || RAY_IS_ERR(vals)) {
+            ray_release(keys);
+            return vals;
+        }
+        return ray_dict_new(keys, vals); /* consumes keys + vals */
     }
 
     return ray_error("nyi", NULL);

--- a/src/store/col.h
+++ b/src/store/col.h
@@ -85,6 +85,10 @@ static inline ray_err_t ray_col_check_format(const ray_t* header) {
  * loads attach that symfile's domain (sym-domain architecture spec). */
 ray_err_t ray_col_save(ray_t* vec, const char* path);
 ray_err_t ray_col_save_bulk(ray_t* vec, const char* path);
+/* Validate the complete object graph accepted by ray_col_save without
+ * opening or modifying a file.  Splayed saves use this before mutating a
+ * symfile or any already-committed column generation. */
+ray_err_t ray_col_save_preflight(ray_t* vec);
 ray_t*    ray_col_load(const char* path);
 ray_t*    ray_col_mmap(const char* path);
 

--- a/src/store/splay.c
+++ b/src/store/splay.c
@@ -150,6 +150,17 @@ static ray_err_t splay_save_impl(ray_t* tbl, const char* dir, const char* sym_pa
     ray_err_t name_err = splay_validate_persisted_names(tbl);
     if (name_err != RAY_OK) return name_err;
 
+    /* Validate every column graph before mkdir, sym-domain growth, or the
+     * first per-column atomic rename.  Without this pass, an unsupported
+     * value in a later recursive LIST cell can return NYI after earlier
+     * columns have already replaced an existing committed generation. */
+    int64_t preflight_ncols = ray_table_ncols(tbl);
+    for (int64_t c = 0; c < preflight_ncols; c++) {
+        ray_t* col = ray_table_get_col_idx(tbl, c);
+        ray_err_t err = ray_col_save_preflight(col);
+        if (err != RAY_OK) return err;
+    }
+
     /* Symfile/column collision guard.  A column is written as `dir/<name>`;
      * the symfile (and its `<sym>.lk` lock) is written at `sym_path`.  A
      * column whose file lands on the symfile path — or its lock path —
@@ -284,8 +295,9 @@ static ray_err_t splay_save_impl(ray_t* tbl, const char* dir, const char* sym_pa
             : (durable ? ray_col_save(col, path)
                        : ray_col_save_bulk(col, path));
         if (err != RAY_OK) {
-            /* No .d written yet: the dir stays in its previous committed
-             * state (old .d) or uncommitted state (no .d) — never torn. */
+            /* No new .d is written.  Preflight prevents deterministic format
+             * failures here; an I/O error or crash can still leave an
+             * existing directory with mixed-generation column files. */
             ray_release(schema);
             if (dom) ray_sym_domain_release(dom);
             return err;

--- a/test/test_lang.c
+++ b/test/test_lang.c
@@ -2965,6 +2965,37 @@ static test_result_t test_eval_insert_list_append(void) {
     PASS();
 }
 
+/* ---- Test: insert into a table with a boxed LIST column --------------- */
+static test_result_t test_eval_insert_list_column(void) {
+    const char* setup =
+        "(set nested_t (table ['k 'sched] (list ['a 'b] "
+        "  (list (list (as 'i64 (list 0)) (as 'f64 (list 5))) "
+        "        (list (as 'i64 (list 0 250000)) "
+        "              (as 'f64 (list 15 10)))))))";
+    ray_t* r = ray_eval_str(setup);
+    TEST_ASSERT_NOT_NULL(r);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(r));
+    ray_release(r);
+
+    /* A table payload is a batch: copy each boxed cell with a retain. */
+    ASSERT_EQ("(insert 'nested_t nested_t)", "'nested_t");
+    ASSERT_EQ("(count nested_t)", "4");
+    ASSERT_EQ("(at nested_t 'sched)",
+              "(list (list [0] [5.0]) "
+              "      (list [0 250000] [15.0 10.0]) "
+              "      (list [0] [5.0]) "
+              "      (list [0 250000] [15.0 10.0]))");
+
+    /* A positional row keeps its nested LIST as one cell, not a batch. */
+    ASSERT_EQ("(insert 'nested_t "
+              "        (list 'c (list [1 2] [3.0 4.0])))",
+              "'nested_t");
+    ASSERT_EQ("(count nested_t)", "5");
+    ASSERT_EQ("(get (at nested_t 'sched) 4)",
+              "(list [1 2] [3.0 4.0])");
+    PASS();
+}
+
 /* ---- Test: insert positional (arity 3, scalar idx) ---- */
 static test_result_t test_eval_insert_vec_positional(void) {
     /* Head, middle, tail (== append) */
@@ -4287,6 +4318,25 @@ static test_result_t test_eval_parted_list_column_impl(const char* root) {
 
     /* The parted view itself must stay usable after the reads. */
     ASSERT_EQ("(at pl 'acct)", "['a 'b 'a 'b]");
+
+    /* Append two boxed rows to the active partition.  The historical LIST
+     * segment stays mmap-backed while the active segment becomes a retained
+     * heap snapshot. */
+    ASSERT_EQ("(insert 'pl 2024.01.02 "
+              "        (table ['acct 'brk] "
+              "               (list ['c 'd] (list [1 2] [3 4 5]))))",
+              "'pl");
+    ASSERT_EQ("(count pl)", "6");
+    ASSERT_EQ("(at pl 'brk)",
+              "(list [0 250000] [0 250000 5000000] "
+              "      [0 250000] [0 250000 5000000] [1 2] [3 4 5])");
+
+    /* A greater key creates a new boxed heap segment. */
+    ASSERT_EQ("(insert 'pl 2024.01.03 "
+              "        (table ['acct 'brk] (list ['e] (list [7 8]))))",
+              "'pl");
+    ASSERT_EQ("(count pl)", "7");
+    ASSERT_EQ("(get (at pl 'brk) 6)", "[7 8]");
     PASS();
 }
 
@@ -8700,6 +8750,7 @@ const test_entry_t lang_entries[] = {
     { "lang/eval/insert", test_eval_insert, lang_setup, lang_teardown },
     { "lang/eval/insert_vec_append", test_eval_insert_vec_append, lang_setup, lang_teardown },
     { "lang/eval/insert_list_append", test_eval_insert_list_append, lang_setup, lang_teardown },
+    { "lang/eval/insert_list_column", test_eval_insert_list_column, lang_setup, lang_teardown },
     { "lang/eval/insert_vec_positional", test_eval_insert_vec_positional, lang_setup, lang_teardown },
     { "lang/eval/insert_list_positional", test_eval_insert_list_positional, lang_setup, lang_teardown },
     { "lang/eval/insert_positional_multi", test_eval_insert_positional_multi, lang_setup, lang_teardown },

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -508,6 +508,114 @@ static test_result_t test_splay_short_strv_roundtrip(void) {
     PASS();
 }
 
+/* ---- test_splay_dict_column_roundtrip --------------------------------- */
+static test_result_t test_splay_dict_column_roundtrip(void) {
+    (void)!system("rm -rf " TMP_SPLAY_DIR);
+
+    int64_t ids_raw[] = {1, 2};
+    ray_t* ids = ray_vec_from_raw(RAY_I64, ids_raw, 2);
+    ray_t* sched = ray_list_new(2);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(ids));
+    TEST_ASSERT_FALSE(RAY_IS_ERR(sched));
+
+    int64_t k0_raw[] = {0};
+    double v0_raw[] = {5.0};
+    int64_t k1_raw[] = {0, 250000};
+    double v1_raw[] = {15.0, 10.0};
+    ray_t* d0 = ray_dict_new(ray_vec_from_raw(RAY_I64, k0_raw, 1),
+                             ray_vec_from_raw(RAY_F64, v0_raw, 1));
+    ray_t* d1 = ray_dict_new(ray_vec_from_raw(RAY_I64, k1_raw, 2),
+                             ray_vec_from_raw(RAY_F64, v1_raw, 2));
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d0));
+    TEST_ASSERT_FALSE(RAY_IS_ERR(d1));
+    sched = ray_list_append(sched, d0);
+    sched = ray_list_append(sched, d1);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(sched));
+    ray_release(d0);
+    ray_release(d1);
+
+    ray_t* tbl = ray_table_new(2);
+    int64_t id_id = ray_sym_intern("id", 2);
+    int64_t sched_id = ray_sym_intern("sched", 5);
+    tbl = ray_table_add_col(tbl, id_id, ids);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(tbl));
+    tbl = ray_table_add_col(tbl, sched_id, sched);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(tbl));
+
+    TEST_ASSERT_EQ_I(ray_splay_save(tbl, TMP_SPLAY_DIR, NULL), RAY_OK);
+    ray_t* loaded = ray_read_splayed(TMP_SPLAY_DIR, NULL);
+    TEST_ASSERT_NOT_NULL(loaded);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(loaded));
+    ray_t* loaded_sched = ray_table_get_col(loaded, sched_id);
+    TEST_ASSERT_NOT_NULL(loaded_sched);
+    TEST_ASSERT_EQ_I(loaded_sched->type, RAY_LIST);
+    TEST_ASSERT_EQ_I(loaded_sched->len, 2);
+
+    ray_t* ld0 = ray_list_get(loaded_sched, 0);
+    ray_t* ld1 = ray_list_get(loaded_sched, 1);
+    TEST_ASSERT_EQ_I(ld0->type, RAY_DICT);
+    TEST_ASSERT_EQ_I(ld1->type, RAY_DICT);
+    TEST_ASSERT_EQ_I(ray_dict_keys(ld0)->type, RAY_I64);
+    TEST_ASSERT_EQ_I(ray_dict_vals(ld1)->type, RAY_F64);
+    TEST_ASSERT_EQ_I(((int64_t*)ray_data(ray_dict_keys(ld1)))[1], 250000);
+    TEST_ASSERT(((double*)ray_data(ray_dict_vals(ld1)))[1] == 10.0,
+                "dict value roundtrip");
+
+    ray_release(loaded);
+    ray_release(tbl);
+    ray_release(ids);
+    ray_release(sched);
+    (void)!system("rm -rf " TMP_SPLAY_DIR);
+    PASS();
+}
+
+/* A deterministic unsupported column must be rejected before an earlier
+ * column can replace the committed generation. */
+static test_result_t test_splay_save_preflight_preserves_generation(void) {
+    (void)!system("rm -rf " TMP_SPLAY_DIR);
+    int64_t k_id = ray_sym_intern("k", 1);
+    int64_t v_id = ray_sym_intern("v", 1);
+
+    int64_t old_k_raw[] = {1, 2};
+    int64_t old_v_raw[] = {3, 4};
+    ray_t* old_k = ray_vec_from_raw(RAY_I64, old_k_raw, 2);
+    ray_t* old_v = ray_vec_from_raw(RAY_I64, old_v_raw, 2);
+    ray_t* good = ray_table_new(2);
+    good = ray_table_add_col(good, k_id, old_k);
+    good = ray_table_add_col(good, v_id, old_v);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(good));
+    TEST_ASSERT_EQ_I(ray_splay_save(good, TMP_SPLAY_DIR, NULL), RAY_OK);
+
+    int64_t new_k_raw[] = {9, 10};
+    int64_t dk_raw[] = {1, 2};
+    int64_t dv_raw[] = {11, 12};
+    ray_t* new_k = ray_vec_from_raw(RAY_I64, new_k_raw, 2);
+    ray_t* unsupported = ray_dict_new(ray_vec_from_raw(RAY_I64, dk_raw, 2),
+                                      ray_vec_from_raw(RAY_I64, dv_raw, 2));
+    ray_t* bad = ray_table_new(2);
+    bad = ray_table_add_col(bad, k_id, new_k);
+    bad = ray_table_add_col(bad, v_id, unsupported);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(bad));
+    TEST_ASSERT_EQ_I(ray_splay_save(bad, TMP_SPLAY_DIR, NULL), RAY_ERR_NYI);
+
+    ray_t* loaded = ray_read_splayed(TMP_SPLAY_DIR, NULL);
+    TEST_ASSERT_NOT_NULL(loaded);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(loaded));
+    ray_t* loaded_k = ray_table_get_col(loaded, k_id);
+    TEST_ASSERT_EQ_I(((int64_t*)ray_data(loaded_k))[0], 1);
+    TEST_ASSERT_EQ_I(((int64_t*)ray_data(loaded_k))[1], 2);
+
+    ray_release(loaded);
+    ray_release(bad);
+    ray_release(unsupported);
+    ray_release(new_k);
+    ray_release(good);
+    ray_release(old_v);
+    ray_release(old_k);
+    (void)!system("rm -rf " TMP_SPLAY_DIR);
+    PASS();
+}
+
 /* ---- test_parted_nrows ------------------------------------------------- */
 
 static test_result_t test_parted_nrows(void) {
@@ -4954,6 +5062,8 @@ const test_entry_t store_entries[] = {
     { "store/splay_open_roundtrip", test_splay_open_roundtrip, store_setup, store_teardown },
     { "store/splay_str_column_roundtrip", test_splay_str_column_roundtrip, store_setup, store_teardown },
     { "store/splay_short_strv_roundtrip", test_splay_short_strv_roundtrip, store_setup, store_teardown },
+    { "store/splay_dict_column_roundtrip", test_splay_dict_column_roundtrip, store_setup, store_teardown },
+    { "store/splay_save_preflight", test_splay_save_preflight_preserves_generation, store_setup, store_teardown },
     { "store/parted_nrows", test_parted_nrows, store_setup, store_teardown },
     { "store/table_nrows_parted", test_table_nrows_parted, store_setup, store_teardown },
     { "store/parted_release", test_parted_release, store_setup, store_teardown },


### PR DESCRIPTION
## Summary

- support boxed LIST columns in plain table inserts
- support boxed LIST segments in partitioned-table inserts
- serialize and deserialize DICT cells recursively inside nested columns
- preflight complete splayed column graphs before replacing persisted files
- add regressions for inserts, persistence round-trips, and failed-overwrite preservation

## Root cause

The plain insert path always allocated a concrete vector, while the partitioned insert validator excluded LIST physical columns. Recursive column serialization handled LIST and TABLE values but returned NYI for DICT cells.

A later-column serialization failure could also occur after earlier column files had already been replaced, producing a deterministic mixed-generation table. The new preflight rejects unsupported object graphs before any splayed-save mutation.

This does not introduce table-wide crash or I/O atomicity; staged generations remain separate storage hardening, consistent with the existing splayed persistence model.

## Validation

- original in-memory LIST-column insert reproducer
- original partitioned LIST-column insert reproducer
- original DICT-cell persistence reproducer
- clean ASan/UBSan debug build with `-Werror`
- full test suite: 3,655 passed, 0 skipped, 0 failed
- `git diff --check`

Closes #362
