### PR TITLE
fix(arith): wrap scalar integer add/sub/mul on overflow instead of UB

### DIFF
--- a/src/ops/arith.c
+++ b/src/ops/arith.c
@@ -138,7 +138,12 @@ ray_t* ray_add_fn(ray_t* a, ray_t* b) {
     if (both_f32_atoms(a, b)) return ray_f32((float)(as_f64(a) + as_f64(b)));
     if (is_float_op(a, b)) return make_f64(as_f64(a) + as_f64(b));
     int8_t rt = promote_int_type(a, b);
-    return make_typed_int(rt, as_i64(a) + as_i64(b));
+    /* Wrap on overflow (defined) rather than signed-overflow UB, matching the
+     * vector arithmetic kernel (src/ops/expr.c OP_ADD/SUB/MUL).  The wrapped
+     * i64 (INT64_MIN on MAX+1) is the null sentinel, so results are unchanged
+     * — only the undefined arithmetic is removed. */
+    int64_t la = as_i64(a), lb = as_i64(b);
+    return make_typed_int(rt, (int64_t)((uint64_t)la + (uint64_t)lb));
 }
 
 ray_t* ray_sub_fn(ray_t* a, ray_t* b) {
@@ -220,7 +225,9 @@ ray_t* ray_sub_fn(ray_t* a, ray_t* b) {
         return make_f64(r);
     }
     int8_t rt = promote_int_type_right(a, b);
-    return make_typed_int(rt, as_i64(a) - as_i64(b));
+    /* uint64 wrap on overflow (defined), like ray_add_fn / the vector kernel. */
+    int64_t la = as_i64(a), lb = as_i64(b);
+    return make_typed_int(rt, (int64_t)((uint64_t)la - (uint64_t)lb));
 }
 
 ray_t* ray_mul_fn(ray_t* a, ray_t* b) {
@@ -254,7 +261,9 @@ ray_t* ray_mul_fn(ray_t* a, ray_t* b) {
     if (both_f32_atoms(a, b)) return ray_f32((float)(as_f64(a) * as_f64(b)));
     if (is_float_op(a, b)) return make_f64(as_f64(a) * as_f64(b));
     int8_t rt = promote_int_type(a, b);
-    return make_typed_int(rt, as_i64(a) * as_i64(b));
+    /* uint64 wrap on overflow (defined), like ray_add_fn / the vector kernel. */
+    int64_t la = as_i64(a), lb = as_i64(b);
+    return make_typed_int(rt, (int64_t)((uint64_t)la * (uint64_t)lb));
 }
 
 ray_t* ray_div_fn(ray_t* a, ray_t* b) {

--- a/test/rfl/arith/overflow_wrap.rfl
+++ b/test/rfl/arith/overflow_wrap.rfl
@@ -1,0 +1,40 @@
+;; overflow_wrap.rfl — scalar integer +, -, * must wrap on overflow with
+;; DEFINED behavior, not signed-integer-overflow UB.
+;;
+;; ray_add_fn / ray_sub_fn / ray_mul_fn computed `as_i64(a) OP as_i64(b)`
+;; directly, so an i64 result that overflowed was undefined behavior — UBSan
+;; reported it at src/ops/arith.c:141 (+), :223 (-), :257 (*).  The wrapped
+;; value (INT64_MIN for MAX+1, which is the i64 null sentinel) was already
+;; what the code returned, so this only removes the UB; results are unchanged.
+;; Matches the vector arithmetic kernel (src/ops/expr.c OP_ADD/SUB/MUL), which
+;; already wraps via uint64.
+
+;; ── addition ────────────────────────────────────────────────────────
+;; MAX + 1 wraps to INT64_MIN, which prints as the i64 null.
+(nil? (+ 9223372036854775807 1)) -- true
+;; MAX + 2 wraps to INT64_MIN + 1 (a concrete, non-null value).
+(+ 9223372036854775807 2) -- -9223372036854775807
+;; Just-below-overflow is exact.
+(+ 9223372036854775806 1) -- 9223372036854775807
+
+;; ── subtraction ─────────────────────────────────────────────────────
+;; -MAX - 2 wraps around to +MAX.
+(- -9223372036854775807 2) -- 9223372036854775807
+;; 0 - INT64_MIN overflows (INT64_MIN has no positive counterpart) → wraps
+;; back to INT64_MIN = null.
+(nil? (- 0 -9223372036854775808)) -- true
+
+;; ── multiplication ──────────────────────────────────────────────────
+(* 9223372036854775807 2) -- -2
+(* 9223372036854775807 3) -- 9223372036854775805
+;; INT64_MIN * -1 overflows → wraps to INT64_MIN = null.
+(nil? (* -9223372036854775808 -1)) -- true
+
+;; ── ordinary arithmetic and narrow types are unaffected ─────────────
+(+ 2 3) -- 5
+(- 10 4) -- 6
+(* 6 7) -- 42
+(* 1000000 1000000) -- 1000000000000
+(+ 100h 200h) -- 300h
+(+ 5i 6i) -- 11i
+(+ 2.5 3.5) -- 6.0


### PR DESCRIPTION
## Problem

`ray_add_fn` / `ray_sub_fn` / `ray_mul_fn` computed `as_i64(a) OP as_i64(b)` directly, so an i64 result that overflowed was signed-integer-overflow undefined behavior:

```
(+ 9223372036854775807 1)   src/ops/arith.c:141  signed integer overflow
(- 0 -9223372036854775808)  src/ops/arith.c:223  signed integer overflow
(* 9223372036854775807 2)   src/ops/arith.c:257  signed integer overflow
```

The wrapped value the code relied on — `INT64_MIN` for `MAX+1`, which is the i64 null sentinel — was already what it returned, so the behavior is correct in practice; only the arithmetic itself is undefined. The vector arithmetic kernel (`src/ops/expr.c` `OP_ADD`/`SUB`/`MUL`) already wraps via `uint64`.

## Fix

Compute the integer result with `uint64` wraparound (defined), matching the vector kernel. Results are unchanged:

| Expression | Before | After |
|---|---|---|
| `(+ 9223372036854775807 1)` | UB (→ `0Nl`) | `0Nl` |
| `(- -9223372036854775807 2)` | UB | `9223372036854775807` |
| `(* 9223372036854775807 2)` | UB | `-2` |
| `(+ 2 3)` | `5` | `5` |

Narrow-type (i16/i32) results are unaffected — their i64 intermediate never overflows and `make_typed_int` still narrows them. `neg`/`abs`/`div`/`mod` already guard their overflow cases and are left as-is.

## Tests

Adds `test/rfl/arith/overflow_wrap.rfl`. Full `make test` passes (3663/3664, 1 skipped, 0 failed) under the default ASan/UBSan build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)