### PR TITLE
fix(test): rely on public runtime declarations

### DIFF
--- a/audit/findings/CF-0004-runtime-api-redeclared-after-public-header.md
+++ b/audit/findings/CF-0004-runtime-api-redeclared-after-public-header.md
@@ -20,14 +20,14 @@ unit:
   - test/test_store.c
   - test/test_term.c
   - test/test_types.c
-status: reported
+status: fixed
 class: null
 members:
   - F-0006
 attempts: 0
 pass: P-01
 created-by: RP-0001
-updated: 2026-07-22
+updated: 2026-08-04
 ---
 
 ## Pattern
@@ -82,5 +82,22 @@ future runtime API redeclarations in files that include `rayforce.h`.
 
 ## Remediation
 
+Removed the redundant public runtime type and lifecycle declarations from all
+sixteen test/fuzz files in the census. The files now rely on `<rayforce.h>` for
+`ray_runtime_t`, `ray_runtime_create`, and `ray_runtime_destroy`, while keeping
+only the genuinely internal `__RUNTIME` extern where the test fixture needs it.
+
+Added `audit/public_runtime_api_not_redeclared` as a lightweight source guard
+over the same census so future edits fail the test suite if a file that includes
+`rayforce.h` reintroduces one of the public runtime API redeclarations.
+
 
 ## Verification
+
+Completed on 2026-08-04:
+
+- `git diff --check`
+- The recorded runtime redeclaration census returns no matches.
+- `./rayforce.test -f audit/public_runtime_api_not_redeclared` passed: 1 of 1
+  passed, 0 skipped, 0 failed.
+- `make test TEST_CORES=2` passed: 3657 of 3658 passed, 1 skipped, 0 failed.

--- a/fuzz/common.h
+++ b/fuzz/common.h
@@ -32,12 +32,8 @@
 
 #include <rayforce.h>
 
-/* Runtime lifecycle — forward-declared the same way test/main.c does, to
- * dodge the ray_vm_t type clash between core/runtime.h and the public
- * header.  We only ever need create(). */
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
+/* Runtime lifecycle is part of the public header; fuzz drivers only need
+ * create(). */
 
 /* Lazy one-time runtime init.  libFuzzer offers LLVMFuzzerInitialize, but
  * a guarded lazy path keeps each driver self-contained and also works when

--- a/test/main.c
+++ b/test/main.c
@@ -50,16 +50,13 @@
 #include "ops/internal.h"
 #include "ops/idxop.h"
 
-/* Forward-declare runtime API — mirrors existing test_lang.c pattern. */
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
+/* __RUNTIME is internal test plumbing; runtime API declarations come from
+ * <rayforce.h>. */
 extern ray_runtime_t* __RUNTIME;
 
 /* Runtime poll accessors (core/runtime.h) + poll lifecycle (core/poll.h),
- * forward-declared the same way to avoid the ray_vm_t clash between
- * core/runtime.h and lang/eval.h (included above). */
+ * forward-declared to avoid the ray_vm_t clash between core/runtime.h and
+ * lang/eval.h (included above). */
 struct ray_poll;
 typedef struct ray_poll ray_poll_t;
 extern ray_poll_t* ray_poll_create(void);

--- a/test/test_audit.c
+++ b/test/test_audit.c
@@ -1293,6 +1293,64 @@ static test_result_t test_filter_reorder_correctness(void) {
     PASS();
 }
 
+static test_result_t test_public_runtime_api_not_redeclared(void) {
+    static const char* files[] = {
+        "fuzz/common.h",
+        "test/main.c",
+        "test/test_compile.c",
+        "test/test_datalog.c",
+        "test/test_embedding.c",
+        "test/test_format.c",
+        "test/test_fused_topk.c",
+        "test/test_ipc.c",
+        "test/test_journal.c",
+        "test/test_lang.c",
+        "test/test_link.c",
+        "test/test_public_api.c",
+        "test/test_repl.c",
+        "test/test_store.c",
+        "test/test_term.c",
+        "test/test_types.c",
+    };
+    static const char* forbidden[] = {
+        "struct ray_runtime_s" ";",
+        "typedef struct ray_runtime_s " "ray_runtime_t;",
+        "ray_runtime_create" "(int argc",
+        "ray_runtime_destroy" "(ray_runtime_t",
+    };
+
+    for (size_t fi = 0; fi < sizeof(files) / sizeof(files[0]); fi++) {
+        FILE* f = fopen(files[fi], "r");
+        if (!f) FAILF("cannot open %s", files[fi]);
+
+        int has_public_header = 0;
+        int bad_line = 0;
+        const char* bad_pattern = NULL;
+        char line[1024];
+        for (int line_no = 1; fgets(line, sizeof line, f); line_no++) {
+            if (strstr(line, "#include <rayforce.h>") ||
+                strstr(line, "#include \"rayforce.h\"")) {
+                has_public_header = 1;
+            }
+            for (size_t pi = 0; pi < sizeof(forbidden) / sizeof(forbidden[0]); pi++) {
+                if (strstr(line, forbidden[pi])) {
+                    bad_line = line_no;
+                    bad_pattern = forbidden[pi];
+                }
+            }
+        }
+        fclose(f);
+
+        TEST_ASSERT_FMT(has_public_header, "%s no longer includes rayforce.h", files[fi]);
+        if (bad_pattern) {
+            FAILF("%s:%d redeclares public runtime API pattern \"%s\"",
+                  files[fi], bad_line, bad_pattern);
+        }
+    }
+
+    PASS();
+}
+
 /* -----------------------------------------------------------------------
  * OP_WCO_JOIN selection audit findings
  * -----------------------------------------------------------------------
@@ -1498,10 +1556,9 @@ const test_entry_t audit_entries[] = {
     { "audit/join_empty_table", test_join_empty_table, NULL, NULL },
     { "audit/const_fold_div_zero", test_const_fold_div_zero, NULL, NULL },
     { "audit/const_fold_int_overflow", test_const_fold_int_overflow, NULL, NULL },
+    { "audit/public_runtime_api_not_redeclared", test_public_runtime_api_not_redeclared, NULL, NULL },
     { "audit/predicate_pushdown_group", test_predicate_pushdown_group, NULL, NULL },
     { "audit/dce_preserves_group_keys", test_dce_preserves_group_keys, NULL, NULL },
     { "audit/filter_reorder_correctness", test_filter_reorder_correctness, NULL, NULL },
     { NULL, NULL, NULL, NULL },
 };
-
-

--- a/test/test_compile.c
+++ b/test/test_compile.c
@@ -36,11 +36,8 @@
 #include "lang/parse.h"
 #include <string.h>
 
-/* Forward-declare runtime API */
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
+/* __RUNTIME is internal test plumbing; runtime API declarations come from
+ * <rayforce.h>. */
 extern ray_runtime_t *__RUNTIME;
 
 /* ---- Setup / Teardown ---- */

--- a/test/test_datalog.c
+++ b/test/test_datalog.c
@@ -36,13 +36,7 @@
 #include <stdlib.h>        /* abort in datalog_rf_setup */
 #include <string.h>
 
-/* Forward-declare runtime API used by the full-runtime fixtures.
- * (Test target doesn't pull in core/runtime.h because it redefines
- * ray_vm_t, which clashes with lang/eval.h's definition — a pre-
- * existing duplication kept out of scope for this PR.) */
-typedef struct ray_runtime_s ray_runtime_t;
-ray_runtime_t* ray_runtime_create(int argc, char** argv);
-void           ray_runtime_destroy(ray_runtime_t* rt);
+/* Full-runtime fixtures use the public runtime API from <rayforce.h>. */
 
 static void datalog_setup(void) {
     ray_heap_init();
@@ -2542,5 +2536,4 @@ const test_entry_t datalog_entries[] = {
     { "datalog/edb_over_arity_domain_guard", test_edb_over_arity_domain_guard, datalog_setup, datalog_teardown },
     { NULL, NULL, NULL, NULL },
 };
-
 

--- a/test/test_embedding.c
+++ b/test/test_embedding.c
@@ -42,10 +42,6 @@
 #include <string.h>
 #include <stdio.h>
 
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
 extern ray_runtime_t* __RUNTIME;
 
 /* Small epsilon for F64 comparisons. */

--- a/test/test_format.c
+++ b/test/test_format.c
@@ -32,11 +32,8 @@
 #include <limits.h>
 #include <math.h>
 
-/* Forward-declare runtime API */
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
+/* __RUNTIME is internal test plumbing; runtime API declarations come from
+ * <rayforce.h>. */
 extern ray_runtime_t *__RUNTIME;
 
 /* ---- Setup / Teardown ---- */
@@ -1768,4 +1765,3 @@ const test_entry_t format_entries[] = {
     { "format/table/na_head", test_fmt_table_na_head, fmt_setup, fmt_teardown },
     { NULL, NULL, NULL, NULL },
 };
-

--- a/test/test_fused_topk.c
+++ b/test/test_fused_topk.c
@@ -47,11 +47,8 @@
 #include "table/sym.h"
 #include <string.h>
 
-/* Forward-declare runtime API — mirrors test_lang.c pattern. */
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
+/* __RUNTIME is internal test plumbing; runtime API declarations come from
+ * <rayforce.h>. */
 extern ray_runtime_t* __RUNTIME;
 
 /* ─── Setup / Teardown ─────────────────────────────────────────────── */

--- a/test/test_ipc.c
+++ b/test/test_ipc.c
@@ -81,11 +81,8 @@ extern ray_t* ray_hpost_fn(ray_t* handle, ray_t* msg);
 #include <stdlib.h>
 #include <time.h>
 
-/* ---- Forward-declare runtime -------------------------------------------- */
+/* ---- Runtime test plumbing ---------------------------------------------- */
 
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
 extern ray_runtime_t* __RUNTIME;
 
 /* ---- Setup / Teardown ---------------------------------------------------- */

--- a/test/test_journal.c
+++ b/test/test_journal.c
@@ -43,10 +43,6 @@
 
 /* ── Runtime fixture (same pattern as test_link.c) ─────────────────── */
 
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
 extern ray_runtime_t* __RUNTIME;
 
 static void jrn_setup(void)    { ray_runtime_create(0, NULL); }

--- a/test/test_lang.c
+++ b/test/test_lang.c
@@ -50,11 +50,8 @@
 #include "ops/ops.h"
 #include "ops/temporal.h"
 
-/* Forward-declare runtime API to avoid ray_vm_t redefinition from runtime.h */
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
+/* __RUNTIME is internal test plumbing; runtime API declarations come from
+ * <rayforce.h>. */
 extern ray_runtime_t *__RUNTIME;
 
 /* ═══════════════════════════════════════════════════════════════

--- a/test/test_link.c
+++ b/test/test_link.c
@@ -47,10 +47,6 @@
 
 /* Tests run inside a runtime so the env is alive (link target lookup
  * needs that).  Use the same setup/teardown shape as test_lang.c. */
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
 extern ray_runtime_t* __RUNTIME;
 
 static void link_setup(void)    { ray_runtime_create(0, NULL); }

--- a/test/test_public_api.c
+++ b/test/test_public_api.c
@@ -34,10 +34,6 @@
 /* Most introspection helpers need a live heap/runtime so vectors and
  * atoms can be constructed via the public API. Match the test_link.c
  * pattern: bring up a runtime in setup, tear it down afterwards. */
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
 extern ray_runtime_t* __RUNTIME;
 
 static void public_api_setup(void)    { ray_runtime_create(0, NULL); }

--- a/test/test_repl.c
+++ b/test/test_repl.c
@@ -73,11 +73,8 @@
 #  include "core/poll.h"
 #endif
 
-/* Forward-declare runtime API — same pattern as test_lang.c. */
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
+/* __RUNTIME is internal test plumbing; runtime API declarations come from
+ * <rayforce.h>. */
 extern ray_runtime_t* __RUNTIME;
 extern void           ray_runtime_set_poll(void* poll);
 extern void*          ray_runtime_get_poll(void);

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -56,11 +56,6 @@
 #include <unistd.h>
 #include <stdlib.h>
 
-/* Forward-declare runtime lifecycle for total_ram test */
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
-
 #define TMP_COL_PATH  "/tmp/rayforce_test_col.dat"
 #define TMP_SPLAY_DIR "/tmp/rayforce_test_splay"
 

--- a/test/test_term.c
+++ b/test/test_term.c
@@ -72,11 +72,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-/* Forward declare the runtime API used by completion tests. */
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
+/* __RUNTIME is internal test plumbing; runtime API declarations come from
+ * <rayforce.h>. */
 extern ray_runtime_t* __RUNTIME;
 
 /* ─── Setup / teardown ─────────────────────────────────────────────── */

--- a/test/test_types.c
+++ b/test/test_types.c
@@ -28,11 +28,8 @@
 #include "lang/env.h"
 #include "ops/ops.h"
 
-/* Forward-declare runtime API (ray_fn_name test needs builtins registered). */
-struct ray_runtime_s;
-typedef struct ray_runtime_s ray_runtime_t;
-extern ray_runtime_t* ray_runtime_create(int argc, char** argv);
-extern void           ray_runtime_destroy(ray_runtime_t* rt);
+/* __RUNTIME is internal test plumbing; runtime API declarations come from
+ * <rayforce.h>. */
 extern ray_runtime_t* __RUNTIME;
 
 static void types_runtime_setup(void) {
@@ -184,5 +181,4 @@ const test_entry_t types_entries[] = {
     { "types/fn_name_builtin", test_fn_name_builtin, types_runtime_setup, types_runtime_teardown },
     { NULL, NULL, NULL, NULL },
 };
-
 


### PR DESCRIPTION
## Summary
- Remediate audit finding CF-0004 from audit/findings/CF-0004-runtime-api-redeclared-after-public-header.md.
- Remove local ray_runtime_t/ray_runtime_create/ray_runtime_destroy redeclarations from the sixteen test/fuzz files that already include rayforce.h.
- Keep internal __RUNTIME test plumbing and add audit/public_runtime_api_not_redeclared to prevent future public runtime API redeclarations.

## Validation
- git diff --check
- Recorded CF-0004 runtime redeclaration census returns no matches
- ./rayforce.test -f audit/public_runtime_api_not_redeclared: 1 of 1 passed
- make test TEST_CORES=2: 3657 of 3658 passed, 1 skipped, 0 failed