### PR TITLE
fix: eliminate the three UBSan errors the test suite was swallowing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ UNAME_S := $(shell uname -s)
 RAY_MARCH ?= native
 
 DEBUG_CFLAGS   = -fPIC $(WARNS) -std=$(STD) -g -O0 -march=$(RAY_MARCH) -DDEBUG \
-  -fsanitize=address,undefined -fno-omit-frame-pointer
+  -fsanitize=address,undefined -fno-sanitize-recover=undefined \
+  -fno-omit-frame-pointer
 RELEASE_CFLAGS = -fPIC $(WARNS) -std=$(STD) -O3 -march=$(RAY_MARCH) \
   -funroll-loops -fomit-frame-pointer -fno-math-errno -falign-functions=64 \
   -fassociative-math -ffp-contract=fast -fno-signed-zeros -fno-trapping-math

--- a/src/ops/filter.c
+++ b/src/ops/filter.c
@@ -287,6 +287,13 @@ ray_t* exec_filter(ray_graph_t* g, ray_op_t* op, ray_t* input, ray_t* pred) {
     if (!input || RAY_IS_ERR(input)) return input;
     if (!pred || RAY_IS_ERR(pred)) return pred;
 
+    /* An atom predicate (scalar subject in a where-clause) has no per-row
+     * bits.  Reject it before any morsel walk: ray_morsel_init derives the
+     * element size from the type, and a negative (atom) type indexes
+     * ray_type_sizes out of bounds. */
+    if (pred->type < 0)
+        return ray_error("length", "filter: predicate must be a BOOL vector matching the input length, got an atom");
+
     /* A plain contiguous BOOL predicate over a large input takes the
      * parallel chunked count/fill; anything else (lazy / morsel-backed
      * pred, small input) keeps the sequential morsel sweep. */

--- a/src/ops/sort.c
+++ b/src/ops/sort.c
@@ -2637,9 +2637,11 @@ static ray_t* sort_indices_ex(ray_t** cols, uint8_t* descs, uint8_t* nulls_first
                         }
                         mins[k] = kmin;
                         maxs[k] = kmax;
-                        uint64_t range = (uint64_t)(kmax - kmin);
+                        /* Unsigned subtraction: kmin can be the i64 null
+                         * sentinel, and kmax - kmin then overflows i64. */
+                        uint64_t range = (uint64_t)kmax - (uint64_t)kmin;
                         uint8_t bits = 1;
-                        while (((uint64_t)1 << bits) <= range && bits < 64)
+                        while (bits < 64 && ((uint64_t)1 << bits) <= range)
                             bits++;
                         total_bits = (uint16_t)(total_bits + bits);
                     }
@@ -2699,9 +2701,11 @@ static ray_t* sort_indices_ex(ray_t** cols, uint8_t* descs, uint8_t* nulls_first
 
                         mins[k] = kmin;
                         maxs[k] = kmax;
-                        uint64_t range = (uint64_t)(kmax - kmin);
+                        /* Unsigned subtraction: kmin can be the i64 null
+                         * sentinel, and kmax - kmin then overflows i64. */
+                        uint64_t range = (uint64_t)kmax - (uint64_t)kmin;
                         uint8_t bits = 1;
-                        while (((uint64_t)1 << bits) <= range && bits < 64)
+                        while (bits < 64 && ((uint64_t)1 << bits) <= range)
                             bits++;
                         total_bits = (uint16_t)(total_bits + bits);
                     }

--- a/test/test_aof.c
+++ b/test/test_aof.c
@@ -82,7 +82,7 @@ static bool collect_cb(int64_t lsn, const void* payload, int64_t len, void* ctx)
         c->lsns[c->n] = lsn;
         c->lens[c->n] = len;
         size_t cp = len < 31 ? (size_t)len : 31;
-        memcpy(c->payloads[c->n], payload, cp);
+        if (cp) memcpy(c->payloads[c->n], payload, cp);
         c->payloads[c->n][cp] = '\0';
     }
     c->n++;


### PR DESCRIPTION
Closes #448.

## What

`make test` builds with `-fsanitize=address,undefined`, but UBSan's default is print-and-continue and nothing failed on the printed line — so the suite exercised three undefined-behavior sites on every CI run and still reported green. #448 surfaced only because the reporter's newer toolchain laid out globals so that ASan's redzone made one of them fatal.

1. **`src/ops/filter.c`** — a scalar where-subject (`(like "keep me" "*keep*")`) evaluates to a BOOL *atom*; `exec_filter` walked it with `ray_morsel_init` before the length check, and the element-size lookup indexed `ray_type_sizes` by the negative atom type — a 1-byte global OOB read (the #448 crash). Atoms are now rejected at entry with the same `length` error class the late check produced, so `rfl/query/legacy_strl_predicates`' assertion is unchanged.
2. **`src/ops/sort.c`** — the composite-key prescan computed `kmax - kmin` in signed arithmetic (overflows when `kmin` is the i64 null sentinel) and evaluated `1 << 64` before the loop's bound check (both copies). Range math moved to the unsigned domain and the condition reordered; the wrapped difference is the same value, so key routing is unchanged.
3. **`test/test_aof.c`** — NULL passed as `memcpy` src for an empty payload.

With all three clean, the last commit adds `-fno-sanitize-recover=undefined` to `DEBUG_CFLAGS`, so the suite now hard-fails on the next UB instead of narrating it into a log nobody reads.

## Verification

- Full suite: 3717/3717 pass with UBSan fatal; `./rayforce.test 2>&1 | grep "runtime error"` is empty (was 4 lines / 3 distinct sites before).
- `UBSAN_OPTIONS=print_stacktrace=1 ./rayforce.test -f legacy_strl` — the #448 repro — is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8TdSm4JwxHB37kiaKxgTN