### PR TITLE
fix(eval): materialize lazy values at compiled boundaries

### DIFF
--- a/src/lang/compile.c
+++ b/src/lang/compile.c
@@ -278,6 +278,10 @@ static void compile_list(compiler_t *c, ray_t *ast) {
             ray_t *name_obj = elems[1];
             if (name_obj->type != -RAY_SYM) { c->error = true; return; }
             compile_expr(c, elems[2]);
+            /* Match ray_set_fn: globals must never retain a single-use lazy
+             * DAG handle.  Materializing one alias consumes its graph and
+             * would leave every other global read pointing at a spent handle. */
+            emit(c, OP_FORCE);
             int32_t idx = add_constant(c, name_obj);
             if (idx < 256) {
                 emit(c, OP_STOREGLOBAL);
@@ -332,6 +336,9 @@ static void compile_list(compiler_t *c, ray_t *ast) {
         /* (if cond then else?) */
         if (sym_id == sf_if && n >= 3) {
             compile_expr(c, elems[1]);
+            /* Match ray_cond_fn: truthiness belongs to the materialized value,
+             * not to the non-NULL lazy handle that happens to contain it. */
+            emit(c, OP_FORCE);
             int32_t jmpf_pos = emit_jump(c, OP_JMPF);
             compile_expr(c, elems[2]);
             if (n >= 4) {

--- a/src/ops/graph.c
+++ b/src/ops/graph.c
@@ -1766,6 +1766,8 @@ ray_t* ray_lazy_wrap(ray_graph_t* g, ray_op_t* op) {
 ray_t* ray_lazy_append(ray_t* lazy, uint16_t opcode) {
     ray_graph_t* g    = RAY_LAZY_GRAPH(lazy);
     ray_op_t*    prev = RAY_LAZY_OP(lazy);
+    if (!g || !prev)
+        return ray_error("domain", "lazy handle already materialized");
 
     /* Determine output type based on opcode */
     int8_t out_type;
@@ -1833,6 +1835,8 @@ ray_t* ray_lazy_append(ray_t* lazy, uint16_t opcode) {
 ray_t* ray_lazy_append_param(ray_t* lazy, uint16_t opcode, int64_t param) {
     ray_graph_t* g    = RAY_LAZY_GRAPH(lazy);
     ray_op_t*    prev = RAY_LAZY_OP(lazy);
+    if (!g || !prev)
+        return ray_error("domain", "lazy handle already materialized");
 
     int8_t out_type;
     switch (opcode) {
@@ -1865,6 +1869,12 @@ ray_t* ray_lazy_materialize(ray_t* val) {
 
     ray_graph_t* g  = RAY_LAZY_GRAPH(val);
     ray_op_t*    op = RAY_LAZY_OP(val);
+    if (!g || !op) {
+        RAY_LAZY_GRAPH(val) = NULL;
+        RAY_LAZY_OP(val) = NULL;
+        ray_release(val);
+        return ray_error("domain", "lazy handle already materialized");
+    }
 
     /* Run the full optimizer pipeline before execution. ray_optimize
        may return a different root (e.g. predicate pushdown). */
@@ -1876,6 +1886,7 @@ ray_t* ray_lazy_materialize(ray_t* val) {
     /* Clear graph pointer before releasing to prevent double-free in
      * ray_release_owned_refs */
     RAY_LAZY_GRAPH(val) = NULL;
+    RAY_LAZY_OP(val) = NULL;
     ray_release(val);
     return result;
 }

--- a/test/test_compile.c
+++ b/test/test_compile.c
@@ -34,6 +34,7 @@
 #include "lang/eval.h"
 #include "lang/env.h"
 #include "lang/parse.h"
+#include "ops/ops.h"
 #include <string.h>
 
 /* __RUNTIME is internal test plumbing; runtime API declarations come from
@@ -87,19 +88,41 @@ static void compile_teardown(void) {
 } while (0)
 
 /* ════════════════════════════════════════════════════════════════════
- * 1. (set name val) inside a compiled lambda body (line 225-230)
- *    The compiler emits OP_CALLD for set because set modifies the
- *    global environment and the compiler defers to the interpreter.
+ * 1. (set name val) inside a compiled lambda body
+ *    The compiler evaluates the value in the current frame, forces lazy
+ *    results, and stores the concrete value in the global environment.
  * ════════════════════════════════════════════════════════════════════ */
 static test_result_t test_compile_set_inside_fn(void) {
-    /* Define a fn that calls (set ...) inside its body using a constant
-     * value (not a local variable) so the deferred AST can resolve.
-     * The compile path for (set name val) delegates to OP_CALLD. */
+    /* Define a fn that calls (set ...) inside its body. */
     EVAL_I64(
         "(do "
           "(set f (fn [] (set compile_set_g 42) compile_set_g)) "
           "(f))",
         42);
+    PASS();
+}
+
+/* A global written by compiled `set` must hold the concrete result, not the
+ * single-use lazy handle returned by first/distinct/etc. */
+static test_result_t test_compile_set_forces_lazy_value(void) {
+    EVAL_I64(
+        "(do "
+          "(set xs [5 1 4 2]) "
+          "(set f (fn [] (do (set lazy_set_g (first xs)) 0))) "
+          "(f) "
+          "(+ lazy_set_g lazy_set_g))",
+        10);
+    PASS();
+}
+
+static test_result_t test_compile_set_forces_lazy_chain(void) {
+    EVAL_I64(
+        "(do "
+          "(set xs [\"aaa\" \"bbb\" \"aaa\"]) "
+          "(set f (fn [] (do (set lazy_set_all (distinct xs)) 0))) "
+          "(f) "
+          "(+ (+ 0 (count lazy_set_all)) (count lazy_set_all)))",
+        4);
     PASS();
 }
 
@@ -120,6 +143,43 @@ static test_result_t test_compile_if_no_else_false(void) {
     EVAL_I64(
         "(do (set f (fn [x] (if (> x 0) 99))) (f -1))",
         0);
+    PASS();
+}
+
+/* A compiled condition must test the value produced by a lazy aggregate. */
+static test_result_t test_compile_if_forces_lazy_condition(void) {
+    EVAL_I64(
+        "(do (set xs [0 1 4 2]) (set f (fn [] (if (first xs) 1 0))) (f))",
+        0);
+    PASS();
+}
+
+/* A stale lazy alias is rejected before graph construction dereferences its
+ * cleared root.  This is a defensive backstop for callers outside bindings. */
+static test_result_t test_compile_spent_lazy_returns_error(void) {
+    ray_t* vec = ray_eval_str("[1 2 1]");
+    TEST_ASSERT_NOT_NULL(vec);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(vec));
+    ray_t* lazy = ray_distinct_fn(vec);
+    TEST_ASSERT_NOT_NULL(lazy);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(lazy));
+    ray_retain(lazy); /* preserve one alias after materialization consumes one */
+    ray_t* concrete = ray_lazy_materialize(lazy);
+    TEST_ASSERT_NOT_NULL(concrete);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(concrete));
+
+    ray_t* err = ray_lazy_append(lazy, OP_COUNT);
+    TEST_ASSERT_NOT_NULL(err);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(err));
+    ray_error_free(err);
+
+    err = ray_lazy_materialize(lazy); /* consumes the final lazy alias */
+    TEST_ASSERT_NOT_NULL(err);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(err));
+    ray_error_free(err);
+
+    ray_release(concrete);
+    ray_release(vec);
     PASS();
 }
 
@@ -948,8 +1008,12 @@ static test_result_t test_compile_default_switch_case(void) {
  * ════════════════════════════════════════════════════════════════════ */
 const test_entry_t compile_entries[] = {
     { "compile/set_inside_fn",       test_compile_set_inside_fn,       compile_setup, compile_teardown },
+    { "compile/set_forces_lazy_value", test_compile_set_forces_lazy_value, compile_setup, compile_teardown },
+    { "compile/set_forces_lazy_chain", test_compile_set_forces_lazy_chain, compile_setup, compile_teardown },
     { "compile/if_no_else_true",     test_compile_if_no_else_true,     compile_setup, compile_teardown },
     { "compile/if_no_else_false",    test_compile_if_no_else_false,    compile_setup, compile_teardown },
+    { "compile/if_forces_lazy_condition", test_compile_if_forces_lazy_condition, compile_setup, compile_teardown },
+    { "compile/spent_lazy_returns_error", test_compile_spent_lazy_returns_error, compile_setup, compile_teardown },
     { "compile/do_inside_fn",        test_compile_do_inside_fn,        compile_setup, compile_teardown },
     { "compile/do_multi_exprs",      test_compile_do_multi_exprs,      compile_setup, compile_teardown },
     { "compile/nested_fn",           test_compile_nested_fn,           compile_setup, compile_teardown },


### PR DESCRIPTION
## Summary

- force lazy values before compiled `set` stores them in the global environment
- force lazy conditions before compiled `if` evaluates truthiness
- reject already-materialized lazy handles with a descriptive domain error
- clear both lazy graph and operation pointers after materialization
- add regressions for repeated global reads, lazy chains, compiled conditions, and stale aliases

## Root cause

The tree-walking interpreter materialized lazy DAG handles at `set` and `if` boundaries, but the bytecode compiler did not. Because lazy handles are single-use and materialization frees their graph, compiled lambdas could retain spent aliases, dereference freed DAG nodes, or test the handle pointer instead of its value.

This addresses the core lazy-handle lifetime defect reported in #390. The issue's independent documentation gaps and papercuts remain separate follow-up work.

## Impact

This prevents the reported crash, repeat-read `nyi`, lazy-chain corruption through compiled global bindings, and silent wrong-branch results in compiled conditionals. Defensive checks turn any remaining stale-handle use into an attributable error.

## Validation

- `make test` — 3,670/3,670 passed
- `./rayforce.test -f compile/` — 56/56 passed
- clean ASan/UBSan debug build
