### PR TITLE
fix(datalog): reject forged dl-program handles instead of dereferencing them

### DIFF
--- a/src/mem/heap.h
+++ b/src/mem/heap.h
@@ -91,6 +91,15 @@
  * Checked by HNSW builtins before dereferencing.  User must (hnsw-free h). */
 #define RAY_ATTR_HNSW         0x04
 
+/* I64 atom carries an owning dl_program_t* (a Datalog program) in its .i64
+ * slot.  Checked by the dl-* builtins before dereferencing, so a forged/plain
+ * integer or an arithmetic copy (which drops attrs) is rejected with a type
+ * error instead of being reinterpreted as a pointer — see dl_unwrap_program.
+ * Reuses 0x20 (RAY_ATTR_SORTED on vectors / ATTR_QUOTED on -RAY_SYM); the
+ * -RAY_I64 type tag disambiguates, and no free-path or generic check reads
+ * 0x20 on a -RAY_I64 atom.  User must (dl-free h). */
+#define RAY_ATTR_DLPROG       0x20
+
 /* Vector is a linked column.  The 8 bytes of the aux union at offset
  * 8 (i.e. parent->_idx_pad / parent->slice_offset / parent->str_pool
  * slot, depending on which arm is in use) hold an int64

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -4409,18 +4409,23 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
  * Programmatic Datalog API builtins
  * ══════════════════════════════════════════ */
 
-/* Opaque handle for dl_program_t stored in a ray_t atom.
- * We store the pointer in the i64 field. */
+/* Opaque handle for dl_program_t stored in a ray_t atom.  The pointer lives
+ * in the i64 field, tagged with RAY_ATTR_DLPROG so dl_unwrap_program can reject
+ * a plain integer (or an arithmetic copy, which does not carry the attr)
+ * instead of dereferencing an arbitrary value as a dl_program_t*.  Mirrors the
+ * RAY_ATTR_GRAPH / RAY_ATTR_HNSW handle scheme. */
 static ray_t* dl_wrap_program(dl_program_t* prog) {
     ray_t* obj = ray_alloc(0);
     if (!obj || RAY_IS_ERR(obj)) return ray_error("oom", NULL);
     obj->type = -RAY_I64;
     obj->i64 = (int64_t)(uintptr_t)prog;
+    obj->attrs |= RAY_ATTR_DLPROG;
     return obj;
 }
 
 static dl_program_t* dl_unwrap_program(ray_t* obj) {
-    if (!obj || obj->type != -RAY_I64) return NULL;
+    if (!obj || obj->type != -RAY_I64 || !(obj->attrs & RAY_ATTR_DLPROG))
+        return NULL;
     return (dl_program_t*)(uintptr_t)obj->i64;
 }
 
@@ -4514,16 +4519,22 @@ ray_t* ray_dl_provenance_fn(ray_t* prog_obj, ray_t* pred_obj) {
 /* (dl-free prog) — free a dl-program handle created by (dl-program).
  * The handle wraps a raw dl_program_t* with no automatic finalizer, so
  * without an explicit free the program block and all relation tables it
- * owns leak. Idempotent: zeroes the handle so a second call is a no-op
- * (returns false) instead of double-freeing. */
+ * owns leak.  On free we clear RAY_ATTR_DLPROG and zero the pointer, so a
+ * second call is an idempotent no-op (returns false) rather than a
+ * double-free.  A tagged pointer that isn't an i64 is a type error, and a
+ * plain/forged integer (RAY_ATTR_DLPROG absent, non-zero value) is rejected
+ * as a type error instead of being dereferenced as a dl_program_t*. */
 ray_t* ray_dl_free_fn(ray_t* x) {
     if (!x || x->type != -RAY_I64)
         return ray_error("type", "dl-free: arg must be a dl-program");
-    dl_program_t* prog = dl_unwrap_program(x);
-    if (!prog) return ray_bool(false);  /* already freed / null handle */
-    dl_program_free(prog);
-    x->i64 = 0;
-    return ray_bool(true);
+    if (x->attrs & RAY_ATTR_DLPROG) {
+        dl_program_free((dl_program_t*)(uintptr_t)x->i64);
+        x->attrs &= (uint8_t)~RAY_ATTR_DLPROG;
+        x->i64 = 0;
+        return ray_bool(true);
+    }
+    if (x->i64 == 0) return ray_bool(false);  /* already-freed handle: idempotent */
+    return ray_error("type", "dl-free: not a dl-program handle");
 }
 
 /* Reset global Datalog rule storage (called from ray_lang_destroy) */

--- a/test/rfl/datalog/datalog_coverage.rfl
+++ b/test/rfl/datalog/datalog_coverage.rfl
@@ -544,6 +544,24 @@
 (dl-query FP 'edge) !- type
 (dl-free 'notprog) !- type
 
+;; --- Claim 5b: forged/copied dl-program handles must not be dereferenced ---
+;; A plain integer is NOT a dl-program handle.  Every dl-* builtin that unwraps
+;; one must reject it with a type error rather than reinterpreting the value as
+;; a dl_program_t* pointer — before the RAY_ATTR_DLPROG tag check, (dl-free 1)
+;; and friends dereferenced address 1 and crashed with SIGSEGV.
+(dl-free 1) !- type
+(dl-stratify 1) !- type
+(dl-eval 1) !- type
+(dl-query 1 'edge) !- type
+(dl-add-edb 1 'edge (table ['a 'b] (list [1] [2])) 2) !- type
+;; An arithmetic copy of a live handle drops the tag (attrs are not carried
+;; through arithmetic), so it can't be freed — which would otherwise
+;; double-free the original.  The original still frees exactly once.
+(set CP (dl-program))
+(set CPcopy (+ CP 0))
+(dl-free CPcopy) !- type
+(dl-free CP) -- true
+
 
 ;; --- Claim 4: fixpoint non-convergence must error loudly, not return a partial result ---
 ;; Reachability over a linear chain needs ~N iterations. The loop caps at 1000.


### PR DESCRIPTION
## How it looks from the user's side

A single line — a typo, or a stray value from an IPC client — takes the whole process down.

**Before** (unpatched `dev`), a user types `(dl-free 1)`:

```text
src/ops/datalog.c:66:31: runtime error: member access within misaligned address
0x000000000001 for type 'dl_program_t', which requires 8 byte alignment

=== rayforce fatal SIGSEGV at fault addr 0x0000000000003a01 ===
2   rayforce   dl_program_free + 192
3   rayforce   ray_dl_free_fn + 416
4   rayforce   ray_eval + 16932
5   rayforce   ray_repl_run_file + 2672
6   rayforce   main + 14000
=== end backtrace ===
```

The value `1` is dereferenced as a `dl_program_t*`. Every `dl-*` builtin unwraps its handle argument, so `(dl-stratify 1)`, `(dl-query 1 'r)`, `(dl-eval 1)`, `(dl-add-edb 1 …)` crash the same way. On a server evaluating client input over IPC (`-U`/`-i`) this is **remotely triggerable** — one client kills every connected session — and since the integer is used directly as a pointer to `free()`/dereference, an attacker-chosen value is an **arbitrary-pointer free/deref** (memory corruption), not merely a DoS.

**After** (this PR) — the same inputs return a clean type error and the process keeps running:

```text
    (dl-free 1)                error: type: dl-free: not a dl-program handle   (exit 1, no crash)

  A user (or IPC client) passes stray / forged values:
    (dl-free 1)        ->  type error   (before: SIGSEGV)
    (dl-stratify 1)    ->  type error   (before: SIGSEGV)
    (dl-query 1 'rel)  ->  type error   (before: SIGSEGV)

  A copy of a real handle is also refused (no double-free):
    (dl-free (+ P 0))  ->  type error   (copy is not a handle)

  Normal Datalog is unaffected:
    (dl-eval P)        ->  true
    (dl-free P)        ->  true
    (dl-free P) again  ->  false   (idempotent)

  >>> process stayed alive the entire time — no crash.
```

## Fix

Tag the handle atom with `RAY_ATTR_DLPROG`, mirroring the existing `RAY_ATTR_GRAPH` / `RAY_ATTR_HNSW` handle scheme, and verify it in `dl_unwrap_program`:

```c
static ray_t* dl_wrap_program(dl_program_t* prog) {
    ...
    obj->i64   = (int64_t)(uintptr_t)prog;
    obj->attrs |= RAY_ATTR_DLPROG;      // tag
    return obj;
}
static dl_program_t* dl_unwrap_program(ray_t* obj) {
    if (!obj || obj->type != -RAY_I64 || !(obj->attrs & RAY_ATTR_DLPROG))
        return NULL;                     // forged/plain integer → rejected
    return (dl_program_t*)(uintptr_t)obj->i64;
}
```

`dl-free` clears the tag and zeroes the pointer on free, so it keeps its **idempotent-`false`** contract for a genuine double-free (`datalog_coverage.rfl` line 542) while rejecting a forged handle with a type error.

**Bit choice:** `RAY_ATTR_DLPROG` reuses `0x20` (same value as `RAY_ATTR_SORTED` on vectors / `ATTR_QUOTED` on `-RAY_SYM`). Those meanings are vector- / `-RAY_SYM`-scoped and are never read on a `-RAY_I64` atom, and — unlike `HAS_INDEX` (0x08) / `SLICE` (0x10) / `ARENA` (0x80) — no heap free-path or finalizer reads `0x20`, so there is no collision on GC. This is the same context-reuse the codebase already does (`RAY_ATTR_HNSW` and `RAY_ATTR_HAS_LINK` share `0x04`).

## Also fixed by the same tag

- **Arithmetic-copy double-free**: `(+ h 0)` produces a fresh `i64` without the tag, so a copy can no longer be freed (which would double-free the original). The original still frees exactly once.
- **Snapshot / `ser`→`de` restored stale handle**: serialization strips atom attrs, so a restored handle loses the tag and is rejected instead of dereferencing an address from the previous process. Verified: `(dl-free (de (ser (dl-program))))` → type error, no crash.

Out of scope (separate follow-ups): a dropped handle still leaks (needs a heap finalizer entry), and restricted-IPC clients can still call `dl-free` (needs `RAY_FN_RESTRICTED`).

## Tests

`test/rfl/datalog/datalog_coverage.rfl`: forged-handle rejection for `dl-free` / `dl-stratify` / `dl-eval` / `dl-query` / `dl-add-edb`, and the arithmetic-copy double-free case. The existing handle-lifecycle claims (free → idempotent-`false` → use-after-free type error) are unchanged.

Full ASan+UBSan suite green: `3708 of 3709 passed (1 skipped, 0 failed)`.
