### PR TITLE
fix(mem): size the scratch arena window from the backing block's real capacity

### DIFF
--- a/src/mem/heap.c
+++ b/src/mem/heap.c
@@ -2689,7 +2689,15 @@ void* ray_scratch_arena_push(ray_scratch_arena_t* a, size_t nbytes) {
     if (!blk) return NULL;
     a->backing[a->n_backing++] = blk;
     a->ptr = (char*)ray_data(blk);
-    a->end = (char*)blk + BSIZEOF(blk->order);
+    /* The window ends at the block's real capacity.  `order` describes the
+     * block size only for buddy blocks: a request at or above
+     * RAY_HEAP_POOL_ORDER comes back as a DIRECT block, mapped at its exact
+     * page-rounded size and tagged with the RAY_ORDER_DIRECT sentinel.
+     * Reading that sentinel as an order claims a 2^39-byte block, and every
+     * push after the one that triggered it is then bump-allocated past the
+     * end of the mapping — a write straight into unmapped address space.
+     * ray_block_data_bytes covers both block kinds. */
+    a->end = a->ptr + ray_block_data_bytes(blk);
 
 bump:;
     void* ret = a->ptr;

--- a/test/test_heap.c
+++ b/test/test_heap.c
@@ -289,6 +289,49 @@ static test_result_t test_scratch_arena_oversize(void) {
     PASS();
 }
 
+static test_result_t test_scratch_arena_direct_backing(void) {
+    /* A backing block at or above RAY_HEAP_POOL_ORDER is a DIRECT
+     * allocation: mapped at its exact page-rounded size and tagged with
+     * the RAY_ORDER_DIRECT sentinel instead of a real buddy order.  The
+     * arena's window has to come from the block's true capacity —
+     * reading the sentinel as an order describes a 2^39-byte block, so
+     * every later push is bump-allocated past the end of the mapping and
+     * writes into unmapped address space. */
+    ray_scratch_arena_t a;
+    ray_scratch_arena_init(&a);
+
+    size_t big = ((size_t)1 << RAY_HEAP_POOL_ORDER) + (1u << 20);
+    unsigned char* p = (unsigned char*)ray_scratch_arena_push(&a, big);
+    TEST_ASSERT_NOT_NULL(p);
+    TEST_ASSERT_EQ_I(a.n_backing, 1);
+    TEST_ASSERT_TRUE(ray_is_direct(a.backing[0]));
+
+    /* The window must stop at the backing's real capacity. */
+    char* cap_end = (char*)ray_data(a.backing[0])
+                  + ray_block_data_bytes(a.backing[0]);
+    TEST_ASSERT_TRUE(a.end <= cap_end);
+
+    /* Consequently the next push cannot be carved out of the leftover of
+     * a block that has none: it must take a backing of its own. */
+    size_t follow = 4u << 20;
+    unsigned char* q = (unsigned char*)ray_scratch_arena_push(&a, follow);
+    TEST_ASSERT_NOT_NULL(q);
+    TEST_ASSERT_EQ_I(a.n_backing, 2);
+    TEST_ASSERT_TRUE((char*)q + follow <= (char*)ray_data(a.backing[1])
+                                       + ray_block_data_bytes(a.backing[1]));
+
+    /* Both regions must be writable end to end and must not overlap. */
+    memset(p, 0x5A, big);
+    memset(q, 0xA5, follow);
+    TEST_ASSERT_EQ_U(p[0], 0x5A);
+    TEST_ASSERT_EQ_U(p[big - 1], 0x5A);
+    TEST_ASSERT_EQ_U(q[0], 0xA5);
+    TEST_ASSERT_EQ_U(q[follow - 1], 0xA5);
+
+    ray_scratch_arena_reset(&a);
+    PASS();
+}
+
 /* ---- ray_heap_release_pages -------------------------------------------- *
  *
  * Walks freelists at order >= 13 (8 KB+) and madvise-releases pages past
@@ -2421,6 +2464,7 @@ const test_entry_t heap_entries[] = {
     { "heap/scratch_arena_basic",      test_scratch_arena_basic,         heap_setup, heap_teardown },
     { "heap/scratch_arena_multi",      test_scratch_arena_multi_backing, heap_setup, heap_teardown },
     { "heap/scratch_arena_oversize",   test_scratch_arena_oversize,      heap_setup, heap_teardown },
+    { "heap/scratch_arena_direct",     test_scratch_arena_direct_backing, heap_setup, heap_teardown },
     { "heap/release_pages",            test_release_pages,               heap_setup, heap_teardown },
     { "heap/gc_reclaim_oversized",     test_gc_reclaim_oversized_pool,   heap_setup, heap_teardown },
     { "heap/gc_serial",                test_heap_gc_serial,              heap_setup, heap_teardown },


### PR DESCRIPTION
The scratch arena computed the end of its window as `blk + BSIZEOF(blk->order)`. `order` describes the size of a buddy block; a request at or above the pool order is not one. Those are served by `heap_alloc_direct`, which maps the exact page-rounded size and tags the header with the `RAY_ORDER_DIRECT` sentinel instead of an order.

Read as an order, that sentinel claims a block of 2^39 bytes. Every push after the one that crossed the threshold is then bump-allocated past the end of the mapping, and the caller's first write goes straight into unmapped address space.

Nothing about the arena's users is special here — any arena that crosses the threshold corrupts memory the same way. Sorting by a SYM column reaches it first because ranking the vocabulary pushes four buffers sized by the number of distinct symbols, so a store with millions of them crosses on one of them. A small vocabulary keeps every push inside a buddy block, which is why this stayed invisible.

`ray_block_data_bytes` already answers the capacity question for both kinds of block. The window is now anchored at the data pointer and sized from it, so the arithmetic no longer depends on the header size either. For buddy blocks the result is byte-identical, so nothing changes on the path this normally takes.

## Verification

`heap/scratch_arena_direct` allocates one backing past the pool order, asserts the window stops at the block's real capacity, and checks that the following push still lands inside it. On the parent commit it fails:

```
test/test_heap.c:312: (a.end <= cap_end): expected true
```

End to end, on a splayed store whose SYM vocabulary runs into the millions: sorting by that column dumps core on the parent and returns its rows after the fix. The failure is intermittent on a release build — the wild store has to reach an unmapped page before anything else notices — and immediate under ASan, which names the store in `build_enum_rank`. Across five runs on the parent it faulted once; with the fix, five out of five completed.

The end-to-end shape needs a vocabulary too large for the suite, so the committed test pins the invariant rather than the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)