### PR TITLE
feat(core): expose restricted poll mode

### DIFF
--- a/docs/docs/guides/ipc.md
+++ b/docs/docs/guides/ipc.md
@@ -326,7 +326,24 @@ The IPC layer is also accessible from C, enabling you to embed Rayforce clients 
 | `ray_ipc_send(handle, msg)` | Synchronous send: serialize `msg`, send, wait for response, return deserialized result. |
 | `ray_ipc_send_async(handle, msg)` | Fire-and-forget send: serialize and send `msg` without waiting for a response. |
 | `ray_ipc_close(handle)` | Close the connection and free the handle. |
+| `ray_poll_set_restricted(poll, restricted)` | Make connections created afterward evaluate in restricted (read-only) mode. Call before servicing an embedded listener. |
 | `ray_ipc_listen(poll, port)` | Register a server socket on the given poll loop. Used internally by `-p` mode. |
+
+An embedded read-only server can use only the public, pointer-based API:
+
+```c
+ray_poll_t* poll = ray_poll_create();
+ray_poll_set_restricted(poll, true);
+ray_runtime_set_poll(poll);
+
+ray_t* listener = ray_eval_str("(.sys.listen 7701)");
+/* Check listener for an error, then service IPC from the host loop. */
+ray_poll_run_for(poll, 200);
+ray_release(listener);
+```
+
+The restriction applies to connections created after the setter call;
+existing connections keep their original evaluation mode.
 
 ### Example: C Client
 

--- a/include/rayforce.h
+++ b/include/rayforce.h
@@ -687,6 +687,12 @@ typedef struct ray_poll ray_poll_t;
 ray_poll_t* ray_poll_create(void);
 void        ray_poll_destroy(ray_poll_t* poll);
 
+/* Mark IPC evaluations on connections subsequently created by poll as
+ * restricted (read-only). Existing connections keep their original mode.
+ * Call from the thread that owns poll before servicing the listener.
+ * A NULL poll is ignored. */
+void ray_poll_set_restricted(ray_poll_t* poll, bool restricted);
+
 /* Run until ray_poll_exit is called. */
 int64_t ray_poll_run(ray_poll_t* poll);
 

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -218,7 +218,7 @@ int main(int argc, char** argv) {
             pw_len = sizeof(poll->auth_secret) - 1;
         memcpy(poll->auth_secret, auth_pw, pw_len);
         poll->auth_secret[pw_len] = '\0';
-        poll->restricted = auth_restricted;
+        ray_poll_set_restricted(poll, auth_restricted);
     }
 
     /* Open journal BEFORE the IPC listener accepts any connection.

--- a/src/core/poll.c
+++ b/src/core/poll.c
@@ -31,6 +31,11 @@ void ray_poll_exit(ray_poll_t* poll, int64_t code)
     if (poll) poll->code = code;
 }
 
+void ray_poll_set_restricted(ray_poll_t* poll, bool restricted)
+{
+    if (poll) poll->restricted = restricted;
+}
+
 ray_selector_t* ray_poll_get(ray_poll_t* poll, int64_t id)
 {
     if (!poll || id < 0 || (uint32_t)id >= poll->n_sels)

--- a/src/core/poll.h
+++ b/src/core/poll.h
@@ -104,6 +104,7 @@ struct ray_poll {
 
 ray_poll_t*     ray_poll_create(void);
 void            ray_poll_destroy(ray_poll_t* poll);
+void            ray_poll_set_restricted(ray_poll_t* poll, bool restricted);
 int64_t         ray_poll_register(ray_poll_t* poll, ray_poll_reg_t* reg);
 void            ray_poll_deregister(ray_poll_t* poll, int64_t id);
 int64_t         ray_poll_run(ray_poll_t* poll);

--- a/test/test_ipc.c
+++ b/test/test_ipc.c
@@ -754,6 +754,65 @@ static test_result_t test_ipc_poll_based_listen(void) {
     PASS();
 }
 
+/* ---- test_ipc_poll_public_restricted ----------------------------------- */
+/*
+ * An embedder can make `.sys.listen` connections read-only without
+ * including the private poll definition.  Exercise the public setter and
+ * verify that the accepted connection evaluates in restricted mode,
+ * including inside compiled lambda bytecode.
+ */
+static test_result_t test_ipc_poll_public_restricted(void) {
+    ray_poll_t* poll = ray_poll_create();
+    TEST_ASSERT_NOT_NULL(poll);
+
+    ray_poll_set_restricted(NULL, true); /* documented no-op */
+    ray_poll_set_restricted(poll, true);
+
+    int64_t listener_id = ray_ipc_listen(poll, 0);
+    TEST_ASSERT((listener_id) >= (0), "listener_id >= 0");
+
+    ray_selector_t* listener_sel = ray_poll_get(poll, listener_id);
+    TEST_ASSERT_NOT_NULL(listener_sel);
+    uint16_t port = get_listen_port((ray_sock_t)listener_sel->fd);
+    TEST_ASSERT((port) > (0), "port > 0");
+
+    ray_vm_t* srv_vm = make_server_vm();
+    TEST_ASSERT_NOT_NULL(srv_vm);
+
+    poll_thread_ctx_t pctx = { .poll = poll, .vm = srv_vm, .running = 1 };
+    ray_thread_t tid;
+    ray_thread_create(&tid, (void(*)(void*))poll_server_thread_fn, &pctx);
+    sleep_ms(20);
+
+    int64_t h = ray_ipc_connect("127.0.0.1", port, NULL, NULL, 0);
+    TEST_ASSERT((h) >= (0), "restricted poll client h >= 0");
+
+    ray_t* arithmetic = ray_str("(+ 3 4)", 7);
+    ray_t* allowed = ray_ipc_send(h, arithmetic);
+    ray_release(arithmetic);
+    TEST_ASSERT_NOT_NULL(allowed);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(allowed));
+    TEST_ASSERT_EQ_I(allowed->i64, 7);
+    ray_release(allowed);
+
+    const char* mutation =
+        "((fn [x] (set '__rf_issue_371_ipc_injected 1)) 0)";
+    ray_t* mutating = ray_str(mutation, strlen(mutation));
+    ray_t* denied = ray_ipc_send(h, mutating);
+    ray_release(mutating);
+    TEST_ASSERT_NOT_NULL(denied);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(denied));
+    TEST_ASSERT_STR_EQ(ray_err_code(denied), "access");
+    ray_release(denied);
+
+    ray_ipc_close(h);
+    poll_stop(poll, port);
+    ray_thread_join(tid);
+    ray_poll_destroy(poll);
+    ray_sys_free(srv_vm);
+    PASS();
+}
+
 /* ---- test_ipc_poll_auth_creds_path ------------------------------------- */
 /*
  * Poll-based auth happy path — exercises ipc_read_creds (lines 503-541) and
@@ -2072,6 +2131,7 @@ const test_entry_t ipc_entries[] = {
     { "ipc/send_invalid_handle",        test_ipc_send_invalid_handle,            ipc_setup, ipc_teardown },
     { "ipc/send_async_invalid_handle",  test_ipc_send_async_invalid_handle,      ipc_setup, ipc_teardown },
     { "ipc/poll_based_listen",          test_ipc_poll_based_listen,              ipc_setup, ipc_teardown },
+    { "ipc/poll_public_restricted",     test_ipc_poll_public_restricted,         ipc_setup, ipc_teardown },
     { "ipc/poll_auth_creds_path",        test_ipc_poll_auth_creds_path,           ipc_setup, ipc_teardown },
     { "ipc/poll_auth_reject",           test_ipc_poll_auth_reject,               ipc_setup, ipc_teardown },
     { "ipc/poll_handshake_version_mismatch", test_ipc_poll_handshake_version_mismatch, ipc_setup, ipc_teardown },

--- a/test/test_public_api.c
+++ b/test/test_public_api.c
@@ -57,6 +57,7 @@ static test_result_t test_public_ipc_client_symbols(void) {
 static test_result_t test_public_poll_symbols(void) {
     ray_poll_t* (*create_fn)(void) = ray_poll_create;
     void        (*destroy_fn)(ray_poll_t*) = ray_poll_destroy;
+    void        (*restricted_fn)(ray_poll_t*, bool) = ray_poll_set_restricted;
     int64_t     (*run_fn)(ray_poll_t*) = ray_poll_run;
     int64_t     (*run_for_fn)(ray_poll_t*, int) = ray_poll_run_for;
     void        (*exit_fn)(ray_poll_t*, int64_t) = ray_poll_exit;
@@ -65,6 +66,7 @@ static test_result_t test_public_poll_symbols(void) {
 
     TEST_ASSERT_NOT_NULL((void*)create_fn);
     TEST_ASSERT_NOT_NULL((void*)destroy_fn);
+    TEST_ASSERT_NOT_NULL((void*)restricted_fn);
     TEST_ASSERT_NOT_NULL((void*)run_fn);
     TEST_ASSERT_NOT_NULL((void*)run_for_fn);
     TEST_ASSERT_NOT_NULL((void*)exit_fn);


### PR DESCRIPTION
## Summary

- add the public, null-safe `ray_poll_set_restricted(ray_poll_t*, bool)` API
- route the CLI `-U` configuration through the public setter
- document the pointer-based embedded read-only listener workflow
- add public-symbol and end-to-end restricted IPC coverage

## Why

Embedded listeners inherit restricted evaluation from `poll->restricted`, but embedders previously had no public way to configure that state. This left read-only embedded servers dependent on the private by-value IPC server API and a C shim.

Connections snapshot the restriction when they are created, so existing connections retain their original evaluation mode.

## Validation

- `make -j2 test` — 3,662/3,662 passed under ASan/UBSan
- `RAYFORCE_CORES=2 ./rayforce.test -f ipc/poll_public_restricted` — passed
- `RAYFORCE_CORES=2 ./rayforce.test -f public/poll_symbols` — passed
- `mkdocs build --strict` — passed
- `git diff --check` — passed

Closes #371
