### PR TITLE
fix(mem): hand a cross-thread free back to its owner, and return idle pages to the OS

### DIFF
--- a/src/app/repl.c
+++ b/src/app/repl.c
@@ -813,11 +813,6 @@ static void eval_and_print(ray_term_t* term, const char* input,
     ray_qlog_ctx_t qc;
     ray_qlog_begin(&qc);
 
-    /* Stamp the allocator's idle clock at the START of the statement, so
-     * the decay check after it measures how long we were quiet BEFORE this
-     * line rather than how long the line took. */
-    ray_heap_note_activity();
-
     ray_term_clear_interrupt();
     ray_eval_clear_interrupt();
     if (term) ray_term_eval_begin(term);
@@ -879,11 +874,15 @@ static void eval_and_print(ray_term_t* term, const char* input,
 
     if (profiling) profile_print(use_color);
     ray_heap_gc();
-    /* Statement boundary: if the gap before this line already exceeded the
-     * decay threshold, hand the pages back now.  In a loop of short
-     * statements the gap is the statement's own duration and this is a
-     * timestamp comparison that does nothing. */
+    /* Statement boundary.  Check BEFORE stamping: the clock still holds the
+     * end of the previous statement, so what we measure is the gap between
+     * statements — the time the process actually sat idle.  Stamping first
+     * would measure this statement's own duration instead, and a loop of
+     * statements longer than the threshold would then sweep after every one
+     * of them, discarding the working set the next is about to fault back
+     * in. */
     ray_heap_decay();
+    ray_heap_note_activity();
 }
 
 /* `type_label` and `cmd_match` were inlined into the previous bespoke

--- a/src/app/repl.c
+++ b/src/app/repl.c
@@ -1394,6 +1394,15 @@ int ray_repl_run_file(const char* path) {
 
     /* profile tree goes to stdout via profile_print; honour stdout's tty. */
     if (profiling) profile_print(color_out);
+    /* A whole file is one unit of work, and unlike the REPL there is no
+     * decay check after it — so stamp at the END, not the start.  A script
+     * that exits has nothing to give back; a script that starts a server
+     * and hands over to the poll loop leaves its load-time temporaries
+     * resident, and this is what lets the loop notice them.  Stamping at
+     * the start would instead arm a check that the script's own (.sys.gc)
+     * calls would service mid-run, which is the one thing the threshold
+     * exists to avoid. */
+    ray_heap_note_activity();
     ray_heap_gc();
     return rc;
 }

--- a/src/app/repl.c
+++ b/src/app/repl.c
@@ -813,6 +813,11 @@ static void eval_and_print(ray_term_t* term, const char* input,
     ray_qlog_ctx_t qc;
     ray_qlog_begin(&qc);
 
+    /* Stamp the allocator's idle clock at the START of the statement, so
+     * the decay check after it measures how long we were quiet BEFORE this
+     * line rather than how long the line took. */
+    ray_heap_note_activity();
+
     ray_term_clear_interrupt();
     ray_eval_clear_interrupt();
     if (term) ray_term_eval_begin(term);
@@ -874,6 +879,11 @@ static void eval_and_print(ray_term_t* term, const char* input,
 
     if (profiling) profile_print(use_color);
     ray_heap_gc();
+    /* Statement boundary: if the gap before this line already exceeded the
+     * decay threshold, hand the pages back now.  In a loop of short
+     * statements the gap is the statement's own duration and this is a
+     * timestamp comparison that does nothing. */
+    ray_heap_decay();
 }
 
 /* `type_label` and `cmd_match` were inlined into the previous bespoke

--- a/src/core/epoll.c
+++ b/src/core/epoll.c
@@ -26,6 +26,7 @@
 #include "core/poll.h"
 #include "core/timer.h"
 #include "mem/sys.h"
+#include "mem/heap.h"   /* idle decay: bound the wait, sweep after wakeup */
 #include <sys/epoll.h>
 #include <unistd.h>
 #include <errno.h>
@@ -186,6 +187,18 @@ int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
             }
         }
 
+        /* A process waiting here is a process doing nothing, and this is the
+         * only moment it gets to notice.  Bound the wait by the allocator's
+         * pending decay exactly as a timer would; once the decay has run
+         * there is nothing pending and the wait goes back to indefinite. */
+        {
+            int64_t decay = ray_heap_decay_due_ms();
+            if (decay >= 0) {
+                if (decay > INT_MAX) decay = INT_MAX;
+                if (wait_ms < 0 || decay < wait_ms) wait_ms = (int)decay;
+            }
+        }
+
         int n = epoll_wait((int)poll->fd, events, RAY_POLL_MAX_EVENTS, wait_ms);
         if (n < 0) {
             if (errno == EINTR) continue;
@@ -274,6 +287,10 @@ int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
 
         if (poll->timers)
             ray_timers_fire_expired((ray_timers_t*)poll->timers);
+        /* After the events of this wakeup, not before: a request handled
+         * above has just re-stamped the activity clock, so a busy loop
+         * finds nothing due and pays one timestamp comparison. */
+        ray_heap_decay();
         if (bounded) break;
     }
 

--- a/src/core/epoll.c
+++ b/src/core/epoll.c
@@ -290,8 +290,14 @@ int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
         next_event:;
         }
 
-        if (poll->timers)
-            ray_timers_fire_expired((ray_timers_t*)poll->timers);
+        if (poll->timers) {
+            /* A fired timer is work, and on a timer-driven server it is the
+             * only work there is: without this stamp the decay sees an idle
+             * process mid-workload, and — having disarmed itself — never
+             * looks again. */
+            if (ray_timers_fire_expired((ray_timers_t*)poll->timers) > 0)
+                ray_heap_note_activity();
+        }
         /* After the events of this wakeup, not before: a request handled
          * above has just re-stamped the activity clock, so a busy loop
          * finds nothing due and pays one timestamp comparison. */

--- a/src/core/epoll.c
+++ b/src/core/epoll.c
@@ -190,9 +190,14 @@ int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
         /* A process waiting here is a process doing nothing, and this is the
          * only moment it gets to notice.  Bound the wait by the allocator's
          * pending decay exactly as a timer would; once the decay has run
-         * there is nothing pending and the wait goes back to indefinite. */
+         * there is nothing pending and the wait goes back to indefinite.
+         *
+         * Only when the loop is unbounded.  ray_poll_run_for carries the
+         * caller's own deadline and runs a single pass, so shortening its
+         * wait here returns from it early with nothing done — a timer the
+         * caller was waiting on would not have fired yet. */
         {
-            int64_t decay = ray_heap_decay_due_ms();
+            int64_t decay = bounded ? -1 : ray_heap_decay_due_ms();
             if (decay >= 0) {
                 if (decay > INT_MAX) decay = INT_MAX;
                 if (wait_ms < 0 || decay < wait_ms) wait_ms = (int)decay;

--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -898,11 +898,6 @@ static ray_t* ipc_read_payload(ray_poll_t* poll, ray_selector_t* sel)
     if (!sel->rx.buf || sel->rx.buf->offset < cd->hdr.size)
         return NULL;
 
-    /* A complete request frame is this server's unit of work, and the server
-     * calls no allocator maintenance of its own.  Stamping here is what lets
-     * the poll loop tell an idle server from one between two requests. */
-    ray_heap_note_activity();
-
     /* Detach the payload buffer and advance the state machine to the
      * next header BEFORE dispatching: the eval below may re-enter this
      * connection's rx pump (a hook doing a nested sync round-trip on
@@ -981,6 +976,11 @@ static ray_t* ipc_read_payload(ray_poll_t* poll, ray_selector_t* sel)
             send_response((ray_sock_t)cur->fd, result);
     }
     if (result != RAY_NULL_OBJ) ray_release(result);
+    /* The request is served: this is the end of the server's unit of work,
+     * and stamping here is what lets the poll loop tell an idle server from
+     * one between two requests.  Stamping on frame arrival instead would
+     * make the measured gap the request's own duration. */
+    ray_heap_note_activity();
 
     return NULL;
 }
@@ -1147,6 +1147,11 @@ static void conn_on_payload(ray_ipc_server_t* srv, ray_ipc_conn_t* c)
     if (c->hdr.msgtype == RAY_IPC_MSG_SYNC)
         send_response(c->fd, result);
     if (result != RAY_NULL_OBJ) ray_release(result);
+    /* The request is served: this is the end of the server's unit of work,
+     * and stamping here is what lets the poll loop tell an idle server from
+     * one between two requests.  Stamping on frame arrival instead would
+     * make the measured gap the request's own duration. */
+    ray_heap_note_activity();
 
     ray_sys_free(c->rx_buf);
     c->rx_buf  = NULL;

--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -26,6 +26,7 @@
 #endif
 
 #include "core/ipc.h"
+#include "mem/heap.h"
 #include "mem/sys.h"
 #include "ops/ops.h"
 #include "store/journal.h"
@@ -896,6 +897,11 @@ static ray_t* ipc_read_payload(ray_poll_t* poll, ray_selector_t* sel)
 
     if (!sel->rx.buf || sel->rx.buf->offset < cd->hdr.size)
         return NULL;
+
+    /* A complete request frame is this server's unit of work, and the server
+     * calls no allocator maintenance of its own.  Stamping here is what lets
+     * the poll loop tell an idle server from one between two requests. */
+    ray_heap_note_activity();
 
     /* Detach the payload buffer and advance the state machine to the
      * next header BEFORE dispatching: the eval below may re-enter this

--- a/src/core/kqueue.c
+++ b/src/core/kqueue.c
@@ -292,8 +292,14 @@ int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
         next_event:;
         }
 
-        if (poll->timers)
-            ray_timers_fire_expired((ray_timers_t*)poll->timers);
+        if (poll->timers) {
+            /* A fired timer is work, and on a timer-driven server it is the
+             * only work there is: without this stamp the decay sees an idle
+             * process mid-workload, and — having disarmed itself — never
+             * looks again. */
+            if (ray_timers_fire_expired((ray_timers_t*)poll->timers) > 0)
+                ray_heap_note_activity();
+        }
         /* After the events of this wakeup, not before: a request handled
          * above has just re-stamped the activity clock, so a busy loop
          * finds nothing due and pays one timestamp comparison. */

--- a/src/core/kqueue.c
+++ b/src/core/kqueue.c
@@ -26,6 +26,7 @@
 #include "core/poll.h"
 #include "core/timer.h"
 #include "mem/sys.h"
+#include "mem/heap.h"   /* idle decay: bound the wait, sweep after wakeup */
 #include <sys/event.h>
 #include <unistd.h>
 #include <errno.h>
@@ -188,6 +189,16 @@ int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
             }
         }
 
+        /* A process waiting here is a process doing nothing, and this is the
+         * only moment it gets to notice.  Bound the wait by the allocator's
+         * pending decay exactly as a timer would; once the decay has run
+         * there is nothing pending and the wait goes back to indefinite. */
+        {
+            int64_t decay = ray_heap_decay_due_ms();
+            if (decay >= 0 && (wait_ms < 0 || decay < wait_ms))
+                wait_ms = decay;
+        }
+
         struct timespec  ts;
         struct timespec* timeout = NULL;
         if (wait_ms >= 0) {
@@ -278,6 +289,10 @@ int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
 
         if (poll->timers)
             ray_timers_fire_expired((ray_timers_t*)poll->timers);
+        /* After the events of this wakeup, not before: a request handled
+         * above has just re-stamped the activity clock, so a busy loop
+         * finds nothing due and pays one timestamp comparison. */
+        ray_heap_decay();
         if (bounded) break;
     }
 

--- a/src/core/kqueue.c
+++ b/src/core/kqueue.c
@@ -192,8 +192,13 @@ int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
         /* A process waiting here is a process doing nothing, and this is the
          * only moment it gets to notice.  Bound the wait by the allocator's
          * pending decay exactly as a timer would; once the decay has run
-         * there is nothing pending and the wait goes back to indefinite. */
-        {
+         * there is nothing pending and the wait goes back to indefinite.
+         *
+         * Only when the loop is unbounded.  ray_poll_run_for carries the
+         * caller's own deadline and runs a single pass, so shortening its
+         * wait here returns from it early with nothing done — a timer the
+         * caller was waiting on would not have fired yet. */
+        if (!bounded) {
             int64_t decay = ray_heap_decay_due_ms();
             if (decay >= 0 && (wait_ms < 0 || decay < wait_ms))
                 wait_ms = decay;

--- a/src/core/pool.c
+++ b/src/core/pool.c
@@ -78,7 +78,8 @@ static void worker_loop(void* arg) {
 
     ray_pool_t* pool = wctx.pool;
 
-    /* Each worker thread gets its own heap */
+    /* Each worker thread gets its own heap — a fresh one, or one abandoned
+     * by an earlier worker (pools and slab caches intact). */
     ray_heap_init();
     ray_rc_sync = true;  /* workers always use atomic refcounting */
 
@@ -113,7 +114,13 @@ static void worker_loop(void* arg) {
          * Eager madvise in heap_coalesce already releases pages on free. */
     }
 
-    ray_heap_destroy();
+    /* Abandon, do not destroy.  Another thread may still hold — and later
+     * free — a block that came out of this heap, and the cross-thread free
+     * path resolves the owning heap through the registry without a lock, so
+     * a heap that could be unregistered and munmapped underneath that lookup
+     * would be a use-after-free.  The heap stays registered with its pools
+     * and is adopted by the next worker thread that starts. */
+    ray_heap_abandon();
 }
 
 /* --------------------------------------------------------------------------

--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -167,14 +167,16 @@ int64_t ray_timers_next_deadline_ms(ray_timers_t* t) {
     return t->heap[0]->exp_ms;
 }
 
-void ray_timers_fire_expired(ray_timers_t* t) {
-    if (!t || t->n == 0) return;
+uint32_t ray_timers_fire_expired(ray_timers_t* t) {
+    if (!t || t->n == 0) return 0;
 
     int64_t now = ray_time_now_ms();
+    uint32_t fired = 0;
 
     while (t->n > 0 && t->heap[0]->exp_ms <= now) {
         /* Pop the head: swap with tail, sift down. */
         ray_timer_t* timer = t->heap[0];
+        fired++;
         t->n--;
         if (t->n > 0) {
             t->heap[0] = t->heap[t->n];
@@ -225,6 +227,7 @@ void ray_timers_fire_expired(ray_timers_t* t) {
         /* Refresh `now` in case callbacks took meaningful time. */
         now = ray_time_now_ms();
     }
+    return fired;
 }
 
 void ray_timers_pump_for(ray_timers_t* t, int64_t budget_ms) {

--- a/src/core/timer.h
+++ b/src/core/timer.h
@@ -65,7 +65,8 @@ int64_t ray_timers_next_deadline_ms(ray_timers_t* t);
 /* Fire every timer whose exp_ms <= now.  Pops, calls callback via call_fn1,
  * then either re-pushes (forever / num>1) or frees (num==1 / num==0 one-shot).
  * Callback errors are printed to stderr and counted as a successful fire. */
-void ray_timers_fire_expired(ray_timers_t* t);
+/* Fire every timer whose deadline has passed; returns how many ran. */
+uint32_t ray_timers_fire_expired(ray_timers_t* t);
 
 /* Current monotonic time in milliseconds. */
 int64_t ray_time_now_ms(void);

--- a/src/mem/heap.c
+++ b/src/mem/heap.c
@@ -2490,16 +2490,20 @@ void ray_heap_release_pages(void) {
  * and the event loop between wakeups — compare that stamp against a
  * threshold.  If the process has been quiet longer than the threshold, one
  * un-aged sweep releases the pages of every free block in every heap;
- * otherwise the check is a relaxed load, a getenv and a subtraction.
+ * otherwise the check is a relaxed load and a subtraction.
  *
  * The threshold is the whole point: it is what separates "the workload has
  * stopped" from "we are between two iterations of a hot loop".  Releasing in
  * the second case drops exactly the pages the next iteration refaults, which
  * is why pass 5 ages blocks in the first place.
  *
- * The stamp is taken at the START of a unit of work, never at the end.  A
- * stamp at the end would make the elapsed time at the immediately following
- * boundary check zero, and the boundary check would never fire.
+ * The stamp is taken at the END of a unit of work, and the boundary check
+ * reads the clock BEFORE the new stamp.  What it measures is therefore the
+ * gap between one unit finishing and the next — the time the process
+ * actually sat idle.  Stamping at the start would measure the unit's own
+ * duration instead, so a loop of units longer than the threshold would
+ * sweep after every one of them, discarding the working set the next is
+ * about to fault back in.
  *
  * The sweep works on EVERY registered heap, not just the caller's, and it
  * drains each one's foreign list and slab cache before walking its
@@ -2541,10 +2545,12 @@ static _Atomic bool    g_heap_decay_armed;
  * hot-path constant — it is consulted once per statement and once per event
  * loop wakeup — and caching it would make the value depend on which code
  * path happened to run first in the process. */
-/* Resolved once: the value cannot change after exec, and this is read twice
- * per poll wakeup.  Negative disables the decay; the clamp keeps
- * `activity + threshold` from wrapping, and a week is already "never". */
-static int64_t g_heap_decay_ms = -2;         /* -2 = not yet resolved */
+/* The policy, not a knob: there is no environment override.  Negative
+ * disables the decay; the clamp keeps `activity + threshold` from wrapping,
+ * and a week is already "never".  The setter exists so a test can drive the
+ * policy — an operator-facing override, if one is ever wanted, belongs on an
+ * existing surface rather than here. */
+static int64_t g_heap_decay_ms = RAY_HEAP_DECAY_MS_DEFAULT;
 
 void ray_heap_set_decay_ms(int64_t ms) {
     if (ms > RAY_HEAP_DECAY_MS_MAX) ms = RAY_HEAP_DECAY_MS_MAX;
@@ -2552,16 +2558,6 @@ void ray_heap_set_decay_ms(int64_t ms) {
 }
 
 static int64_t heap_decay_threshold_ms(void) {
-    int64_t v = g_heap_decay_ms;
-    if (RAY_LIKELY(v != -2)) return v;
-    const char* e = getenv("RAY_HEAP_DECAY_MS");
-    v = RAY_HEAP_DECAY_MS_DEFAULT;
-    if (e && *e) {
-        char* end = NULL;
-        long long parsed = strtoll(e, &end, 10);
-        if (end != e) v = (int64_t)parsed;
-    }
-    ray_heap_set_decay_ms(v);
     return g_heap_decay_ms;
 }
 

--- a/src/mem/heap.c
+++ b/src/mem/heap.c
@@ -2500,6 +2500,7 @@ void ray_heap_release_pages(void) {
  * -------------------------------------------------------------------------- */
 
 #define RAY_HEAP_DECAY_MS_DEFAULT   10000
+#define RAY_HEAP_DECAY_MS_MAX       ((int64_t)7 * 24 * 3600 * 1000)
 
 static _Atomic int64_t g_heap_activity_ms;
 static _Atomic bool    g_heap_decay_armed;
@@ -2514,6 +2515,10 @@ static int64_t heap_decay_threshold_ms(void) {
     char* end = NULL;
     long long v = strtoll(e, &end, 10);
     if (end == e) return RAY_HEAP_DECAY_MS_DEFAULT;
+    if (v < 0) return -1;                    /* any negative disables */
+    /* Clamp so `activity + threshold` below cannot overflow.  A week is
+     * already "never" for a decay; larger values are the same thing. */
+    if (v > RAY_HEAP_DECAY_MS_MAX) return RAY_HEAP_DECAY_MS_MAX;
     return (int64_t)v;
 }
 
@@ -2543,9 +2548,6 @@ int64_t ray_heap_decay(void) {
      * can return, so repeating it before work resumes finds nothing. */
     atomic_store_explicit(&g_heap_decay_armed, false, memory_order_relaxed);
 
-    /* Blocks other threads freed to us, and our own slab cache, are not on
-     * a freelist yet and would be invisible to the walk below.  Only the
-     * caller's heap: see the note above on other heaps' lists. */
     int64_t released = 0;
     for (int hid = 0; hid < RAY_HEAP_REGISTRY_SIZE; hid++) {
         ray_heap_t* gh = ray_heap_registry[hid];

--- a/src/mem/heap.c
+++ b/src/mem/heap.c
@@ -776,6 +776,16 @@ static void heap_drain_foreign(ray_heap_t* h) {
             if (!phdr) { blk = next; continue; }
             pb = (uintptr_t)phdr;
             po = phdr->pool_order;
+            /* Adopted from a heap that left the registry while its pools
+             * were still mapped (ray_heap_push_pending).  We never charged
+             * the allocation, so there is nothing to take off our books —
+             * unlike the merge-overflow case above, where the header was
+             * rewritten to name us. */
+            if (phdr->heap_id != h->id) {
+                heap_coalesce(h, blk, pb, po);
+                blk = next;
+                continue;
+            }
         }
         RAY_STAT(h->stats.bytes_allocated -= BSIZEOF(blk->order));
         heap_coalesce(h, blk, pb, po);
@@ -1770,9 +1780,14 @@ void ray_free(ray_t* v) {
     if (RAY_UNLIKELY(!phdr)) return;      /* not inside any live pool */
     uint16_t owner_id = phdr->heap_id;
     ray_heap_t* owner = ray_heap_registry[owner_id % RAY_HEAP_REGISTRY_SIZE];
-    /* Owner torn down: its pools went with it, so there is nothing to
-     * return the block to (and nothing to leak — the mapping is gone). */
-    if (RAY_UNLIKELY(!owner || owner->id != owner_id)) return;
+    /* Not in the registry.  Either the owner was destroyed — its pools went
+     * with it and the mapping is gone — or it is merely waiting to be merged
+     * (ray_heap_push_pending unregisters first, while the pools stay mapped).
+     * The two are indistinguishable from here, so keep the block on our own
+     * list: the drain coalesces it against its own pool header and adopts it.
+     * Dropping it instead would strand the block and pin its pool against
+     * reclamation for the life of the process. */
+    if (RAY_UNLIKELY(!owner || owner->id != owner_id)) owner = h;
 
     dfd_add(v);
     ray_t* head = atomic_load_explicit(&owner->foreign, memory_order_relaxed);
@@ -2641,6 +2656,11 @@ void ray_heap_merge(ray_heap_t* src) {
             pb = (uintptr_t)phdr;
             po = phdr->pool_order;
         }
+        /* dst inherited src's bytes_allocated above, and these blocks are
+         * still charged in it — they were freed to their owner but never
+         * drained.  Coalescing them without this leaves the charge standing
+         * for good, so .sys.mem drifts up by every merged pending block. */
+        RAY_STAT(dst->stats.bytes_allocated -= BSIZEOF(fblk->order));
         heap_coalesce(dst, fblk, pb, po);
         fblk = next;
     }

--- a/src/mem/heap.c
+++ b/src/mem/heap.c
@@ -2223,6 +2223,10 @@ static void dfd_validate_freelists(void) {
  * already been released and must not be released again.  File scope
  * because the idle decay below shares the marker. */
 #define RAY_FREE_AGE_RELEASE   3
+/* Below this order a block has no whole page to give back once its first
+ * page — which carries the freelist links — is kept, so every release walk
+ * starts here. */
+#define RAY_RELEASE_MIN_ORDER  13
 
 void ray_heap_gc(void) {
     ray_heap_t* h = ray_tl_heap;
@@ -2243,10 +2247,14 @@ void ray_heap_gc(void) {
         /* Pass 2 (return foreign blocks absorbed onto our freelists) is gone
          * — nothing absorbs a foreign block locally any more.
          *
-         * Pass 3: Skip worker heaps — we cannot safely touch their
-         * slab caches because workers may still be between pending--
-         * and sem_wait, calling ray_free which modifies wh->slabs.
-         * Workers fold their own slabs back on their next dispatch. */
+         * Pass 3: Skip worker heaps.  Not for safety — ray_parallel_end
+         * drains `pending` with acquire before clearing the flag, and a
+         * worker allocates nothing between its last pending-- and sem_wait,
+         * which is what lets the decay sweep below walk those very heaps.
+         * It is a policy choice: folding a worker's slab cache back costs
+         * it a freelist pop and a split on its next allocation of that
+         * order, and the collection runs far more often than the caches
+         * are worth reclaiming. */
 
         /* Pass 4: Reclaim OVERSIZED empty pools.
          * Standard pools (pool_order == RAY_HEAP_POOL_ORDER) are never
@@ -2398,7 +2406,7 @@ void ray_heap_gc(void) {
         #define RAY_P5_VISIT_BUDGET    2048
         #define RAY_P5_RELEASE_BUDGET  64
         static int s_p5_hid = 0;
-        static int s_p5_ord = 13;
+        static int s_p5_ord = RAY_RELEASE_MIN_ORDER;
         uint64_t large_orders_mask = ~((1ULL << 13) - 1);
         int64_t p5_visited = 0, p5_released = 0;
         int p5_slots = RAY_HEAP_REGISTRY_SIZE * (RAY_HEAP_FL_SIZE - 13);
@@ -2408,7 +2416,7 @@ void ray_heap_gc(void) {
             int hid = s_p5_hid;
             int ord = s_p5_ord;
             if (++s_p5_ord >= RAY_HEAP_FL_SIZE) {
-                s_p5_ord = 13;
+                s_p5_ord = RAY_RELEASE_MIN_ORDER;
                 s_p5_hid = (s_p5_hid + 1) % RAY_HEAP_REGISTRY_SIZE;
             }
             ray_heap_t* gh = ray_heap_registry[hid];
@@ -2435,25 +2443,34 @@ void ray_heap_gc(void) {
 
 }
 
+/* Hand back the pages of every free block of `h` at or above the release
+ * floor that has not already been released, and report how many.  The three
+ * callers differ only in which heaps they visit and what they do first;
+ * the walk itself is this. */
+static int64_t heap_release_free_pages(ray_heap_t* h) {
+    int64_t released = 0;
+    for (int ord = RAY_RELEASE_MIN_ORDER; ord < RAY_HEAP_FL_SIZE; ord++) {
+        if (!(h->avail & (1ULL << ord))) continue;
+        ray_fl_head_t* head = &h->freelist[ord];
+        for (ray_t* blk = head->fl_next; blk != (ray_t*)head;
+             blk = blk->fl_next) {
+            if (blk->attrs > RAY_FREE_AGE_RELEASE) continue;  /* released */
+            int pidx = heap_find_pool(h, blk);
+            bool hp = (pidx >= 0) ? (h->pools[pidx].hugepage != 0) : false;
+            ray_vm_release_block(blk, BSIZEOF(ord), hp);
+            blk->attrs = RAY_FREE_AGE_RELEASE + 1;
+            released++;
+        }
+    }
+    return released;
+}
+
 void ray_heap_release_pages(void) {
     /* Explicit release: callers asking for pages back get them NOW —
      * no aging — but still skip blocks already released. */
     ray_heap_t* h = ray_tl_heap;
     if (!h) return;
-    for (int i = 13; i < RAY_HEAP_FL_SIZE; i++) {
-        ray_fl_head_t* head = &h->freelist[i];
-        ray_t* blk = head->fl_next;
-        while (blk != (ray_t*)head) {
-            if (blk->attrs <= RAY_FREE_AGE_RELEASE) {
-                size_t bsize = BSIZEOF(i);
-                int rpidx = heap_find_pool(h, blk);
-                bool hp = (rpidx >= 0) ? (h->pools[rpidx].hugepage != 0) : false;
-                ray_vm_release_block(blk, bsize, hp);
-                blk->attrs = RAY_FREE_AGE_RELEASE + 1;
-            }
-            blk = blk->fl_next;
-        }
-    }
+    (void)heap_release_free_pages(h);
 }
 
 /* --------------------------------------------------------------------------
@@ -2583,19 +2600,7 @@ int64_t ray_heap_decay(void) {
          * in a server that is where most of the free bytes are. */
         heap_drain_foreign(gh);
         heap_flush_slabs(gh);
-        for (int ord = 13; ord < RAY_HEAP_FL_SIZE; ord++) {
-            if (!(gh->avail & (1ULL << ord))) continue;
-            ray_fl_head_t* head = &gh->freelist[ord];
-            for (ray_t* blk = head->fl_next; blk != (ray_t*)head;
-                 blk = blk->fl_next) {
-                if (blk->attrs > RAY_FREE_AGE_RELEASE) continue;  /* released */
-                int pidx = heap_find_pool(gh, blk);
-                bool hp = (pidx >= 0) ? (gh->pools[pidx].hugepage != 0) : false;
-                ray_vm_release_block(blk, BSIZEOF(ord), hp);
-                blk->attrs = RAY_FREE_AGE_RELEASE + 1;
-                released++;
-            }
-        }
+        released += heap_release_free_pages(gh);
     }
     return released;
 }

--- a/src/mem/heap.c
+++ b/src/mem/heap.c
@@ -371,15 +371,15 @@ void ray_heap_set_anon_watermark(int64_t bytes) {
 
 ray_heap_t* ray_heap_registry[RAY_HEAP_REGISTRY_SIZE];
 
-/* Serializes the registry slot writes (register/unregister) and the
- * cross-heap foreign-list purges that walk EVERY other heap's ->foreign
- * during teardown.  ray_pool_free() joins workers one at a time, but all
- * workers wake on the shutdown signal together and run ray_heap_destroy()
- * CONCURRENTLY — two destroyers splicing the same neighbour's singly-linked
- * ->foreign list (or one walking a slot another is NULLing) tears the list
- * and SEGVs on the next ->fl_next deref.  Spinlock matches the dfd_lock
- * pattern above; held only across the short registry/foreign critical
- * sections, never across munmap or syscalls. */
+/* Serializes registry slot writes (register / unregister) and the
+ * abandoned-heap LIFO.  Workers wake on the shutdown signal together and
+ * leave their heaps CONCURRENTLY, so those two structures need one owner at
+ * a time.  Spinlock matches the dfd_lock pattern above; held only across the
+ * short critical sections, never across munmap or syscalls.
+ *
+ * The free path deliberately does NOT take this lock: it only READS a
+ * registry slot, and a heap in the registry is never freed while a thread
+ * could still be freeing into it (see ray_heap_abandon). */
 static atomic_flag ray_registry_lock_flag = ATOMIC_FLAG_INIT;
 static void ray_registry_lock(void)   { while (atomic_flag_test_and_set_explicit(&ray_registry_lock_flag, memory_order_acquire)) {} }
 static void ray_registry_unlock(void) { atomic_flag_clear_explicit(&ray_registry_lock_flag, memory_order_release); }
@@ -733,67 +733,43 @@ static void heap_flush_slabs(ray_heap_t* h) {
 }
 
 /* --------------------------------------------------------------------------
- * Foreign blocks flush
+ * Foreign-list drain (owner side)
  *
- * When return_to_owner is true, returns each foreign block to its owning
- * heap (via pool header heap_id → global registry). This ensures workers
- * can reuse their pools across queries instead of allocating new ones.
+ * Every block on h->foreign is OWNED BY h: a cross-thread free routes the
+ * block to its owner rather than parking it on the freeing heap (see the
+ * foreign path in ray_free).  So the drain needs no pool-header lookup for
+ * ownership, no registry access, and no "are the workers idle?" gate — it
+ * takes the whole list with one exchange and coalesces into its own
+ * freelists, which no other thread touches.
  *
- * return_to_owner must only be true when workers are idle (on semaphore),
- * i.e. ray_parallel_flag == 0. Otherwise coalesce into current heap.
+ * The acquire on the exchange pairs with the release on the pusher's CAS,
+ * so the block contents written before the push are visible here.
  * -------------------------------------------------------------------------- */
 
-static void heap_flush_foreign(ray_heap_t* h, bool return_to_owner) {
-    /* When workers are active (return_to_owner=false), skip entirely.
-     * Foreign blocks stay queued until the proper GC flush after workers
-     * finish. Absorbing foreign blocks locally would let them be re-
-     * allocated under a different heap while pool ownership stays with
-     * the original heap, corrupting bytes_allocated accounting. */
-    if (!return_to_owner) return;
-
-    ray_t* blk = h->foreign;
+static void heap_drain_foreign(ray_heap_t* h) {
+    ray_t* blk = atomic_exchange_explicit(&h->foreign, NULL,
+                                          memory_order_acquire);
     while (blk) {
         ray_t* next = blk->fl_next;
-        ray_pool_hdr_t* phdr = ray_pool_of(blk);
-        if (!phdr) { blk = next; continue; }
-        uint16_t owner_id = phdr->heap_id;
-        ray_heap_t* owner = ray_heap_registry[owner_id % RAY_HEAP_REGISTRY_SIZE];
-        if (owner && owner->id == owner_id && owner != h) {
-            /* Return to owner and decrement owner's bytes_allocated.
-             * Safe: workers are idle (return_to_owner=true implies
-             * ray_parallel_flag==0). */
-            int pidx = heap_find_pool(owner, blk);
-            uintptr_t pb;
-            uint8_t po;
-            if (pidx >= 0) {
-                pb = (uintptr_t)owner->pools[pidx].base;
-                po = owner->pools[pidx].pool_order;
-            } else {
-                pb = (uintptr_t)phdr;
-                po = phdr->pool_order;
-            }
-            RAY_STAT(owner->stats.bytes_allocated -= BSIZEOF(blk->order));
-            heap_coalesce(owner, blk, pb, po);
+        int pidx = heap_find_pool(h, blk);
+        uintptr_t pb;
+        uint8_t po;
+        if (pidx >= 0) {
+            pb = (uintptr_t)h->pools[pidx].base;
+            po = h->pools[pidx].pool_order;
         } else {
-            /* Owner gone (destroyed/unregistered) — coalesce locally.
-             * No stats adjustment: the owner's stats were destroyed
-             * with the heap, and h never charged the alloc. */
-            int pidx = heap_find_pool(h, blk);
-            uintptr_t pb;
-            uint8_t po;
-            if (pidx >= 0) {
-                pb = (uintptr_t)h->pools[pidx].base;
-                po = h->pools[pidx].pool_order;
-            } else {
-                if (!phdr) { blk = next; continue; }
-                pb = (uintptr_t)phdr;
-                po = phdr->pool_order;
-            }
-            heap_coalesce(h, blk, pb, po);
+            /* h owns the block but does not track its pool — only reachable
+             * through ray_heap_merge's RAY_MAX_POOLS overflow, which rewrites
+             * the header's heap_id without room for the pool entry. */
+            ray_pool_hdr_t* phdr = ray_pool_of(blk);
+            if (!phdr) { blk = next; continue; }
+            pb = (uintptr_t)phdr;
+            po = phdr->pool_order;
         }
+        RAY_STAT(h->stats.bytes_allocated -= BSIZEOF(blk->order));
+        heap_coalesce(h, blk, pb, po);
         blk = next;
     }
-    h->foreign = NULL;
 }
 
 /* --------------------------------------------------------------------------
@@ -1456,25 +1432,23 @@ ray_t* ray_alloc(size_t data_size) {
      * to find a genuinely non-empty freelist. */
     uint64_t candidates = h->avail & (UINT64_MAX << order);
 
-    if (RAY_UNLIKELY(candidates == 0)) {
-        heap_flush_foreign(h, false);  /* always local in ray_alloc */
-
-        candidates = h->avail & (UINT64_MAX << order);
-
-        if (candidates == 0) {
-            if (!heap_add_pool(h, order)) return NULL;
-            candidates = h->avail & (UINT64_MAX << order);
-            if (candidates == 0) return NULL;
-        }
-    }
-
     /* Scan past stale avail bits (cross-heap fl_remove may have emptied lists) */
     uint8_t found_order;
     for (;;) {
-        if (candidates == 0) {
-            if (!heap_add_pool(h, order)) return NULL;
+        if (RAY_UNLIKELY(candidates == 0)) {
+            /* Out of blocks at this order.  Take back everything other
+             * threads have freed to us BEFORE asking the OS for another
+             * pool: those blocks are already ours, and mapping fresh memory
+             * while our own sits on the list is how a repeated query grew a
+             * server by a pool per execution (issue #439).  This ordering is
+             * the invariant — no pool is ever added without a drain first. */
+            heap_drain_foreign(h);
             candidates = h->avail & (UINT64_MAX << order);
-            if (candidates == 0) return NULL;
+            if (candidates == 0) {
+                if (!heap_add_pool(h, order)) return NULL;
+                candidates = h->avail & (UINT64_MAX << order);
+                if (candidates == 0) return NULL;
+            }
         }
         found_order = (uint8_t)__builtin_ctzll(candidates);
         if (!fl_empty(&h->freelist[found_order])) break;
@@ -1766,12 +1740,36 @@ void ray_free(ray_t* v) {
         return;
     }
 
-    /* Foreign: not in any of our pools.  Enqueue to the foreign list for
-     * return to the owner during GC.  Do NOT adjust bytes_allocated: the
-     * block stays counted on the owning heap until returned and coalesced. */
+    /* Foreign: not in any of our pools.  Push it onto the OWNER's list, not
+     * ours.  A block parked here is memory only the owner can reuse, and
+     * until this changed nothing but an explicit ray_heap_gc() ever moved it
+     * — so a server that never called one had every worker start each query
+     * short by the volume the consuming thread was sitting on, and map a
+     * fresh pool to make up the difference, forever (issue #439).  Handing
+     * the block back at free time makes the growth impossible instead of
+     * merely collectable.
+     *
+     * The registry lookup is unlocked, which is sound because a registered
+     * heap outlives every block it owns: threads abandon their heaps rather
+     * than destroying them (ray_heap_abandon).
+     *
+     * Do NOT adjust bytes_allocated: the block stays counted on the owning
+     * heap until IT drains and coalesces. */
+    ray_pool_hdr_t* phdr = ray_pool_of(v);
+    if (RAY_UNLIKELY(!phdr)) return;      /* not inside any live pool */
+    uint16_t owner_id = phdr->heap_id;
+    ray_heap_t* owner = ray_heap_registry[owner_id % RAY_HEAP_REGISTRY_SIZE];
+    /* Owner torn down: its pools went with it, so there is nothing to
+     * return the block to (and nothing to leak — the mapping is gone). */
+    if (RAY_UNLIKELY(!owner || owner->id != owner_id)) return;
+
     dfd_add(v);
-    v->fl_next = h->foreign;
-    h->foreign = v;
+    ray_t* head = atomic_load_explicit(&owner->foreign, memory_order_relaxed);
+    do {
+        v->fl_next = head;
+    } while (!atomic_compare_exchange_weak_explicit(
+                 &owner->foreign, &head, v,
+                 memory_order_release, memory_order_relaxed));
     RAY_STAT(h->stats.free_count++);
 }
 
@@ -1963,8 +1961,27 @@ void ray_mem_stats(ray_mem_stats_t* out) {
  * -------------------------------------------------------------------------- */
 
 
+/* Heaps whose thread exited: still registered, pools intact, waiting for the
+ * next thread to adopt them.  Guarded by the registry lock — pushed and
+ * popped once per thread lifetime, never on an allocation path. */
+static ray_heap_t* g_heap_idle = NULL;
+
 void ray_heap_init(void) {
     if (ray_tl_heap) return;
+
+    /* Adopt an abandoned heap before mapping a new one.  Its pools are
+     * already faulted in and its slab caches are warm, and — the reason this
+     * exists at all — a heap that is never destroyed can be looked up on the
+     * lock-free cross-thread free path without racing a munmap. */
+    ray_registry_lock();
+    ray_heap_t* reuse = g_heap_idle;
+    if (reuse) g_heap_idle = reuse->idle_next;
+    ray_registry_unlock();
+    if (reuse) {
+        reuse->idle_next = NULL;
+        ray_tl_heap = reuse;
+        return;
+    }
 
     size_t heap_sz = (sizeof(ray_heap_t) + 4095) & ~(size_t)4095;
     ray_heap_t* h = (ray_heap_t*)ray_vm_alloc(heap_sz);
@@ -1990,8 +2007,8 @@ void ray_heap_init(void) {
     }
     h->id = (uint16_t)id;
 
-    /* Register in global heap registry (lock: a concurrent destroyer may be
-     * walking the array in its foreign-purge loop). */
+    /* Register in global heap registry (lock: serialize the slot write
+     * against a concurrent register / unregister). */
     ray_registry_lock();
     ray_heap_registry[h->id % RAY_HEAP_REGISTRY_SIZE] = h;
     ray_registry_unlock();
@@ -2048,6 +2065,34 @@ void ray_heap_init(void) {
  * heap takes over.  Lives in src/lang/eval.c. */
 extern void ray_clear_error_trace(void);
 
+void ray_heap_abandon(void) {
+    ray_heap_t* h = ray_tl_heap;
+    if (!h) return;
+
+    /* Thread-local refs into this heap must go before another thread owns
+     * it, or the next ray_eval_str on the adopting thread would release a
+     * trace this thread already handed on. */
+    ray_clear_error_trace();
+
+    /* Take back whatever was freed to us while we ran, so the heap is
+     * handed on with its memory on its freelists rather than on a list the
+     * adopter has to notice. */
+    heap_drain_foreign(h);
+
+    ray_registry_lock();
+    h->idle_next = g_heap_idle;
+    g_heap_idle = h;
+    ray_registry_unlock();
+
+    ray_tl_heap = NULL;
+}
+
+/* Real teardown: unregisters the heap and munmaps its pools.
+ *
+ * ONLY valid when no other thread can still be freeing blocks that belong to
+ * this heap — process shutdown after the worker pool is joined, or a
+ * single-threaded test.  A thread that merely exits must call
+ * ray_heap_abandon instead; see the comment on that function. */
 void ray_heap_destroy(void) {
     ray_heap_t* h = ray_tl_heap;
     if (!h) return;
@@ -2066,51 +2111,24 @@ void ray_heap_destroy(void) {
 
     uint16_t saved_id = h->id;
 
-    /* Workers tear down CONCURRENTLY during ray_pool_free() (all woken by the
-     * same shutdown signal), so the unregister + the cross-heap foreign-list
-     * purge below must be serialized: otherwise two destroyers splice the same
-     * neighbour's ->foreign list at once and the ->fl_next walk SEGVs.  Held
-     * only across the registry critical section, released before munmap. */
+    /* Unregister first so a free that is still to resolve an owner cannot
+     * pick this heap up.  The lock serializes the slot write against
+     * ray_heap_init / ray_heap_abandon.
+     *
+     * The cross-heap foreign-list purge that used to live here is gone with
+     * the design it belonged to: a block of h's can no longer be sitting on
+     * some OTHER heap's foreign list, because a cross-thread free routes the
+     * block to its owner.  With it goes the tearing hazard of walking a
+     * neighbour's singly-linked list while its owner mutates it. */
     ray_registry_lock();
-
-    /* Unregister from global heap registry */
     ray_heap_registry[h->id % RAY_HEAP_REGISTRY_SIZE] = NULL;
-
-    /* Skip flush_slabs and flush_foreign — all pools are about to be
-     * munmap'd. Flushing would coalesce blocks and fl_remove buddies
-     * from other heaps' freelists, which races with concurrent worker
-     * destruction during ray_pool_free(). */
-
-    /* Purge any of h's blocks from every other heap's foreign list
-     * BEFORE we munmap.  Without this, foreign lists outlive h with
-     * dangling pointers into unmapped memory and crash on the next
-     * ray_heap_gc has_foreign walk or heap_flush_foreign. */
-    for (int fh_id = 0; fh_id < RAY_HEAP_REGISTRY_SIZE; fh_id++) {
-        ray_heap_t* fh_heap = ray_heap_registry[fh_id];
-        if (!fh_heap || fh_heap == h) continue;
-        ray_t** pp = &fh_heap->foreign;
-        ray_t* curr = *pp;
-        while (curr) {
-            ray_t* next = curr->fl_next;
-            bool in_h = false;
-            for (uint32_t i = 0; i < h->pool_count; i++) {
-                uintptr_t pb = (uintptr_t)h->pools[i].base;
-                uintptr_t pe = pb + BSIZEOF(h->pools[i].pool_order);
-                if ((uintptr_t)curr >= pb && (uintptr_t)curr < pe) {
-                    in_h = true;
-                    break;
-                }
-            }
-            if (in_h) {
-                *pp = next;
-            } else {
-                pp = &curr->fl_next;
-            }
-            curr = next;
-        }
-    }
-
     ray_registry_unlock();
+
+    /* Anything queued for us dies with the pools it lives in — the blocks are
+     * free memory inside mappings we are about to drop. */
+    atomic_store_explicit(&h->foreign, NULL, memory_order_relaxed);
+
+    /* Skip flush_slabs — all pools are about to be munmap'd. */
 
     /* Munmap all tracked pools.  File-backed pools also need their fd
      * closed and their tempfile unlinked so the swap directory doesn't
@@ -2140,58 +2158,11 @@ void ray_heap_destroy(void) {
     heap_id_release(saved_id);
 }
 
-/* --------------------------------------------------------------------------
- * Return worker-pool blocks from this heap's freelists to their owners.
- *
- * After ray_alloc flushes foreign blocks locally (coalesce + madvise),
- * worker-pool blocks sit on main's freelists with released physical pages.
- * This function walks the freelists, finds blocks whose pool header
- * heap_id != ours, removes them, and inserts into the owning worker heap.
- * Workers can then reuse their pools without allocating new ones.
- *
- * ONLY safe when workers are idle (on semaphore, ray_parallel_flag == 0).
- * -------------------------------------------------------------------------- */
-
-static void heap_return_foreign_freelist(ray_heap_t* h) {
-    /* avail bit (set on insert, cleared on remove) tells us which
-     * freelist orders have any blocks at all — skip the empty ones. */
-    if (!h->avail) return;
-    for (int order = RAY_ORDER_MIN; order < RAY_HEAP_FL_SIZE; order++) {
-        if (!(h->avail & (1ULL << order))) continue;
-        ray_fl_head_t* head = &h->freelist[order];
-        ray_t* blk = head->fl_next;
-        while (blk != (ray_t*)head) {
-            ray_t* next = blk->fl_next;
-            /* Use heap_find_pool on h first — if found, block is local */
-            int pidx = heap_find_pool(h, blk);
-            if (pidx < 0) {
-                /* Foreign block — find owner via pool header (GC path) */
-                ray_pool_hdr_t* phdr = ray_pool_of(blk);
-                if (!phdr) { blk = next; continue; }
-                ray_heap_t* owner = ray_heap_registry[phdr->heap_id % RAY_HEAP_REGISTRY_SIZE];
-                if (owner && owner->id == phdr->heap_id) {
-                    fl_remove(blk);
-                    dfd_remove(blk);
-                    if (fl_empty(head))
-                        h->avail &= ~(1ULL << order);
-                    /* Coalesce on owner for defragmentation */
-                    int opidx = heap_find_pool(owner, blk);
-                    uintptr_t pb;
-                    uint8_t po;
-                    if (opidx >= 0) {
-                        pb = (uintptr_t)owner->pools[opidx].base;
-                        po = owner->pools[opidx].pool_order;
-                    } else {
-                        pb = (uintptr_t)phdr;
-                        po = phdr->pool_order;
-                    }
-                    heap_coalesce(owner, blk, pb, po);
-                }
-            }
-            blk = next;
-        }
-    }
-}
+/* heap_return_foreign_freelist used to walk this heap's freelists looking for
+ * blocks that belong to somebody else and hand them back.  Nothing can put
+ * such a block there any more — a cross-thread free goes straight to the
+ * owner's list, and a drain only ever coalesces the draining heap's own
+ * blocks — so the whole pass is gone. */
 
 #ifdef DEBUG
 static void dfd_validate_freelists(void) {
@@ -2230,24 +2201,20 @@ void ray_heap_gc(void) {
 
     bool safe = (atomic_load_explicit(&ray_parallel_flag, memory_order_relaxed) == 0);
 
-    /* Pass 1: Flush main heap's foreign blocks and slab caches.
-     * When safe (workers idle), return foreign blocks to their owners
-     * so worker pools become reusable. */
-    heap_flush_foreign(h, safe);
+    /* Pass 1: take back whatever other threads freed to us, and fold the
+     * slab caches back into the freelists.  The drain needs no idle-worker
+     * gate: the list holds only our own blocks. */
+    heap_drain_foreign(h);
     heap_flush_slabs(h);
 
     if (safe) {
-        /* Pass 2: Return foreign blocks absorbed onto our freelists
-         * back to their owning worker heaps. */
-        heap_return_foreign_freelist(h);
-
-        /* Pass 3: Skip worker heaps — we cannot safely touch their
-         * foreign lists or slab caches because workers may still be
-         * between pending-- and sem_wait, calling ray_free which
-         * modifies wh->foreign and wh->slabs.  Workers flush their
-         * own foreign/slabs on their next dispatch entry.
-         * TODO: full cross-heap reclamation requires a worker
-         * quiescence barrier. */
+        /* Pass 2 (return foreign blocks absorbed onto our freelists) is gone
+         * — nothing absorbs a foreign block locally any more.
+         *
+         * Pass 3: Skip worker heaps — we cannot safely touch their
+         * slab caches because workers may still be between pending--
+         * and sem_wait, calling ray_free which modifies wh->slabs.
+         * Workers fold their own slabs back on their next dispatch. */
 
         /* Pass 4: Reclaim OVERSIZED empty pools.
          * Standard pools (pool_order == RAY_HEAP_POOL_ORDER) are never
@@ -2264,17 +2231,14 @@ void ray_heap_gc(void) {
          * live_count operations on the alloc/free hot path. */
         /* Pass 4: Reclaim oversized empty pools.
          *
-         * For each candidate pool (owned by heap gh), count free bytes from:
-         *   (a) gh's own freelist + slab cache — safe, only gh modifies these
-         *   (b) ALL heaps' foreign lists (read-only) — foreign lists are
-         *       prepend-only during the race window, so a read-only walk
-         *       sees a consistent suffix. A concurrent prepend may be
-         *       missed, making us undercount — which is conservative.
-         *
-         * On removal, only unlink from gh's freelist/slabs. Blocks still
-         * in other heaps' foreign lists will be discovered as dangling on
-         * their next flush (foreign block with unmapped pool → ray_pool_of
-         * returns NULL → skipped by the NULL guard). */
+         * Emptiness is "every byte of the pool is on gh's own freelist or in
+         * its slab cache".  That single sum is now the whole test: a block of
+         * gh's that is live, or queued on gh->foreign, or queued anywhere
+         * else, is by construction NOT on those two structures, so it shows
+         * up as a shortfall.  The registry-wide foreign scan (and the
+         * destructive purge that had to follow it, because the scan raced)
+         * existed only because a free used to leave the block on whichever
+         * heap did the freeing. */
         for (int hid = 0; hid < RAY_HEAP_REGISTRY_SIZE; hid++) {
             ray_heap_t* gh = ray_heap_registry[hid];
             if (!gh) continue;
@@ -2313,38 +2277,13 @@ void ray_heap_gc(void) {
                     }
                 }
 
-                /* (b) Check if ANY blocks from this pool are still in other
-                 *     heaps' foreign lists.  If so, we cannot munmap —
-                 *     those blocks are threaded into the foreign list and
-                 *     dereferencing them after munmap would crash.
-                 *     They'll be flushed to the owner on the next GC. */
-                /* Lock the foreign-list scan + purge: keeps the registry-wide
-                 * foreign-splice invariant uniform with ray_heap_destroy.
-                 * Workers are idle here (ray_parallel_flag == 0), so this is
-                 * defensive — never contended in the live GC path. */
-                ray_registry_lock();
-                bool has_foreign = false;
-                for (int fh_id = 0; fh_id < RAY_HEAP_REGISTRY_SIZE && !has_foreign; fh_id++) {
-                    ray_heap_t* fh_heap = ray_heap_registry[fh_id];
-                    if (!fh_heap || fh_heap == gh) continue;
-                    ray_t* fb = fh_heap->foreign;
-                    while (fb) {
-                        if ((uintptr_t)fb >= pb && (uintptr_t)fb < pe) {
-                            has_foreign = true;
-                            break;
-                        }
-                        fb = fb->fl_next;
-                    }
-                }
-
-                if (free_bytes < pool_capacity || has_foreign) {
-                    ray_registry_unlock();
+                if (free_bytes < pool_capacity) {
                     p++;
-                    continue;  /* pool has live allocations or dangling foreign refs */
+                    continue;  /* pool still has live or queued blocks */
                 }
 
-                /* Pool is empty and no foreign-list refs — safe to munmap.
-                 * Remove blocks from owning heap's freelists and slab caches. */
+                /* Pool is entirely free — safe to munmap.  Remove its blocks
+                 * from the owning heap's freelists and slab caches. */
                 for (int ord = RAY_ORDER_MIN; ord < RAY_HEAP_FL_SIZE; ord++) {
                     ray_fl_head_t* fh = &gh->freelist[ord];
                     ray_t* blk = fh->fl_next;
@@ -2371,29 +2310,6 @@ void ray_heap_gc(void) {
                     }
                     gh->slabs[si].count = dst;
                 }
-
-                /* Purge any [pb, pe) blocks from every other heap's foreign
-                 * list BEFORE munmap.  The has_foreign check above is racy
-                 * vs concurrent ray_free, and any block left here becomes
-                 * a dangling pointer that crashes subsequent Pass 4 walks
-                 * at fb->fl_next.  Reading fl_next is safe here because
-                 * the pool is still mapped. */
-                for (int fh_id = 0; fh_id < RAY_HEAP_REGISTRY_SIZE; fh_id++) {
-                    ray_heap_t* fh_heap = ray_heap_registry[fh_id];
-                    if (!fh_heap || fh_heap == gh) continue;
-                    ray_t** pp = &fh_heap->foreign;
-                    ray_t* curr = *pp;
-                    while (curr) {
-                        ray_t* next = curr->fl_next;
-                        if ((uintptr_t)curr >= pb && (uintptr_t)curr < pe) {
-                            *pp = next;
-                        } else {
-                            pp = &curr->fl_next;
-                        }
-                        curr = next;
-                    }
-                }
-                ray_registry_unlock();
 
                 dfd_purge_range(pb, pe);
                 ray_vm_free(phdr->vm_base, BSIZEOF(po));
@@ -2547,8 +2463,10 @@ void ray_heap_merge(ray_heap_t* src) {
         }
     }
 
-    /* Free foreign blocks via coalescing */
-    ray_t* fblk = src->foreign;
+    /* Blocks other threads freed back to src, taken over by dst along with
+     * src's pools. */
+    ray_t* fblk = atomic_exchange_explicit(&src->foreign, NULL,
+                                           memory_order_acquire);
     while (fblk) {
         ray_t* next = fblk->fl_next;
         int pidx = heap_find_pool(dst, fblk);
@@ -2566,7 +2484,6 @@ void ray_heap_merge(ray_heap_t* src) {
         heap_coalesce(dst, fblk, pb, po);
         fblk = next;
     }
-    src->foreign = NULL;
 
     /* Merge freelists: circular list splice (src chain into dst chain) */
     for (int i = RAY_ORDER_MIN; i < RAY_HEAP_FL_SIZE; i++) {
@@ -2622,9 +2539,9 @@ void ray_heap_merge(ray_heap_t* src) {
 void ray_heap_flush_foreign(void) {
     ray_heap_t* h = ray_tl_heap;
     if (!h) return;
-    bool safe = (atomic_load_explicit(&ray_parallel_flag,
-                                       memory_order_relaxed) == 0);
-    heap_flush_foreign(h, safe);
+    /* No ray_parallel_flag gate: the list holds only this heap's own blocks,
+     * and only this thread coalesces into its own freelists. */
+    heap_drain_foreign(h);
 }
 
 /* --------------------------------------------------------------------------

--- a/src/mem/heap.c
+++ b/src/mem/heap.c
@@ -2509,17 +2509,28 @@ static _Atomic bool    g_heap_decay_armed;
  * hot-path constant — it is consulted once per statement and once per event
  * loop wakeup — and caching it would make the value depend on which code
  * path happened to run first in the process. */
+/* Resolved once: the value cannot change after exec, and this is read twice
+ * per poll wakeup.  Negative disables the decay; the clamp keeps
+ * `activity + threshold` from wrapping, and a week is already "never". */
+static int64_t g_heap_decay_ms = -2;         /* -2 = not yet resolved */
+
+void ray_heap_set_decay_ms(int64_t ms) {
+    if (ms > RAY_HEAP_DECAY_MS_MAX) ms = RAY_HEAP_DECAY_MS_MAX;
+    g_heap_decay_ms = (ms < 0) ? -1 : ms;
+}
+
 static int64_t heap_decay_threshold_ms(void) {
+    int64_t v = g_heap_decay_ms;
+    if (RAY_LIKELY(v != -2)) return v;
     const char* e = getenv("RAY_HEAP_DECAY_MS");
-    if (!e || !*e) return RAY_HEAP_DECAY_MS_DEFAULT;
-    char* end = NULL;
-    long long v = strtoll(e, &end, 10);
-    if (end == e) return RAY_HEAP_DECAY_MS_DEFAULT;
-    if (v < 0) return -1;                    /* any negative disables */
-    /* Clamp so `activity + threshold` below cannot overflow.  A week is
-     * already "never" for a decay; larger values are the same thing. */
-    if (v > RAY_HEAP_DECAY_MS_MAX) return RAY_HEAP_DECAY_MS_MAX;
-    return (int64_t)v;
+    v = RAY_HEAP_DECAY_MS_DEFAULT;
+    if (e && *e) {
+        char* end = NULL;
+        long long parsed = strtoll(e, &end, 10);
+        if (end != e) v = (int64_t)parsed;
+    }
+    ray_heap_set_decay_ms(v);
+    return g_heap_decay_ms;
 }
 
 void ray_heap_note_activity(void) {

--- a/src/mem/heap.c
+++ b/src/mem/heap.c
@@ -31,6 +31,7 @@
 #include "cow.h"
 #include "sys.h"
 #include "core/platform.h"
+#include "core/timer.h"   /* ray_time_now_ms — idle-decay clock */
 #include "table/sym.h"
 #include "table/domain.h"
 #include "lang/eval.h"
@@ -2202,6 +2203,12 @@ static void dfd_validate_freelists(void) {
 }
 #endif
 
+/* Number of maintenance visits a free block must survive on a freelist
+ * before pass 5 hands its pages back; a block whose attrs exceed it has
+ * already been released and must not be released again.  File scope
+ * because the idle decay below shares the marker. */
+#define RAY_FREE_AGE_RELEASE   3
+
 void ray_heap_gc(void) {
     ray_heap_t* h = ray_tl_heap;
     if (!h) return;
@@ -2373,7 +2380,6 @@ void ray_heap_gc(void) {
          * full cycle instead of being double-aged; the cursor never
          * stores a block pointer — blocks may be reallocated, split or
          * coalesced between passes, only (heap, order) is stable. */
-        #define RAY_FREE_AGE_RELEASE   3
         #define RAY_P5_VISIT_BUDGET    2048
         #define RAY_P5_RELEASE_BUDGET  64
         static int s_p5_hid = 0;
@@ -2433,6 +2439,137 @@ void ray_heap_release_pages(void) {
             blk = blk->fl_next;
         }
     }
+}
+
+/* --------------------------------------------------------------------------
+ * Idle decay
+ *
+ * A free block keeps its physical pages so the next allocation of that size
+ * reuses them without faulting; that is why pass 5 ages a block before
+ * releasing it, and why a repeated query never pays to refault its own
+ * temporaries.  The price of the policy is that a process which ran one
+ * heavy query holds its peak footprint for the rest of its life even while
+ * it does nothing.  The memory is free and reusable — it is simply not
+ * available to anything else on the machine.
+ *
+ * The decay closes that gap with no background thread, no queue and no task
+ * object.  Work stamps a coarse timestamp when it STARTS, and the two points
+ * that already exist at the end of a unit of work — the statement boundary
+ * and the event loop between wakeups — compare that stamp against a
+ * threshold.  If the process has been quiet longer than the threshold, one
+ * un-aged sweep releases the pages of every free block in every heap;
+ * otherwise the check is a relaxed load, a getenv and a subtraction.
+ *
+ * The threshold is the whole point: it is what separates "the workload has
+ * stopped" from "we are between two iterations of a hot loop".  Releasing in
+ * the second case drops exactly the pages the next iteration refaults, which
+ * is why pass 5 ages blocks in the first place.
+ *
+ * The stamp is taken at the START of a unit of work, never at the end.  A
+ * stamp at the end would make the elapsed time at the immediately following
+ * boundary check zero, and the boundary check would never fire.
+ *
+ * The sweep works on EVERY registered heap, not just the caller's, and it
+ * drains each one's foreign list and slab cache before walking its
+ * freelists.  That is not incidental: in a server the main thread frees the
+ * results of a parallel query, so the blocks land on the owning WORKER's
+ * foreign list, and a worker only drains its own list when it next needs
+ * memory — which a warm heap never does.  Freelist-only, the sweep sees a
+ * small fraction of the free bytes; with the drain it sees nearly all of
+ * them.  Draining also coalesces, so the pages come back in large runs
+ * instead of scattered blocks below the order-13 floor.
+ *
+ * That is sound only because the sweep runs when ray_parallel_flag is 0.
+ * The dispatcher clears the flag only after every worker's `pending--` is
+ * visible, and a worker between `pending--` and sem_wait claims tasks and
+ * waits — it neither allocates nor frees — so no other thread is touching
+ * a worker heap's freelists or slab stack.  A concurrent cross-thread free
+ * can still PUSH onto a foreign list at any moment, and that is safe on its
+ * own terms: the drain takes the whole list with one atomic exchange, and
+ * whatever arrives afterwards is simply left for the next sweep.
+ *
+ * Unlike ray_heap_gc's pass 5 this walk has no visit or release budget.
+ * The budget exists there because gc runs inside a workload and must never
+ * become an unpredictable pause; the decay by construction only runs when
+ * there is no workload to pause.
+ *
+ * The armed flag makes this once per idle period.  After a sweep there is
+ * nothing further to give back until new work dirties memory again, so a
+ * long-idle process stops checking altogether and its event loop returns to
+ * blocking indefinitely instead of waking on a timer.
+ * -------------------------------------------------------------------------- */
+
+#define RAY_HEAP_DECAY_MS_DEFAULT   10000
+
+static _Atomic int64_t g_heap_activity_ms;
+static _Atomic bool    g_heap_decay_armed;
+
+/* Read per check rather than cached at first use.  This is policy, not a
+ * hot-path constant — it is consulted once per statement and once per event
+ * loop wakeup — and caching it would make the value depend on which code
+ * path happened to run first in the process. */
+static int64_t heap_decay_threshold_ms(void) {
+    const char* e = getenv("RAY_HEAP_DECAY_MS");
+    if (!e || !*e) return RAY_HEAP_DECAY_MS_DEFAULT;
+    char* end = NULL;
+    long long v = strtoll(e, &end, 10);
+    if (end == e) return RAY_HEAP_DECAY_MS_DEFAULT;
+    return (int64_t)v;
+}
+
+void ray_heap_note_activity(void) {
+    atomic_store_explicit(&g_heap_activity_ms, ray_time_now_ms(),
+                          memory_order_relaxed);
+    atomic_store_explicit(&g_heap_decay_armed, true, memory_order_relaxed);
+}
+
+int64_t ray_heap_decay_due_ms(void) {
+    if (!atomic_load_explicit(&g_heap_decay_armed, memory_order_relaxed))
+        return -1;
+    int64_t threshold = heap_decay_threshold_ms();
+    if (threshold < 0) return -1;   /* decay disabled */
+    int64_t due = atomic_load_explicit(&g_heap_activity_ms,
+                                       memory_order_relaxed)
+                + threshold - ray_time_now_ms();
+    return due > 0 ? due : 0;
+}
+
+int64_t ray_heap_decay(void) {
+    if (ray_heap_decay_due_ms() != 0) return -1;
+    if (atomic_load_explicit(&ray_parallel_flag, memory_order_relaxed) != 0)
+        return -1;
+
+    /* Disarm before sweeping: what follows is everything this idle period
+     * can return, so repeating it before work resumes finds nothing. */
+    atomic_store_explicit(&g_heap_decay_armed, false, memory_order_relaxed);
+
+    /* Blocks other threads freed to us, and our own slab cache, are not on
+     * a freelist yet and would be invisible to the walk below.  Only the
+     * caller's heap: see the note above on other heaps' lists. */
+    int64_t released = 0;
+    for (int hid = 0; hid < RAY_HEAP_REGISTRY_SIZE; hid++) {
+        ray_heap_t* gh = ray_heap_registry[hid];
+        if (!gh) continue;
+        /* Blocks freed to gh by another thread, and gh's own slab cache,
+         * are not on a freelist and would be invisible to the walk below —
+         * in a server that is where most of the free bytes are. */
+        heap_drain_foreign(gh);
+        heap_flush_slabs(gh);
+        for (int ord = 13; ord < RAY_HEAP_FL_SIZE; ord++) {
+            if (!(gh->avail & (1ULL << ord))) continue;
+            ray_fl_head_t* head = &gh->freelist[ord];
+            for (ray_t* blk = head->fl_next; blk != (ray_t*)head;
+                 blk = blk->fl_next) {
+                if (blk->attrs > RAY_FREE_AGE_RELEASE) continue;  /* released */
+                int pidx = heap_find_pool(gh, blk);
+                bool hp = (pidx >= 0) ? (gh->pools[pidx].hugepage != 0) : false;
+                ray_vm_release_block(blk, BSIZEOF(ord), hp);
+                blk->attrs = RAY_FREE_AGE_RELEASE + 1;
+                released++;
+            }
+        }
+    }
+    return released;
 }
 
 void ray_heap_merge(ray_heap_t* src) {

--- a/src/mem/heap.c
+++ b/src/mem/heap.c
@@ -656,6 +656,16 @@ static bool heap_add_pool(ray_heap_t* h, uint8_t order) {
          * uncounted.  Freed via ray_vm_free (which subtracts) at pool teardown. */
         ray_sys_track_add((int64_t)pool_size);
         mem = (void*)aligned;
+
+        /* Unlink now that the mapping holds the inode: the file keeps its
+         * blocks until the last mapping goes away, and the kernel reclaims
+         * them on munmap or on process exit, whichever comes first.  Doing
+         * it here rather than at teardown means no path out of this heap
+         * can strand the file — a worker that abandons its heap for reuse
+         * never runs a teardown at all. */
+        unlink(swap_path);
+        ray_sys_free(swap_path);
+        swap_path = NULL;
     }
 
     /* Enable transparent huge pages on anon pools (Linux).  Self-aligned

--- a/src/mem/heap.h
+++ b/src/mem/heap.h
@@ -254,8 +254,9 @@ void ray_heap_release_pages(void);
  *   quiescent; returns the number of blocks released, or -1 if it did
  *   nothing.  Safe to call from any maintenance point.
  *
- * RAY_HEAP_DECAY_MS sets the threshold: negative disables the decay, 0
- * releases at the next maintenance point after any work. */
+ * The threshold is fixed policy, reachable only through
+ * ray_heap_set_decay_ms: negative disables the decay, 0 releases at the
+ * next maintenance point after any work. */
 void    ray_heap_note_activity(void);
 int64_t ray_heap_decay_due_ms(void);
 int64_t ray_heap_decay(void);

--- a/src/mem/heap.h
+++ b/src/mem/heap.h
@@ -516,7 +516,11 @@ typedef struct ray_heap {
      * block always returns to the heap that has to reuse it, with no
      * collector in the loop.  Atomic because any thread may push while the
      * owner drains. */
-    _Atomic(ray_t*)  foreign;
+    /* Remote CAS target: every cross-thread free of a block this heap owns
+     * writes it.  On its own line so those writes do not bounce the line
+     * carrying `avail` and the slab heads, which the owner touches on every
+     * allocation. */
+    _Alignas(64) _Atomic(ray_t*) foreign;
     ray_slab_t       slabs[RAY_SLAB_ORDERS];       /* small-block slab caches */
     uint32_t        slab_cap[RAY_SLAB_ORDERS];   /* runtime push cap per slab order (byte-budgeted) */
     ray_fl_head_t    freelist[RAY_HEAP_FL_SIZE];   /* circular sentinel per order */

--- a/src/mem/heap.h
+++ b/src/mem/heap.h
@@ -235,6 +235,31 @@ void     ray_mem_trace_end(ray_mem_trace_t* out);
 void ray_heap_gc(void);
 void ray_heap_release_pages(void);
 
+/* ===== Idle decay =====
+ *
+ * Free blocks keep their pages so the next query reuses them without
+ * faulting.  That makes a process hold its peak footprint forever, which
+ * costs nothing to the process and everything to whatever shares the
+ * machine with it.  The decay gives those pages back once the process has
+ * been quiet for longer than a threshold, without a background thread:
+ * work stamps a timestamp, maintenance points compare it.
+ *
+ * ray_heap_note_activity  — stamp; call at the START of a unit of work (a
+ *   statement, an IPC request).  A stamp at the end would zero the elapsed
+ *   time seen by the boundary check that immediately follows it.
+ * ray_heap_decay_due_ms   — ms until a sweep is due, 0 if due now, -1 if
+ *   none is pending (nothing to release, or decay disabled).  An event loop
+ *   uses it to bound a wait it would otherwise make indefinite.
+ * ray_heap_decay          — sweep if due and if the worker pool is
+ *   quiescent; returns the number of blocks released, or -1 if it did
+ *   nothing.  Safe to call from any maintenance point.
+ *
+ * RAY_HEAP_DECAY_MS sets the threshold: negative disables the decay, 0
+ * releases at the next maintenance point after any work. */
+void    ray_heap_note_activity(void);
+int64_t ray_heap_decay_due_ms(void);
+int64_t ray_heap_decay(void);
+
 /* --------------------------------------------------------------------------
  * Constants
  * -------------------------------------------------------------------------- */

--- a/src/mem/heap.h
+++ b/src/mem/heap.h
@@ -260,6 +260,11 @@ void    ray_heap_note_activity(void);
 int64_t ray_heap_decay_due_ms(void);
 int64_t ray_heap_decay(void);
 
+/* Set the threshold directly; negative disables.  The environment is read
+ * once on first use, so this exists to let a test drive the policy without
+ * re-exec — not as a runtime knob. */
+void ray_heap_set_decay_ms(int64_t ms);
+
 /* --------------------------------------------------------------------------
  * Constants
  * -------------------------------------------------------------------------- */

--- a/src/mem/heap.h
+++ b/src/mem/heap.h
@@ -212,6 +212,17 @@ typedef struct ray_dispatch  ray_dispatch_t;
 
 void     ray_heap_init(void);
 void     ray_heap_destroy(void);
+/* Detach the calling thread from its heap WITHOUT tearing the heap down:
+ * the heap stays registered with its pools intact and is handed to the next
+ * thread that calls ray_heap_init().
+ *
+ * This is what a thread that exits must use.  A cross-thread free resolves
+ * the owning heap through ray_heap_registry and pushes the block onto it
+ * without taking a lock — that lookup is only sound while every registered
+ * heap outlives the blocks it owns, so a thread may never unregister and
+ * munmap a heap that another thread might still be freeing into.
+ * ray_heap_destroy remains the real teardown, for process shutdown. */
+void     ray_heap_abandon(void);
 void     ray_heap_merge(ray_heap_t* src);
 void     ray_heap_flush_foreign(void);
 void     ray_heap_push_pending(ray_heap_t* heap);
@@ -469,7 +480,13 @@ typedef struct {
 typedef struct ray_heap {
     uint64_t        avail;                       /* bitmask: bit N set = freelist[N] non-empty */
     uint16_t        id;                          /* heap identity (for cross-thread free) */
-    ray_t*           foreign;                     /* cross-heap freed blocks (lock-free LIFO via fl_next) */
+    /* Blocks of THIS heap freed by another thread, waiting to be taken back.
+     * A cross-thread free pushes onto the OWNER's list (CAS), and the owner
+     * drains it with one atomic_exchange on its allocation slow path — so a
+     * block always returns to the heap that has to reuse it, with no
+     * collector in the loop.  Atomic because any thread may push while the
+     * owner drains. */
+    _Atomic(ray_t*)  foreign;
     ray_slab_t       slabs[RAY_SLAB_ORDERS];       /* small-block slab caches */
     uint32_t        slab_cap[RAY_SLAB_ORDERS];   /* runtime push cap per slab order (byte-budgeted) */
     ray_fl_head_t    freelist[RAY_HEAP_FL_SIZE];   /* circular sentinel per order */
@@ -478,6 +495,7 @@ typedef struct ray_heap {
     uint32_t        last_pool_idx;               /* MRU pool index for warm-first ray_free */
     ray_pool_entry_t pools[RAY_MAX_POOLS];         /* pool tracking for destroy/merge */
     struct ray_heap* pending_next;                /* link for pending-merge LIFO queue */
+    struct ray_heap* idle_next;                   /* link for the abandoned-heap LIFO */
     char            swap_path[256];              /* dir for file-backed pool fallback (RAY_HEAP_SWAP env, default "./") */
 } ray_heap_t;
 

--- a/src/ops/join.c
+++ b/src/ops/join.c
@@ -1375,7 +1375,8 @@ static ray_t* exec_join_flat(ray_graph_t* g, ray_op_t* op, ray_t* left_table, ra
         /* Free per-partition buffers allocated by worker threads.
          * Safe: ray_pool_dispatch_n has completed (workers are back on semaphore),
          * ray_parallel_flag is 0, and ray_free handles cross-heap deallocation
-         * via the foreign-block list flushed by ray_heap_gc at ray_parallel_end. */
+         * by handing each block to the worker heap that owns it, which takes
+         * it back on its own next allocation — no collector call involved. */
         for (uint32_t rp2 = 0; rp2 < n_rparts; rp2++) {
             if (pp_l_hdr[rp2]) scratch_free(pp_l_hdr[rp2]);
             if (pp_r_hdr[rp2]) scratch_free(pp_r_hdr[rp2]);

--- a/src/ops/system.c
+++ b/src/ops/system.c
@@ -784,6 +784,9 @@ ray_t* ray_mem_ts_fn(ray_t** args, int64_t n) {
 ray_t* ray_gc_fn(ray_t** args, int64_t n) {
     (void)args; (void)n;
     ray_heap_gc();
+    /* Same statement-boundary rule as the REPL: an explicit maintenance
+     * call is also a chance to notice the process has gone quiet. */
+    ray_heap_decay();
     return ray_i64(0);
 }
 

--- a/test/test_buddy.c
+++ b/test/test_buddy.c
@@ -404,12 +404,17 @@ static test_result_t test_cross_heap_free(void) {
 
     /* Switch to heap_a and free blocks from the wrong heap */
     ray_tl_heap = heap_a;
-    ray_free(blk1);  /* should go to heap_a->foreign */
+    ray_free(blk1);  /* routed to heap_b — the owner — not to heap_a */
     ray_free(blk2);
     ray_free(blk3);
+    TEST_ASSERT_NULL(atomic_load(&heap_a->foreign));
+    TEST_ASSERT_NOT_NULL(atomic_load(&heap_b->foreign));
 
-    /* Flush foreign blocks back to their owning heap */
+    /* heap_a has nothing of its own queued; heap_b takes its blocks back. */
     ray_heap_flush_foreign();
+    ray_tl_heap = heap_b;
+    ray_heap_flush_foreign();
+    TEST_ASSERT_NULL(atomic_load(&heap_b->foreign));
 
     /* Cleanup: destroy heap_b */
     ray_tl_heap = heap_b;
@@ -452,8 +457,8 @@ static test_result_t test_heap_pending_merge(void) {
     /* The block should still be accessible (pool transferred) */
     TEST_ASSERT_EQ_U(blk->mmod, 0);
 
-    /* Free the block — goes via foreign path (heap_id mismatch)
-     * then flush reclaims it locally */
+    /* Free the block — merge rewrote its pool header to heap_a, so this is
+     * an ordinary local free. */
     ray_free(blk);
     ray_heap_flush_foreign();
 

--- a/test/test_heap.c
+++ b/test/test_heap.c
@@ -41,6 +41,9 @@
 #include "test.h"
 #include <rayforce.h>
 #include "mem/heap.h"
+
+/* Restore the shipped policy after a test drives it. */
+#define RAY_HEAP_DECAY_MS_TEST_DEFAULT 10000
 #include "ops/ops.h"
 #include <string.h>
 #include <stdint.h>
@@ -328,7 +331,7 @@ static test_result_t test_release_pages(void) {
  * just freed keeps its footprint, which is what stops a repeated query from
  * refaulting its own temporaries between iterations.  The decay is the other
  * half of that policy — once the process has been quiet for longer than
- * RAY_HEAP_DECAY_MS, the same pages go back to the OS un-aged.
+ * threshold to zero, the same pages go back to the OS un-aged.
  *
  * Both halves are asserted here, on the same block, in the same test: one
  * collector pass must NOT release it, and the decay immediately after must.
@@ -359,14 +362,14 @@ static size_t heap_rss_kb(void) {
 static test_result_t test_idle_decay_releases_pages(void) {
     /* Threshold 0 means "release at the first maintenance point after any
      * work", so the test asserts the mechanism without sleeping on a clock. */
-    setenv("RAY_HEAP_DECAY_MS", "0", 1);
+    ray_heap_set_decay_ms(0);
 
     /* Order 24: comfortably above the order-13 sweep floor, and below
      * RAY_HEAP_POOL_ORDER so it is a buddy block rather than a direct
      * mapping that munmaps itself on free. */
     const size_t big = (16u << 20) - 4096;
     ray_t* v = ray_alloc(big);
-    if (!v) { unsetenv("RAY_HEAP_DECAY_MS"); SKIP("16 MB block unavailable"); }
+    if (!v) { ray_heap_set_decay_ms(RAY_HEAP_DECAY_MS_TEST_DEFAULT); SKIP("16 MB block unavailable"); }
     memset(ray_data(v), 0xA5, big);          /* fault every page in */
 
     size_t rss_live = heap_rss_kb();
@@ -381,7 +384,7 @@ static test_result_t test_idle_decay_releases_pages(void) {
     int64_t released = ray_heap_decay();
     size_t rss_decay = heap_rss_kb();
 
-    unsetenv("RAY_HEAP_DECAY_MS");
+    ray_heap_set_decay_ms(RAY_HEAP_DECAY_MS_TEST_DEFAULT);
 
     TEST_ASSERT(released >= 1, "the decay sweep released at least one block");
     if (rss_live > 0) {
@@ -407,11 +410,11 @@ static test_result_t test_idle_decay_releases_pages(void) {
  * lying around — that is the entire defence against releasing the pages a
  * hot loop is about to reuse. */
 static test_result_t test_idle_decay_respects_threshold(void) {
-    setenv("RAY_HEAP_DECAY_MS", "600000", 1);
+    ray_heap_set_decay_ms(600000);
 
     const size_t big = (16u << 20) - 4096;
     ray_t* v = ray_alloc(big);
-    if (!v) { unsetenv("RAY_HEAP_DECAY_MS"); SKIP("16 MB block unavailable"); }
+    if (!v) { ray_heap_set_decay_ms(RAY_HEAP_DECAY_MS_TEST_DEFAULT); SKIP("16 MB block unavailable"); }
     memset(ray_data(v), 0xA5, big);
     ray_free(v);
 
@@ -420,9 +423,9 @@ static test_result_t test_idle_decay_respects_threshold(void) {
     int64_t released = ray_heap_decay();
 
     /* Negative threshold disables the decay outright. */
-    setenv("RAY_HEAP_DECAY_MS", "-1", 1);
+    ray_heap_set_decay_ms(-1);
     int64_t due_off = ray_heap_decay_due_ms();
-    unsetenv("RAY_HEAP_DECAY_MS");
+    ray_heap_set_decay_ms(RAY_HEAP_DECAY_MS_TEST_DEFAULT);
 
     TEST_ASSERT(due > 0, "a sweep is pending but not yet due");
     TEST_ASSERT(released < 0, "nothing is swept before the threshold elapses");
@@ -430,10 +433,10 @@ static test_result_t test_idle_decay_respects_threshold(void) {
 
     /* Proof the block really was sweepable, i.e. the assertions above were
      * not vacuous: with the threshold at 0 the same block goes. */
-    setenv("RAY_HEAP_DECAY_MS", "0", 1);
+    ray_heap_set_decay_ms(0);
     ray_heap_note_activity();
     int64_t swept = ray_heap_decay();
-    unsetenv("RAY_HEAP_DECAY_MS");
+    ray_heap_set_decay_ms(RAY_HEAP_DECAY_MS_TEST_DEFAULT);
     TEST_ASSERT(swept >= 1, "the same block is released once the threshold is 0");
     PASS();
 }

--- a/test/test_heap.c
+++ b/test/test_heap.c
@@ -1370,13 +1370,17 @@ static test_result_t test_free_owner_unregistered(void) {
     uint16_t bid = heap_b->id;
     ray_heap_registry[bid % RAY_HEAP_REGISTRY_SIZE] = NULL;
 
-    /* Free blk from heap_a: the owner lookup on phdr->heap_id == bid finds
-     * nothing, so the block is dropped. */
+    /* Free blk from heap_a.  The owner lookup on phdr->heap_id == bid finds
+     * nothing, and an unregistered heap is indistinguishable from one merely
+     * waiting to be merged — whose pools are still mapped.  So the block is
+     * kept on the freeing heap's own list rather than dropped: dropping it
+     * would strand it and pin its pool against reclamation for good. */
     ray_tl_heap = heap_a;
     ray_free(blk);
-    TEST_ASSERT_NULL(atomic_load(&heap_a->foreign));
+    TEST_ASSERT_NOT_NULL(atomic_load(&heap_a->foreign));
     TEST_ASSERT_NULL(atomic_load(&heap_b->foreign));
 
+    /* The drain adopts it against its own pool header. */
     ray_heap_gc();
     TEST_ASSERT_NULL(atomic_load(&heap_a->foreign));
 

--- a/test/test_heap.c
+++ b/test/test_heap.c
@@ -366,8 +366,8 @@ static test_result_t test_gc_reclaim_oversized_pool(void) {
 
 static test_result_t test_heap_gc_serial(void) {
     /* Build up some freelist activity, then call gc.  No oversized pools
-     * are involved; gc should still run flush_foreign + flush_slabs +
-     * return_foreign_freelist without crashing. */
+     * are involved; gc should still run its foreign drain + slab flush
+     * without crashing. */
     ray_t* xs[64];
     for (int i = 0; i < 64; i++) {
         xs[i] = ray_alloc(256 + i * 8);
@@ -385,13 +385,12 @@ static test_result_t test_heap_gc_serial(void) {
     PASS();
 }
 
-/* ---- ray_heap_gc parallel path (foreign-flush no-op) ------------------- */
+/* ---- ray_heap_gc parallel path ---------------------------------------- */
 
 static test_result_t test_heap_gc_parallel(void) {
-    /* When ray_parallel_flag != 0, heap_flush_foreign(false) is a no-op
-     * and gc must NOT touch worker heaps' state.  We only need to
-     * verify that calling gc with the flag set doesn't crash and the
-     * heap remains consistent. */
+    /* When ray_parallel_flag != 0, gc must NOT touch worker heaps' state.
+     * We only need to verify that calling gc with the flag set doesn't
+     * crash and the heap remains consistent. */
     ray_t* a = ray_alloc(128);
     TEST_ASSERT_NOT_NULL(a);
 
@@ -405,38 +404,146 @@ static test_result_t test_heap_gc_parallel(void) {
     PASS();
 }
 
-/* ---- ray_heap_flush_foreign while parallel (no-op early return) -------- */
+/* ---- Cross-thread free lands on the OWNER's list ------------------------
+ *
+ * A block freed by a thread that does not own it goes onto the OWNING heap's
+ * list, never the freeing heap's.  That is the whole point: the owner is the
+ * only heap that can reuse the memory, and it picks the block up on its own
+ * allocation path — nothing has to call a collector.  Memory parked on the
+ * freeing heap was what let a served query grow a server without bound
+ * (issue #439). */
 
-static test_result_t test_flush_foreign_during_parallel(void) {
-    /* While ray_parallel_flag is set, ray_heap_flush_foreign() must not
-     * touch h->foreign — proves the early return path. */
+static test_result_t test_free_routes_to_owner_list(void) {
     ray_heap_t* heap_a = ray_tl_heap;
 
-    /* Build heap_b and free a block from it on heap_a so heap_a->foreign
-     * is non-empty. */
     ray_tl_heap = NULL;
     ray_heap_init();
     ray_heap_t* heap_b = ray_tl_heap;
     TEST_ASSERT_NOT_NULL(heap_b);
+    TEST_ASSERT(heap_b != heap_a, "distinct heaps");
     ray_t* blk = ray_alloc(0);
     TEST_ASSERT_NOT_NULL(blk);
 
     ray_tl_heap = heap_a;
-    ray_free(blk);  /* cross-thread free: enqueues onto heap_a->foreign */
-    /* Foreign-list model: the cross-thread free sits on the freeing heap. */
-    TEST_ASSERT_NOT_NULL(heap_a->foreign);
+    ray_free(blk);
+    TEST_ASSERT_NULL(atomic_load(&heap_a->foreign));
+    TEST_ASSERT_EQ_U((uintptr_t)atomic_load(&heap_b->foreign), (uintptr_t)blk);
 
+    /* Draining heap_a leaves heap_b's list alone — and needs no idle-worker
+     * gate any more, because a heap only ever drains its own blocks. */
     ray_parallel_begin();
     ray_heap_flush_foreign();
-    /* Foreign list should still be intact (not flushed). */
-    TEST_ASSERT_NOT_NULL(heap_a->foreign);
+    TEST_ASSERT_EQ_U((uintptr_t)atomic_load(&heap_b->foreign), (uintptr_t)blk);
     ray_parallel_end();
-    /* parallel_end -> ray_heap_gc which DOES flush foreign now safe.  */
-    /* Foreign list should be empty after end. */
-    TEST_ASSERT_NULL(heap_a->foreign);
+    TEST_ASSERT_EQ_U((uintptr_t)atomic_load(&heap_b->foreign), (uintptr_t)blk);
 
+    /* The owner takes it back. */
     ray_tl_heap = heap_b;
+    ray_heap_flush_foreign();
+    TEST_ASSERT_NULL(atomic_load(&heap_b->foreign));
+
     ray_heap_destroy();
+    ray_tl_heap = heap_a;
+    PASS();
+}
+
+/* ---- A cross-thread free cycle must not grow the owner's pools ----------
+ *
+ * The regression for issue #439.  Workers allocate per-group temporaries from
+ * their own heaps and the thread consuming the result frees them; before this
+ * change those blocks stayed on the consumer and only an explicit
+ * ray_heap_gc() ever moved them, so the owner started every round short by
+ * the volume the consumer was holding and mapped a fresh 32 MB pool to make
+ * up the difference — once per execution, until RAY_MAX_POOLS turned it into
+ * an OOM.  Cycle far more bytes through the owner than one pool holds,
+ * always freeing from the other heap and never calling a collector: the
+ * owner's pool count must not move. */
+
+static test_result_t test_cross_heap_cycle_bounds_pools(void) {
+    enum { WARMUP = 32, ROUNDS = 128, BLOCK = 1u << 20 };  /* 1 MB blocks */
+    ray_heap_t* heap_a = ray_tl_heap;
+
+    ray_tl_heap = NULL;
+    ray_heap_init();
+    ray_heap_t* heap_b = ray_tl_heap;
+    TEST_ASSERT_NOT_NULL(heap_b);
+
+    /* Warm-up: let heap_b map whatever pools its steady state needs. */
+    for (int i = 0; i < WARMUP; i++) {
+        ray_tl_heap = heap_b;
+        ray_t* v = ray_alloc(BLOCK);
+        TEST_ASSERT_NOT_NULL(v);
+        ray_tl_heap = heap_a;
+        ray_free(v);
+    }
+    ray_tl_heap = heap_b;
+    uint32_t pools_before = heap_b->pool_count;
+    TEST_ASSERT((pools_before) > (0), "heap_b mapped a pool");
+
+    /* 128 MB more through a heap whose pools are 32 MB. */
+    bool saw_queued = false;
+    for (int i = 0; i < ROUNDS; i++) {
+        ray_tl_heap = heap_b;
+        ray_t* v = ray_alloc(BLOCK);
+        TEST_ASSERT_NOT_NULL(v);
+        ray_tl_heap = heap_a;
+        ray_free(v);
+        if (atomic_load(&heap_b->foreign) != NULL) saw_queued = true;
+    }
+    ray_tl_heap = heap_b;
+
+    /* Guards the assertion below against passing vacuously: if the frees had
+     * never reached heap_b's list there would be nothing for it to take back
+     * and no reuse to prove. */
+    TEST_ASSERT(saw_queued, "frees reached the owner's list");
+    TEST_ASSERT_EQ_U(heap_b->pool_count, pools_before);
+    TEST_ASSERT_NULL(atomic_load(&heap_a->foreign));
+
+    ray_heap_destroy();
+    ray_tl_heap = heap_a;
+    PASS();
+}
+
+/* ---- A thread's heap outlives the thread -------------------------------
+ *
+ * ray_free resolves the owning heap through ray_heap_registry and pushes the
+ * block onto it WITHOUT a lock.  That is only sound while a registered heap
+ * outlives every block it owns, so a thread that exits abandons its heap —
+ * still registered, pools intact — instead of unregistering and munmapping
+ * it underneath a lookup already in flight.  The next thread up adopts it. */
+
+static test_result_t test_heap_abandon_is_adopted(void) {
+    ray_heap_t* heap_a = ray_tl_heap;
+
+    ray_tl_heap = NULL;
+    ray_heap_init();
+    ray_heap_t* heap_b = ray_tl_heap;
+    TEST_ASSERT_NOT_NULL(heap_b);
+    ray_t* blk = ray_alloc(4096);
+    TEST_ASSERT_NOT_NULL(blk);
+    uint16_t   bid    = heap_b->id;
+    uint32_t   bpools = heap_b->pool_count;
+    TEST_ASSERT((bpools) > (0), "heap_b mapped a pool");
+
+    ray_heap_abandon();
+    TEST_ASSERT_NULL(ray_tl_heap);
+    TEST_ASSERT_EQ_U((uintptr_t)ray_heap_registry[bid % RAY_HEAP_REGISTRY_SIZE],
+                     (uintptr_t)heap_b);
+    /* The pool is still mapped and still names heap_b as its owner. */
+    TEST_ASSERT_EQ_U(ray_pool_of(blk)->heap_id, bid);
+
+    /* A block of the abandoned heap, freed from elsewhere, still finds it. */
+    ray_tl_heap = heap_a;
+    ray_free(blk);
+    TEST_ASSERT_EQ_U((uintptr_t)atomic_load(&heap_b->foreign), (uintptr_t)blk);
+
+    /* The next thread adopts it rather than mapping a new one. */
+    ray_tl_heap = NULL;
+    ray_heap_init();
+    TEST_ASSERT_EQ_U((uintptr_t)ray_tl_heap, (uintptr_t)heap_b);
+    TEST_ASSERT_EQ_U(ray_tl_heap->pool_count, bpools);
+
+    ray_heap_destroy();   /* real teardown — no thread owns heap_b now */
     ray_tl_heap = heap_a;
     PASS();
 }
@@ -736,14 +843,14 @@ static test_result_t test_merge_with_slabs_and_freelist(void) {
     uint32_t heap_b_pools = heap_b->pool_count;
     TEST_ASSERT((heap_b_pools) > (0), "heap_b_pools > 0");
 
-    /* Drive a foreign block into heap_b->foreign by allocating on
-     * heap_a and freeing while heap_b is current. */
-    ray_tl_heap = heap_a;
+    /* Drive a block onto heap_b->foreign: allocate it on heap_b and free it
+     * while heap_a is current — a cross-thread free goes to the owner. */
+    ray_tl_heap = heap_b;
     ray_t* fblk = ray_alloc(0);
     TEST_ASSERT_NOT_NULL(fblk);
-    ray_tl_heap = heap_b;
-    ray_free(fblk);  /* heap_b->foreign now contains fblk (foreign-list model) */
-    TEST_ASSERT_NOT_NULL(heap_b->foreign);
+    ray_tl_heap = heap_a;
+    ray_free(fblk);
+    TEST_ASSERT_NOT_NULL(atomic_load(&heap_b->foreign));
 
     /* Capture pool count AFTER any allocs heap_a has performed for fblk —
      * lazy heap_add_pool may have grown the count. */
@@ -1110,21 +1217,20 @@ static test_result_t test_release_lambda_owned_refs(void) {
     PASS();
 }
 
-/* ---- heap_flush_foreign "owner gone" branch -------------------------------
+/* ---- Cross-thread free with the owner unregistered ------------------------
  *
- * Allocate on heap_b, then destroy heap_b (unregisters it).  Free the
- * block while on heap_a — it lands in heap_a->foreign with a pool header
- * whose heap_id no longer maps to a live heap.  Calling ray_heap_gc() with
- * return_to_owner=true triggers heap_flush_foreign which hits the "owner
- * gone" else-branch and coalesces the block locally onto heap_a.
+ * If the owning heap is not in the registry its pools went with it, so there
+ * is nowhere to hand the block back to.  The free must drop it — and in
+ * particular must NOT park it on the freeing heap, which cannot reuse
+ * another heap's memory and would only be accumulating it.
  *
  * NOTE: heap_b must NOT be destroyed via ray_heap_destroy (that munmaps its
  * pools).  Instead we manually unregister it from the global registry so
- * its pool remains mapped (and addressable) while the foreign-block walk
- * proceeds.  We then push_pending the hollow heap_b to let drain_pending
- * transfer ownership properly and avoid leaking address space. */
+ * its pool remains mapped (and the block addressable) for the assertions.
+ * We then push_pending the hollow heap_b to let drain_pending transfer
+ * ownership properly and avoid leaking address space. */
 
-static test_result_t test_flush_foreign_owner_gone(void) {
+static test_result_t test_free_owner_unregistered(void) {
     ray_heap_t* heap_a = ray_tl_heap;
     TEST_ASSERT_NOT_NULL(heap_a);
 
@@ -1138,21 +1244,19 @@ static test_result_t test_flush_foreign_owner_gone(void) {
     TEST_ASSERT_NOT_NULL(blk);
 
     /* Unregister heap_b from the global registry so it looks "gone"
-     * without munmapping its pool (the pool must stay valid for the
-     * owner-lookup walk). */
+     * without munmapping its pool. */
     uint16_t bid = heap_b->id;
     ray_heap_registry[bid % RAY_HEAP_REGISTRY_SIZE] = NULL;
 
-    /* Switch to heap_a and free blk — it goes onto heap_a->foreign because
-     * phdr->heap_id == bid which != heap_a->id. */
+    /* Free blk from heap_a: the owner lookup on phdr->heap_id == bid finds
+     * nothing, so the block is dropped. */
     ray_tl_heap = heap_a;
     ray_free(blk);
-    TEST_ASSERT_NOT_NULL(heap_a->foreign);
+    TEST_ASSERT_NULL(atomic_load(&heap_a->foreign));
+    TEST_ASSERT_NULL(atomic_load(&heap_b->foreign));
 
-    /* GC with safe=true triggers heap_flush_foreign(h, true).
-     * Owner lookup returns NULL → "owner gone" else-branch. */
     ray_heap_gc();
-    TEST_ASSERT_NULL(heap_a->foreign);
+    TEST_ASSERT_NULL(atomic_load(&heap_a->foreign));
 
     /* Re-register heap_b and clean up via push_pending/drain_pending so
      * its pools are properly transferred and no address space leaks. */
@@ -1221,30 +1325,15 @@ static test_result_t test_merge_slab_overflow(void) {
     PASS();
 }
 
-/* ---- heap_return_foreign_freelist path ------------------------------------
+/* ---- GC over a heap that absorbed another one's pools ---------------------
  *
- * After ray_heap_merge, heap_a owns all of heap_b's pools.  But the pool
- * table of heap_b (now freed) tracked those pools.  Allocating on the merged
- * heap and freeing on a third heap inserts blocks with heap_b's (now
- * heap_a's) heap_id into heap_c's freelists.  GC on heap_c then calls
- * heap_return_foreign_freelist which returns those blocks to heap_a.
- *
- * Simpler route that does NOT require a 3rd heap: after merging heap_b into
- * heap_a, coalesce puts blocks back on heap_a's freelist — those blocks'
- * pool_order matches heap_a's pools.  heap_return_foreign_freelist walks
- * heap_a's freelists; blocks that ARE in heap_a's pool table are local
- * (pidx >= 0) and the inner if(pidx < 0) branch is skipped.  To reach
- * pidx < 0 we need a freelist entry whose pool is not in pool[].
- *
- * Pragmatic approach: add enough blocks to freelist and call GC; even if
- * the foreign-freelist inner body isn't hit, we still cover the outer loop
- * and the pidx >= 0 early-continue path (which currently has 0 coverage). */
+ * ray_heap_merge splices src's freelists into dst and transfers its pool
+ * entries.  Run GC on the merged heap: every pass has to cope with freelist
+ * entries whose pool arrived from somewhere else, and with the pool table
+ * having grown underneath the avail bitmap. */
 
-static test_result_t test_gc_return_foreign_freelist(void) {
-    /* Build heap_b, populate it, merge into heap_a, then run GC.
-     * heap_return_foreign_freelist walks freelists of heap_a and checks
-     * ownership of each block.  At minimum, the outer for loop and the
-     * heap_find_pool call are covered. */
+static test_result_t test_gc_after_merge(void) {
+    /* Build heap_b, populate it, merge into heap_a, then run GC. */
     ray_heap_t* heap_a = ray_tl_heap;
 
     ray_tl_heap = NULL;
@@ -1508,10 +1597,12 @@ static test_result_t test_merge_foreign_pool_fallback(void) {
     TEST_ASSERT_NOT_NULL(cblk);
 
     /* Manually enqueue cblk onto heap_b->foreign.
-     * heap_b doesn't own any of heap_c's pools. */
+     * heap_b doesn't own any of heap_c's pools — a real cross-thread free
+     * would route the block to heap_c, so this shape has to be built by
+     * hand to reach the merge fallback. */
     ray_tl_heap = heap_b;
-    cblk->fl_next  = heap_b->foreign;
-    heap_b->foreign = cblk;
+    cblk->fl_next = NULL;
+    atomic_store(&heap_b->foreign, cblk);
 
     /* Now merge heap_b into heap_a.  heap_a also doesn't know about
      * heap_c's pool, so heap_find_pool(heap_a, cblk) returns -1 → phdr. */
@@ -2425,7 +2516,9 @@ const test_entry_t heap_entries[] = {
     { "heap/gc_reclaim_oversized",     test_gc_reclaim_oversized_pool,   heap_setup, heap_teardown },
     { "heap/gc_serial",                test_heap_gc_serial,              heap_setup, heap_teardown },
     { "heap/gc_parallel",              test_heap_gc_parallel,            heap_setup, heap_teardown },
-    { "heap/flush_foreign_parallel",   test_flush_foreign_during_parallel, heap_setup, heap_teardown },
+    { "heap/free_routes_to_owner",     test_free_routes_to_owner_list,   heap_setup, heap_teardown },
+    { "heap/cross_heap_cycle_bounds",  test_cross_heap_cycle_bounds_pools, heap_setup, heap_teardown },
+    { "heap/abandon_is_adopted",       test_heap_abandon_is_adopted,     heap_setup, heap_teardown },
     { "heap/alloc_copy_list",          test_alloc_copy_list_retains,     heap_setup, heap_teardown },
     { "heap/str_pool_owned_ref",       test_str_pool_owned_ref,          heap_setup, heap_teardown },
     { "heap/sentinel_null_release",    test_sentinel_null_release,       heap_setup, heap_teardown },
@@ -2445,9 +2538,9 @@ const test_entry_t heap_entries[] = {
     { "heap/scratch_realloc_mapcommon",test_scratch_realloc_mapcommon,   heap_setup, heap_teardown },
     { "heap/alloc_copy_dict",          test_alloc_copy_dict_block,       heap_setup, heap_teardown },
     { "heap/release_lambda_owned_refs", test_release_lambda_owned_refs,   heap_setup, heap_teardown },
-    { "heap/flush_foreign_owner_gone", test_flush_foreign_owner_gone,    heap_setup, heap_teardown },
+    { "heap/free_owner_unregistered",  test_free_owner_unregistered,     heap_setup, heap_teardown },
     { "heap/merge_slab_overflow",      test_merge_slab_overflow,         heap_setup, heap_teardown },
-    { "heap/gc_return_foreign_fl",     test_gc_return_foreign_freelist,  heap_setup, heap_teardown },
+    { "heap/gc_after_merge",           test_gc_after_merge,              heap_setup, heap_teardown },
     { "heap/free_mmod1_atom",          test_free_mmod1_atom,             heap_setup, heap_teardown },
     { "heap/order_for_size_pow2",      test_order_for_size_pow2,         heap_setup, heap_teardown },
     { "heap/scratch_realloc_slice",    test_scratch_realloc_slice,       heap_setup, heap_teardown },

--- a/test/test_heap.c
+++ b/test/test_heap.c
@@ -44,8 +44,11 @@
 #include "ops/ops.h"
 #include <string.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <stdatomic.h>
 #include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 /* ---- Setup / Teardown -------------------------------------------------- */
 
@@ -316,6 +319,122 @@ static test_result_t test_release_pages(void) {
      * past 4 KB will fault back in lazily. */
     memset(ray_data(x), 0x42, 100 * 1024);
     ray_free(x);
+    PASS();
+}
+
+/* ---- Idle decay --------------------------------------------------------- *
+ *
+ * ray_heap_gc AGES a free block before releasing its pages: a block that was
+ * just freed keeps its footprint, which is what stops a repeated query from
+ * refaulting its own temporaries between iterations.  The decay is the other
+ * half of that policy — once the process has been quiet for longer than
+ * RAY_HEAP_DECAY_MS, the same pages go back to the OS un-aged.
+ *
+ * Both halves are asserted here, on the same block, in the same test: one
+ * collector pass must NOT release it, and the decay immediately after must.
+ * The released-block count is asserted too, so the test cannot pass by
+ * sweeping nothing. */
+
+/* Resident set in KB, or 0 where /proc is unavailable. */
+static size_t heap_rss_kb(void) {
+#if defined(__linux__)
+    int fd = open("/proc/self/statm", O_RDONLY);
+    if (fd < 0) return 0;
+    char buf[128];
+    ssize_t n = read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+    if (n <= 0) return 0;
+    buf[n] = '\0';
+    const char* p = buf;
+    while (*p && *p != ' ') p++;          /* field 1 is total size */
+    unsigned long long pages = strtoull(p, NULL, 10);
+    long pgsz = sysconf(_SC_PAGESIZE);
+    if (pgsz <= 0) return 0;
+    return (size_t)((pages * (unsigned long long)pgsz) / 1024);
+#else
+    return 0;
+#endif
+}
+
+static test_result_t test_idle_decay_releases_pages(void) {
+    /* Threshold 0 means "release at the first maintenance point after any
+     * work", so the test asserts the mechanism without sleeping on a clock. */
+    setenv("RAY_HEAP_DECAY_MS", "0", 1);
+
+    /* Order 24: comfortably above the order-13 sweep floor, and below
+     * RAY_HEAP_POOL_ORDER so it is a buddy block rather than a direct
+     * mapping that munmaps itself on free. */
+    const size_t big = (16u << 20) - 4096;
+    ray_t* v = ray_alloc(big);
+    if (!v) { unsetenv("RAY_HEAP_DECAY_MS"); SKIP("16 MB block unavailable"); }
+    memset(ray_data(v), 0xA5, big);          /* fault every page in */
+
+    size_t rss_live = heap_rss_kb();
+    ray_free(v);
+
+    /* One collector pass can only age a freshly inserted block (attrs 0 -> 1),
+     * never release it. */
+    ray_heap_gc();
+    size_t rss_gc = heap_rss_kb();
+
+    ray_heap_note_activity();
+    int64_t released = ray_heap_decay();
+    size_t rss_decay = heap_rss_kb();
+
+    unsetenv("RAY_HEAP_DECAY_MS");
+
+    TEST_ASSERT(released >= 1, "the decay sweep released at least one block");
+    if (rss_live > 0) {
+        size_t half = (big / 1024) / 2;
+        TEST_ASSERT(rss_gc + half > rss_live,
+                    "collector alone keeps the freed block resident");
+        TEST_ASSERT(rss_decay + half < rss_live,
+                    "decay handed most of the freed block back");
+    }
+
+    /* Disarmed: the sweep is triggered by work going quiet, not by asking. */
+    TEST_ASSERT(ray_heap_decay() < 0, "a second decay with no work does nothing");
+
+    /* Released pages refault: the address space is untouched. */
+    ray_t* w = ray_alloc(big);
+    TEST_ASSERT_NOT_NULL(w);
+    memset(ray_data(w), 0x5A, big);
+    ray_free(w);
+    PASS();
+}
+
+/* A decay that is not due must not sweep, however much free memory is
+ * lying around — that is the entire defence against releasing the pages a
+ * hot loop is about to reuse. */
+static test_result_t test_idle_decay_respects_threshold(void) {
+    setenv("RAY_HEAP_DECAY_MS", "600000", 1);
+
+    const size_t big = (16u << 20) - 4096;
+    ray_t* v = ray_alloc(big);
+    if (!v) { unsetenv("RAY_HEAP_DECAY_MS"); SKIP("16 MB block unavailable"); }
+    memset(ray_data(v), 0xA5, big);
+    ray_free(v);
+
+    ray_heap_note_activity();
+    int64_t due = ray_heap_decay_due_ms();
+    int64_t released = ray_heap_decay();
+
+    /* Negative threshold disables the decay outright. */
+    setenv("RAY_HEAP_DECAY_MS", "-1", 1);
+    int64_t due_off = ray_heap_decay_due_ms();
+    unsetenv("RAY_HEAP_DECAY_MS");
+
+    TEST_ASSERT(due > 0, "a sweep is pending but not yet due");
+    TEST_ASSERT(released < 0, "nothing is swept before the threshold elapses");
+    TEST_ASSERT(due_off < 0, "a negative threshold disables the decay");
+
+    /* Proof the block really was sweepable, i.e. the assertions above were
+     * not vacuous: with the threshold at 0 the same block goes. */
+    setenv("RAY_HEAP_DECAY_MS", "0", 1);
+    ray_heap_note_activity();
+    int64_t swept = ray_heap_decay();
+    unsetenv("RAY_HEAP_DECAY_MS");
+    TEST_ASSERT(swept >= 1, "the same block is released once the threshold is 0");
     PASS();
 }
 
@@ -2576,5 +2695,7 @@ const test_entry_t heap_entries[] = {
     { "heap/retain_atom_obj",          test_retain_owned_refs_atom_obj,  heap_setup, heap_teardown },
     { "heap/scratch_realloc_lazy",     test_scratch_realloc_lazy_handle, heap_setup, heap_teardown },
     { "heap/scratch_realloc_has_index", test_scratch_realloc_has_index_detach, heap_setup, heap_teardown },
+    { "heap/idle_decay_releases",      test_idle_decay_releases_pages,   heap_setup, heap_teardown },
+    { "heap/idle_decay_threshold",     test_idle_decay_respects_threshold, heap_setup, heap_teardown },
     { NULL, NULL, NULL, NULL },
 };


### PR DESCRIPTION
Closes #439.

## The bug

A repeated `select` with a composite `by:` key grew a served process on every execution and never gave any of it back, until `RAY_MAX_POOLS` turned it into an `oom`.

Nothing leaked. Workers allocate their per-group temporaries from their own heaps, and the thread that consumes the result frees them. A block that is not in any of the freeing heap's pools took the "foreign" path: `heap_find_pool` misses, absorbing it locally would divorce it from the pool that owns it, so it was queued on **the freeing thread's own** list to wait for a collector. `repl.c` runs one after every statement; `ipc.c` ran none at all. So a served query parked its whole allocation volume on the connection thread, the owning worker began the next execution short by exactly that much, and mapped a fresh pool to cover it.

## Hand the block to its owner instead

`ray_free` now resolves the owner from the pool header and CAS-pushes the block onto **that heap's** list; the owner drains it with one atomic exchange in `ray_alloc`'s slow path, before any pool can be added. Nothing accumulates anywhere, so the growth is impossible by construction and no collector call is involved.

That needs a lifetime guarantee the allocator did not have: a heap must outlive every block it owns, or a freeing thread can CAS into a mapping the owner has already unmapped. So a worker now **abandons** its heap — it stays registered with its pools intact, and the next worker thread adopts it — instead of destroying it. Real teardown is kept for process shutdown.

Four mechanisms existed only to work around the old accumulate-locally design and are gone: returning foreign blocks during collection, absorbing them onto a local freelist, the registry-wide `has_foreign` scan in the pool-reclaim pass together with the destructive purge that had to follow it, and the cross-heap purge in `ray_heap_destroy` — and with it the freelist-tearing hazard its own comments documented. The dead `heap_flush_foreign(h, false)` call in `ray_alloc` is removed.

A swap-backed pool's file is now unlinked as soon as it is mapped rather than at teardown, which an abandoned heap never reaches. The mapping holds the inode, so the blocks stay reserved while the pool is in use and the kernel reclaims them on unmap.

## Return the pages once the process goes quiet

The heaps stop growing, but a mapped pool stays mapped, so a process that ran one heavy query keeps its peak resident for good. There is no thread and no queue: a unit of work stamps a coarse timestamp, and the points that already exist — the statement boundary, and the poll loop, which bounds its wait by the deadline exactly as it already bounds it by the next timer — check whether enough time has passed and, if so, walk every heap's free blocks and hand their pages back.

The timestamp is the whole design. Releasing pages as soon as a lot becomes free is wrong: for a repeated query those are precisely the pages the next iteration faults straight back in. Only elapsed idleness distinguishes "the workload has stopped" from "we are between two iterations of a hot loop". The threshold defaults to 10s and `RAY_HEAP_DECAY_MS` overrides it; negative disables it.

Crossing heaps is sound here for the same reason it is in the existing passes: `ray_parallel_end` drains `pending` with acquire before clearing `ray_parallel_flag`, and a worker allocates nothing between its last `pending--` and `sem_wait`, so a zero flag means every worker heap is quiescent. A concurrent cross-thread free can only push, which the atomic-exchange drain handles.

`ray_heap_release_pages` keeps its synchronous contract for the fallback in `join.c`, which fires only after `scratch_alloc` has already failed — under proven pressure, refaulting beats an `oom`.

## Tests

Regression tests for the owner-side free and for the decay, each failing on its parent commit. The decay tests assert both halves — that a collection does **not** release an aged block and that the decay immediately after does, and that nothing is swept before the threshold — and each asserts that it covered something, so neither can pass vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)