### PR TITLE
fix(builtins): reject malformed strings in TIME cast

### DIFF
--- a/src/ops/builtins.c
+++ b/src/ops/builtins.c
@@ -1627,21 +1627,60 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
              * matching wall-clock semantics. */
             return ray_time((int64_t)(ts_ns_in_day(val->i64) / 1000000LL));
         if (val->type == -RAY_STR) {
-            /* Parse "HH:MM:SS[.mmm]" */
+            /* Parse "[-]HH:MM[:SS][.fff]" with a bounded cursor that must
+             * consume the whole string.  TIME is a signed duration — ms-of-day
+             * can exceed a day and go negative (see .csv.read round-tripping) —
+             * so the hour field is variable width and unbounded, but minutes
+             * and seconds are 0-59.  The old sscanf path accepted trailing
+             * garbage ("12:34:56junk") and out-of-range fields ("25:99:99" →
+             * 26:40:39), silently corrupting the value; mirror the strict DATE
+             * / TIMESTAMP string casts. */
             const char* sp = ray_str_ptr(val);
-            int th = 0, tm = 0, ts = 0, tms = 0;
-            int nr = sscanf(sp, "%d:%d:%d", &th, &tm, &ts);
-            if (nr < 2) return ray_error("domain", "as: cannot parse str as time, expected HH:MM:SS[.mmm]");
-            const char* dot = strchr(sp, '.');
-            if (dot) {
-                dot++;
+            size_t sl = ray_str_len(val);
+            size_t i = 0;
+            int64_t sign = 1;
+            if (i < sl && sp[i] == '-') { sign = -1; i++; }
+            /* Variable-width hour, >= 1 digit, capped so ms cannot overflow. */
+            if (i >= sl || sp[i] < '0' || sp[i] > '9')
+                return ray_error("domain", "as: cannot parse str as time, expected [-]HH:MM[:SS][.fff]");
+            int64_t hh = 0;
+            int hd = 0;
+            while (i < sl && sp[i] >= '0' && sp[i] <= '9') {
+                hh = hh * 10 + (sp[i] - '0'); i++;
+                if (++hd > 7) return ray_error("domain", "as: cannot parse str as time, hour field too long");
+            }
+            /* Read exactly 2 digits into `out`, validate 0..59. */
+            #define TM_2DIGIT(out) do {                                                       \
+                if (i + 1 >= sl || sp[i] < '0' || sp[i] > '9' || sp[i+1] < '0' || sp[i+1] > '9') \
+                    return ray_error("domain", "as: cannot parse str as time, expected 2-digit field"); \
+                (out) = (sp[i]-'0')*10 + (sp[i+1]-'0'); i += 2;                              \
+                if ((out) > 59) return ray_error("domain", "as: cannot parse str as time, minute/second out of range"); \
+            } while (0)
+            if (i >= sl || sp[i] != ':')
+                return ray_error("domain", "as: cannot parse str as time, expected ':' after hour");
+            i++;
+            int mm = 0, ss = 0, tms = 0;
+            TM_2DIGIT(mm);
+            if (i < sl && sp[i] == ':') { i++; TM_2DIGIT(ss); }
+            #undef TM_2DIGIT
+            /* Optional fractional seconds → milliseconds; a bare trailing '.'
+             * is accepted as .000. */
+            if (i < sl && sp[i] == '.') {
+                i++;
                 char mbuf[4] = "000";
                 int mi = 0;
-                while (*dot >= '0' && *dot <= '9' && mi < 3) mbuf[mi++] = *dot++;
+                while (i < sl && sp[i] >= '0' && sp[i] <= '9') {
+                    if (mi < 3) mbuf[mi++] = sp[i];
+                    i++;
+                }
                 tms = (int)strtol(mbuf, NULL, 10);
             }
-            int32_t ms = (int32_t)th * 3600000 + (int32_t)tm * 60000 + (int32_t)ts * 1000 + tms;
-            return ray_time((int64_t)ms);
+            if (i != sl)
+                return ray_error("domain", "as: cannot parse str as time, unexpected trailing characters");
+            int64_t ms = sign * (hh * 3600000LL + (int64_t)mm * 60000LL + (int64_t)ss * 1000LL + tms);
+            if (ms > INT32_MAX || ms < INT32_MIN)
+                return ray_error("domain", "as: cannot parse str as time, out of int32 millisecond range");
+            return ray_time(ms);
         }
         /* Vector cast */
         if (ray_is_vec(val) || val->type == RAY_LIST)

--- a/test/rfl/type/as.rfl
+++ b/test/rfl/type/as.rfl
@@ -325,6 +325,21 @@
 (as 'time "20:00:00") -- 20:00:00.000
 (as 'time "20:00:00.") -- 20:00:00.000
 (as 'time "20:00:00.0") -- 20:00:00.000
+;; TIME is a signed duration: hours may exceed a day and go negative,
+;; and HH:MM (no seconds) is accepted.
+(as 'time "25:00:00") -- 25:00:00.000
+(as 'time "-5:00:00") -- -05:00:00.000
+(as 'time "12:34") -- 12:34:00.000
+;; Malformed TIME strings must be REJECTED, not silently normalized.
+;; The old sscanf path accepted trailing garbage and out-of-range fields
+;; ("25:99:99" wrapped to 26:40:39).
+(as 'time "12:34:56junk") !- domain
+(as 'time "12:34:56.789junk") !- domain
+(as 'time "25:99:99") !- domain
+(as 'time "99:99:99") !- domain
+(as 'time "12x34x56") !- domain
+(as 'time "12:3") !- domain
+(as 'time "x") !- domain
 ;; time literals with 1-3 digit fractional seconds
 10:00:00.1 -- 10:00:00.001
 10:00:00.01 -- 10:00:00.001


### PR DESCRIPTION
## Problem

`(as 'TIME str)` parsed with an unanchored `sscanf` and never range-checked the minute/second fields, so it silently accepted malformed input and produced a wrong-but-valid value — the same data-corruption class the DATE (#382) and TIMESTAMP (#361) string casts were hardened against, but the TIME cast was left on the old path:

| Input | Before | After |
|---|---|---|
| `"12:34:56junk"` | `12:34:56.000` (garbage ignored) | `domain` error |
| `"12:34:56.789junk"` | `12:34:56.789` | `domain` error |
| `"25:99:99"` | `26:40:39.000` (min/sec out of range, normalized) | `domain` error |
| `"12x34x56"` | `domain` | `domain` |

## Fix

Parse `[-]HH:MM[:SS][.fff]` with a bounded cursor that must consume the whole string, validating that minutes and seconds are `0-59`.

TIME is a **signed duration** — its ms-of-day may exceed a day and go negative (see `.csv.read` round-tripping, #379) — so the hour field stays variable width and unbounded, `HH:MM` (no seconds) is accepted, and a bare trailing `.` is accepted as `.000`. The result is range-checked against the int32 millisecond domain. The string-**vector** cast routes through this same atom path, so it is fixed too.

Preserved (still accepted): `12:30:45`, `12:30:45.123`, `20:00:00.`, `25:00:00` (>24h duration), `-5:00:00` (negative), `12:34`.

## Tests

Extends the TIME-cast coverage in `type/as.rfl` with the duration, negative, and rejection cases. Full `make test` passes (3662/3663, 1 skipped, 0 failed) under the default ASan/UBSan build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)