### PR TITLE
fix(eval): enforce restricted mode in compiled lambdas

### DIFF
--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -2282,6 +2282,11 @@ op_storeglobal: {
     ray_t *name_obj = cpool[idx];
     /* `set` returns its value, so the result must stay on the stack;
      * PEEK rather than POP.  ray_env_set retains its own ref. */
+    if (RAY_UNLIKELY(__VM->restricted)) {
+        ray_release(POP());
+        vm_err_obj = ray_error("access", "restricted");
+        goto vm_error;
+    }
     ray_t *val = PEEK();
     ray_err_t err = ray_env_set(name_obj->i64, val);
     if (err != RAY_OK) {
@@ -2296,6 +2301,11 @@ op_storeglobal_w: {
     uint16_t idx = (uint16_t)((code[ip] << 8) | code[ip + 1]);
     ip += 2;
     ray_t *name_obj = cpool[idx];
+    if (RAY_UNLIKELY(__VM->restricted)) {
+        ray_release(POP());
+        vm_err_obj = ray_error("access", "restricted");
+        goto vm_error;
+    }
     ray_t *val = PEEK();
     ray_err_t err = ray_env_set(name_obj->i64, val);
     if (err != RAY_OK) {
@@ -2327,6 +2337,12 @@ op_jmpf: {
 op_call1: {
     ray_t *arg = POP();
     ray_t *fn_obj = POP();
+    if (RAY_UNLIKELY(fn_is_restricted(fn_obj))) {
+        ray_release(arg);
+        ray_release(fn_obj);
+        vm_err_obj = ray_error("access", "restricted");
+        goto vm_error;
+    }
     ray_unary_fn fn = (ray_unary_fn)(uintptr_t)fn_obj->i64;
     ray_t *result;
     /* Materialise lazy args for non-lazy-aware fns.
@@ -2359,6 +2375,13 @@ op_call2: {
     ray_t *right = POP();
     ray_t *left = POP();
     ray_t *fn_obj = POP();
+    if (RAY_UNLIKELY(fn_is_restricted(fn_obj))) {
+        ray_release(left);
+        ray_release(right);
+        ray_release(fn_obj);
+        vm_err_obj = ray_error("access", "restricted");
+        goto vm_error;
+    }
     ray_binary_fn fn = (ray_binary_fn)(uintptr_t)fn_obj->i64;
     ray_t *result;
     /* Materialise lazy args for non-lazy-aware fns.
@@ -2407,6 +2430,12 @@ op_calln: {
     for (int32_t i = n - 1; i >= 0; i--)
         fn_args[i] = POP();
     ray_t *fn_obj = POP();
+    if (RAY_UNLIKELY(fn_is_restricted(fn_obj))) {
+        for (int32_t i = 0; i < n; i++) ray_release(fn_args[i]);
+        ray_release(fn_obj);
+        vm_err_obj = ray_error("access", "restricted");
+        goto vm_error;
+    }
     ray_vary_fn fn = (ray_vary_fn)(uintptr_t)fn_obj->i64;
     if (!(fn_obj->attrs & RAY_FN_LAZY_AWARE)) {
         ray_t* err = materialize_owned_args(fn_args, n);

--- a/test/test_lang.c
+++ b/test/test_lang.c
@@ -6377,6 +6377,82 @@ static test_result_t test_eval_restricted_fn(void) {
     PASS();
 }
 
+/* Evaluate one expression with the same VM-wide flag used by restricted IPC.
+ * Restore the caller's state before inspecting the result so a failed
+ * assertion cannot leak restricted mode into the next test. */
+static ray_t* eval_restricted_expr(const char* expr) {
+    bool previous = ray_eval_get_restricted();
+    ray_eval_set_restricted(true);
+    ray_t* result = ray_eval_str(expr);
+    ray_eval_set_restricted(previous);
+    return result;
+}
+
+static bool restricted_expr_returns_access(const char* expr) {
+    ray_t* result = eval_restricted_expr(expr);
+    bool access = result && RAY_IS_ERR(result) &&
+                  ray_err_code(result) &&
+                  strcmp(ray_err_code(result), "access") == 0;
+    if (result) {
+        if (RAY_IS_ERR(result)) ray_error_free(result);
+        else ray_release(result);
+    }
+    return access;
+}
+
+/* Restricted builtins must be rejected at the actual invocation boundary,
+ * including compiled lambda bytecode.  Invalid filesystem arguments are
+ * deliberate: before the fix they return os/type instead of access without
+ * performing a useful side effect. */
+static test_result_t test_eval_restricted_lambda_bypass(void) {
+    /* OP_CALL1: unary restricted builtin. */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access(
+        "((fn [x] (.sys.exec \"true\")) 0)"));
+
+    /* OP_CALL2: binary restricted builtin. */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access(
+        "((fn [x] (write \"/__rayforce_issue_363_missing__/file\" \"x\")) 0)"));
+
+    /* OP_CALLN: variadic restricted builtin. */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access(
+        "((fn [x] (.db.splayed.set 1 2)) 0)"));
+
+    /* OP_STOREGLOBAL: the compiler lowers `set` directly instead of calling
+     * the registered restricted special form. */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access(
+        "((fn [x] (set '__rf_issue_363_injected 1)) 0)"));
+
+    /* The wide-constant opcode is a separate VM handler and must enforce the
+     * same rule.  Fill the constant pool before compiling `set` so its name
+     * index exceeds one byte and OP_STOREGLOBAL_W is emitted. */
+    char wide_set[4096];
+    size_t used = (size_t)snprintf(wide_set, sizeof(wide_set),
+                                   "((fn [x] (do ");
+    for (int i = 0; i < 260 && used < sizeof(wide_set); i++)
+        used += (size_t)snprintf(wide_set + used, sizeof(wide_set) - used,
+                                 "%d ", i);
+    if (used < sizeof(wide_set))
+        used += (size_t)snprintf(wide_set + used, sizeof(wide_set) - used,
+                                 "(set '__rf_issue_363_wide 1))) 0)");
+    TEST_ASSERT(used < sizeof(wide_set), "wide restricted set expression fits buffer");
+    TEST_ASSERT_TRUE(restricted_expr_returns_access(wide_set));
+
+    /* Nested bytecode and dynamic callable dispatch stay restricted too. */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access(
+        "((fn [x] ((fn [y] (read \"/__rayforce_issue_363_missing__/file\")) x)) 0)"));
+    TEST_ASSERT_TRUE(restricted_expr_returns_access(
+        "((fn [f] (f \"/__rayforce_issue_363_missing__/file\")) read)"));
+
+    /* Pure computation remains available in read-only mode. */
+    ray_t* allowed = eval_restricted_expr("((fn [x] (+ x 1)) 2)");
+    TEST_ASSERT_NOT_NULL(allowed);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(allowed));
+    TEST_ASSERT_EQ_I(allowed->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(allowed->i64, 3);
+    ray_release(allowed);
+    PASS();
+}
+
 /* --- self-recursive lambda via recursion (tests op_calls path) --- */
 static test_result_t test_eval_self_recursion_direct(void) {
     /* Direct recursion using named function — compiler may use op_calls */
@@ -8904,6 +8980,7 @@ const test_entry_t lang_entries[] = {
     { "lang/eval/table_list_col_f64_promote", test_eval_table_list_col_f64_i64_promote, lang_setup, lang_teardown },
     { "lang/eval/cond_and_branches", test_eval_cond_and_branches, lang_setup, lang_teardown },
     { "lang/eval/restricted_fn", test_eval_restricted_fn, lang_setup, lang_teardown },
+    { "lang/eval/restricted_lambda_bypass", test_eval_restricted_lambda_bypass, lang_setup, lang_teardown },
     { "lang/eval/self_recursion_direct", test_eval_self_recursion_direct, lang_setup, lang_teardown },
     { "lang/eval/nested_lambda_calls", test_eval_nested_lambda_calls, lang_setup, lang_teardown },
     { "lang/eval/vm_empty_ret", test_eval_vm_empty_ret, lang_setup, lang_teardown },

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -3727,6 +3727,28 @@ static test_result_t test_ipc_restricted(void) {
     TEST_ASSERT_TRUE(RAY_IS_ERR(r4));
     ray_release(r4);
 
+    /* Entering compiled lambda bytecode must preserve the connection's
+     * restricted context.  These are the request-level escapes from #363. */
+    const char* q_lambda =
+        "((fn [x] (.sys.exec \"true\")) 0)";
+    ray_t* msg5 = ray_str(q_lambda, strlen(q_lambda));
+    ray_t* r5 = ray_ipc_send(h, msg5);
+    ray_release(msg5);
+    TEST_ASSERT_NOT_NULL(r5);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(r5));
+    TEST_ASSERT_STR_EQ(ray_err_code(r5), "access");
+    ray_release(r5);
+
+    const char* q_lambda_set =
+        "((fn [x] (set '__rf_issue_363_ipc_injected 1)) 0)";
+    ray_t* msg6 = ray_str(q_lambda_set, strlen(q_lambda_set));
+    ray_t* r6 = ray_ipc_send(h, msg6);
+    ray_release(msg6);
+    TEST_ASSERT_NOT_NULL(r6);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(r6));
+    TEST_ASSERT_STR_EQ(ray_err_code(r6), "access");
+    ray_release(r6);
+
     ray_ipc_close(h);
     srv.running = false;
     ray_thread_join(tid);


### PR DESCRIPTION
## Summary
- enforce restricted-function checks in compiled unary, binary, and variadic call opcodes
- block compiler-lowered `set` in both narrow and wide global-store opcodes
- add direct VM and real IPC regressions for lambda-wrapped shell, file, storage, and global mutation paths
- preserve pure read-only computation inside lambdas

## Root cause
The tree-walking evaluator and higher-order helpers checked `RAY_FN_RESTRICTED`, but `OP_CALL1`, `OP_CALL2`, and `OP_CALLN` invoked builtin pointers without the check. The compiler also lowered `set` directly to `OP_STOREGLOBAL`/`OP_STOREGLOBAL_W`, bypassing the registered restricted special form.

A restricted IPC request that entered compiled lambda bytecode could therefore execute shell commands, read/write files, persist data, or mutate globals with server privileges.

## Validation
- regression reproduced before the fix
- direct VM coverage for all affected opcodes, nested lambdas, and dynamic call dispatch
- real restricted IPC coverage for lambda-wrapped `.sys.exec` and `set`
- clean ASan/UBSan debug build with `-Werror`
- full test suite: 3,656 passed, 0 skipped, 0 failed
- `git diff --check`

Closes #363
