### PR TITLE
feat(core): add bounded poll step for embedders

### DIFF
--- a/include/rayforce.h
+++ b/include/rayforce.h
@@ -675,6 +675,33 @@ ray_runtime_t* ray_runtime_create_with_sym_err(const char* sym_path,
  * exactly one ray_runtime_create* call. */
 void ray_runtime_destroy(ray_runtime_t* rt);
 
+/* ===== Host-Driven Event Loop API =====
+ *
+ * Embedders that own the runtime thread can attach a poll to the runtime,
+ * create listeners from Rayfall (for example `(.sys.listen 7701)`), and
+ * service IPC and Rayfall timers in bounded slices.  The runtime borrows
+ * the poll: detach and destroy it before destroying the runtime. */
+
+typedef struct ray_poll ray_poll_t;
+
+ray_poll_t* ray_poll_create(void);
+void        ray_poll_destroy(ray_poll_t* poll);
+
+/* Run until ray_poll_exit is called. */
+int64_t ray_poll_run(ray_poll_t* poll);
+
+/* Serve events and timers for at most timeout_ms milliseconds.
+ * A negative timeout preserves ray_poll_run's blocking behavior; zero
+ * performs one non-blocking drain.  Returns 0 (or an exit code) normally
+ * and -1 when poll is NULL or the platform event queue fails. */
+int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms);
+
+void ray_poll_exit(ray_poll_t* poll, int64_t code);
+
+/* The runtime borrows this pointer; pass NULL to detach it. */
+void  ray_runtime_set_poll(void* poll);
+void* ray_runtime_get_poll(void);
+
 /* Parse and evaluate a Rayfall source string against the global env.
  * Returns RAY_NULL_OBJ for successful void / null results, an error ray_t*
  * on failure (test with RAY_IS_ERR and inspect with ray_err_code), or the

--- a/src/core/epoll.c
+++ b/src/core/epoll.c
@@ -156,14 +156,23 @@ void ray_poll_deregister(ray_poll_t* poll, int64_t id)
     poll->sels[id] = NULL;
 }
 
-int64_t ray_poll_run(ray_poll_t* poll)
+int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
 {
     if (!poll) return -1;
 
     struct epoll_event events[RAY_POLL_MAX_EVENTS];
+    bool bounded = timeout_ms >= 0;
+    int64_t end_ms = bounded ? ray_time_now_ms() + timeout_ms : INT64_MAX;
 
     while (poll->code < 0) {
         int wait_ms = -1;
+        if (bounded) {
+            int64_t remaining = end_ms - ray_time_now_ms();
+            if (remaining < 0) remaining = 0;
+            if (remaining > INT_MAX) remaining = INT_MAX;
+            wait_ms = (int)remaining;
+        }
+
         if (poll->timers) {
             int64_t deadline = ray_timers_next_deadline_ms(
                 (ray_timers_t*)poll->timers);
@@ -172,7 +181,8 @@ int64_t ray_poll_run(ray_poll_t* poll)
                 int64_t delta = deadline - now;
                 if (delta < 0) delta = 0;
                 if (delta > INT_MAX) delta = INT_MAX;
-                wait_ms = (int)delta;
+                if (wait_ms < 0 || delta < wait_ms)
+                    wait_ms = (int)delta;
             }
         }
 
@@ -264,9 +274,15 @@ int64_t ray_poll_run(ray_poll_t* poll)
 
         if (poll->timers)
             ray_timers_fire_expired((ray_timers_t*)poll->timers);
+        if (bounded) break;
     }
 
-    return poll->code;
+    return poll->code >= 0 ? poll->code : 0;
+}
+
+int64_t ray_poll_run(ray_poll_t* poll)
+{
+    return ray_poll_run_for(poll, -1);
 }
 
 #endif /* __linux__ */

--- a/src/core/iocp.c
+++ b/src/core/iocp.c
@@ -51,10 +51,15 @@ void ray_poll_deregister(ray_poll_t* poll, int64_t id)
     (void)poll; (void)id;
 }
 
+int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
+{
+    (void)poll; (void)timeout_ms;
+    return -1;
+}
+
 int64_t ray_poll_run(ray_poll_t* poll)
 {
-    (void)poll;
-    return -1;
+    return ray_poll_run_for(poll, -1);
 }
 
 #endif /* _WIN32 */

--- a/src/core/kqueue.c
+++ b/src/core/kqueue.c
@@ -29,6 +29,7 @@
 #include <sys/event.h>
 #include <unistd.h>
 #include <errno.h>
+#include <limits.h>
 #include <string.h>
 
 #define RAY_POLL_MAX_EVENTS 64
@@ -159,15 +160,22 @@ void ray_poll_deregister(ray_poll_t* poll, int64_t id)
     poll->sels[id] = NULL;
 }
 
-int64_t ray_poll_run(ray_poll_t* poll)
+int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
 {
     if (!poll) return -1;
 
     struct kevent events[RAY_POLL_MAX_EVENTS];
+    bool bounded = timeout_ms >= 0;
+    int64_t end_ms = bounded ? ray_time_now_ms() + timeout_ms : INT64_MAX;
 
     while (poll->code < 0) {
-        struct timespec  ts;
-        struct timespec* timeout = NULL;
+        int64_t wait_ms = -1;
+        if (bounded) {
+            int64_t remaining = end_ms - ray_time_now_ms();
+            if (remaining < 0) remaining = 0;
+            wait_ms = remaining;
+        }
+
         if (poll->timers) {
             int64_t deadline = ray_timers_next_deadline_ms(
                 (ray_timers_t*)poll->timers);
@@ -175,10 +183,17 @@ int64_t ray_poll_run(ray_poll_t* poll)
                 int64_t now = ray_time_now_ms();
                 int64_t delta = deadline - now;
                 if (delta < 0) delta = 0;
-                ts.tv_sec  = (time_t)(delta / 1000);
-                ts.tv_nsec = (long)((delta % 1000) * 1000000L);
-                timeout = &ts;
+                if (wait_ms < 0 || delta < wait_ms)
+                    wait_ms = delta;
             }
+        }
+
+        struct timespec  ts;
+        struct timespec* timeout = NULL;
+        if (wait_ms >= 0) {
+            ts.tv_sec  = (time_t)(wait_ms / 1000);
+            ts.tv_nsec = (long)((wait_ms % 1000) * 1000000L);
+            timeout = &ts;
         }
 
         int n = kevent((int)poll->fd, NULL, 0, events,
@@ -263,9 +278,15 @@ int64_t ray_poll_run(ray_poll_t* poll)
 
         if (poll->timers)
             ray_timers_fire_expired((ray_timers_t*)poll->timers);
+        if (bounded) break;
     }
 
-    return poll->code;
+    return poll->code >= 0 ? poll->code : 0;
+}
+
+int64_t ray_poll_run(ray_poll_t* poll)
+{
+    return ray_poll_run_for(poll, -1);
 }
 
 #endif /* __APPLE__ */

--- a/src/core/poll.h
+++ b/src/core/poll.h
@@ -107,6 +107,7 @@ void            ray_poll_destroy(ray_poll_t* poll);
 int64_t         ray_poll_register(ray_poll_t* poll, ray_poll_reg_t* reg);
 void            ray_poll_deregister(ray_poll_t* poll, int64_t id);
 int64_t         ray_poll_run(ray_poll_t* poll);
+int64_t         ray_poll_run_for(ray_poll_t* poll, int timeout_ms);
 void            ray_poll_exit(ray_poll_t* poll, int64_t code);
 ray_selector_t* ray_poll_get(ray_poll_t* poll, int64_t id);
 

--- a/test/test_pool.c
+++ b/test/test_pool.c
@@ -31,17 +31,20 @@
 #include "core/pool.h"
 #include "core/poll.h"
 #include "core/platform.h"
+#include "core/timer.h"
 #include "mem/heap.h"
 #include "ops/ops.h"
 #include <stdatomic.h>
 #include <string.h>
 #include <math.h>
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
 #include <unistd.h>
 #include <sys/socket.h>
 #include <time.h>
+#endif
 
+#if defined(__linux__)
 static void epoll_sleep_ms(long ms) {
     struct timespec ts = { .tv_sec = ms / 1000, .tv_nsec = (ms % 1000) * 1000000L };
     nanosleep(&ts, NULL);
@@ -995,6 +998,82 @@ static test_result_t test_dispatch_n_exact_cap(void) {
 }
 
 /* ==========================================================================
+ * Bounded poll-step tests
+ * ========================================================================== */
+
+#if defined(__linux__) || defined(__APPLE__)
+
+typedef struct {
+    int calls;
+} poll_run_for_ctx_t;
+
+static int64_t poll_run_for_recv(int64_t fd, uint8_t* buf, int64_t len) {
+    return (int64_t)read((int)fd, buf, (size_t)len);
+}
+
+static ray_t* poll_run_for_read(ray_poll_t* poll, ray_selector_t* sel) {
+    poll_run_for_ctx_t* ctx = (poll_run_for_ctx_t*)sel->data;
+    ctx->calls++;
+    ray_poll_deregister(poll, sel->id);
+    return NULL;
+}
+
+static test_result_t test_poll_run_for_zero_drains_ready_event(void) {
+    ray_poll_t* poll = ray_poll_create();
+    TEST_ASSERT_NOT_NULL(poll);
+
+    int pfd[2];
+    TEST_ASSERT_EQ_I(pipe(pfd), 0);
+
+    poll_run_for_ctx_t ctx = {0};
+    ray_poll_reg_t reg;
+    memset(&reg, 0, sizeof(reg));
+    reg.fd      = pfd[0];
+    reg.type    = RAY_SEL_SOCKET;
+    reg.data    = &ctx;
+    reg.recv_fn = poll_run_for_recv;
+    reg.read_fn = poll_run_for_read;
+
+    int64_t id = ray_poll_register(poll, &reg);
+    TEST_ASSERT_TRUE(id >= 0);
+    ray_selector_t* sel = ray_poll_get(poll, id);
+    TEST_ASSERT_NOT_NULL(sel);
+    ray_poll_rx_request(poll, sel, 1);
+
+    TEST_ASSERT_EQ_I(write(pfd[1], "x", 1), 1);
+    TEST_ASSERT_EQ_I(ray_poll_run_for(poll, 0), 0);
+    TEST_ASSERT_EQ_I(ctx.calls, 1);
+
+    close(pfd[0]);
+    close(pfd[1]);
+    ray_poll_destroy(poll);
+    PASS();
+}
+
+static test_result_t test_poll_run_for_positive_timeout(void) {
+    TEST_ASSERT_EQ_I(ray_poll_run_for(NULL, 10), -1);
+
+    ray_poll_t* poll = ray_poll_create();
+    TEST_ASSERT_NOT_NULL(poll);
+
+    int64_t before = ray_time_now_ms();
+    TEST_ASSERT_EQ_I(ray_poll_run_for(poll, 25), 0);
+    int64_t elapsed = ray_time_now_ms() - before;
+
+    TEST_ASSERT_FMT(elapsed >= 15,
+                    "bounded poll returned too early (%lld ms)",
+                    (long long)elapsed);
+    TEST_ASSERT_FMT(elapsed < 500,
+                    "bounded poll exceeded its budget (%lld ms)",
+                    (long long)elapsed);
+
+    ray_poll_destroy(poll);
+    PASS();
+}
+
+#endif
+
+/* ==========================================================================
  * epoll.c region-coverage tests
  *
  * These tests are Linux-only and exercise paths in src/core/epoll.c that
@@ -1258,6 +1337,10 @@ const test_entry_t pool_entries[] = {
     { "pool/destroy_when_uninit",   test_destroy_when_uninit,   NULL, NULL },
     { "pool/dispatch_n_multi_grow", test_dispatch_n_multi_grow, NULL, NULL },
     { "pool/dispatch_n_exact_cap",  test_dispatch_n_exact_cap,  NULL, NULL },
+#if defined(__linux__) || defined(__APPLE__)
+    { "pool/poll_run_for_zero_drains_ready_event", test_poll_run_for_zero_drains_ready_event, NULL, NULL },
+    { "pool/poll_run_for_positive_timeout", test_poll_run_for_positive_timeout, NULL, NULL },
+#endif
 #if defined(__linux__)
     { "pool/epoll_sel_cap_growth",  test_epoll_sel_cap_growth,  NULL, NULL },
     { "pool/epoll_hup_branch",      test_epoll_hup_branch,      NULL, NULL },
@@ -1265,4 +1348,3 @@ const test_entry_t pool_entries[] = {
 #endif
     { NULL, NULL, NULL, NULL },
 };
-

--- a/test/test_public_api.c
+++ b/test/test_public_api.c
@@ -58,6 +58,25 @@ static test_result_t test_public_ipc_client_symbols(void) {
     PASS();
 }
 
+static test_result_t test_public_poll_symbols(void) {
+    ray_poll_t* (*create_fn)(void) = ray_poll_create;
+    void        (*destroy_fn)(ray_poll_t*) = ray_poll_destroy;
+    int64_t     (*run_fn)(ray_poll_t*) = ray_poll_run;
+    int64_t     (*run_for_fn)(ray_poll_t*, int) = ray_poll_run_for;
+    void        (*exit_fn)(ray_poll_t*, int64_t) = ray_poll_exit;
+    void        (*set_fn)(void*) = ray_runtime_set_poll;
+    void*       (*get_fn)(void) = ray_runtime_get_poll;
+
+    TEST_ASSERT_NOT_NULL((void*)create_fn);
+    TEST_ASSERT_NOT_NULL((void*)destroy_fn);
+    TEST_ASSERT_NOT_NULL((void*)run_fn);
+    TEST_ASSERT_NOT_NULL((void*)run_for_fn);
+    TEST_ASSERT_NOT_NULL((void*)exit_fn);
+    TEST_ASSERT_NOT_NULL((void*)set_fn);
+    TEST_ASSERT_NOT_NULL((void*)get_fn);
+    PASS();
+}
+
 static test_result_t test_public_query_and_format_symbols(void) {
     ray_t* (*select_fn)(ray_t**, int64_t) = ray_select;
     ray_t* (*update_fn)(ray_t**, int64_t) = ray_update;
@@ -661,6 +680,7 @@ static test_result_t test_public_nullability_matrix(void) {
 
 const test_entry_t public_api_entries[] = {
     { "public/ipc_client_symbols",        test_public_ipc_client_symbols,        NULL, NULL },
+    { "public/poll_symbols",              test_public_poll_symbols,              NULL, NULL },
     { "public/query_and_format_symbols",  test_public_query_and_format_symbols,  NULL, NULL },
 
     { "public/obj_type_atom_i64",   test_public_obj_type_atom_i64,   public_api_setup, public_api_teardown },

--- a/test/test_runtime.c
+++ b/test/test_runtime.c
@@ -716,6 +716,34 @@ static test_result_t test_syscov_time_timer_fires(void) {
     PASS();
 }
 
+/* The production poll driver must also service Rayfall timers while an
+ * embedder lends it the thread for a bounded slice. */
+static test_result_t test_poll_run_for_fires_timer(void) {
+    ray_poll_t* poll = (ray_poll_t*)ray_runtime_get_poll();
+    TEST_ASSERT_NOT_NULL(poll);
+
+    ray_t* setup_counter = ray_eval_str("(set bounded_timer_fired 0)");
+    TEST_ASSERT_NOT_NULL(setup_counter);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(setup_counter));
+    ray_release(setup_counter);
+
+    ray_t* setup_timer = ray_eval_str(
+        "(.time.timer.set 5 1 (fn [t] (set bounded_timer_fired 1)))");
+    TEST_ASSERT_NOT_NULL(setup_timer);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(setup_timer));
+    ray_release(setup_timer);
+
+    TEST_ASSERT_EQ_I(ray_poll_run_for(poll, 30), 0);
+
+    ray_t* fired = ray_eval_str("bounded_timer_fired");
+    TEST_ASSERT_NOT_NULL(fired);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(fired));
+    TEST_ASSERT_EQ_I(fired->type, -RAY_I64);
+    TEST_ASSERT_EQ_I(fired->i64, 1);
+    ray_release(fired);
+    PASS();
+}
+
 /* ─── timer.c deep coverage (heap helpers + edge paths) ───────
  *
  * The static heap helpers (heap_less, heap_swap, heap_up sift body,
@@ -1173,6 +1201,7 @@ const test_entry_t runtime_entries[] = {
     { "runtime/syscov_time_now",             test_syscov_time_now,             sys_setup, sys_teardown },
     { "runtime/syscov_time_timer_set_del",   test_syscov_time_timer_set_del,   sys_setup_with_poll, sys_teardown_with_poll },
     { "runtime/syscov_time_timer_fires",     test_syscov_time_timer_fires,     sys_setup_with_poll, sys_teardown_with_poll },
+    { "runtime/poll_run_for_fires_timer",    test_poll_run_for_fires_timer,    sys_setup_with_poll, sys_teardown_with_poll },
     { "runtime/timer_heap_grow_past_initial_cap", test_timer_heap_grow_past_initial_cap, sys_setup_with_poll, sys_teardown_with_poll },
     { "runtime/timer_next_deadline_ms",      test_timer_next_deadline_ms,      sys_setup_with_poll, sys_teardown_with_poll },
     { "runtime/timer_heap_sift_paths",       test_timer_heap_sift_paths,       sys_setup_with_poll, sys_teardown_with_poll },
@@ -1193,5 +1222,4 @@ const test_entry_t runtime_entries[] = {
 
     { NULL, NULL, NULL, NULL },
 };
-
 


### PR DESCRIPTION
## Summary
- add the public `ray_poll_run_for(poll, timeout_ms)` embedding API
- expose the poll lifecycle needed to attach `.sys.listen` to a host-owned runtime loop
- bound epoll and kqueue waits by both the host timeout and the next Rayfall timer
- preserve `ray_poll_run` as the negative-timeout, run-until-exit behavior
- add public-symbol, ready-event, timeout, and timer regressions

## Behavior
- `timeout_ms < 0`: retain the existing blocking poll loop until `ray_poll_exit`
- `timeout_ms == 0`: perform one non-blocking dispatch step
- `timeout_ms > 0`: wait for and dispatch one ready batch, returning no later than the timeout
- return `0` after an ordinary bounded step, an exit code when the poll was stopped, and `-1` for an invalid or broken event queue

This lets an embedder keep ownership of the runtime thread while serving real poll-based IPC, connection hooks, server push, and Rayfall timers between host work cycles.

## Validation
- regression-first coverage for zero-time ready-event dispatch
- positive timeout-bound coverage
- timer firing through the production poll driver
- public-header symbol coverage
- clean ASan/UBSan debug build with `-Werror`
- full test suite: 3,659 passed, 0 skipped, 0 failed
- `git diff --check`

The related `bind_addr` request remains separate from this bounded polling change.

Closes #364
