### PR TITLE
fix(serde): reject table frames with mismatched schema/column counts

### DIFF
--- a/src/store/serde.c
+++ b/src/store/serde.c
@@ -801,6 +801,17 @@ static ray_t* de_raw_inner(uint8_t* buf, int64_t* len) {
             return e;
         }
 
+        /* Schema names and columns must be 1:1.  The build loop below is
+         * bounded by min(cols->len, schema->len), so a crafted frame with a
+         * shorter schema (or more columns) would otherwise be accepted as a
+         * silently truncated table instead of being rejected. */
+        if (schema->len != cols->len) {
+            ray_t* e = ray_error("domain", "deserialize table: schema/column count mismatch (%lld names, %lld columns)", (long long)schema->len, (long long)cols->len);
+            ray_release(schema);
+            ray_release(cols);
+            return e;
+        }
+
         int64_t ncols = cols->len;
         ray_t* tbl = ray_table_new(ncols);
         if (!tbl || RAY_IS_ERR(tbl)) {

--- a/test/rfl/system/serde.rfl
+++ b/test/rfl/system/serde.rfl
@@ -28,3 +28,14 @@
 ;; Both the value bits AND the null mask must survive serialize/deser.
 (count (de (ser [1 0N 3]))) -- 3
 (sum (de (ser [1 0N 3])))   -- 4
+
+;; ────────────── table frame: schema/column count must match ──────────────
+;; The table decoder loops over min(cols->len, schema->len), so a crafted frame
+;; whose schema names and columns disagree would be silently accepted as a
+;; truncated table.  Splice a 2-name i64 schema with a 1-column list into one
+;; table payload ([0x62 attrs] + ser(schema) + ser(cols), each self-consistent)
+;; and confirm it is rejected rather than decoded as a 1-column table.
+(set _s74p (concat (concat (as 'U8 [0x62 0x00]) (drop (ser (as 'I64 [7 7])) 16)) (drop (ser (list (as 'I64 [1]))) 16)))
+(set _s74h (take (ser 0) 16))
+(set _s74f (concat (concat (concat (take _s74h 8) (as 'U8 (enlist (count _s74p)))) (drop _s74h 9)) _s74p))
+(de _s74f) !- domain


### PR DESCRIPTION
## How it looks from the user's side

`de` — and object file-load / IPC decode, which share the same path — accepts a serialized table whose schema-name count and column count disagree (the kind of frame a truncated read or a partially-written blob leaves behind) and silently loads it as a *truncated* table instead of erroring.

Reproduced with a hand-crafted frame carrying **2 schema names but 1 column**:

**Before** — the decoder loops over `min(names, columns)`, so the extra name is dropped and the corrupt/truncated frame deserializes into a plausible-but-wrong 1-column table, with no error:

```text
(table [<] (list [1]))
```

**After** — the mismatch is rejected up front:

```text
error: domain: deserialize table: schema/column count mismatch (2 names, 1 columns)
```

The danger is that the truncated table is indistinguishable from a real one, so it flows on into joins/queries/aggregations silently, rather than failing at the point the corruption entered.

## Fix

`ray_de_raw`'s table case set `ncols = cols->len` but bounded the rebuild loop by `min(cols->len, schema->len)`, so a frame with unequal counts was accepted as the shorter of the two (extra columns dropped, or extra schema names ignored). Reject up front when `schema->len != cols->len` with a `domain` error, before building the table.

## Tests

Adds a `serde.rfl` regression that splices a well-formed 2-name i64 schema with a well-formed 1-column list into one table payload and asserts `de` rejects it.

Full ASan+UBSan suite green: `3713 of 3714 passed (1 skipped, 0 failed)`.
