### PR TITLE
fix(serde): validate table/dict counts and lengths on decode

### DIFF
--- a/include/rayforce.h
+++ b/include/rayforce.h
@@ -643,6 +643,7 @@ ray_err_t ray_env_set(int64_t sym_id, ray_t* val);
 
 ray_t*       ray_table_new(int64_t ncols);
 ray_t*       ray_table_add_col(ray_t* tbl, int64_t name_id, ray_t* col_vec);
+ray_t*       ray_table_validate_rectangular(ray_t* tbl, const char* context);
 ray_t*       ray_table_get_col(ray_t* tbl, int64_t name_id);
 ray_t*       ray_table_get_col_idx(ray_t* tbl, int64_t idx);
 int64_t     ray_table_col_name(ray_t* tbl, int64_t idx);

--- a/src/store/col.c
+++ b/src/store/col.c
@@ -590,6 +590,11 @@ static ray_t* col_read_recursive(const uint8_t** pp, size_t* remaining) {
             ray_release(col);  /* table_add_col retains */
             if (!tbl || RAY_IS_ERR(tbl)) return tbl;
         }
+        ray_t* shape_err = ray_table_validate_rectangular(tbl, "col load table");
+        if (shape_err) {
+            ray_release(tbl);
+            return shape_err;
+        }
         return tbl;
     }
 

--- a/src/store/serde.c
+++ b/src/store/serde.c
@@ -828,7 +828,6 @@ static ray_t* de_raw_inner(uint8_t* buf, int64_t* len) {
                 : ray_read_sym(name_data, i, RAY_SYM, schema->attrs);
             ray_t* new_tbl = ray_table_add_col(tbl, name_id, col_ptrs[i]);
             if (!new_tbl || RAY_IS_ERR(new_tbl)) {
-                ray_release(tbl);
                 ray_release(schema);
                 ray_release(cols);
                 return new_tbl;

--- a/src/store/serde.c
+++ b/src/store/serde.c
@@ -812,6 +812,20 @@ static ray_t* de_raw_inner(uint8_t* buf, int64_t* len) {
             return e;
         }
 
+        /* Every column must have the same length (the table's row count).  A
+         * frame with ragged columns would leave ray_table_nrows reporting
+         * column 0's length while row-wise ops read past the shorter ones. */
+        ray_t** cps = (ray_t**)ray_data(cols);
+        int64_t nrows = (cols->len > 0 && cps[0]) ? cps[0]->len : 0;
+        for (int64_t i = 1; i < cols->len; i++) {
+            if (!cps[i] || cps[i]->len != nrows) {
+                ray_t* e = ray_error("domain", "deserialize table: ragged columns (column %lld has %lld rows, expected %lld)", (long long)i, (long long)(cps[i] ? cps[i]->len : -1), (long long)nrows);
+                ray_release(schema);
+                ray_release(cols);
+                return e;
+            }
+        }
+
         int64_t ncols = cols->len;
         ray_t* tbl = ray_table_new(ncols);
         if (!tbl || RAY_IS_ERR(tbl)) {
@@ -822,7 +836,7 @@ static ray_t* de_raw_inner(uint8_t* buf, int64_t* len) {
 
         void* name_data = ray_data(schema);
         ray_t** col_ptrs = (ray_t**)ray_data(cols);
-        for (int64_t i = 0; i < ncols && i < schema->len; i++) {
+        for (int64_t i = 0; i < ncols; i++) {   /* ncols == schema->len (guarded above) */
             int64_t name_id = (schema->type == RAY_I64)
                 ? ((int64_t*)name_data)[i]
                 : ray_read_sym(name_data, i, RAY_SYM, schema->attrs);
@@ -855,6 +869,18 @@ static ray_t* de_raw_inner(uint8_t* buf, int64_t* len) {
         if (!vals || RAY_IS_ERR(vals)) {
             ray_release(keys);
             return vals;
+        }
+
+        /* One value per key: a dict probe finds a key index in [0, keys->len)
+         * and reads the value at that index, so a crafted dict with more keys
+         * than values would index the value block out of bounds (OOB
+         * read/release).  vals may be a LIST of column vectors or a flat value
+         * vector — either way its length must equal keys->len. */
+        if (keys->len != vals->len) {
+            ray_t* e = ray_error("domain", "deserialize dict: key/value count mismatch (%lld keys, %lld values)", (long long)keys->len, (long long)vals->len);
+            ray_release(keys);
+            ray_release(vals);
+            return e;
         }
 
         /* Build dict: alloc with 2 slots */

--- a/src/store/serde.c
+++ b/src/store/serde.c
@@ -812,20 +812,6 @@ static ray_t* de_raw_inner(uint8_t* buf, int64_t* len) {
             return e;
         }
 
-        /* Every column must have the same length (the table's row count).  A
-         * frame with ragged columns would leave ray_table_nrows reporting
-         * column 0's length while row-wise ops read past the shorter ones. */
-        ray_t** cps = (ray_t**)ray_data(cols);
-        int64_t nrows = (cols->len > 0 && cps[0]) ? cps[0]->len : 0;
-        for (int64_t i = 1; i < cols->len; i++) {
-            if (!cps[i] || cps[i]->len != nrows) {
-                ray_t* e = ray_error("domain", "deserialize table: ragged columns (column %lld has %lld rows, expected %lld)", (long long)i, (long long)(cps[i] ? cps[i]->len : -1), (long long)nrows);
-                ray_release(schema);
-                ray_release(cols);
-                return e;
-            }
-        }
-
         int64_t ncols = cols->len;
         ray_t* tbl = ray_table_new(ncols);
         if (!tbl || RAY_IS_ERR(tbl)) {
@@ -848,6 +834,14 @@ static ray_t* de_raw_inner(uint8_t* buf, int64_t* len) {
                 return new_tbl;
             }
             tbl = new_tbl;
+        }
+
+        ray_t* shape_err = ray_table_validate_rectangular(tbl, "deserialize table");
+        if (shape_err) {
+            ray_release(tbl);
+            ray_release(schema);
+            ray_release(cols);
+            return shape_err;
         }
 
         ray_release(schema);

--- a/src/table/dict.c
+++ b/src/table/dict.c
@@ -40,6 +40,10 @@
 
 #define DICT_DATA_SIZE  (2 * sizeof(ray_t*))
 
+static bool dict_side_is_list_or_vec(ray_t* side) {
+    return side && !RAY_IS_ERR(side) && (side->type == RAY_LIST || ray_is_vec(side));
+}
+
 static ray_t* dict_alloc_block(ray_t* keys, ray_t* vals) {
     ray_t* d = ray_alloc(DICT_DATA_SIZE);
     if (!d || RAY_IS_ERR(d)) return d;
@@ -68,6 +72,26 @@ ray_t* ray_dict_new(ray_t* keys, ray_t* vals) {
     if (!vals || RAY_IS_ERR(vals)) {
         ray_release(keys);
         return vals ? vals : ray_error("type", "dict: vals vector is null");
+    }
+    if (!dict_side_is_list_or_vec(keys)) {
+        ray_release(keys);
+        ray_release(vals);
+        return ray_error("domain", "dict: keys must be list/vector-like, got %s",
+                         ray_type_name(keys->type));
+    }
+    if (!dict_side_is_list_or_vec(vals)) {
+        ray_release(keys);
+        ray_release(vals);
+        return ray_error("domain", "dict: vals must be list/vector-like, got %s",
+                         ray_type_name(vals->type));
+    }
+    if (keys->len != vals->len) {
+        int64_t klen = keys->len;
+        int64_t vlen = vals->len;
+        ray_release(keys);
+        ray_release(vals);
+        return ray_error("domain", "dict: key/value count mismatch (%lld keys, %lld values)",
+                         (long long)klen, (long long)vlen);
     }
     ray_t* d = dict_alloc_block(keys, vals);
     if (!d || RAY_IS_ERR(d)) {

--- a/src/table/table.c
+++ b/src/table/table.c
@@ -58,6 +58,21 @@ static inline ray_t* tbl_cols(ray_t* tbl) {
     return tbl_slots(tbl)[1];
 }
 
+static bool table_col_is_valid(ray_t* col) {
+    if (!col || RAY_IS_ERR(col)) return false;
+    return col->type == RAY_LIST ||
+           ray_is_vec(col) ||
+           RAY_IS_PARTED(col->type) ||
+           col->type == RAY_MAPCOMMON;
+}
+
+static int64_t table_col_nrows(ray_t* col) {
+    if (!col) return 0;
+    if (RAY_IS_PARTED(col->type) || col->type == RAY_MAPCOMMON)
+        return ray_parted_nrows(col);
+    return col->len;
+}
+
 /* --------------------------------------------------------------------------
  * ray_table_new — allocates an empty table with capacity for `ncols`.
  *
@@ -103,7 +118,9 @@ ray_t* ray_table_new(int64_t ncols) {
 
 ray_t* ray_table_add_col(ray_t* tbl, int64_t name_id, ray_t* col_vec) {
     if (!tbl || RAY_IS_ERR(tbl)) return tbl;
-    if (!col_vec || RAY_IS_ERR(col_vec)) return ray_error("type", "table add_col: column must be a vector, got %s", col_vec ? ray_type_name(col_vec->type) : "null");
+    if (!table_col_is_valid(col_vec))
+        return ray_error("domain", "table add_col: column must be list/vector-like, got %s",
+                         col_vec ? ray_type_name(col_vec->type) : "null");
 
     tbl = ray_cow(tbl);
     if (!tbl || RAY_IS_ERR(tbl)) return tbl;
@@ -125,6 +142,41 @@ ray_t* ray_table_add_col(ray_t* tbl, int64_t name_id, ray_t* col_vec) {
     slots[1] = new_cols;
 
     return tbl;
+}
+
+ray_t* ray_table_validate_rectangular(ray_t* tbl, const char* context) {
+    const char* where = context ? context : "table";
+    if (!tbl || RAY_IS_ERR(tbl)) return tbl;
+    if (tbl->type != RAY_TABLE)
+        return ray_error("type", "%s: expected table, got %s", where, ray_type_name(tbl->type));
+
+    ray_t* schema = tbl_schema(tbl);
+    ray_t* cols = tbl_cols(tbl);
+    if (!schema || !cols || RAY_IS_ERR(schema) || RAY_IS_ERR(cols))
+        return ray_error("domain", "%s: malformed table storage", where);
+    if (schema->len != cols->len)
+        return ray_error("domain",
+                         "%s: schema/column count mismatch (%lld names, %lld columns)",
+                         where, (long long)schema->len, (long long)cols->len);
+
+    ray_t** col_ptrs = (ray_t**)ray_data(cols);
+    int64_t expected = 0;
+    for (int64_t i = 0; i < cols->len; i++) {
+        ray_t* col = col_ptrs[i];
+        if (!table_col_is_valid(col))
+            return ray_error("domain", "%s: column must be list/vector-like, got %s",
+                             where, col ? ray_type_name(col->type) : "null");
+        int64_t got = table_col_nrows(col);
+        if (i == 0) {
+            expected = got;
+        } else if (got != expected) {
+            return ray_error("domain",
+                             "%s: ragged columns (column %lld has %lld rows, expected %lld)",
+                             where, (long long)i, (long long)got, (long long)expected);
+        }
+    }
+
+    return NULL;
 }
 
 /* --------------------------------------------------------------------------

--- a/src/table/table.c
+++ b/src/table/table.c
@@ -118,9 +118,11 @@ ray_t* ray_table_new(int64_t ncols) {
 
 ray_t* ray_table_add_col(ray_t* tbl, int64_t name_id, ray_t* col_vec) {
     if (!tbl || RAY_IS_ERR(tbl)) return tbl;
-    if (!table_col_is_valid(col_vec))
+    if (!table_col_is_valid(col_vec)) {
+        ray_release(tbl);
         return ray_error("domain", "table add_col: column must be list/vector-like, got %s",
                          col_vec ? ray_type_name(col_vec->type) : "null");
+    }
 
     tbl = ray_cow(tbl);
     if (!tbl || RAY_IS_ERR(tbl)) return tbl;
@@ -146,7 +148,10 @@ ray_t* ray_table_add_col(ray_t* tbl, int64_t name_id, ray_t* col_vec) {
 
 ray_t* ray_table_validate_rectangular(ray_t* tbl, const char* context) {
     const char* where = context ? context : "table";
-    if (!tbl || RAY_IS_ERR(tbl)) return tbl;
+    if (!tbl) return ray_error("type", "%s: expected table, got null", where);
+    if (RAY_IS_ERR(tbl))
+        return ray_error(ray_err_code(tbl) ? ray_err_code(tbl) : "error",
+                         "%s: expected table, got error", where);
     if (tbl->type != RAY_TABLE)
         return ray_error("type", "%s: expected table, got %s", where, ray_type_name(tbl->type));
 

--- a/test/rfl/system/serde.rfl
+++ b/test/rfl/system/serde.rfl
@@ -29,13 +29,7 @@
 (count (de (ser [1 0N 3]))) -- 3
 (sum (de (ser [1 0N 3])))   -- 4
 
-;; ────────────── table frame: schema/column count must match ──────────────
-;; The table decoder loops over min(cols->len, schema->len), so a crafted frame
-;; whose schema names and columns disagree would be silently accepted as a
-;; truncated table.  Splice a 2-name i64 schema with a 1-column list into one
-;; table payload ([0x62 attrs] + ser(schema) + ser(cols), each self-consistent)
-;; and confirm it is rejected rather than decoded as a 1-column table.
-(set _s74p (concat (concat (as 'U8 [0x62 0x00]) (drop (ser (as 'I64 [7 7])) 16)) (drop (ser (list (as 'I64 [1]))) 16)))
-(set _s74h (take (ser 0) 16))
-(set _s74f (concat (concat (concat (take _s74h 8) (as 'U8 (enlist (count _s74p)))) (drop _s74h 9)) _s74p))
-(de _s74f) !- domain
+;; Container-frame count/length validation (table schema-vs-columns, ragged
+;; columns, dict keys-vs-values) is covered in test/test_store.c
+;; (store/serde_container_count_mismatch), which builds frames via
+;; sizeof(ray_ipc_header_t) rather than hard-coding the wire layout.

--- a/test/test_journal.c
+++ b/test/test_journal.c
@@ -1616,14 +1616,12 @@ static test_result_t test_journal_snapshot_rename_fails(void) {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════
- *  20. Snapshot: .qdb dict with more keys than values (missing-val path).
+ *  20. Snapshot: .qdb dict cannot be built with more keys than values.
  * ═══════════════════════════════════════════════════════════════════════ */
 
 static test_result_t test_journal_open_qdb_missing_val(void) {
-    char base[256]; make_base(base, sizeof(base), "oc_qdbmissing");
-    char qpath[270]; qdb_path(qpath, sizeof(qpath), base);
-
-    /* Build a dict: 2 sym keys, 1 value — second key has no corresponding val. */
+    /* Build a dict: 2 sym keys, 1 value.  Public construction rejects this
+     * before it can become a partially-loaded snapshot. */
     int64_t s1 = ray_sym_intern("jrn_k1", 6);
     int64_t s2 = ray_sym_intern("jrn_k2", 6);
     ray_t* keys = ray_sym_vec_new(RAY_SYM_W64, 2);
@@ -1638,24 +1636,10 @@ static test_result_t test_journal_open_qdb_missing_val(void) {
 
     ray_t* d = ray_dict_new(keys, vals);
     TEST_ASSERT_NOT_NULL(d);
-    TEST_ASSERT_FALSE(RAY_IS_ERR(d));
+    TEST_ASSERT_TRUE(RAY_IS_ERR(d));
+    TEST_ASSERT_STR_EQ(ray_err_code(d), "domain");
+    ray_error_free(d);
 
-    ray_err_t se = ray_obj_save(d, qpath);
-    ray_release(d);
-    TEST_ASSERT_EQ_I(se, RAY_OK);
-
-    /* Open: should warn about missing val for sym jrn_k2, but succeed. */
-    ray_err_t e = ray_journal_open(base, RAY_JOURNAL_ASYNC);
-    /* Partial load — bind_errs == 0 (we skipped, not failed), so OK. */
-    if (e == RAY_OK) {
-        TEST_ASSERT_TRUE(ray_journal_is_open());
-        TEST_ASSERT_EQ_I(ray_journal_close(), RAY_OK);
-    } else {
-        /* If open returned domain, still OK for test purposes. */
-        TEST_ASSERT_FALSE(ray_journal_is_open());
-    }
-
-    cleanup_base(base);
     PASS();
 }
 

--- a/test/test_pool.c
+++ b/test/test_pool.c
@@ -634,10 +634,10 @@ static test_result_t test_pool_zero_workers(void) {
     TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), 3);
     TEST_ASSERT_EQ_I(atomic_load(&ctx.elem_sum), 8192LL * 3);
 
-    /* Worker 0 (main) must have participated; worker 1 may or may not have
-     * picked up tasks depending on scheduling — at least worker 0 is set. */
+    /* No per-id participation assert: workers may drain these tiny tasks
+     * before the main thread enters the claim loop, depending on scheduling. */
     uint32_t mask = atomic_load(&ctx.saw_worker);
-    TEST_ASSERT_TRUE((mask & 0x1u) != 0);  /* main thread always = worker 0 */
+    TEST_ASSERT_TRUE(mask != 0);
 
     ray_pool_free(&pool);
     ray_heap_destroy();

--- a/test/test_pool.c
+++ b/test/test_pool.c
@@ -634,10 +634,10 @@ static test_result_t test_pool_zero_workers(void) {
     TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), 3);
     TEST_ASSERT_EQ_I(atomic_load(&ctx.elem_sum), 8192LL * 3);
 
-    /* No per-id participation assert: workers may drain these tiny tasks
-     * before the main thread enters the claim loop, depending on scheduling. */
+    /* Worker 0 (main) must have participated; worker 1 may or may not have
+     * picked up tasks depending on scheduling — at least worker 0 is set. */
     uint32_t mask = atomic_load(&ctx.saw_worker);
-    TEST_ASSERT_TRUE(mask != 0);
+    TEST_ASSERT_TRUE((mask & 0x1u) != 0);  /* main thread always = worker 0 */
 
     ray_pool_free(&pool);
     ray_heap_destroy();

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -643,7 +643,8 @@ static test_result_t test_splay_save_preflight_preserves_generation(void) {
                                       ray_vec_from_raw(RAY_I64, dv_raw, 2));
     ray_t* bad = ray_table_new(2);
     bad = ray_table_add_col(bad, k_id, new_k);
-    bad = ray_table_add_col(bad, v_id, unsupported);
+    bad = ray_table_add_col(bad, v_id, old_v);
+    ray_table_set_col_idx(bad, 1, unsupported);
     TEST_ASSERT_FALSE(RAY_IS_ERR(bad));
     TEST_ASSERT_EQ_I(ray_splay_save(bad, TMP_SPLAY_DIR, NULL), RAY_ERR_NYI);
 
@@ -3184,6 +3185,17 @@ static test_result_t test_serde_table_dict_de_errors(void) {
  * real serialized sub-objects, wrapped in a fresh ipc header.  Uses ray_ser and
  * sizeof(ray_ipc_header_t), so it stays honest if the wire layout ever changes
  * (rather than hard-coding the header size / field offsets). */
+#define TEST_ASSERT_ERR_CODE_MSG(r, code, needle) do {                       \
+    TEST_ASSERT_NOT_NULL(r);                                                 \
+    TEST_ASSERT_TRUE(RAY_IS_ERR(r));                                         \
+    TEST_ASSERT_STR_EQ(ray_err_code(r), code);                               \
+    const char* _msg = ray_error_msg();                                      \
+    TEST_ASSERT_NOT_NULL(_msg);                                              \
+    TEST_ASSERT_FMT(strstr(_msg, needle) != NULL,                            \
+                    "error message \"%s\" does not contain \"%s\"",         \
+                    _msg, needle);                                           \
+} while (0)
+
 static ray_t* serde_splice_container(uint8_t type_byte, ray_t* a, ray_t* b) {
     size_t hdrsz = sizeof(ray_ipc_header_t);
     ray_t* fa = ray_ser(a);
@@ -3198,12 +3210,17 @@ static ray_t* serde_splice_container(uint8_t type_byte, ray_t* a, ray_t* b) {
     int64_t payload = 2 + (int64_t)pa + (int64_t)pb;
     int64_t total = (int64_t)hdrsz + payload;
     ray_t* buf = ray_vec_new(RAY_U8, total);
+    if (!buf || RAY_IS_ERR(buf)) {
+        ray_release(fa);
+        ray_release(fb);
+        return buf;
+    }
     buf->len = total;
     uint8_t* p = (uint8_t*)ray_data(buf);
     ray_ipc_header_t* hdr = (ray_ipc_header_t*)p;
     hdr->prefix  = RAY_SERDE_PREFIX;
     hdr->version = RAY_SERDE_WIRE_VERSION;
-    hdr->flags = 0; hdr->endian = 0; hdr->msgtype = 0;
+    hdr->flags = 0; hdr->endian = RAY_SERDE_ENDIAN; hdr->msgtype = 0;
     hdr->size = payload;
     uint8_t* pl = p + hdrsz;
     pl[0] = type_byte;
@@ -3224,12 +3241,14 @@ static test_result_t test_serde_container_count_mismatch(void) {
         ray_t* schema = ray_vec_from_raw(RAY_I64, names, 2);
         int64_t c0[] = { 1 };
         ray_t* cols = ray_list_new(1);
-        cols = ray_list_append(cols, ray_vec_from_raw(RAY_I64, c0, 1));
+        ray_t* col0 = ray_vec_from_raw(RAY_I64, c0, 1);
+        cols = ray_list_append(cols, col0);
+        ray_release(col0);
         ray_t* frame = serde_splice_container((uint8_t)RAY_TABLE, schema, cols);
         TEST_ASSERT_NOT_NULL(frame);
         ray_t* r = ray_de(frame);
-        TEST_ASSERT_NOT_NULL(r); TEST_ASSERT_TRUE(RAY_IS_ERR(r));
-        ray_release(r); ray_release(frame); ray_release(schema); ray_release(cols);
+        TEST_ASSERT_ERR_CODE_MSG(r, "domain", "schema/column count mismatch");
+        ray_error_free(r); ray_release(frame); ray_release(schema); ray_release(cols);
     }
     /* TABLE: 2 columns of unequal length (2 and 1) → rejected (ragged rows). */
     {
@@ -3238,13 +3257,35 @@ static test_result_t test_serde_container_count_mismatch(void) {
         int64_t c0[] = { 1, 2 };
         int64_t c1[] = { 3 };
         ray_t* cols = ray_list_new(2);
-        cols = ray_list_append(cols, ray_vec_from_raw(RAY_I64, c0, 2));
-        cols = ray_list_append(cols, ray_vec_from_raw(RAY_I64, c1, 1));
+        ray_t* col0 = ray_vec_from_raw(RAY_I64, c0, 2);
+        ray_t* col1 = ray_vec_from_raw(RAY_I64, c1, 1);
+        cols = ray_list_append(cols, col0);
+        cols = ray_list_append(cols, col1);
+        ray_release(col0);
+        ray_release(col1);
         ray_t* frame = serde_splice_container((uint8_t)RAY_TABLE, schema, cols);
         TEST_ASSERT_NOT_NULL(frame);
         ray_t* r = ray_de(frame);
-        TEST_ASSERT_NOT_NULL(r); TEST_ASSERT_TRUE(RAY_IS_ERR(r));
-        ray_release(r); ray_release(frame); ray_release(schema); ray_release(cols);
+        TEST_ASSERT_ERR_CODE_MSG(r, "domain", "ragged columns");
+        ray_error_free(r); ray_release(frame); ray_release(schema); ray_release(cols);
+    }
+    /* TABLE: atom columns are not valid columns even when their scalar payloads
+     * match, because row-wise code would read from non-existent vector data. */
+    {
+        int64_t names[] = { 7, 8 };
+        ray_t* schema = ray_vec_from_raw(RAY_I64, names, 2);
+        ray_t* cols = ray_list_new(2);
+        ray_t* col0 = ray_i64(2);
+        ray_t* col1 = ray_i64(2);
+        cols = ray_list_append(cols, col0);
+        cols = ray_list_append(cols, col1);
+        ray_release(col0);
+        ray_release(col1);
+        ray_t* frame = serde_splice_container((uint8_t)RAY_TABLE, schema, cols);
+        TEST_ASSERT_NOT_NULL(frame);
+        ray_t* r = ray_de(frame);
+        TEST_ASSERT_ERR_CODE_MSG(r, "domain", "column must be list/vector-like");
+        ray_error_free(r); ray_release(frame); ray_release(schema); ray_release(cols);
     }
     /* DICT: 2 keys, 1 value → rejected (a probe would index vals[idx] with
      * idx < keys->len, an OOB read past the shorter value block). */
@@ -3256,8 +3297,8 @@ static test_result_t test_serde_container_count_mismatch(void) {
         ray_t* frame = serde_splice_container((uint8_t)RAY_DICT, k, v);
         TEST_ASSERT_NOT_NULL(frame);
         ray_t* r = ray_de(frame);
-        TEST_ASSERT_NOT_NULL(r); TEST_ASSERT_TRUE(RAY_IS_ERR(r));
-        ray_release(r); ray_release(frame); ray_release(k); ray_release(v);
+        TEST_ASSERT_ERR_CODE_MSG(r, "domain", "key/value count mismatch");
+        ray_error_free(r); ray_release(frame); ray_release(k); ray_release(v);
     }
     PASS();
 }
@@ -5137,6 +5178,109 @@ static test_result_t test_col_recursive_table(void) {
     PASS();
 }
 
+static bool test_write_exact(FILE* f, const void* data, size_t n) {
+    return fwrite(data, 1, n, f) == n;
+}
+
+static bool test_write_i8(FILE* f, int8_t v) {
+    return test_write_exact(f, &v, sizeof(v));
+}
+
+static bool test_write_u32(FILE* f, uint32_t v) {
+    return test_write_exact(f, &v, sizeof(v));
+}
+
+static bool test_write_i64(FILE* f, int64_t v) {
+    return test_write_exact(f, &v, sizeof(v));
+}
+
+static bool test_write_i64_vec(FILE* f, const int64_t* vals, int64_t len) {
+    return test_write_i8(f, (int8_t)RAY_I64) &&
+           test_write_i64(f, len) &&
+           test_write_exact(f, vals, (size_t)len * sizeof(vals[0]));
+}
+
+/* ---- test_col_recursive_container_guards -------------------------------- */
+static test_result_t test_col_recursive_container_guards(void) {
+    enum {
+        TEST_COL_LIST_MAGIC  = 0x4754534CU, /* "LSTG" */
+        TEST_COL_TABLE_MAGIC = 0x4C425454U  /* "TTBL" */
+    };
+
+    /* TABLE with atom columns: recursive on-disk decoding must hit the same
+     * shared table invariant as the serde decoder. */
+    {
+        FILE* f = fopen(TMP_COL_PATH, "wb");
+        TEST_ASSERT_NOT_NULL(f);
+        int64_t name_a = ray_sym_intern("bad_a", 5);
+        int64_t name_b = ray_sym_intern("bad_b", 5);
+        bool ok = test_write_u32(f, TEST_COL_TABLE_MAGIC) &&
+                  test_write_i8(f, (int8_t)RAY_TABLE) &&
+                  test_write_i64(f, 2) &&
+                  test_write_i64(f, 2) &&
+                  test_write_i64(f, name_a) &&
+                  test_write_i8(f, (int8_t)-RAY_I64) &&
+                  test_write_i64(f, 2) &&
+                  test_write_i64(f, name_b) &&
+                  test_write_i8(f, (int8_t)-RAY_I64) &&
+                  test_write_i64(f, 2);
+        fclose(f);
+        TEST_ASSERT_TRUE(ok);
+
+        ray_t* bad = ray_col_load(TMP_COL_PATH);
+        TEST_ASSERT_ERR_CODE_MSG(bad, "domain", "column must be list/vector-like");
+        ray_error_free(bad);
+    }
+
+    /* TABLE with ragged vector columns. */
+    {
+        FILE* f = fopen(TMP_COL_PATH, "wb");
+        TEST_ASSERT_NOT_NULL(f);
+        int64_t name_a = ray_sym_intern("bad_a", 5);
+        int64_t name_b = ray_sym_intern("bad_b", 5);
+        int64_t a[] = { 1, 2 };
+        int64_t b[] = { 3 };
+        bool ok = test_write_u32(f, TEST_COL_TABLE_MAGIC) &&
+                  test_write_i8(f, (int8_t)RAY_TABLE) &&
+                  test_write_i64(f, 2) &&
+                  test_write_i64(f, 2) &&
+                  test_write_i64(f, name_a) &&
+                  test_write_i64_vec(f, a, 2) &&
+                  test_write_i64(f, name_b) &&
+                  test_write_i64_vec(f, b, 1);
+        fclose(f);
+        TEST_ASSERT_TRUE(ok);
+
+        ray_t* bad = ray_col_load(TMP_COL_PATH);
+        TEST_ASSERT_ERR_CODE_MSG(bad, "domain", "ragged columns");
+        ray_error_free(bad);
+    }
+
+    /* DICT with two keys and one value, nested inside a generic list so it is
+     * decoded by col_read_recursive. */
+    {
+        FILE* f = fopen(TMP_COL_PATH, "wb");
+        TEST_ASSERT_NOT_NULL(f);
+        int64_t keys[] = { 7, 8 };
+        int64_t vals[] = { 1 };
+        bool ok = test_write_u32(f, TEST_COL_LIST_MAGIC) &&
+                  test_write_i8(f, (int8_t)RAY_LIST) &&
+                  test_write_i64(f, 1) &&
+                  test_write_i8(f, (int8_t)RAY_DICT) &&
+                  test_write_i64_vec(f, keys, 2) &&
+                  test_write_i64_vec(f, vals, 1);
+        fclose(f);
+        TEST_ASSERT_TRUE(ok);
+
+        ray_t* bad = ray_col_load(TMP_COL_PATH);
+        TEST_ASSERT_ERR_CODE_MSG(bad, "domain", "key/value count mismatch");
+        ray_error_free(bad);
+    }
+
+    unlink(TMP_COL_PATH);
+    PASS();
+}
+
 /* ---- test_col_recursive_read_corrupt ------------------------------------ */
 /* Covers col_read_recursive corruption guards:
  *   line 398/402: LIST with truncated count / count < 0 => "corrupt"
@@ -5334,6 +5478,7 @@ const test_entry_t store_entries[] = {
     { "store/col_str_validate_corrupt", test_col_str_validate_corrupt, store_setup, store_teardown },
     { "store/col_recursive_list_in_list", test_col_recursive_list_in_list, store_setup, store_teardown },
     { "store/col_recursive_table", test_col_recursive_table, store_setup, store_teardown },
+    { "store/col_recursive_container_guards", test_col_recursive_container_guards, store_setup, store_teardown },
     { "store/col_recursive_read_corrupt", test_col_recursive_read_corrupt, store_setup, store_teardown },
     { "store/col_link_sidecar_whitespace", test_col_link_sidecar_whitespace, store_setup, store_teardown },
     { "store/col_save_nyi_type", test_col_save_nyi_type, store_setup, store_teardown },

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -3180,6 +3180,88 @@ static test_result_t test_serde_table_dict_de_errors(void) {
     PASS();
 }
 
+/* Splice a container frame — [type][attrs] + payload(a) + payload(b) — from two
+ * real serialized sub-objects, wrapped in a fresh ipc header.  Uses ray_ser and
+ * sizeof(ray_ipc_header_t), so it stays honest if the wire layout ever changes
+ * (rather than hard-coding the header size / field offsets). */
+static ray_t* serde_splice_container(uint8_t type_byte, ray_t* a, ray_t* b) {
+    size_t hdrsz = sizeof(ray_ipc_header_t);
+    ray_t* fa = ray_ser(a);
+    ray_t* fb = ray_ser(b);
+    if (!fa || RAY_IS_ERR(fa) || !fb || RAY_IS_ERR(fb)) {
+        if (fa) ray_release(fa);
+        if (fb) ray_release(fb);
+        return NULL;
+    }
+    size_t pa = (size_t)fa->len - hdrsz;
+    size_t pb = (size_t)fb->len - hdrsz;
+    int64_t payload = 2 + (int64_t)pa + (int64_t)pb;
+    int64_t total = (int64_t)hdrsz + payload;
+    ray_t* buf = ray_vec_new(RAY_U8, total);
+    buf->len = total;
+    uint8_t* p = (uint8_t*)ray_data(buf);
+    ray_ipc_header_t* hdr = (ray_ipc_header_t*)p;
+    hdr->prefix  = RAY_SERDE_PREFIX;
+    hdr->version = RAY_SERDE_WIRE_VERSION;
+    hdr->flags = 0; hdr->endian = 0; hdr->msgtype = 0;
+    hdr->size = payload;
+    uint8_t* pl = p + hdrsz;
+    pl[0] = type_byte;
+    pl[1] = 0;
+    memcpy(pl + 2, (uint8_t*)ray_data(fa) + hdrsz, pa);
+    memcpy(pl + 2 + pa, (uint8_t*)ray_data(fb) + hdrsz, pb);
+    ray_release(fa);
+    ray_release(fb);
+    return buf;
+}
+
+/* A container frame whose two counts disagree must be rejected, not silently
+ * accepted as the shorter of the two. */
+static test_result_t test_serde_container_count_mismatch(void) {
+    /* TABLE: 2 schema names, 1 column → rejected (not truncated to 1 column). */
+    {
+        int64_t names[] = { 7, 7 };
+        ray_t* schema = ray_vec_from_raw(RAY_I64, names, 2);
+        int64_t c0[] = { 1 };
+        ray_t* cols = ray_list_new(1);
+        cols = ray_list_append(cols, ray_vec_from_raw(RAY_I64, c0, 1));
+        ray_t* frame = serde_splice_container((uint8_t)RAY_TABLE, schema, cols);
+        TEST_ASSERT_NOT_NULL(frame);
+        ray_t* r = ray_de(frame);
+        TEST_ASSERT_NOT_NULL(r); TEST_ASSERT_TRUE(RAY_IS_ERR(r));
+        ray_release(r); ray_release(frame); ray_release(schema); ray_release(cols);
+    }
+    /* TABLE: 2 columns of unequal length (2 and 1) → rejected (ragged rows). */
+    {
+        int64_t names[] = { 7, 8 };
+        ray_t* schema = ray_vec_from_raw(RAY_I64, names, 2);
+        int64_t c0[] = { 1, 2 };
+        int64_t c1[] = { 3 };
+        ray_t* cols = ray_list_new(2);
+        cols = ray_list_append(cols, ray_vec_from_raw(RAY_I64, c0, 2));
+        cols = ray_list_append(cols, ray_vec_from_raw(RAY_I64, c1, 1));
+        ray_t* frame = serde_splice_container((uint8_t)RAY_TABLE, schema, cols);
+        TEST_ASSERT_NOT_NULL(frame);
+        ray_t* r = ray_de(frame);
+        TEST_ASSERT_NOT_NULL(r); TEST_ASSERT_TRUE(RAY_IS_ERR(r));
+        ray_release(r); ray_release(frame); ray_release(schema); ray_release(cols);
+    }
+    /* DICT: 2 keys, 1 value → rejected (a probe would index vals[idx] with
+     * idx < keys->len, an OOB read past the shorter value block). */
+    {
+        int64_t keys[] = { 7, 8 };
+        ray_t* k = ray_vec_from_raw(RAY_I64, keys, 2);
+        int64_t vals[] = { 1 };
+        ray_t* v = ray_vec_from_raw(RAY_I64, vals, 1);
+        ray_t* frame = serde_splice_container((uint8_t)RAY_DICT, k, v);
+        TEST_ASSERT_NOT_NULL(frame);
+        ray_t* r = ray_de(frame);
+        TEST_ASSERT_NOT_NULL(r); TEST_ASSERT_TRUE(RAY_IS_ERR(r));
+        ray_release(r); ray_release(frame); ray_release(k); ray_release(v);
+    }
+    PASS();
+}
+
 /* ---- serde coverage: TABLE deser type-mismatch and more error paths ------ */
 
 static test_result_t test_serde_table_de_type_mismatch(void) {
@@ -5289,6 +5371,7 @@ const test_entry_t store_entries[] = {
     { "store/serde_save_serde_error",     test_serde_save_serde_error,     store_setup, store_teardown },
     { "store/serde_de_raw_default",       test_serde_de_raw_default_and_errors, store_setup, store_teardown },
     { "store/serde_table_dict_de_errors", test_serde_table_dict_de_errors, store_setup, store_teardown },
+    { "store/serde_container_count_mismatch", test_serde_container_count_mismatch, store_setup, store_teardown },
     { "store/serde_table_de_type_mismatch", test_serde_table_de_type_mismatch, store_setup, store_teardown },
     { "store/serde_de_size_bounds",        test_serde_de_size_bounds,        store_setup, store_teardown },
     { "store/total_ram", test_total_ram, NULL, NULL },

--- a/test/test_table.c
+++ b/test/test_table.c
@@ -398,7 +398,7 @@ static test_result_t test_table_add_col_null_tbl(void) {
     PASS();
 }
 
-/* NULL/error col_vec yields a type error; table is left untouched (table.c:105). */
+/* NULL/error col_vec yields a domain error and consumes the input table. */
 static test_result_t test_table_add_col_bad_colvec(void) {
     ray_t* tbl = ray_table_new(2);
 
@@ -407,14 +407,13 @@ static test_result_t test_table_add_col_bad_colvec(void) {
     TEST_ASSERT_TRUE(RAY_IS_ERR(r));
     ray_error_free(r);
 
-    /* tbl was not consumed on the NULL-col_vec early return */
+    tbl = ray_table_new(2);
     ray_t* err = ray_error("test", NULL);
     r = ray_table_add_col(tbl, id, err);
     TEST_ASSERT_TRUE(RAY_IS_ERR(r));
     ray_error_free(r);
     ray_error_free(err);
 
-    ray_release(tbl);
     PASS();
 }
 
@@ -620,5 +619,4 @@ const test_entry_t table_entries[] = {
     { "table/nrows_empty_col", test_table_nrows_empty_col, table_setup, table_teardown },
     { NULL, NULL, NULL, NULL },
 };
-
 


### PR DESCRIPTION
Follow-up to #444, addressing the review notes on the same decode paths.

## How it looks from the user's side

Before this PR, `de` and object/file-load decode could accept corrupt serialized TABLE/DICT payloads and build plausible but broken in-memory objects. A user would not see an error at load time; the failure surfaced later as bad rows, an out-of-bounds read, or an ASan crash.

Concrete cases:

- A TABLE whose schema and column count differ could silently drop data.
- A TABLE with atom "columns" could report rows from the atom payload even though there is no column vector data to read.
- A TABLE with ragged columns could report column 0's length and let row-wise code read past a shorter column.
- A DICT with more keys than values could find a key index and then read past the shorter value block.

After this change, corrupt payloads fail where they enter the system:

```text
error: domain: deserialize table: schema/column count mismatch (2 names, 1 columns)
error: domain: deserialize table: column must be list/vector-like, got RAY_I64
error: domain: deserialize table: ragged columns (column 1 has 1 rows, expected 2)
error: domain: deserialize dict: key/value count mismatch (2 keys, 1 values)
```

The same checks now apply to recursive on-disk column/table decoding, so a crafted `.col`/splayed file cannot bypass the serde guard.

## Fix

- Keep TABLE schema/column count validation in the serde decoder.
- Require table columns added through `ray_table_add_col` to be list/vector-like, so atom columns are rejected through the shared constructor.
- Keep `ray_table_add_col`'s ownership contract consistent on the new invalid-column error path: the input table ref is consumed, matching the later append-failure paths and avoiding leaks in recursive on-disk decode.
- Add `ray_table_validate_rectangular` and call it from both serde TABLE decode and recursive on-disk TABLE decode, so ragged decoded tables are rejected by shared table logic without breaking existing runtime table use cases that intentionally construct short/broadcast columns.
- Enforce DICT invariants in `ray_dict_new`: keys and values must be list/vector-like and their lengths must match. This closes serde, recursive on-disk decode, snapshot construction, and future callers through one constructor path.
- Remove the out-of-scope pool test change from the final PR diff.

## Tests

- Strengthened `store/serde_container_count_mismatch` to assert both error class and message substring.
- Added atom-column coverage for serde TABLE decode.
- Added recursive on-disk guards for atom TABLE columns, ragged TABLE columns, and DICT key/value mismatch.
- Fixed the serde splice helper to set `RAY_SERDE_ENDIAN`, check `ray_vec_new`, and release inline-appended vectors.

Full ASan+UBSan suite:

```text
=== 3720 of 3721 passed (1 skipped, 0 failed) ===
```
