### PR TITLE
fix(builtins): validate hex digits and dash layout in GUID string cast

### DIFF
--- a/src/ops/builtins.c
+++ b/src/ops/builtins.c
@@ -1830,19 +1830,37 @@ ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val) {
         ray_release(s);
         if (val->type == -RAY_GUID) { ray_retain(val); return val; }
         if (val->type == -RAY_STR) {
-            /* Parse UUID string: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" */
+            /* Parse UUID string: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx".
+             * Require the canonical hyphenated form exactly: 32 hex
+             * nibbles with the four dashes at offsets 8/13/18/23.  The old
+             * parser skipped '-' anywhere and decoded any character as a
+             * nibble, so non-hex garbage (e.g. all-'z') silently produced a
+             * wrong-but-valid GUID. */
             const char* sp = ray_str_ptr(val);
             size_t sl = ray_str_len(val);
-            if (sl < 36) return ray_error("domain", "as: cannot parse str as guid, expected 36 chars, got %lld", (long long)sl);
+            if (sl != 36) return ray_error("domain", "as: cannot parse str as guid, expected 36 chars, got %lld", (long long)sl);
             uint8_t bytes[16];
-            const char* p = sp;
-            for (int bi = 0; bi < 16; bi++) {
-                if (*p == '-') p++;
-                char hi = *p++;
-                char lo = *p++;
-                int h = (hi >= 'a') ? hi - 'a' + 10 : (hi >= 'A') ? hi - 'A' + 10 : hi - '0';
-                int l = (lo >= 'a') ? lo - 'a' + 10 : (lo >= 'A') ? lo - 'A' + 10 : lo - '0';
-                bytes[bi] = (uint8_t)((h << 4) | l);
+            int nib = 0;
+            for (size_t j = 0; j < sl; j++) {
+                char c = sp[j];
+                /* Offsets 8/13/18/23 MUST be the dash; every other position
+                 * MUST be a hex digit.  This is position-driven (rather than
+                 * "reject a misplaced dash") so the 32 non-dash positions are
+                 * exactly 32 nibbles — nib never exceeds 31 and bytes[nib>>1]
+                 * cannot run past bytes[16]. */
+                if (j == 8 || j == 13 || j == 18 || j == 23) {
+                    if (c != '-')
+                        return ray_error("domain", "as: cannot parse str as guid, expected '-' at offset %lld", (long long)j);
+                    continue;
+                }
+                int v;
+                if (c >= '0' && c <= '9')        v = c - '0';
+                else if (c >= 'a' && c <= 'f')   v = c - 'a' + 10;
+                else if (c >= 'A' && c <= 'F')   v = c - 'A' + 10;
+                else return ray_error("domain", "as: cannot parse str as guid, non-hex character '%c'", c);
+                if ((nib & 1) == 0) bytes[nib >> 1] = (uint8_t)(v << 4);
+                else                bytes[nib >> 1] |= (uint8_t)v;
+                nib++;
             }
             return ray_guid(bytes);
         }

--- a/test/rfl/type/as.rfl
+++ b/test/rfl/type/as.rfl
@@ -451,6 +451,24 @@
 (type (as 'guid "d49f18a4-1969-49e8-9b8a-6bb9a4832eea")) -- 'guid
 ;; String → GUID → STR round-trip preserves the canonical 36-char form.
 (as 'STR (as 'guid "d49f18a4-1969-49e8-9b8a-6bb9a4832eea")) -- "d49f18a4-1969-49e8-9b8a-6bb9a4832eea"
+;; Malformed GUID strings must be REJECTED, not silently decoded into a
+;; wrong-but-valid GUID.  The old parser skipped '-' anywhere and decoded
+;; any character as a nibble, so "zzzz…" became a plausible GUID.
+(as 'guid "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz") !- domain
+(as 'guid "gggggggg-gggg-gggg-gggg-gggggggggggg") !- domain
+(as 'guid "d49f18a4:1969-49e8-9b8a-6bb9a4832eea") !- domain
+(as 'guid "d49f18a4_1969-49e8-9b8a-6bb9a4832eea") !- domain
+(as 'guid "d49f18a4-1969-49e8-9b8a6bb9a4832eea") !- domain
+(as 'guid "d49f18a4-1969-49e8-9b8a-6bb9a4832eea-") !- domain
+(as 'guid "d49f18a4-1969-49e8-9b8a-6bb9a4832ee") !- domain
+(as 'guid "d49f18a4-1969-49e8-9b8a-6bb9a4832eeax") !- domain
+;; A 36-char all-hex string (a dash position holding a hex digit) must be
+;; rejected, not decoded — the byte index would otherwise run past
+;; bytes[16] (stack overflow).
+(as 'guid "0123456789abcdef0123456789abcdef0123") !- domain
+(as 'guid "d49f18a4a1969-49e8-9b8a-6bb9a4832eea") !- domain
+;; Uppercase hex is accepted and normalized on the round-trip.
+(as 'STR (as 'guid "ABCDEF01-2345-6789-ABCD-EF0123456789")) -- "abcdef01-2345-6789-abcd-ef0123456789"
 ;; ========== IDENTITY CASTS (same type) ==========
 (as 'b8 true) -- true
 (as 'u8 0xFF) -- 0xFF


### PR DESCRIPTION
## Problem

The STR→GUID decoder skipped `-` wherever it appeared and decoded any character as a nibble, so malformed input silently produced a wrong-but-valid GUID:

```
(as 'guid "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz")
-> 33333333-3333-3333-3333-333333333333
```

— the same silent data-corruption class the DATE (#382), TIMESTAMP (#361), and TIME (#389) string casts were hardened against.

## Fix

Require the canonical `8-4-4-4-12` hyphenated form exactly: 36 chars, a dash at offsets 8/13/18/23, every other position a valid hex digit, else a `domain` error.

The parse is **position-driven** — a dash is *required* at 8/13/18/23, not merely "reject a misplaced dash". This also closes a memory-safety hole: with the "reject-misplaced" approach a hex digit where a dash belongs (e.g. a 36-char all-hex string) yields >32 nibbles and writes past the 16-byte stack buffer (ASan stack-buffer-overflow). Position-driven parsing bounds it to exactly 32 nibbles, so the index cannot run past `bytes[16]`; such input is now a clean reject. The string-vector cast routes through this same atom path.

| Input | Before | After |
|---|---|---|
| `"zzzzzzzz-…"` | `33333333-…` | `domain` |
| `"0123456789abcdef0123456789abcdef0123"` (36 hex, no dashes) | **stack overflow** | `domain` |
| `"01234567-89ab-cdef-0123-456789abcdef"` | ok | ok |

## Tests

Adds GUID-cast rejection coverage (non-hex, wrong length, misplaced/missing dashes, and the all-hex overflow case) to `type/as.rfl`. Full `make test` passes (3667/3668, 1 skipped, 0 failed) under the default ASan/UBSan build.
