### PR TITLE
feat(repl): add .repl.complete namespace completion verb (#441)

### DIFF
--- a/src/app/repl.c
+++ b/src/app/repl.c
@@ -40,6 +40,7 @@
 #include "lang/parse.h"
 #include "lang/syscmd.h"
 #include "mem/heap.h"
+#include "mem/sys.h"
 #include "ops/ops.h"
 #include "core/profile.h"
 #include "core/qlog.h"
@@ -665,6 +666,56 @@ ray_t* ray_repl_disconnect_fn(ray_t** args, int64_t n) {
     g_remote_addr[0]   = '\0';
     if (g_active_term) ray_term_set_prompt_prefix(g_active_term, NULL);
     return RAY_NULL_OBJ;
+}
+
+/* strcmp comparator over char* cells, for sorting completion candidates. */
+static int repl_comp_cmp(const void* a, const void* b) {
+    return strcmp(*(const char* const*)a, *(const char* const*)b);
+}
+
+/* (.repl.complete "prefix") -> sorted sym vector of namespace candidates
+ * whose name begins with `prefix`: builtins, keywords, and user bindings.
+ *
+ * This is the engine side of the REPL's own tab-completion (issue #441),
+ * exposed as a read-only verb so editor tooling can query it over IPC and
+ * get semantic completion of names the engine knows in the live session,
+ * not just a static keyword list.  It reuses ray_env_lookup_prefix — the
+ * same primitive the terminal client's completion draws from — so the two
+ * can never drift.  History-word completion is intentionally omitted: it
+ * is client-local and meaningless to a remote caller. */
+ray_t* ray_repl_complete_fn(ray_t* prefix_str) {
+    if (!ray_is_atom(prefix_str) || prefix_str->type != -RAY_STR)
+        return ray_error("type", ".repl.complete expects a string prefix, got %s",
+                         ray_type_name(prefix_str->type));
+
+    const char* prefix = ray_str_ptr(prefix_str);
+    int64_t     plen   = (int64_t)ray_str_len(prefix_str);
+
+    /* Size the candidate buffer to cover every global binding plus
+     * headroom for the static keyword list.  ray_env_lookup_prefix caps
+     * itself at max_results and dedups, so this never overruns. */
+    int64_t      cap     = (int64_t)ray_env_global_count() + 256;
+    const char** results = (const char**)ray_sys_alloc((size_t)cap * sizeof(const char*));
+    if (!results) return ray_error("oom", NULL);
+
+    int64_t count = ray_env_lookup_prefix(prefix ? prefix : "", plen, results, cap);
+
+    /* Sort for a stable, editor-friendly ordering (mirrors .fs.list). */
+    if (count > 1)
+        qsort(results, (size_t)count, sizeof(const char*), repl_comp_cmp);
+
+    ray_t* out = ray_vec_new(RAY_SYM, count);
+    if (!out || RAY_IS_ERR(out)) {
+        ray_sys_free(results);
+        return out ? out : ray_error("oom", NULL);
+    }
+    out->len = count;
+    int64_t* ids = (int64_t*)ray_data(out);
+    for (int64_t i = 0; i < count; i++)
+        ids[i] = ray_sym_intern(results[i], strlen(results[i]));
+
+    ray_sys_free(results);
+    return out;
 }
 
 /* eval_and_print's remote branch: send the raw input string to the

--- a/src/app/repl.h
+++ b/src/app/repl.h
@@ -61,5 +61,6 @@ const char* ray_repl_remote_addr(void);
 
 ray_t* ray_repl_connect_fn(ray_t* host_port_str);
 ray_t* ray_repl_disconnect_fn(ray_t** args, int64_t n);
+ray_t* ray_repl_complete_fn(ray_t* prefix_str);
 
 #endif /* RAY_IO_REPL_H */

--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -3407,6 +3407,10 @@ static void ray_register_builtins(void) {
      * src/app/repl_remote.c for the state model. */
     register_unary(".repl.connect",    RAY_FN_RESTRICTED, ray_repl_connect_fn);
     register_vary( ".repl.disconnect", RAY_FN_RESTRICTED, ray_repl_disconnect_fn);
+    /* Read-only namespace completion (issue #441): builtins + keywords +
+     * user bindings whose name begins with the given prefix.  RAY_FN_NONE
+     * so remote editor clients can query it over IPC. */
+    register_unary(".repl.complete",   RAY_FN_NONE,       ray_repl_complete_fn);
 
     /* Transaction-log journaling under `.log.*` — the -l/-L feature.
      * The CLI flags -l <base> / -L <base> call ray_journal_open() at

--- a/test/rfl/system/repl_complete.rfl
+++ b/test/rfl/system/repl_complete.rfl
@@ -1,0 +1,32 @@
+;; .repl.complete — prefix completion over the live namespace (issue #441).
+;;
+;; Wraps ray_env_lookup_prefix (builtins + keywords + user bindings),
+;; sorts, and returns a sym vector.  This is the engine side of "what the
+;; REPL does", now reachable over IPC so editor tooling (tree-sitter /
+;; LSP-style clients) can offer semantic completion of names the engine
+;; knows at runtime — not just static keywords.
+
+;; ── user bindings are completed, and the result is sorted ──
+(set zzq_alpha 1)
+(set zzq_gamma 3)
+(set zzq_beta  2)
+(.repl.complete "zzq_") -- ['zzq_alpha 'zzq_beta 'zzq_gamma]
+
+;; ── a narrower prefix narrows the candidate set ──
+(.repl.complete "zzq_a") -- ['zzq_alpha]
+
+;; ── no match → empty vector ──
+(count (.repl.complete "zzq_no_such_prefix_xyzzy")) -- 0
+
+;; ── the set includes builtins/keywords, not just user names
+;;    (membership so the assertion survives future additions) ──
+(in 'take   (.repl.complete "take")) -- true
+(in 'select (.repl.complete "sel"))  -- true
+
+;; ── the verb is self-discoverable, and dotted names round-trip ──
+(in '.repl.complete (.repl.complete ".repl.")) -- true
+
+;; ── type errors: the argument must be a string atom ──
+(.repl.complete 42)    !- type
+(.repl.complete 'zzq_) !- type
+(.repl.complete [1 2]) !- type


### PR DESCRIPTION
Closes #441.

Vincent (@vbmithr) built a tree-sitter grammar + emacs extension for Rayfall and asked for a completion endpoint so editor tooling can suggest names the way the REPL does.

A grammar gives the *syntax* tree; completing function names, user bindings, and tables is *semantic* — it depends on what's bound in the live session, which only the engine knows. The REPL already computes this, but the logic lived entirely in the terminal client (`ray_term_collect_completions`) and wasn't reachable over IPC.

### Change

Adds `.repl.complete "prefix"` — a read-only (`RAY_FN_NONE`) verb returning a sorted `sym` vector of builtins, keywords, and user bindings whose name begins with the prefix:

```
(set greet_a 1) (set greet_b 2)
(.repl.complete "gr")     -> ['greet_a 'greet_b]
(.repl.complete "sel")    -> ['select ...]
(.repl.complete ".repl.") -> ['.repl.complete '.repl.connect '.repl.disconnect]
```

It reuses `ray_env_lookup_prefix` — the same primitive the terminal client's tab-completion draws from — so the two can't drift. Because it runs against the caller's live session, a connected editor gets the actual functions and tables bound there, not a static keyword list. History-word completion is deliberately omitted (client-local, meaningless to a remote caller).

`RAY_FN_NONE` so remote editor clients (`-U`) can query it over IPC; it exposes only binding *names*. Return shape mirrors `.fs.list` (sorted sym vector).

### Tests

`test/rfl/system/repl_complete.rfl`: sorted user-binding completion, prefix narrowing, empty result, builtin/keyword membership, self-discovery of the verb, dotted-name round-trip, and type errors on non-string input.

### Follow-up

Context-aware column completion (`from:`-scoped) — the terminal already does this locally; exposing it is a natural next step.

https://claude.ai/code/session_01UuALKV4AXnW8uqw9NyMkHa
