### PR TITLE
fix(join): a null equi-join key equals another null key

### DIFF
--- a/docs/docs/queries/joins.md
+++ b/docs/docs/queries/joins.md
@@ -126,6 +126,22 @@ The `anti-join` function keeps rows from the left table whose key does not appea
 ;  3 MSFT
 ```
 
+## Null-key semantics (equi-joins)
+
+`inner-join`, `left-join`, `full-join` and `anti-join` treat **a null key as equal to another null key**, and never equal to a non-null one:
+
+```lisp
+(set left  (table [k v] (list (as 'SYM ["a" ""]) [1 2])))
+(set right (table [k w] (list (as 'SYM ["a" ""]) [10 20])))
+
+(at (left-join [k] left right) 'w)  ; [10 20]  — the null key finds its match
+(count (anti-join [k] left left))   ; 0        — X anti-joined with itself is empty
+```
+
+This is the rule the rest of the runtime already applies to key columns: `distinct` keeps exactly one null, group-by folds nulls into a single group, and `in` matches a null against a null. It differs from SQL, where `NULL = NULL` is unknown and a self-anti-join can return rows. The invariant that follows — `(anti-join [cols] X X)` is empty for every `X` and every key set — is what makes anti-join usable for "which of these tuples have I not seen yet".
+
+As-of join is the exception — its null keys never match. See its own [Null-key semantics](#null-key-semantics) section below.
+
 ## As-of Join
 
 The `asof-join` function is designed for time-series data. For each row in the left table, it finds the most recent matching row in the right table where the time column is less than or equal to the left's time value. The last column in the key list is the temporal column; any preceding keys are exact-match equality keys.

--- a/src/ops/join.c
+++ b/src/ops/join.c
@@ -102,16 +102,26 @@ static inline bool join_str_eq_hashed(const ray_str_t* a, const char* pool_a,
     return memcmp(pa, pb, a->len) == 0;
 }
 
+/* Hash payload for a null key cell.  One canonical value per key POSITION
+ * (the ray_hash_combine chain below still mixes in k), so every null in a
+ * given key column lands in the same bucket on both sides of the join —
+ * the precondition for join_keys_eq's null == null.  Any collision with a
+ * real key's hash is resolved by join_keys_eq, as for any other hash. */
+#define JOIN_NULL_KEY_HASH INT64_C(0x5B7A6D3F2E1C0A94)
+
 static uint64_t hash_row_keys(ray_t** key_vecs, uint32_t n_keys, int64_t row) {
     uint64_t h = 0;
     for (uint32_t k = 0; k < n_keys; k++) {
         ray_t* col = key_vecs[k];
         if (!col) continue;
-        /* NULL key — produce unique hash that won't match any other row */
-        if (ray_vec_is_null(col, row))
-            return h ^ ((uint64_t)row * 0x9E3779B97F4A7C15ULL);
         uint64_t kh;
-        if (col->type == RAY_STR) {
+        if (ray_vec_is_null(col, row)) {
+            /* null == null: hash every null cell alike instead of giving the
+             * row a private hash.  A per-row hash made a null key unmatchable
+             * even against itself, so `anti-join [c] X X` came back non-empty
+             * and a null-keyed left-join row missed its real match. */
+            kh = ray_hash_i64(JOIN_NULL_KEY_HASH);
+        } else if (col->type == RAY_STR) {
             const char* pool = NULL;
             const ray_str_t* str = join_str_cell(col, row, &pool);
             kh = ray_str_is_inline(str)
@@ -576,8 +586,26 @@ static inline bool join_keys_eq(ray_t* const* l_vecs, ray_t* const* r_vecs, uint
         ray_t* lc = l_vecs[k];
         ray_t* rc = r_vecs[k];
         if (!lc || !rc) return false;
-        /* NULL != NULL in join predicates */
-        if (ray_vec_is_null(lc, l) || ray_vec_is_null(rc, r)) return false;
+        /* null == null, null != non-null.  This is the rule the rest of the
+         * runtime already applies to key columns: collection.c's hashset
+         * folds every null into one bucket (so `distinct` keeps exactly one
+         * null and `in` matches null against null), group.c folds them into
+         * one group, and atom_eq answers 1 for two nulls.  Joins used to
+         * reject a null outright, which made `anti-join [c] X X` non-empty
+         * whenever c held a null and made left-join miss a null-keyed match.
+         * As-of join keeps its own documented NULLs-never-match rule; it
+         * does not route through here. */
+        bool l_null = ray_vec_is_null(lc, l);
+        bool r_null = ray_vec_is_null(rc, r);
+        if (l_null || r_null) {
+            if (l_null != r_null) return false;
+            /* No looser than the value arms below: they pair STR only with
+             * STR and GUID only with GUID, so two nulls of those types are
+             * equal only to their own kind. */
+            if ((lc->type == RAY_STR)  != (rc->type == RAY_STR))  return false;
+            if ((lc->type == RAY_GUID) != (rc->type == RAY_GUID)) return false;
+            continue;
+        }
         if (lc->type == RAY_STR || rc->type == RAY_STR) {
             if (lc->type != RAY_STR || rc->type != RAY_STR) return false;
             const char* lpool = NULL;

--- a/test/rfl/join/null_key_equality.rfl
+++ b/test/rfl/join/null_key_equality.rfl
@@ -1,0 +1,95 @@
+;; null_key_equality.rfl -- a null equi-join key equals another null key.
+;;
+;; Regression: hash_row_keys handed every null-keyed row a private, row-derived
+;; hash and join_keys_eq returned false the moment either side was null, so a
+;; null key matched nothing -- not even a null sitting in the same cell of the
+;; same table.  Two consequences, both pinned below:
+;;
+;;   * `anti-join [cols] X X` was NON-EMPTY whenever a key column held a null.
+;;     Self-anti-join must be empty for every table and every key set; a service
+;;     using anti-join to find not-yet-seen tuples re-reported every null-keyed
+;;     tuple on every pass and grew without bound.
+;;   * left-join filled a null payload for a left row whose null key DID have a
+;;     match on the right, instead of returning that match.
+;;
+;; null == null is the rule the rest of the runtime already applies to key
+;; columns: `distinct` keeps exactly one null (test/rfl/null/distinct.rfl),
+;; group-by folds nulls into a single group, and `in`/atom_eq answer true for
+;; two nulls (collection.c).  As-of join is the ONE documented exception and is
+;; unchanged -- pinned at the bottom.
+
+;; ── The reported reproduction ─────────────────────────────────────────────
+;; A left-join miss produces a null V; anti-joining the result against ITSELF
+;; on V must still be empty.
+(set NKL (table [K] (list (as 'I32 [1 2 3]))))
+(set NKR (table [K V] (list (as 'I32 [1 2]) (as 'F64 [10.0 20.0]))))
+(set NKJ (left-join [K] NKL NKR))
+(count (select {from: NKJ where: (nil? V)})) -- 1
+(count (anti-join [V] NKJ NKJ)) -- 0
+(count (anti-join [K] NKJ NKJ)) -- 0
+
+;; ── Self-anti-join is empty for every key type that can carry a null ──────
+(set NKT (table [i f s u] (list [1 0N 3] (as 'F64 [1.0 0N 3.0]) (as 'SYM ["a" "" "c"]) (as 'STR ["a" "" "c"]))))
+(count (anti-join [i] NKT NKT))     -- 0
+(count (anti-join [f] NKT NKT))     -- 0
+(count (anti-join [s] NKT NKT))     -- 0
+(count (anti-join [u] NKT NKT))     -- 0
+(count (anti-join [i f] NKT NKT))   -- 0
+(count (anti-join [i f s u] NKT NKT)) -- 0
+
+;; ── A null key MATCHES a null key: it is not merely "kept" ────────────────
+(set NKA (table [s x] (list (as 'SYM ["a" "" "c"]) [1 2 3])))
+(set NKB (table [s y] (list (as 'SYM ["" "c"]) [20 30])))
+(at (left-join [s] NKA NKB) 'y)  -- [0Nl 20 30]
+(count (inner-join [s] NKA NKB)) -- 2
+(at (anti-join [s] NKA NKB) 'x)  -- [1]
+
+;; ── ...and a null still never equals a NON-null ───────────────────────────
+(set NKC (table [s z] (list (as 'SYM ["a" "b"]) [10 20])))
+(count (inner-join [s] NKA NKC)) -- 1
+(at (anti-join [s] NKA NKC) 'x)  -- [2 3]
+
+;; ── F64: the null is a NaN payload, so `!=` alone would reject it ─────────
+(set NKF (table [f n] (list (as 'F64 [1.0 0N 3.0]) [1 2 3])))
+(set NKG (table [f m] (list (as 'F64 [0N 3.0]) [200 300])))
+(at (left-join [f] NKF NKG) 'm) -- [0Nl 200 300]
+(count (anti-join [f] NKF NKG)) -- 1
+
+;; ── STR keys: the radix path specializes single STR keys onto raw
+;;    descriptors, the chained path goes through join_keys_eq.  Same answer.
+(set NKU (table [u x] (list (as 'STR ["a" "" "c"]) [1 2 3])))
+(set NKV (table [u y] (list (as 'STR ["" "c"]) [20 30])))
+(at (left-join [u] NKU NKV) 'y)  -- [0Nl 20 30]
+(at (anti-join [u] NKU NKV) 'x)  -- [1]
+
+;; ── Multi-key: a null in ONE key column does not swallow the other ────────
+(set NKM (table [a b w] (list (as 'SYM ["p" "p" ""]) [1 0N 1] [10 20 30])))
+(set NKN2 (table [a b] (list (as 'SYM ["p" ""]) [0N 1])))
+(at (anti-join [a b] NKM NKN2) 'w) -- [10]
+(count (anti-join [a b] NKM NKM))  -- 0
+
+;; ── The radix path (build side past RAY_PARALLEL_THRESHOLD = 65536) reaches
+;;    the same conclusion as the chained hash table used for small inputs.
+;;    NKBIG key k: row 0 null, row i (i>0) holds i-1; payload v holds 100+i.
+;;    Asserted on sums, not positions: the radix path consolidates per
+;;    partition, so left-row output order is not part of the contract here.
+(set NKN 70000)
+(set NKBIG (table [k v] (list (concat [0N] (til (- NKN 1))) (+ 100 (til NKN)))))
+(count NKBIG) -- 70000
+(set NKPROBE (table [k p] (list [0N 5 999999] [1 2 3])))
+(set NKLJ (left-join [k] NKPROBE NKBIG))
+(count NKLJ) -- 3
+;; 100 (the null key matched right row 0) + 106 (k=5 sits at right row 6)
+(sum (at NKLJ 'v)) -- 206
+(count (select {from: NKLJ where: (nil? v)})) -- 1
+(count (inner-join [k] NKPROBE NKBIG)) -- 2
+(at (anti-join [k] NKPROBE NKBIG) 'p)  -- [3]
+(count (anti-join [k] NKBIG NKBIG))    -- 0
+
+;; ── As-of join is the documented exception and is NOT changed.  Its merge
+;;    walk skips null-keyed right rows and lets null-keyed left rows fall
+;;    through to the left-outer null fill; it never routes through
+;;    join_keys_eq.  See docs/queries/joins.md, "Null-key semantics".
+(set NKAT (table [S Time Price] (list (as 'SYM ["" "b"]) [10:00:01.000 10:00:01.000] (as 'F64 [1.0 2.0]))))
+(set NKAQ (table [S Time Bid] (list (as 'SYM ["" "b"]) [10:00:00.000 10:00:00.000] (as 'F64 [99.0 88.0]))))
+(at (asof-join [S Time] NKAT NKAQ) 'Bid) -- (as 'F64 [0Nf 88.0])

--- a/test/rfl/ops/join_branch_cov.rfl
+++ b/test/rfl/ops/join_branch_cov.rfl
@@ -9,25 +9,26 @@
 
 ;; ──────────────────────────────────────────────────────────────────
 ;; L35: hash_row_keys — NULL values in join key column
-;; NULL keys should produce unique hashes, so NULLs never match.
+;; NULL keys hash to one canonical value: a null matches another null and
+;; nothing else.  See test/rfl/join/null_key_equality.rfl for the semantics.
 ;; ──────────────────────────────────────────────────────────────────
 
-;; inner-join with null keys in left — nulls don't match
+;; inner-join with a null key on the left only — nothing on the right to match
 (set jL (table [id val] (list [1 0Nl 3] [10 20 30])))
 (set jR (table [id val2] (list [1 3] [100 300])))
 (count (inner-join [id] jL jR)) -- 2
 (at (inner-join [id] jL jR) 'val) -- [10 30]
 
-;; inner-join with null keys in right — nulls don't match
+;; inner-join with a null key on the right only — nothing on the left to match
 (set jL2 (table [id val] (list [1 2 3] [10 20 30])))
 (set jR2 (table [id val2] (list [1 0Nl 3] [100 200 300])))
 (count (inner-join [id] jL2 jR2)) -- 2
 (at (inner-join [id] jL2 jR2) 'val2) -- [100 300]
 
-;; inner-join with null keys in both sides — nulls never match nulls
+;; inner-join with a null key on BOTH sides — null == null, so it matches
 (set jL3 (table [id val] (list [0Nl 2 3] [10 20 30])))
 (set jR3 (table [id val2] (list [0Nl 2 3] [100 200 300])))
-(count (inner-join [id] jL3 jR3)) -- 2
+(count (inner-join [id] jL3 jR3)) -- 3
 
 ;; left-join with null keys — unmatched left rows preserved with null right
 (set jL4 (table [id val] (list [1 0Nl 3] [10 20 30])))
@@ -68,10 +69,10 @@
 (count (inner-join [k1 k2] mkL mkR)) -- 2
 (at (inner-join [k1 k2] mkL mkR) 'val2) -- [1000 3000]
 
-;; Multi-key with both nulls — no match
+;; Multi-key with a null on both sides of k1 — null == null, so it matches
 (set mkL2 (table [k1 k2 val] (list [0Nl] [10.0] [100])))
 (set mkR2 (table [k1 k2 val2] (list [0Nl] [10.0] [1000])))
-(count (inner-join [k1 k2] mkL2 mkR2)) -- 0
+(count (inner-join [k1 k2] mkL2 mkR2)) -- 1
 
 ;; ──────────────────────────────────────────────────────────────────
 ;; anti-join with null keys

--- a/test/stress_eval.c
+++ b/test/stress_eval.c
@@ -636,9 +636,9 @@ done:
 }
 
 /* (c) join cardinality: count of the language's inner-join live x hist on
- * ticker vs the shadow's sum over distinct non-null live tickers of
- * live_count(k) * hist_count(k).  Canonical empty/null keys do not join.
- * Sides are projected to disjoint
+ * ticker vs the shadow's sum over distinct live tickers of
+ * live_count(k) * hist_count(k) — including the "" null key, which the
+ * join matches like any other (probed).  Sides are projected to disjoint
  * non-key column names first (live/hist share price+qty names). */
 static bool verify_join_cardinality(stress_ctx_t* c, const char* live_dir) {
     if (c->nparts == 0) {
@@ -648,7 +648,6 @@ static bool verify_join_cardinality(stress_ctx_t* c, const char* live_dir) {
     int64_t expect = 0;
     for (int64_t i = 0; i < c->live.len; i++) {
         const char* k = c->live.rows[i].ticker;
-        if (k[0] == '\0') continue;
         bool seen = false;
         for (int64_t j = 0; j < i && !seen; j++)
             seen = strcmp(k, c->live.rows[j].ticker) == 0;


### PR DESCRIPTION
## The invariant

`(anti-join [cols] X X)` must be empty for every table `X` and every key set. It was not: a null in a key column made a row unmatchable against **itself**, so a table anti-joined with itself came back holding exactly its null-keyed rows.

`left-join` has the same defect from the other side — a left row whose key is null never finds the right row that carries the same null key, so it yields a null payload instead of the match that is actually there.

## Minimal reproduction

```lisp
(set L (table [K]   (list (as 'I32 [1 2 3]))))
(set R (table [K V] (list (as 'I32 [1 2]) (as 'F64 [10.0 20.0]))))
(set J (left-join [K] L R))     ;; row K=3 gets V = null

(count (select {from: J where: (nil? V)}))  ;; 1
(count (anti-join [V] J J))                 ;; 1  — MUST be 0
(count (anti-join [K] J J))                 ;; 0  — correct, K has no nulls
```

Deterministic, and reproduced on SYM, STR, F64 and integer key columns alike — this is the shared key path, not a per-type issue.

## Root cause

Two helpers in `src/ops/join.c`, both shared by the radix and chained hash paths and by all four equi-join verbs:

- `hash_row_keys` returned `h ^ (row * 0x9E37...)` for a null key — a **per-row** hash, so two nulls never even landed in the same bucket.
- `join_keys_eq` returned `false` the moment either side was null (`/* NULL != NULL in join predicates */`).

## How it was found

`anti-join` used as a set difference — "which of these keys have I not seen yet" — over a key column that admits nulls. Every null-keyed row came back as unseen on every pass, so the caller kept re-adding rows it already held, and the id it looked up afterwards came back null. Verified against core commit 057f519; the reproduction above is independent of any particular caller.

## Why nulls should match here

This is a semantic choice, so it is worth stating why it lands on "match" rather than SQL's "unknown".

**The rest of this runtime already matches nulls on key columns.** `collection.c`'s hashset folds every null into a single null bucket, so `distinct` keeps exactly one null (`test/rfl/null/distinct.rfl`) and `in` answers true for null ∈ {…null…}; `group.c` folds nulls into one group; `atom_eq` returns 1 for two nulls. Joins were the only holdout, which made `distinct`/`group`/`anti-join` disagree about what "the same key" means.

**The join path was not even self-consistent.** The radix single-STR-key specialization compares raw `ray_str_t` descriptors via `join_str_eq_hashed`, where two zero-length (null) cells already came out **equal**. So the same single-STR-key join answered one way below `RAY_PARALLEL_THRESHOLD` and the other way above it.

**The never-match rule was never chosen for symbol keys.** It is original v2-engine code (4a3a0c7), written when "null" meant a numeric sentinel. Empty `SYM`/`STR` only became canonical nulls in bfb5b38 (`fix(core): normalize null and schema handling`, Fixes #411/#414/#415) — a commit that **never touched `src/ops/join.c`** but silently dragged symbol keys under the rule. In the same commit the stress oracle was rewritten from:

> the shadow's sum over distinct live tickers of `live_count(k) * hist_count(k)` — **including the `""` null key, which the join matches like any other (probed)**

to "Canonical empty/null keys do not join." So symbol keys *used* to join on null and stopped without anyone deciding they should. This PR restores that, and makes it uniform across every key type instead of just symbols.

**kdb+/q — where this system's surface syntax and users come from — matches nulls** in `lj`/`ij` and in `distinct`/`group`.

**The invariant is what makes anti-join useful.** "Which of these tuples have I not seen yet" is only answerable if a tuple is comparable to itself.

Nothing in the tree documented the old behaviour: the one written rule, `docs/queries/joins.md` → "Null-key semantics", is scoped to **as-of join**, and as-of join is deliberately left alone (see below).

## The change

- Nulls hash to one canonical payload per key position, so both sides land in the same bucket.
- `join_keys_eq` answers: null == null, null != non-null. The null branch is no looser than the value arms that follow it — STR pairs only with STR, GUID only with GUID.
- Both helpers are shared, so `inner-join` / `left-join` / `full-join` / `anti-join` move together across the radix and chained paths.

**As-of join is untouched.** Its NULLs-never-match rule is documented, is load-bearing (a null time must not be read as time zero), and its merge walk carries its own per-row null bitsets — it never routes through `join_keys_eq`. `docs/queries/joins.md` now states the equi-join rule alongside it, and the regression test pins that as-of behaviour did not move.

## Tests

New `test/rfl/join/null_key_equality.rfl` covers the self-anti-join invariant across I64 / F64 / SYM / STR and multi-key sets, anti-join and left-join with nulls on either side, that a null still never equals a non-null, the radix path past `RAY_PARALLEL_THRESHOLD`, and the unchanged as-of behaviour.

Two existing expectations encoded the old rule and move with it:

- `test/stress_eval.c` — the join-cardinality shadow oracle counts the `""` key again. This is an exact revert of the bfb5b38 hunk quoted above.
- `test/rfl/ops/join_branch_cov.rfl` — its two **both-sides-null** cases move: the single-key inner-join now expects 3 rather than 2, and the multi-key one expects 1 rather than 0. Everything else in that file is untouched and still passes — the one-sided-null inner-joins, the left-joins, the anti-joins, and all eight as-of assertions. That is the useful signal: only null-meets-null moved.

Full suite green before and after: `3713 of 3714 passed (1 skipped, 0 failed)` before, `3714 of 3715 passed (1 skipped, 0 failed)` after (+1 is the new file).

> Note on the local run: this machine is macOS 26.6.2 with Apple clang 17, where **any** `-fsanitize=address` binary hangs in `__asan::InitializeShadowMemory` at startup (a bare hello-world reproduces it). The suite was therefore built and run with the sanitizers disabled — same objects, same tests, `DEBUG_CFLAGS`/`DEBUG_LDFLAGS` overridden. CI's ASan run is the one to trust for sanitizer coverage.

