### PR TITLE
refactor(ops): drop unreachable ISNULL paths; pin load-select mask regression

### DIFF
--- a/src/ops/expr.c
+++ b/src/ops/expr.c
@@ -2699,17 +2699,7 @@ ray_t* exec_elementwise_unary(ray_graph_t* g, ray_op_t* op, ray_t* input) {
             out_off += n;
         }
     } else if (in_type == RAY_I64 && out_type == RAY_BOOL) {
-        if (opc == OP_ISNULL) {
-            /* ISNULL over a non-null vec: always false here; the
-             * null-propagation pass at the end of the function sets
-             * dst[i]=1 for null rows of the input. */
-            while (ray_morsel_next(&m)) {
-                int64_t n = m.morsel_len;
-                uint8_t* dst = (uint8_t*)((char*)ray_data(result) + out_off);
-                for (int64_t i = 0; i < n; i++) dst[i] = 0;
-                out_off += n;
-            }
-        } else if (opc == OP_CAST) {
+        if (opc == OP_CAST) {
             /* (as 'BOOL i64_col) — truthy semantics; NULL_I64 = INT64_MIN
              * sentinel is non-zero but logically missing, so skip it. */
             while (ray_morsel_next(&m)) {
@@ -2854,18 +2844,10 @@ ray_t* exec_elementwise_unary(ray_graph_t* g, ray_op_t* op, ray_t* input) {
         }
     }
 
-    /* Propagate null bitmap from input to result.
-     * ISNULL is special: set output to 1 for null elements. */
-    if (vec_may_have_nulls(input)) {
-        if (op->opcode == OP_ISNULL) {
-            for (int64_t i = 0; i < len; i++) {
-                if (ray_vec_is_null(input, i))
-                    ((uint8_t*)ray_data(result))[i] = 1;
-            }
-        } else {
-            propagate_nulls(input, result, len);
-        }
-    }
+    /* Propagate null bitmap from input to result.  OP_ISNULL never reaches
+     * here — it is handled and returned before the typed dispatch above. */
+    if (vec_may_have_nulls(input))
+        propagate_nulls(input, result, len);
 
     /* OP_NEG/OP_ABS over i64: |INT64_MIN| and -INT64_MIN don't fit — surface
      * as typed null (by convention).  Loop above used unsigned wrap, so

--- a/test/rfl/regress/load_select_isnull_mask.rfl
+++ b/test/rfl/regress/load_select_isnull_mask.rfl
@@ -1,0 +1,51 @@
+;; Regression: load → select ISNULL WHERE-mask corruption.
+;;
+;; exec_elementwise_unary once had dedicated ISNULL kernels for only some
+;; input types; every other type fell through the typed morsel dispatch
+;; without writing a byte, so the BOOL result buffer came back as whatever
+;; the allocator recycled.  Trigger: a splayed table with a file .sym
+;; domain, queried after a `load` interned new symbols — the FILE-domain
+;; SYM column then bails from the fused expression path
+;; (EXPR_BAIL_SYM_DOMAIN) into the typed fallback, and
+;; `(select {where: (nil? sym)})` over 1000 rows returned 0, 539, 570 or
+;; 1000 rows depending only on the size of the previously loaded file.
+;;
+;; OP_ISNULL is now answered for every input type before the typed
+;; dispatch (expr.c exec_elementwise_unary); this file pins the original
+;; end-to-end symptom.
+
+(.sys.exec "rm -rf /tmp/rfl_isnull_mask") -- 0
+(.sys.exec "mkdir -p /tmp/rfl_isnull_mask") -- 0
+
+;; 1000-row table: SYM column cycling aa..dd (never null), I64 column with
+;; nulls at rows 0 and 999, F64 column with a null at row 500.
+(set SymM (at [aa bb cc dd] (% (til 1000) 4)))
+(set QtyM (concat (concat [0N] (+ 1 (til 998))) [0N]))
+(set PxM (as 'F64 (concat (concat (til 500) [0N]) (+ 501 (til 499)))))
+(set T-Mask (table [sym qty px] (list SymM QtyM PxM)))
+(.db.splayed.set "/tmp/rfl_isnull_mask/t" T-Mask "/tmp/rfl_isnull_mask/sym")
+
+;; Pad script: 60 `(set padN 1)` lines.  Loading it interns 60 symbols the
+;; file .sym domain doesn't have, reproducing the original trigger.
+(.sys.exec "awk 'BEGIN{for(i=1;i<=60;i++) printf \"(set pad%d 1)\\n\", i}' > /tmp/rfl_isnull_mask/pad.rfl") -- 0
+(load "/tmp/rfl_isnull_mask/pad.rfl")
+pad60 -- 1
+
+(set S-Mask (.db.splayed.get "/tmp/rfl_isnull_mask/t" "/tmp/rfl_isnull_mask/sym"))
+(count S-Mask) -- 1000
+
+;; SYM: no null syms, so the mask must be all-false — every row survives
+;; `not nil?` and none survives `nil?`.  Pre-fix this pair was the garbage
+;; readout (0 / 539 / 570 of 1000).
+(count (select {from: S-Mask where: (not (nil? sym))})) -- 1000
+(count (select {from: S-Mask where: (nil? sym)})) -- 0
+
+;; Sentinel nulls survive the round trip and drive the mask exactly.
+(count (select {from: S-Mask where: (nil? qty)})) -- 2
+(count (select {from: S-Mask where: (not (nil? qty))})) -- 998
+(count (select {from: S-Mask where: (nil? px)})) -- 1
+
+;; The WHERE mask agrees with per-element evaluation of the same predicate.
+(sum (map nil? (at S-Mask 'sym))) -- 0
+(sum (map nil? (at S-Mask 'qty))) -- 2
+(sum (map nil? (at S-Mask 'px))) -- 1


### PR DESCRIPTION
## What this PR is now

Reworked per review onto current dev (a93763c3). The original uninitialized-ISNULL-mask bug this branch fixed was fixed more completely on dev by bfb5b380 (`exec_elementwise_unary` now answers `OP_ISNULL` for every input type before the typed dispatch). What dev still carried was the dead code that early-out orphaned, and no end-to-end repro of the original symptom. This PR supplies both:

- **Delete the unreachable I64→BOOL ISNULL kernel** in the typed dispatch — the `OP_ISNULL` early-out returns before any dispatch branch runs, so this kernel could never execute and merely duplicated a zero-fill.
- **Delete the unreachable ISNULL arm of the null-propagation pass** — same reason; the pass now unconditionally does `propagate_nulls` for the ops that reach it.
- **Add `test/rfl/regress/load_select_isnull_mask.rfl`** pinning the original load→select symptom: a 1000-row splayed table with a file `.sym` domain, a `load` that interns 60 fresh symbols (flipping the FILE-domain SYM column off the fused path into the typed fallback), then `nil?` / `not nil?` WHERE counts over SYM, I64 and F64 columns, cross-checked against per-element `map nil?`. Pre-bfb5b380 this returned 0/539/570/1000 of 1000 rows depending on allocator garbage; neither the original fix here nor bfb5b380 pinned the repro.

No vec.c change: the dead `case RAY_STR:` flagged earlier is already gone on dev — bfb5b380 made the SYM/STR payload-null checks live at the top of `ray_vec_is_null`.

## Validation

- Full suite on the rebased branch (UBSan build): 3710 of 3711 passed, 1 skipped, 0 failed.
- The new regression test fails meaningfully if the early-out regresses (verified it exercises the FILE-domain fallback trigger from the original report).
