### PR TITLE
fix(csv): round-trip signed and >=24h TIME values in .csv.read

### DIFF
--- a/src/io/csv.c
+++ b/src/io/csv.c
@@ -502,27 +502,52 @@ RAY_INLINE int32_t fast_date(const char* p, size_t len, bool* is_null) {
     return civil_to_days(y, m, d);
 }
 
-/* TIME → int32_t milliseconds since midnight */
+/* TIME → int32_t milliseconds since midnight.
+ *
+ * RAY_TIME is a *signed* ms-of-day, and csv_write_time renders a negative
+ * or >=24h duration verbatim — a leading '-' plus an unbounded hour field
+ * (e.g. "-00:00:01", "25:00:00") rather than wrapping modulo a day.  Parse
+ * that same shape back so .csv.write -> .csv.read [TIME] round-trips: an
+ * optional sign, a variable-width hour field (NOT capped at 23), then MM:SS
+ * with an optional fractional part.  MM/SS stay at the fixed offsets after
+ * the hour field and the separator characters are not themselves validated,
+ * matching the historical lenient behaviour.  A magnitude that overflows
+ * int32 milliseconds is rejected as null. */
 RAY_INLINE int32_t fast_time(const char* p, size_t len, bool* is_null) {
-    if (RAY_UNLIKELY(len < 8)) { *is_null = true; return 0; }
     *is_null = false;
-    int h  = (p[0]-'0')*10 + (p[1]-'0');
-    int mi = (p[3]-'0')*10 + (p[4]-'0');
-    int s  = (p[6]-'0')*10 + (p[7]-'0');
-    if (RAY_UNLIKELY(h > 23 || mi > 59 || s > 59)) { *is_null = true; return 0; }
-    int32_t ms = h * 3600000 + mi * 60000 + s * 1000;
+    size_t  o    = 0;
+    int64_t sign = 1;
+    if (len > 0 && p[0] == '-') { sign = -1; o = 1; }
+    /* Variable-width hour field: >=1 digit, capped so the int64 accumulator
+     * below cannot overflow before the range check. */
+    int64_t h  = 0;
+    size_t  hd = o;
+    while (hd < len && (unsigned)(p[hd] - '0') <= 9u) {
+        h = h * 10 + (p[hd] - '0');
+        if (RAY_UNLIKELY(++hd - o > 7)) { *is_null = true; return 0; }
+    }
+    size_t w = hd - o;                        /* hour digit count */
+    /* Need the hour field plus ":MM:SS" (6 more chars). */
+    if (RAY_UNLIKELY(w == 0 || o + w + 6 > len)) { *is_null = true; return 0; }
+    int mi = (p[o+w+1]-'0')*10 + (p[o+w+2]-'0');
+    int s  = (p[o+w+4]-'0')*10 + (p[o+w+5]-'0');
+    if (RAY_UNLIKELY(mi > 59 || s > 59)) { *is_null = true; return 0; }
+    int64_t ms = h * 3600000 + (int64_t)mi * 60000 + (int64_t)s * 1000;
     /* Fractional seconds → milliseconds */
-    if (len > 8 && p[8] == '.') {
+    size_t fi = o + w + 6;
+    if (fi < len && p[fi] == '.') {
         int frac = 0, digits = 0;
-        for (size_t i = 9; i < len && digits < 3; i++, digits++) {
+        for (size_t i = fi + 1; i < len && digits < 3; i++, digits++) {
             unsigned di = (unsigned char)p[i] - '0';
             if (di > 9) break;
             frac = frac * 10 + (int)di;
         }
         while (digits < 3) { frac *= 10; digits++; }
-        ms += (int32_t)frac;
+        ms += frac;
     }
-    return ms;
+    ms *= sign;
+    if (RAY_UNLIKELY(ms > INT32_MAX || ms < INT32_MIN)) { *is_null = true; return 0; }
+    return (int32_t)ms;
 }
 
 /* Timestamp time component → int64_t nanoseconds.

--- a/test/rfl/io/csv_types.rfl
+++ b/test/rfl/io/csv_types.rfl
@@ -138,11 +138,31 @@
 ;; Note: NULL_I32 sentinel so sum excludes nulls
 
 ;; ════════════════════════════════════════════════════════════════════════════
-;; 12. fast_time: h>23, mi>59, s>59 → is_null=true (line 436)
+;; 12. fast_time: TIME is a signed ms-of-day duration. csv_write_time emits
+;;     negative and >=24h values verbatim, so .csv.read [TIME] round-trips
+;;     them; only mi>59 / s>59 (and int32-overflowing magnitudes) are null.
 ;; ════════════════════════════════════════════════════════════════════════════
 (.sys.exec "printf 'a\n24:00:00\n12:60:00\n12:00:60\n12:30:45\n' > rf_test_csv_types_badtime.csv") -- 0
 (set Tbt (.csv.read [TIME] "rf_test_csv_types_badtime.csv"))
 (count Tbt) -- 4
+;; 24:00:00 is a valid >=24h duration; only mi>59 / s>59 rows are null.
+(at (at Tbt 'a) 0) -- 24:00:00.000
+(nil? (at (at Tbt 'a) 1)) -- true
+(nil? (at (at Tbt 'a) 2)) -- true
+(at (at Tbt 'a) 3) -- 12:30:45.000
+;; Signed / >23h durations round-trip through .csv.write -> .csv.read [TIME].
+(set Trt (table [t] (list (as 'TIME [-1000 -1 86400000 90000000 1000]))))
+(.csv.write Trt "rf_test_csv_types_timert.csv") -- 0
+(set Trtb (.csv.read [TIME] "rf_test_csv_types_timert.csv"))
+(at (at Trtb 't) 0) -- -00:00:01.000
+(at (at Trtb 't) 1) -- -00:00:00.001
+(at (at Trtb 't) 2) -- 24:00:00.000
+(at (at Trtb 't) 3) -- 25:00:00.000
+(at (at Trtb 't) 4) -- 00:00:01.000
+;; int32-ms overflow (huge hour field) is rejected as null.
+(.sys.exec "printf 't\n9999999:00:00\n' > rf_test_csv_types_timeovf.csv") -- 0
+(nil? (at (at (.csv.read [TIME] "rf_test_csv_types_timeovf.csv") 't) 0)) -- true
+(.sys.exec "rm -f rf_test_csv_types_timert.csv rf_test_csv_types_timeovf.csv") -- 0
 
 ;; ════════════════════════════════════════════════════════════════════════════
 ;; 13. fast_timestamp: invalid time component → is_null (line 487)

--- a/test/test_csv.c
+++ b/test/test_csv.c
@@ -1114,13 +1114,14 @@ static test_result_t test_csv_roundtrip_date_time_ts(void) {
     int32_t* d2 = (int32_t*)ray_data(dc);
     for (int i = 0; i < 3; i++) TEST_ASSERT_EQ_I(d2[i], dates[i]);
 
-    /* Positive TIME values must round-trip exactly. Negative time is
-     * written as "-HH:MM:SS" by csv_write_time, but fast_time only
-     * accepts unsigned HH:MM:SS, so the negative cell parses as null.
-     * This is a known source limitation (no src/ changes allowed). */
+    /* All TIME values must round-trip exactly, including negative durations:
+     * csv_write_time renders a signed ms-of-day as "-HH:MM:SS" / "HH:MM:SS"
+     * with an unbounded hour field, and fast_time now parses that same shape
+     * back (previously the signed cell was a known limitation, read as null). */
     int32_t* t2 = (int32_t*)ray_data(tc);
     TEST_ASSERT_EQ_I(t2[0], times[0]);
-    TEST_ASSERT_TRUE(ray_vec_is_null(tc, 1));   /* negative time → null on read-back */
+    TEST_ASSERT_FALSE(ray_vec_is_null(tc, 1));  /* negative time now round-trips */
+    TEST_ASSERT_EQ_I(t2[1], times[1]);
     TEST_ASSERT_EQ_I(t2[2], times[2]);
 
     ray_release(loaded);


### PR DESCRIPTION
## Summary

`RAY_TIME` is a **signed ms-of-day**, and `csv_write_time` deliberately
renders a negative or `>=24h` duration verbatim — a leading `-` plus an
unbounded hour field (`-00:00:01`, `25:00:00`) rather than wrapping modulo a
day (its own comment documents this intent). But the reader `fast_time`
(`src/io/csv.c`):

- read the hours from two **fixed** offsets (`p[0]`, `p[1]`), so a sign or a
  3-digit hour field misaligned every subsequent field;
- had **no sign** handling;
- rejected any **hour > 23** as null.

So `.csv.write` → `.csv.read [TIME]` silently lost every signed / `>=24h`
value: they came back as `0Nt`, and a schema-less read demoted the whole
column to `SYM`. `test/test_csv.c` even documented this as a "known source
limitation (no src/ changes allowed)".

## Fix

Parse the exact shape `csv_write_time` emits: an optional leading `-` and a
variable-width hour field (not capped at 23), then `MM:SS` with an optional
fractional part, plus an int32-millisecond overflow guard. Separator
characters keep the historical lenient handling, and `MM > 59` / `SS > 59`
still return null.

The `TIMESTAMP` time component is untouched — it goes through `fast_time_ns`,
which correctly keeps the `0–23h` wall-clock range (`…T25:00:00` in a
`TIMESTAMP` remains invalid; only a standalone `TIME` duration may exceed a
day).

## Behaviour

| CSV cell, schema `[TIME]` | before | after |
|---|---|---|
| `-00:00:01` | `0Nt` | `-00:00:01.000` |
| `24:00:00` / `25:00:00` | `0Nt` | `24:00:00.000` / `25:00:00.000` |
| `12:60:00` / `12:00:60` | `0Nt` | `0Nt` (unchanged) |
| `9999999:00:00` (int32 overflow) | `0Nt` | `0Nt` |
| `12:34:56.789` (normal) | round-trips | round-trips |

## Test

- `test/rfl/io/csv_types.rfl` §12: adds a `.csv.write` → `.csv.read [TIME]`
  round-trip over negative / `>=24h` durations, keeps the `mi>59`/`s>59` null
  cases, and adds the overflow-guard case.
- `test/test_csv.c`: the negative-time cell in `roundtrip_date_time_ts` now
  asserts an exact round-trip instead of null (the documented limitation is
  resolved).

Full suite green under ASan+UBSan: `3659 of 3660 passed (1 skipped, 0 failed)`.

Found via `RAYFORCE_FUNCTIONAL_BUG_CANDIDATES.md` (candidate 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
