### PR TITLE
fix(str): propagate null start/length in substr instead of overflowing

### DIFF
--- a/src/ops/string.c
+++ b/src/ops/string.c
@@ -1247,6 +1247,19 @@ static ray_t* substr_str_scalar_start_len_view(ray_t* input,
     return result;
 }
 
+/* True when a whole-column (scalar) start/length argument is null.  Such an
+ * argument applies to every row, so the entire result is null — and a null
+ * integer scalar is INT64_MIN, which must never reach the `scalar - 1`
+ * subtraction in the row loop (signed-overflow UB).  Only scalars are tested
+ * here; the per-row vector case is handled inline via ray_vec_is_null. */
+static bool substr_scalar_is_null(ray_t* v) {
+    if (!v) return false;
+    if (ray_is_atom(v)) return RAY_ATOM_IS_NULL(v);
+    if (ray_is_vec(v) && v->len == 1 && (v->attrs & RAY_ATTR_HAS_NULLS))
+        return ray_vec_is_null(v, 0);
+    return false;
+}
+
 ray_t* exec_substr(ray_graph_t* g, ray_op_t* op) {
     ray_t* input = exec_node(g, op_child(g, op, 0));
     ray_t* start_v = exec_node(g, op_child(g, op, 1));
@@ -1331,10 +1344,18 @@ ray_t* exec_substr(ray_graph_t* g, ray_op_t* op) {
     else if (len_v->type == RAY_I32) l_data_i32 = (const int32_t*)ray_data(len_v);
     else l_data = (const int64_t*)ray_data(len_v);
 
+    /* A scalar (whole-column) null start or length makes every result row
+     * null.  The per-row check below only inspects the vector (s_data /
+     * l_data) case, so a scalar NULL_I64 start would otherwise reach the
+     * `s_scalar - 1` subtraction and overflow (signed-overflow UB). */
+    bool s_all_null = !s_data && !s_data_i32 && substr_scalar_is_null(start_v);
+    bool l_all_null = !l_data && !l_data_i32 && substr_scalar_is_null(len_v);
+
     for (int64_t i = 0; i < nrows; i++) {
         /* Propagate null — from input, start, or length */
         /* STR input has no null; start/len are I64 and can be null. */
-        if (((s_data || s_data_i32) && ray_vec_is_null((ray_t*)start_v, i)) ||
+        if (s_all_null || l_all_null ||
+            ((s_data || s_data_i32) && ray_vec_is_null((ray_t*)start_v, i)) ||
             ((l_data || l_data_i32) && ray_vec_is_null((ray_t*)len_v, i))) {
             if (is_str) {
                 result = ray_str_vec_append(result, "", 0);

--- a/src/ops/strop.c
+++ b/src/ops/strop.c
@@ -284,6 +284,22 @@ static ray_t* substr_atom(ray_t* str, ray_t* start_obj, ray_t* len_obj) {
     int64_t start = 0, amount = 0;
     if (!str_atom_bytes(str, &sp, &sl, &is_sym))
         return ray_error("type", "substr: expected string or symbol, got %s", ray_type_name(str->type));
+
+    /* A null start or length propagates to the empty (null) string.  In
+     * Rayforce a STR/SYM has no null distinct from ""/' (see
+     * ray_atom_is_null_fn), so the empty value IS the null result — matching
+     * the per-row null propagation in exec_substr.  Checked BEFORE the
+     * 1-based->0-based `start - 1` below: a null integer atom is INT64_MIN,
+     * so the subtraction would be signed-overflow undefined behaviour
+     * (reported by UBSan at this line). */
+    if (RAY_ATOM_IS_NULL(start_obj) || RAY_ATOM_IS_NULL(len_obj)) {
+        if (is_sym) {
+            int64_t sid = ray_sym_intern("", 0);
+            return sid >= 0 ? ray_sym(sid) : ray_error("oom", NULL);
+        }
+        return ray_str("", 0);
+    }
+
     if (!intish_atom_value(start_obj, &start))
         return ray_error("type", "substr: start must be an integer atom");
     if (!intish_atom_value(len_obj, &amount))

--- a/test/rfl/strop/standalone_string_ops.rfl
+++ b/test/rfl/strop/standalone_string_ops.rfl
@@ -23,6 +23,19 @@
 (substr (as 'STR (list "abcdefghijklmnopqrstuvwxyz" "short")) 5 -1) -- ["efghijklmnopqrstuvwxyz" "t"]
 (substr ["abcdef" "xyz"] [1 2] [3 9]) -- ["abc" "yz"]
 
+;; Null start/length propagates to the empty (null) string — a STR/SYM has no
+;; null distinct from ""/'.  A null integer atom is INT64_MIN, so it must be
+;; handled before the 1-based->0-based `start - 1` (else signed-overflow UB;
+;; regression for src/ops/strop.c substr_atom + src/ops/string.c exec_substr).
+(substr "abcdef" 0N 3) -- ""
+(substr "abcdef" 2 0N) -- ""
+(substr "abcdef" 0N 0N) -- ""
+(substr 'abcdef 0N 3) -- '
+(substr 'abcdef 2 0N) -- '
+;; Columnar path: a scalar null start/length nulls every row.
+(substr ["abcdef" "xyz"] 0N 2) -- ["" ""]
+(substr ["abcdef" "xyz"] 1 0N) -- ["" ""]
+
 (replace "banana" "a" "A") -- "bAnAnA"
 (replace "banana" "na" "NA") -- "baNANA"
 (replace 'banana "a" "A") -- 'bAnAnA


### PR DESCRIPTION
## Summary

`substr` converted its 1-based `start` to 0-based with `start - 1` **before**
checking whether the argument was null. A null integer atom is `INT64_MIN`,
so the subtraction was signed-overflow **undefined behaviour**. UBSan reports
it in two independent places:

- `src/ops/strop.c` — the atom path (`substr_atom`), e.g. `(substr "alphabet" 0N 3)`.
- `src/ops/string.c` — the columnar path (`exec_substr`) when a **scalar** null
  start reaches the per-row loop, e.g. `(substr strvec 0N 3)` or
  `(select {r: (substr s 0N 3) from: t})`. The existing per-row guard only
  covered a null *vector* element, not a scalar-null argument.

Two secondary issues on the same code: the atom path silently returned `""`
via the wrapped (huge) index, and a **null length** was treated as "take the
rest of the string" instead of propagating.

## Fix

Detect a null `start` or `length` **before** the subtraction in both paths and
propagate it to the empty (null) string. In Rayforce a `STR`/`SYM` has no null
distinct from `""`/`'` (`ray_atom_is_null_fn`), so the empty value **is** the
null result — and `exec_substr` already does exactly this for per-row null
vector elements. The atom and columnar paths now agree.

## Behaviour

| expression | before | after |
|---|---|---|
| `(substr "alphabet" 0N 3)` | `""` (via UB) | `""` (no UB) |
| `(substr "alphabet" 1 0N)` | `"alphabet"` | `""` |
| `(substr strvec 0N 3)` (columnar) | `["" …]` (via UB) | `["" …]` (no UB) |
| `(substr strvec 1 0N)` (columnar) | whole strings | `["" …]` |
| normal + per-row-null cases | — | unchanged |

## Test

Adds null-argument regression assertions (atom + columnar scalar-null) to
`test/rfl/strop/standalone_string_ops.rfl`. Full suite green under ASan+UBSan:
`3659 of 3660 passed (1 skipped, 0 failed)`, zero sanitizer reports.

Found via `RAYFORCE_FUNCTIONAL_BUG_CANDIDATES.md` (candidate 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
