### PR TITLE
fix(builtins): clamp out-of-range float in scalar numeric casts

### DIFF
--- a/src/ops/builtins.c
+++ b/src/ops/builtins.c
@@ -1325,7 +1325,7 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
     if (cast_match(tname, tlen, "I64") || cast_match(tname, tlen, "i64")) {
         ray_release(s);
         if (val->type == -RAY_I64) { ray_retain(val); return val; }
-        if (val->type == -RAY_F64) return make_i64((int64_t)val->f64);
+        if (val->type == -RAY_F64) return make_i64(ray_cast_f64_to_i64_null(val->f64));
         if (val->type == -RAY_BOOL) return make_i64(val->b8 ? 1 : 0);
         if (val->type == -RAY_I32 || val->type == -RAY_DATE || val->type == -RAY_TIME)
             return make_i64(val->i32);
@@ -1353,7 +1353,7 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
         if (val->type == -RAY_U8)  return ray_i32((int32_t)val->u8);
         if (val->type == -RAY_I16) return ray_i32(val->i16);
         if (val->type == -RAY_I64) return ray_i32((int32_t)val->i64);
-        if (val->type == -RAY_F64) return ray_i32((int32_t)val->f64);
+        if (val->type == -RAY_F64) return ray_i32(ray_cast_f64_to_i32_null(val->f64));
         if (val->type == -RAY_DATE || val->type == -RAY_TIME) return ray_i32(val->i32);
         if (val->type == -RAY_TIMESTAMP) return ray_i32((int32_t)val->i64);
         if (val->type == -RAY_STR) {
@@ -1375,7 +1375,7 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
         if (val->type == -RAY_U8)  return ray_i16((int16_t)val->u8);
         if (val->type == -RAY_I32) return ray_i16((int16_t)val->i32);
         if (val->type == -RAY_I64) return ray_i16((int16_t)val->i64);
-        if (val->type == -RAY_F64) return ray_i16((int16_t)val->f64);
+        if (val->type == -RAY_F64) return ray_i16(ray_cast_f64_to_i16_null(val->f64));
         if (val->type == -RAY_DATE || val->type == -RAY_TIME) return ray_i16((int16_t)val->i32);
         if (val->type == -RAY_TIMESTAMP) return ray_i16((int16_t)val->i64);
         if (val->type == -RAY_STR) {
@@ -1549,7 +1549,7 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
         if (val->type == -RAY_I16) return ray_date((int64_t)val->i16);
         if (val->type == -RAY_I32) return ray_date((int64_t)val->i32);
         if (val->type == -RAY_I64) return ray_date(val->i64);
-        if (val->type == -RAY_F64) return ray_date((int64_t)val->f64);
+        if (val->type == -RAY_F64) return ray_date(ray_cast_f64_to_i32_null(val->f64));
         if (val->type == -RAY_TIME) return ray_date((int64_t)val->i32);
         if (val->type == -RAY_TIMESTAMP) return ray_date(ts_days_floor(val->i64));
         if (val->type == -RAY_STR) {
@@ -1583,7 +1583,7 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
         if (val->type == -RAY_I16) return ray_time((int64_t)val->i16);
         if (val->type == -RAY_I32) return ray_time((int64_t)val->i32);
         if (val->type == -RAY_I64) return ray_time(val->i64);
-        if (val->type == -RAY_F64) return ray_time((int64_t)val->f64);
+        if (val->type == -RAY_F64) return ray_time(ray_cast_f64_to_i32_null(val->f64));
         if (val->type == -RAY_DATE) return ray_time((int64_t)val->i32);
         if (val->type == -RAY_TIMESTAMP)
             /* TIMESTAMP is ns since epoch; TIME stores ms-of-day.  Use
@@ -1622,7 +1622,7 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
         if (val->type == -RAY_I16) return ray_timestamp((int64_t)val->i16);
         if (val->type == -RAY_I32) return ray_timestamp((int64_t)val->i32);
         if (val->type == -RAY_I64) return ray_timestamp(val->i64);
-        if (val->type == -RAY_F64) return ray_timestamp((int64_t)val->f64);
+        if (val->type == -RAY_F64) return ray_timestamp(ray_cast_f64_to_i64_null(val->f64));
         if (val->type == -RAY_TIME) return ray_timestamp((int64_t)val->i32);
         if (val->type == -RAY_DATE) {
             int64_t days = val->i32;
@@ -1755,7 +1755,7 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
         if (val->type == -RAY_I16) return ray_u8((uint8_t)val->i16);
         if (val->type == -RAY_I32) return ray_u8((uint8_t)val->i32);
         if (val->type == -RAY_I64) return ray_u8((uint8_t)val->i64);
-        if (val->type == -RAY_F64) return ray_u8((uint8_t)val->f64);
+        if (val->type == -RAY_F64) return ray_u8(ray_cast_f64_to_u8_null(val->f64));
         if (val->type == -RAY_STR) {
             const char* sp = ray_str_ptr(val);
             char* end; long v = strtol(sp, &end, 10);

--- a/test/rfl/type/as.rfl
+++ b/test/rfl/type/as.rfl
@@ -519,3 +519,27 @@
 (count (as 'U8 (til 100000))) -- 100000
 ;; f64 -> i64
 (sum (as 'I64 (as 'F64 (til 100000)))) -- 4999950000
+
+;; ========== OUT-OF-RANGE / NaN SCALAR FLOAT CASTS ==========
+;; A scalar float cast must clamp (and null a NaN) exactly like the vector
+;; cast path.  The scalar path previously did a raw (intN_t)val->f64, which
+;; is signed-overflow undefined behavior for an out-of-range magnitude
+;; (UBSan: "outside the range of representable values of type 'long long'").
+;; Clamp targets: INT64_MAX / INT64_MIN+1, etc. — matching the helpers used
+;; by the vector path.
+(as 'I64 9.3e18) -- 9223372036854775807
+(as 'I64 -9.9e18) -- -9223372036854775807
+(as 'I32 5e9) -- 2147483647
+(as 'I32 -5e9) -- -2147483647
+(as 'I16 70000.0) -- 32767h
+(as 'U8 300.0) -- 0xff
+(as 'U8 -5.0) -- 0x00
+;; Scalar result must equal the one-element vector result.
+(as 'I64 9.3e18) -- (at (as 'I64 [9.3e18]) 0)
+(as 'I32 5e9) -- (at (as 'I32 [5e9]) 0)
+(as 'I16 70000.0) -- (at (as 'I16 [70000.0]) 0)
+;; NaN float → typed null, like the vector path (was UB before).
+(set NaNf (sqrt -1.0))
+(nil? (as 'I64 NaNf)) -- true
+(nil? (as 'I32 NaNf)) -- true
+(nil? (as 'I16 NaNf)) -- true


### PR DESCRIPTION
## Problem

A scalar `(as 'I64/'I32/'I16/'U8/'DATE/'TIME/'TIMESTAMP f64)` converted the double with a raw `(intN_t)val->f64`. For an out-of-range magnitude that is signed-integer-overflow undefined behavior, and a NaN produced an unspecified integer.

```
(as 'I64 9.3e18)
src/ops/builtins.c:1328:52: runtime error: 9.3e+18 is outside the range of
representable values of type 'long long'
```

The **vector** cast path (`cast_vec_numeric`) already routes F64 through the `ray_cast_f64_to_*_null` helpers, which saturate to the type's min/max and map NaN to the typed null — so the scalar and vector paths disagreed, and only the scalar path invoked UB:

| Expression | Before | After |
|---|---|---|
| `(as 'I64 9.3e18)` | UB (UBSan) | `9223372036854775807` |
| `(at (as 'I64 [9.3e18]) 0)` | `9223372036854775807` | `9223372036854775807` |
| `(as 'I32 5e9)` | UB | `2147483647` |
| `(as 'U8 300.0)` | UB | `0xff` |
| `(as 'I64 (sqrt -1.0))` | unspecified | `0Nl` (null) |

## Fix

Use the same `ray_cast_f64_to_*_null` helpers on the scalar path so a scalar cast and the equivalent one-element vector cast agree, and no cast invokes UB. `DATE`/`TIME` clamp through the i32 helper and `TIMESTAMP` through the i64 helper, matching how `cast_vec_numeric` treats each type. Seven sites, no new machinery — just the existing helpers.

## Tests

Adds out-of-range and NaN scalar-cast coverage to `type/as.rfl`, including scalar-equals-vector checks. Full `make test` passes (0 failed) under the default ASan/UBSan build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)