### PR TITLE
fix(builtins): validate bounds in DATE string cast

### DIFF
--- a/src/ops/builtins.c
+++ b/src/ops/builtins.c
@@ -1553,18 +1553,48 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
         if (val->type == -RAY_TIME) return ray_date((int64_t)val->i32);
         if (val->type == -RAY_TIMESTAMP) return ray_date(ts_days_floor(val->i64));
         if (val->type == -RAY_STR) {
-            /* Parse "YYYY.MM.DD" format */
+            /* Parse "YYYY.MM.DD" with a bounded cursor that must consume the
+             * whole string.  The old sscanf path accepted trailing garbage
+             * ("2024.01.02junk") and, worse, never range-checked the month:
+             * a month > 13 drove the days-in-month table index out of bounds
+             * — e.g. (as 'DATE "9999.99.99") read md[99] (ASan OOB). Validate
+             * the month BEFORE indexing the table, and the day against the
+             * actual days in that (possibly leap) month. Mirrors the strict
+             * TIMESTAMP string cast. */
             const char* sp = ray_str_ptr(val);
-            int y, m, d2;
-            if (sscanf(sp, "%d.%d.%d", &y, &m, &d2) != 3) return ray_error("domain", "as: cannot parse str as date, expected YYYY.MM.DD");
+            size_t sl = ray_str_len(val);
+            size_t i = 0;
+            int y = 0, m = 0, d2 = 0;
+            #define DT_DIGITS(w, out) do {                                                 \
+                (out) = 0;                                                                 \
+                for (int _k = 0; _k < (w); _k++) {                                         \
+                    if (i >= sl || sp[i] < '0' || sp[i] > '9')                             \
+                        return ray_error("domain", "as: cannot parse str as date, expected YYYY.MM.DD"); \
+                    (out) = (out) * 10 + (sp[i] - '0'); i++;                               \
+                }                                                                         \
+            } while (0)
+            DT_DIGITS(4, y);
+            if (i >= sl || sp[i] != '.') return ray_error("domain", "as: cannot parse str as date, expected YYYY.MM.DD");
+            i++;
+            DT_DIGITS(2, m);
+            if (i >= sl || sp[i] != '.') return ray_error("domain", "as: cannot parse str as date, expected YYYY.MM.DD");
+            i++;
+            DT_DIGITS(2, d2);
+            if (i != sl) return ray_error("domain", "as: cannot parse str as date, unexpected trailing characters");
+            #undef DT_DIGITS
+            static const int dt_md[] = {0,31,28,31,30,31,30,31,31,30,31,30,31};
+            int leap = (y % 4 == 0 && (y % 100 != 0 || y % 400 == 0));
+            if (m < 1 || m > 12)
+                return ray_error("domain", "as: cannot parse str as date, month out of range");
+            int mdays = dt_md[m] + (m == 2 && leap ? 1 : 0);
+            if (d2 < 1 || d2 > mdays)
+                return ray_error("domain", "as: cannot parse str as date, day out of range for month");
             int64_t days = 0;
             { int ty;
               for (ty = 2000; ty < y; ty++) days += (ty % 4 == 0 && (ty % 100 != 0 || ty % 400 == 0)) ? 366 : 365;
               for (ty = y; ty < 2000; ty++) days -= (ty % 4 == 0 && (ty % 100 != 0 || ty % 400 == 0)) ? 366 : 365;
             }
-            { static const int md2[] = {0,31,28,31,30,31,30,31,31,30,31,30,31};
-              int leap = (y % 4 == 0 && (y % 100 != 0 || y % 400 == 0));
-              for (int mi = 1; mi < m; mi++) days += md2[mi] + (mi == 2 && leap ? 1 : 0);
+            { for (int mi = 1; mi < m; mi++) days += dt_md[mi] + (mi == 2 && leap ? 1 : 0);
               days += d2 - 1;
             }
             return ray_date(days);

--- a/test/rfl/type/as.rfl
+++ b/test/rfl/type/as.rfl
@@ -262,6 +262,22 @@
 (as 'date 2000.01.02D00:00:00.000000000) -- 2000.01.02
 ;; date <- String
 (as 'date "2024.03.20") -- 2024.03.20
+;; Leap day is valid in a leap year, rejected otherwise.
+(as 'date "2024.02.29") -- 2024.02.29
+(as 'date "2023.02.29") !- domain
+;; date <- String: malformed input must be REJECTED, not silently parsed.
+;; A month past 12 used to index the days-in-month table out of bounds
+;; (ASan OOB read); trailing garbage and loose fields were also accepted.
+(as 'date "9999.99.99") !- domain
+(as 'date "2024.13.01") !- domain
+(as 'date "2024.00.10") !- domain
+(as 'date "2024.02.31") !- domain
+(as 'date "2024.04.31") !- domain
+(as 'date "2024.01.00") !- domain
+(as 'date "2024.01.02junk") !- domain
+(as 'date "2024.1.2") !- domain
+(as 'date "2024/01/02") !- domain
+(as 'date "2024-01-02") !- domain
 ;; ========== DATE VECTOR CASTS ==========
 (type (as 'DATE [0 1 2])) -- 'DATE
 (as 'I64 (as 'DATE [0 1 2])) -- [0 1 2]


### PR DESCRIPTION
## Problem

`(as 'DATE str)` parsed `"YYYY.MM.DD"` with an unanchored `sscanf` and never range-checked the month. A month greater than 13 walked the days-in-month table out of bounds:

```
(as 'DATE "9999.99.99")
src/ops/builtins.c:1567:54: runtime error: index 99 out of bounds for type 'const int[13]'
```

ASan reports this as an out-of-bounds read of the static `md[]` table (`for (mi = 1; mi < m; mi++) days += md[mi]` with `m = 99`). The same path also silently accepted trailing garbage and impossible calendar days:

| Input | Before | After |
|---|---|---|
| `"9999.99.99"` | OOB read → bogus date | `domain` error |
| `"2024.13.01"` | wrong date | `domain` error |
| `"2024.02.31"` | normalized to March | `domain` error |
| `"2023.02.29"` (non-leap) | normalized to March 1 | `domain` error |
| `"2024.01.02junk"` | ignored trailing bytes | `domain` error |
| `"2024.1.2"` (loose) | accepted | `domain` error |

## Fix

Replace the `sscanf` with a **bounded cursor** over `YYYY.MM.DD` that must consume the whole string, validates the month `(1-12)` **before** indexing the table, and validates the day against the actual number of days in that (leap-aware) month. This mirrors the strict `TIMESTAMP` string cast (#361).

## Compatibility

All valid dates still round-trip, including the leap day `2024.02.29`. Malformed input now returns a `domain` error instead of reading out of bounds or fabricating a date. Covered by new rejection/validation cases in `type/as.rfl`; full `make test` passes (3659/3660, 1 skipped, 0 failed) under the default ASan/UBSan build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)