### PR TITLE
feat(io): add binary file read and write

### DIFF
--- a/docs/docs/language/functions.md
+++ b/docs/docs/language/functions.md
@@ -436,7 +436,9 @@ Cross-temporal comparisons are supported: dates, times, and timestamps are all c
 | `.csv.read` | variadic | Load CSV file into table | `(.csv.read "data.csv")` |
 | `.csv.write` | variadic | Write table to CSV file | `(.csv.write trades "out.csv")` |
 | `read` | unary | Read file contents as string | `(read "file.txt")` |
-| `write` | binary | Write string to file | `(write "file.txt" "content")` |
+| `read-bytes` | unary | Read file contents as a `U8` byte vector | `(read-bytes "file.bin")` |
+| `write` | binary | Write a string to a file | `(write "file.txt" "content")` |
+| `write-bytes` | binary | Write a `U8` byte vector to a file | `(write-bytes "file.bin" bytes)` |
 | `load` | unary | Load and evaluate a Rayfall script | `(load "lib.rfl")` |
 
 ## Control Flow

--- a/docs/docs/reference/all-functions.md
+++ b/docs/docs/reference/all-functions.md
@@ -44,7 +44,7 @@ Generated from `src/lang/eval.c` in this checkout. The categorized reference bel
 `signum`, `sum`, `prod`, `all`, `any`, `count`, `avg`, `min`, `max`,
 `first`, `last`, `med`, `mode`, `dev`, `stddev`, `stddev_pop`, `dev_pop`, `var`, `var_pop`, `raise`, `distinct`,
 `reverse`, `til`, `lag`, `lead`, `deltas`, `ratios`, `fills`, `sums`, `avgs`, `mins`, `maxs`, `prds`,
-`differ`, `asc`, `desc`, `iasc`, `idesc`, `rank`, `key`, `cols`, `value`, `type`, `read`, `load`, `exit`,
+`differ`, `asc`, `desc`, `iasc`, `idesc`, `rank`, `key`, `cols`, `value`, `type`, `read`, `read-bytes`, `load`, `exit`,
 `nil?`, `where`, `group`, `raze`, `ungroup`, `ser`, `de`, `guid`, `date`, `time`, `timestamp`, `ss`, `hh`,
 `minute`, `yyyy`, `mm`, `dd`, `dow`, `doy`, `eval`, `parse`, `meta`, `fkeys`, `.sys.exec`, `.sys.cmd`, `.sys.listen`,
 `.os.getenv`, `.fs.size`, `.fs.list`, `.ipc.close`, `.repl.connect`, `.log.write`, `.log.replay`,
@@ -57,7 +57,7 @@ Generated from `src/lang/eval.c` in this checkout. The categorized reference bel
 
 `+`, `-`, `*`, `/`, `%`, `>`, `<`, `>=`, `<=`, `==`, `!=`, `pow`, `top`, `bot`, `pearson_corr`, `cov`, `scov`, `wsum`, `wavg`, `quantile`, `percentile`, `set`, `let`,
 `try`, `filter`, `in`, `except`, `union`, `sect`, `take`, `drop`, `rotate`, `cut`, `cross`, `at`, `find`, `fill`, `min`, `max`, `msum`, `mavg`, `mmin`, `mmax`,
-`mcount`, `mvar`, `mdev`, `xasc`, `xdesc`, `table`, `union-all`, `xbar`, `as`, `write`, `dict`, `concat`, `within`, `div`,
+`mcount`, `mvar`, `mdev`, `xasc`, `xdesc`, `table`, `union-all`, `xbar`, `as`, `write`, `write-bytes`, `dict`, `concat`, `within`, `div`,
 `rand`, `bin`, `binr`, `split`, `str-find`, `str-join`, `like`, `.os.setenv`, `.ipc.send`, `.ipc.post`, `get`, `remove`, `row`,
 `unify`, `xcol`, `xcols`, `xkey`, `xgroup`, `xrank`, `dl-query`, `dl-provenance`, `cos-dist`, `inner-prod`, `l2-dist`, `hnsw-save`, `.attr.set`,
 `.col.link`
@@ -614,7 +614,9 @@ Printing, file I/O, CSV loading, and script execution.
 | `.csv.read` | variadic | restricted | Load CSV file into table (mmap, parallel parse) | `(.csv.read "data.csv")` |
 | `.csv.write` | variadic | restricted | Write table to CSV file | `(.csv.write trades "out.csv")` |
 | `read` | unary | restricted | Read file contents as string | `(read "file.txt")` |
-| `write` | binary | restricted | Write string to file | `(write "file.txt" "content")` |
+| `read-bytes` | unary | restricted | Read file contents as a `U8` byte vector | `(read-bytes "file.bin")` |
+| `write` | binary | restricted | Write a string to a file | `(write "file.txt" "content")` |
+| `write-bytes` | binary | restricted | Write a `U8` byte vector to a file | `(write-bytes "file.bin" bytes)` |
 | `load` | unary | restricted | Load and evaluate a Rayfall script file | `(load "lib.rfl")` |
 | `exit` | unary | restricted | Exit the process with status code | `(exit 0)` |
 | `resolve` | variadic | special | Resolve a symbol in the current scope | `(resolve 'x)` |

--- a/docs/docs/storage/ipc.md
+++ b/docs/docs/storage/ipc.md
@@ -65,8 +65,8 @@ In restricted mode, specific builtins that write files, mutate state, or control
 | Category | Blocked Builtins |
 |---|---|
 | Mutation | `set`, `del`, `update`, `insert`, `upsert`, `modify` |
-| File writes | `write`, `.csv.write`, `load`, `.db.splayed.set` |
-| File reads | `read`, `.csv.read` |
+| File writes | `write`, `write-bytes`, `.csv.write`, `load`, `.db.splayed.set` |
+| File reads | `read`, `read-bytes`, `.csv.read` |
 | System | `.sys.exec`, `.os.getenv`, `.os.setenv`, `exit` |
 | IPC chaining | `.ipc.open`, `.ipc.close`, `.ipc.send`, `.ipc.post` |
 

--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -3284,7 +3284,9 @@ static void ray_register_builtins(void) {
     register_binary("as",       RAY_FN_NONE, ray_cast_fn);
     register_unary("type",      RAY_FN_NONE, ray_type_fn);
     register_unary("read",      RAY_FN_RESTRICTED, ray_read_file_fn);
+    register_unary("read-bytes", RAY_FN_RESTRICTED, ray_read_bytes_fn);
     register_binary("write",    RAY_FN_RESTRICTED, ray_write_file_fn);
+    register_binary("write-bytes", RAY_FN_RESTRICTED, ray_write_bytes_fn);
     register_unary("load",      RAY_FN_RESTRICTED, ray_load_file_fn);
     register_unary("exit",      RAY_FN_RESTRICTED, ray_exit_fn);
     register_vary("resolve",    RAY_FN_SPECIAL_FORM, ray_resolve_fn);

--- a/src/lang/eval.h
+++ b/src/lang/eval.h
@@ -336,7 +336,9 @@ ray_t* ray_println_fn(ray_t** args, int64_t n);
 ray_t* ray_read_csv_fn(ray_t** args, int64_t n);
 ray_t* ray_write_csv_fn(ray_t** args, int64_t n);
 ray_t* ray_read_file_fn(ray_t* path_obj);
+ray_t* ray_read_bytes_fn(ray_t* path_obj);
 ray_t* ray_write_file_fn(ray_t* path_obj, ray_t* content);
+ray_t* ray_write_bytes_fn(ray_t* path_obj, ray_t* content);
 
 /* Vector similarity / embeddings / HNSW.
  * cos-dist and l2-dist return distance (lower = closer); inner-prod is

--- a/src/lang/internal.h
+++ b/src/lang/internal.h
@@ -683,8 +683,10 @@ ray_t* ray_write_csv_fn(ray_t** args, int64_t n);
 ray_t* ray_cast_fn(ray_t* type_sym, ray_t* val);
 ray_t* ray_type_fn(ray_t* val);
 ray_t* ray_read_file_fn(ray_t* path_obj);
+ray_t* ray_read_bytes_fn(ray_t* path_obj);
 ray_t* ray_load_file_fn(ray_t* path_obj);
 ray_t* ray_write_file_fn(ray_t* path_obj, ray_t* content);
+ray_t* ray_write_bytes_fn(ray_t* path_obj, ray_t* content);
 
 /* Misc builtins (formerly in eval.c, now in ops/builtins.c) */
 ray_t* ray_dict_fn(ray_t* keys, ray_t* vals);

--- a/src/ops/builtins.c
+++ b/src/ops/builtins.c
@@ -1973,27 +1973,49 @@ ray_t* ray_type_fn(ray_t* val) {
     return ray_sym(id);
 }
 
-/* (read path) — read a file's contents as a string */
-ray_t* ray_read_file_fn(ray_t* path_obj) {
-    if (path_obj->type != -RAY_STR) return ray_error("type", "read: path must be str, got %s", ray_type_name(path_obj->type));
+static ray_t* read_file_bytes(ray_t* path_obj, const char* op) {
+    if (path_obj->type != -RAY_STR)
+        return ray_error("type", "%s: path must be str, got %s", op, ray_type_name(path_obj->type));
     const char* path = ray_str_ptr(path_obj);
-    if (!path) return ray_error("domain", "read: empty path");
+    if (!path || ray_str_len(path_obj) == 0)
+        return ray_error("domain", "%s: empty path", op);
+
     FILE* fp = fopen(path, "rb");
     if (!fp) return ray_error("io", NULL);
-    fseek(fp, 0, SEEK_END);
+    if (fseek(fp, 0, SEEK_END) != 0) { fclose(fp); return ray_error("io", NULL); }
     long sz = ftell(fp);
-    fseek(fp, 0, SEEK_SET);
     if (sz < 0) { fclose(fp); return ray_error("io", NULL); }
-    /* Use ray_alloc for the buffer */
-    ray_t* buf = ray_alloc((size_t)sz + 1);
-    if (!buf || RAY_IS_ERR(buf)) { fclose(fp); return ray_error("oom", NULL); }
-    char* data = (char*)ray_data(buf);
-    size_t rd = fread(data, 1, (size_t)sz, fp);
-    fclose(fp);
-    data[rd] = '\0';
-    ray_t* result = ray_str(data, rd);
-    ray_release(buf);
+    if (fseek(fp, 0, SEEK_SET) != 0) { fclose(fp); return ray_error("io", NULL); }
+
+    ray_t* result = ray_vec_new(RAY_U8, (int64_t)sz);
+    if (!result || RAY_IS_ERR(result)) {
+        fclose(fp);
+        return result ? result : ray_error("oom", NULL);
+    }
+    result->len = (int64_t)sz;
+
+    size_t rd = sz > 0 ? fread(ray_data(result), 1, (size_t)sz, fp) : 0;
+    int close_rc = fclose(fp);
+    if (rd != (size_t)sz || close_rc != 0) {
+        ray_release(result);
+        return ray_error("io", NULL);
+    }
     return result;
+}
+
+/* (read path) — read a file's contents as a string */
+ray_t* ray_read_file_fn(ray_t* path_obj) {
+    ray_t* bytes = read_file_bytes(path_obj, "read");
+    if (RAY_IS_ERR(bytes)) return bytes;
+
+    ray_t* result = ray_str((const char*)ray_data(bytes), (size_t)bytes->len);
+    ray_release(bytes);
+    return result;
+}
+
+/* (read-bytes path) — read a file's contents as a U8 byte vector */
+ray_t* ray_read_bytes_fn(ray_t* path_obj) {
+    return read_file_bytes(path_obj, "read-bytes");
 }
 
 /* (load path) — read and evaluate a Rayfall script file via mmap */
@@ -2064,20 +2086,37 @@ ray_t* ray_load_file_fn(ray_t* path_obj) {
 #endif
 }
 
-/* (write path content) — write string to a file */
-ray_t* ray_write_file_fn(ray_t* path_obj, ray_t* content) {
-    if (path_obj->type != -RAY_STR) return ray_error("type", "write: path must be str, got %s", ray_type_name(path_obj->type));
-    if (content->type != -RAY_STR) return ray_error("type", "write: content must be str, got %s", ray_type_name(content->type));
+static ray_t* write_file_data(ray_t* path_obj, const void* data, size_t len,
+                              const char* op) {
+    if (path_obj->type != -RAY_STR)
+        return ray_error("type", "%s: path must be str, got %s", op, ray_type_name(path_obj->type));
     const char* path = ray_str_ptr(path_obj);
-    const char* data = ray_str_ptr(content);
-    size_t len = ray_str_len(content);
-    if (!path || !data) return ray_error("domain", "write: empty path or content");
+    if (!path || ray_str_len(path_obj) == 0)
+        return ray_error("domain", "%s: empty path", op);
+    if (len > 0 && !data) return ray_error("domain", "%s: invalid content", op);
+
     FILE* fp = fopen(path, "wb");
     if (!fp) return ray_error("io", NULL);
-    size_t written = fwrite(data, 1, len, fp);
-    fclose(fp);
-    if (written != len) return ray_error("io", NULL);
+    size_t written = len > 0 ? fwrite(data, 1, len, fp) : 0;
+    int close_rc = fclose(fp);
+    if (written != len || close_rc != 0) return ray_error("io", NULL);
     return make_i64(0);
+}
+
+/* (write path content) — write a string to a file */
+ray_t* ray_write_file_fn(ray_t* path_obj, ray_t* content) {
+    if (content->type != -RAY_STR)
+        return ray_error("type", "write: content must be str, got %s", ray_type_name(content->type));
+    return write_file_data(path_obj, ray_str_ptr(content), ray_str_len(content),
+                           "write");
+}
+
+/* (write-bytes path content) — write a U8 byte vector to a file */
+ray_t* ray_write_bytes_fn(ray_t* path_obj, ray_t* content) {
+    if (content->type != RAY_U8)
+        return ray_error("type", "write-bytes: content must be U8, got %s", ray_type_name(content->type));
+    return write_file_data(path_obj, ray_data(content), (size_t)content->len,
+                           "write-bytes");
 }
 
 /* ══════════════════════════════════════════

--- a/test/test_lang.c
+++ b/test/test_lang.c
@@ -7680,7 +7680,73 @@ static test_result_t test_builtin_load_file_fn(void) {
     PASS();
 }
 
-/* (write path content) — write a string to a file. */
+/* (read-bytes path) — read a file as a U8 byte vector. */
+static test_result_t test_builtin_read_bytes_fn(void) {
+    char path[64];
+    snprintf(path, sizeof(path), "/tmp/ray_test_read_bytes_%d.bin", (int)getpid());
+    static const uint8_t expected[] = { 0x00, 0x01, 0x7f, 0x80, 0xff };
+
+    FILE* fp = fopen(path, "wb");
+    TEST_ASSERT_NOT_NULL(fp);
+    TEST_ASSERT_EQ_U(fwrite(expected, 1, sizeof(expected), fp), sizeof(expected));
+    TEST_ASSERT_EQ_I(fclose(fp), 0);
+
+    ray_t* p = ray_str(path, strlen(path));
+    ray_t* bytes = ray_read_bytes_fn(p);
+    TEST_ASSERT_NOT_NULL(bytes);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(bytes));
+    TEST_ASSERT_EQ_I(bytes->type, RAY_U8);
+    TEST_ASSERT_EQ_I(bytes->len, (int64_t)sizeof(expected));
+    TEST_ASSERT_MEM_EQ(sizeof(expected), ray_data(bytes), expected);
+
+    /* The existing text reader keeps its string contract after sharing the
+     * exact-read path, including explicit length across embedded NULs. */
+    ray_t* text = ray_read_file_fn(p);
+    TEST_ASSERT_NOT_NULL(text);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(text));
+    TEST_ASSERT_EQ_I(text->type, -RAY_STR);
+    TEST_ASSERT_EQ_U(ray_str_len(text), sizeof(expected));
+    TEST_ASSERT_MEM_EQ(sizeof(expected), ray_str_ptr(text), expected);
+
+    /* Exercise public builtin registration, not only the C entry point. */
+    char expr[128];
+    snprintf(expr, sizeof(expr), "(read-bytes \"%s\")", path);
+    ray_t* eval_bytes = ray_eval_str(expr);
+    TEST_ASSERT_NOT_NULL(eval_bytes);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(eval_bytes));
+    TEST_ASSERT_EQ_I(eval_bytes->type, RAY_U8);
+    TEST_ASSERT_EQ_I(eval_bytes->len, (int64_t)sizeof(expected));
+    TEST_ASSERT_MEM_EQ(sizeof(expected), ray_data(eval_bytes), expected);
+
+    /* Empty files produce an empty U8 vector. */
+    fp = fopen(path, "wb");
+    TEST_ASSERT_NOT_NULL(fp);
+    TEST_ASSERT_EQ_I(fclose(fp), 0);
+    ray_t* empty = ray_read_bytes_fn(p);
+    TEST_ASSERT_NOT_NULL(empty);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(empty));
+    TEST_ASSERT_EQ_I(empty->type, RAY_U8);
+    TEST_ASSERT_EQ_I(empty->len, 0);
+
+    ray_t* bad_path = ray_i64(0);
+    ray_t* type_err = ray_read_bytes_fn(bad_path);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(type_err));
+    unlink(path);
+    ray_t* io_err = ray_read_bytes_fn(p);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(io_err));
+
+    ray_release(io_err);
+    ray_release(type_err);
+    ray_release(bad_path);
+    ray_release(empty);
+    ray_release(eval_bytes);
+    ray_release(text);
+    ray_release(bytes);
+    ray_release(p);
+    PASS();
+}
+
+/* Text and byte file writers have distinct public builtins. */
 static test_result_t test_builtin_write_file_fn(void) {
     char path[64];
     snprintf(path, sizeof(path), "/tmp/ray_test_write_%d.txt", (int)getpid());
@@ -7701,6 +7767,47 @@ static test_result_t test_builtin_write_file_fn(void) {
     TEST_ASSERT_EQ_U(rd, 11);
     TEST_ASSERT_TRUE(memcmp(buf, "hello world", 11) == 0);
 
+    /* write-bytes writes U8 content verbatim, including embedded NULs and
+     * bytes that are not valid text. */
+    static const uint8_t expected[] = { 0x00, 0x01, 0x7f, 0x80, 0xff };
+    ray_t* bytes = ray_vec_from_raw(RAY_U8, expected, (int64_t)sizeof(expected));
+    TEST_ASSERT_NOT_NULL(bytes);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(bytes));
+
+    ray_t* rbb = ray_write_bytes_fn(p, bytes);
+    TEST_ASSERT_NOT_NULL(rbb);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(rbb));
+    char expr[192];
+    snprintf(expr, sizeof(expr),
+             "(write-bytes \"%s\" (as 'U8 [0 1 127 128 255]))", path);
+    ray_t* eval_write = ray_eval_str(expr);
+    TEST_ASSERT_NOT_NULL(eval_write);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(eval_write));
+    fp = fopen(path, "rb");
+    TEST_ASSERT_NOT_NULL(fp);
+    uint8_t byte_buf[sizeof(expected)] = {0};
+    rd = fread(byte_buf, 1, sizeof(byte_buf), fp);
+    fclose(fp);
+    TEST_ASSERT_EQ_U(rd, sizeof(expected));
+    TEST_ASSERT_MEM_EQ(sizeof(expected), byte_buf, expected);
+
+    ray_t* string_err = ray_write_bytes_fn(p, c);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(string_err));
+    ray_t* bytes_err = ray_write_file_fn(p, bytes);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(bytes_err));
+
+    /* Empty byte vectors truncate/create an empty file. */
+    ray_t* empty = ray_vec_new(RAY_U8, 0);
+    TEST_ASSERT_NOT_NULL(empty);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(empty));
+    ray_t* re = ray_write_bytes_fn(p, empty);
+    TEST_ASSERT_NOT_NULL(re);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(re));
+    fp = fopen(path, "rb");
+    TEST_ASSERT_NOT_NULL(fp);
+    TEST_ASSERT_EQ_I(fgetc(fp), EOF);
+    fclose(fp);
+
     /* Wrong-type paths. */
     ray_t* bad_path = ray_i64(0);
     ray_t* re1 = ray_write_file_fn(bad_path, c);
@@ -7710,6 +7817,13 @@ static test_result_t test_builtin_write_file_fn(void) {
     TEST_ASSERT_TRUE(RAY_IS_ERR(re2));
 
     unlink(path);
+    ray_release(bytes_err);
+    ray_release(string_err);
+    ray_release(eval_write);
+    ray_release(rbb);
+    ray_release(re);
+    ray_release(empty);
+    ray_release(bytes);
     ray_release(re2);
     ray_release(bad_content);
     ray_release(re1);
@@ -9074,6 +9188,7 @@ const test_entry_t lang_entries[] = {
     { "lang/builtin/show",        test_builtin_show_fn,        lang_setup, lang_teardown },
     { "lang/builtin/timeit",      test_builtin_timeit_fn,      lang_setup, lang_teardown },
     { "lang/builtin/load_file",   test_builtin_load_file_fn,   lang_setup, lang_teardown },
+    { "lang/builtin/read_bytes",  test_builtin_read_bytes_fn,  lang_setup, lang_teardown },
     { "lang/builtin/write_file",  test_builtin_write_file_fn,  lang_setup, lang_teardown },
     { "lang/builtin/group_ht_grow_i64",   test_builtin_group_ht_grow_i64,   lang_setup, lang_teardown },
     { "lang/builtin/group_ht_grow_guid",  test_builtin_group_ht_grow_guid,  lang_setup, lang_teardown },


### PR DESCRIPTION
## What & why

Add symmetric binary file I/O builtins alongside the existing text APIs:

- `read` returns `str`; `write` accepts only `str`
- `read-bytes` returns `U8`; `write-bytes` accepts only `U8`
- Preserve embedded NULs and arbitrary byte values, including empty files
- Register both byte operations as restricted builtins and document them

The original file I/O surface only exposed string operations, so callers could not represent arbitrary binary payloads with an explicit byte-oriented contract. Separate strict APIs keep text and binary intent clear without compatibility concerns because this feature has not shipped.

Impact: Rayfall code can now round-trip binary files exactly. Existing text behavior remains unchanged, and cross-type writes fail with a type error.

## Checks

- [x] Clean ASan/UBSan build
- [x] `make test` — 3675/3675 passed
- [x] `mkdocs build --strict`
- [x] `git diff --check`

## Checklist

- [x] PR targets `dev` (not `master`)
- [x] Commits follow Conventional Commits (`feat:` / `fix:` / `perf:` / `docs:` / …)
- [x] `make` builds cleanly (no new warnings)
- [x] `make test` passes; tests added/updated for behaviour changes
