### PR TITLE
fix(system): reject partially-numeric .ipc.open ports

### DIFF
--- a/src/ops/system.c
+++ b/src/ops/system.c
@@ -1435,8 +1435,16 @@ ray_t* ray_hopen_fn(ray_t** args, int64_t n) {
     if (part_lens[1] >= sizeof(port_str)) return ray_error("domain", ".ipc.open port field too long, got %lld bytes", (long long)part_lens[1]);
     memcpy(port_str, parts[1], part_lens[1]);
     port_str[part_lens[1]] = '\0';
-    int port = atoi(port_str);
-    if (port <= 0 || port > 65535) return ray_error("domain", ".ipc.open port must be in 1..65535, got %d", port);
+    /* Strict parse: atoi("1abc") returns 1, silently accepting a malformed
+     * port with a numeric prefix.  Require the whole field to be digits. */
+    char* endp;
+    errno = 0;
+    long port_l = strtol(port_str, &endp, 10);
+    if (endp == port_str || *endp != '\0')
+        return ray_error("domain", ".ipc.open port must be numeric 1..65535, got \"%s\"", port_str);
+    if (errno == ERANGE || port_l <= 0 || port_l > 65535)
+        return ray_error("domain", ".ipc.open port must be in 1..65535, got \"%s\"", port_str);
+    int port = (int)port_l;
 
     char user[128] = "";
     char password[128] = "";

--- a/test/rfl/system/system_branch_cov2.rfl
+++ b/test/rfl/system/system_branch_cov2.rfl
@@ -130,6 +130,11 @@
 (.ipc.open "localhost:-1") !- domain
 (.ipc.open "localhost:65536") !- domain
 (.ipc.open "localhost:abc") !- domain
+;; Partial-numeric ports must be rejected, not truncated by atoi to their
+;; numeric prefix ("1abc" -> 1).  strtol requires the whole field to be digits,
+;; so these are a domain error at parse time — never a connection attempt.
+(.ipc.open "localhost:1abc") !- domain
+(.ipc.open "localhost:19876x") !- domain
 (.ipc.open "127.0.0.1:19876") !- io
 (.ipc.open "127.0.0.1:19876:user:pass") !- io
 (.ipc.open "127.0.0.1:19876:extra") !- io


### PR DESCRIPTION
## How it looks from the user's side

A user opens an IPC connection but the port field has a typo, or trailing garbage — `1abc` instead of `1234`:

```clojure
(.ipc.open "127.0.0.1:1abc" 1)
```

**Before** — `atoi("1abc")` stops at the first non-digit and returns `1`, so the client silently targets the *wrong* port. The user gets a confusing error naming a port they never typed:

```text
error: io: connection refused: 127.0.0.1:1
```

**After** — the malformed field is rejected up front, before any socket work, with a message that names the actual input:

```text
error: domain: .ipc.open port must be numeric 1..65535, got "1abc"
```

(`"abc"` and `"70000"` already errored — `atoi("abc") == 0` fails the `<= 0` check and `70000` fails `> 65535` — so only the numeric-prefix case slipped through.)

## Fix

`.ipc.open` parsed the port field with `atoi()`, which stops at the first non-digit. Parse it with `strtol` instead and require the whole field to be digits (reject any trailing characters), keeping the `1..65535` range check plus `ERANGE`. A malformed port is now a `domain` error at parse time, before any connection attempt.

## Tests

Adds `"1abc"` / `"19876x"` cases to `test/rfl/system/system_branch_cov2.rfl`, alongside the existing `abc` / `70000` / `-1` / `0` port-validation checks.

Full ASan+UBSan suite green: `3712 of 3713 passed (1 skipped, 0 failed)`.
