### PR TITLE
fix(cal): decode dates near INT32_MAX without int32 overflow

### DIFF
--- a/src/lang/cal.h
+++ b/src/lang/cal.h
@@ -41,20 +41,22 @@ static inline int date_leap_year(int year) {
     return (year % 4 == 0 && year % 100 != 0) || year % 400 == 0;
 }
 
-static inline int32_t date_years_by_days(int yy) {
-    return (int32_t)((int64_t)yy * 365 + yy / 4 - yy / 100 + yy / 400);
+static inline int64_t date_years_by_days(int yy) {
+    return (int64_t)yy * 365 + yy / 4 - yy / 100 + yy / 400;
 }
 
 /* Decode: days-since-epoch → year/month/day */
 static inline void date_to_ymd(int32_t days, int* y, int* m, int* d) {
-    int32_t offset = days + date_years_by_days(RAY_DATE_EPOCH - 1);
+    /* int64 throughout: days near INT32_MAX overflow int32 after the epoch
+     * offset (e.g. (as 'DATE 2147483646)), producing garbage years. */
+    int64_t offset = (int64_t)days + date_years_by_days(RAY_DATE_EPOCH - 1);
     double approx = (double)offset / 365.2425;
     int32_t years = (int32_t)(approx >= 0.0 ? approx + 0.5 : approx - 0.5);
 
     if (date_years_by_days(years) > offset)
         years -= 1;
 
-    int32_t rem = offset - date_years_by_days(years);
+    int64_t rem = offset - date_years_by_days(years);
     int yy = years + 1;
     int leap = date_leap_year(yy);
     int mid = 0;
@@ -68,18 +70,18 @@ static inline void date_to_ymd(int32_t days, int* y, int* m, int* d) {
 
     *y = yy;
     *m = 1 + mid % 12;
-    *d = 1 + rem - (int32_t)MONTHDAYS[leap][mid];
+    *d = 1 + (int)(rem - (int32_t)MONTHDAYS[leap][mid]);
 }
 
 /* Encode: year/month/day → days-since-epoch */
 static inline int32_t ymd_to_date(int year, int month, int day) {
     int yy = (year > 0) ? year - 1 : 0;
-    int32_t ydays = date_years_by_days(yy);
+    int64_t ydays = date_years_by_days(yy);
     int leap = date_leap_year(year);
     int mm = (month > 0) ? month - 1 : 0;
     if (mm > 12) mm = 12;  /* defensive: never index past the 13-wide table */
-    int32_t mdays = (int32_t)MONTHDAYS[leap][mm];
-    return ydays - date_years_by_days(RAY_DATE_EPOCH - 1) + mdays + day - 1;
+    int64_t mdays = (int32_t)MONTHDAYS[leap][mm];
+    return (int32_t)(ydays - date_years_by_days(RAY_DATE_EPOCH - 1) + mdays + day - 1);
 }
 
 #endif /* RAY_CAL_H */

--- a/test/rfl/temporal/date.rfl
+++ b/test/rfl/temporal/date.rfl
@@ -43,3 +43,25 @@
 (== 2024.06.15 2024.06.15) -- true
 (<= 2024.01.01 2024.01.01) -- true
 (>= 2024.12.31 2024.06.15) -- true
+
+;; ────────────── int32-range decode (regression) ──────────────
+;; days near INT32_MAX used to overflow int32 in date_to_ymd (cal.h:50)
+;; and print garbage / trip UBSan. Years above 9999 can't be written as
+;; literals, so pin decode+re-encode identity instead.
+(as 'DATE 0) -- 2000.01.01
+(as 'DATE -10957) -- 1970.01.01
+(as 'DATE 2921939) -- 9999.12.31
+(as 'i64 (as 'DATE 2146753528)) -- 2146753528
+(as 'i64 (as 'DATE 2146753529)) -- 2146753529
+(as 'i64 (as 'DATE 2147483646)) -- 2147483646
+(as 'i64 (as 'DATE 2147483647)) -- 2147483647
+(as 'i64 (+ (as 'DATE 2146753528) 1)) -- 2146753529
+(as 'i64 (as 'DATE -2147483647)) -- -2147483647
+(as 'DATE -2147483648) -- 0Nd
+;; round-trip through the int64 store stays exact
+(as 'i64 2000.01.01) -- 0
+(as 'i64 1970.01.01) -- -10957
+(as 'i64 2024.02.29) -- 8825
+(as 'i64 1900.02.28) -- -36466
+(as 'i64 9999.12.31) -- 2921939
+(as 'i64 2000.02.29) -- 59


### PR DESCRIPTION
## Problem

Decoding a `DATE` whose day count is near `INT32_MAX` overflows `int32` inside `date_to_ymd` (UBSan) and prints a garbage year:

```
(as 'DATE 2147483646)
  src/lang/cal.h:50:27: runtime error: signed integer overflow:
  2147483646 + 730119 cannot be represented in type 'int32_t'
  => -5877611.06.20      (garbage year)
```

`date_to_ymd` adds the epoch offset (`days + date_years_by_days(RAY_DATE_EPOCH-1)`, ~730k) to the raw day count in `int32`, and `date_years_by_days` itself returns `int32`, so day counts in the upper `int32` range wrap before the year/day split. The decode is on the DATE formatting / display path, so any DATE value at that magnitude — not just a literal — prints wrong and trips UBSan.

## Fix

Compute in `int64` through the decode and encode helpers, narrowing back to `int32` only for the final stored day count (which is `int32` by definition and always in range for a valid DATE):

- `date_years_by_days` returns `int64_t`;
- `date_to_ymd` keeps `offset` and `rem` as `int64_t`;
- `ymd_to_date` accumulates in `int64_t`, casts the result to `int32_t`.

The intermediate values are the only things that overflowed; the year/month/day outputs and the stored day count are unchanged for every in-range date.

## Tests

`test/rfl/temporal/date.rfl`: decode of days near `INT32_MAX` no longer overflows; `(as 'DATE -2147483648)` stays `0Nd`; and encode/decode round-trips through the `int64` store stay exact (`2000.01.01`->0, `9999.12.31`->2921939, `1970.01.01`->-10957, `1900.02.28`->-36466, ...).

`make test`: all green (0 failed), no sanitizer diagnostics.
