### PR TITLE
fix(vec): flag sentinel nulls in every from_raw payload, not just SYM

### DIFF
--- a/src/vec/vec.c
+++ b/src/vec/vec.c
@@ -928,13 +928,34 @@ ray_t* ray_vec_from_raw(int8_t type, const void* data, int64_t count) {
         memcpy(ray_data(v), data, data_size);
     }
 
-    if (type == RAY_SYM) {
-        for (int64_t i = 0; i < count; i++) {
-            if (ray_read_sym(ray_data(v), i, RAY_SYM, v->attrs) == 0) {
-                v->attrs |= RAY_ATTR_HAS_NULLS;
-                break;
+    /* Raw payloads arrive with in-band null sentinels already in place
+     * (e.g. a binding passing INT64_MIN for an absent quantity), and
+     * HAS_NULLS is the fast-path gate ray_vec_is_null and the query/
+     * serde paths trust — a sentinel without the flag renders and
+     * aggregates as ordinary data.  Scan once at construction; the
+     * sentinel stays the source of truth. */
+    switch (type) {
+        case RAY_SYM:
+            for (int64_t i = 0; i < count; i++) {
+                if (ray_read_sym(ray_data(v), i, RAY_SYM, v->attrs) == 0) {
+                    v->attrs |= RAY_ATTR_HAS_NULLS;
+                    break;
+                }
             }
-        }
+            break;
+        case RAY_F64: case RAY_F32:
+        case RAY_I64: case RAY_TIMESTAMP:
+        case RAY_I32: case RAY_DATE: case RAY_TIME:
+        case RAY_I16: case RAY_GUID:
+            for (int64_t i = 0; i < count; i++) {
+                if (sentinel_is_null(v, i)) {
+                    v->attrs |= RAY_ATTR_HAS_NULLS;
+                    break;
+                }
+            }
+            break;
+        default:
+            break;  /* BOOL/U8/LIST/TABLE: non-nullable or pointer payloads */
     }
 
     /* LIST/TABLE elements are child pointers — retain them */

--- a/test/test_exec.c
+++ b/test/test_exec.c
@@ -16483,12 +16483,16 @@ static test_result_t test_expr_binary_range_f64_nan_branches(void) {
     ray_heap_init();
     (void)ray_sym_init();
 
-    /* F64 vectors WITHOUT HAS_NULLS — raw NaN values, no bitmap null.
-     * ray_vec_from_raw does NOT set HAS_NULLS; NaN is just a bit pattern. */
+    /* F64 vectors WITHOUT HAS_NULLS.  from_raw flags sentinel NaNs (#445),
+     * so strip the attr deliberately: this test pins the tolerance path for
+     * unflagged sentinels (legacy / flag-dropped vectors), where NaN is
+     * just a bit pattern. */
     double rawa[] = {NAN, NAN, 1.0};
     double rawb[] = {NAN, 1.0, NAN};
     ray_t* va = ray_vec_from_raw(RAY_F64, rawa, 3);
     ray_t* vb = ray_vec_from_raw(RAY_F64, rawb, 3);
+    va->attrs &= (uint8_t)~RAY_ATTR_HAS_NULLS;
+    vb->attrs &= (uint8_t)~RAY_ATTR_HAS_NULLS;
     /* Verify: no bitmap null set */
     TEST_ASSERT_FALSE(va->attrs & RAY_ATTR_HAS_NULLS);
     TEST_ASSERT_FALSE(vb->attrs & RAY_ATTR_HAS_NULLS);

--- a/test/test_idx_route.c
+++ b/test/test_idx_route.c
@@ -2168,13 +2168,15 @@ static test_result_t test_distinct_f64_nan_no_null_attr(void) {
     ray_heap_init();
     (void)ray_sym_init();
 
-    /* Three rows of canonical NaN, no HAS_NULLS flag. */
+    /* Three rows of canonical NaN, no HAS_NULLS flag.  from_raw flags
+     * sentinel NaNs (#445), so strip the attr deliberately — this test pins
+     * distinct's behavior on an unflagged (legacy / flag-dropped) vector. */
     double nan_val = __builtin_nan("");
     double raw[5] = { 1.0, nan_val, nan_val, nan_val, 2.0 };
     ray_t* v_no_idx = ray_vec_from_raw(RAY_F64, raw, 5);
     TEST_ASSERT_FALSE(RAY_IS_ERR(v_no_idx));
-    /* Confirm HAS_NULLS is NOT set */
-    TEST_ASSERT((v_no_idx->attrs & 0x40) == 0, "HAS_NULLS must not be set on raw-constructed vector");
+    v_no_idx->attrs &= (uint8_t)~RAY_ATTR_HAS_NULLS;
+    TEST_ASSERT((v_no_idx->attrs & 0x40) == 0, "HAS_NULLS stripped for the unflagged-sentinel path");
 
     ray_t* r_no_idx = distinct_vec_eager(v_no_idx);
     TEST_ASSERT_FALSE(RAY_IS_ERR(r_no_idx));
@@ -2182,6 +2184,7 @@ static test_result_t test_distinct_f64_nan_no_null_attr(void) {
 
     ray_t* v_idx = ray_vec_from_raw(RAY_F64, raw, 5);
     TEST_ASSERT_FALSE(RAY_IS_ERR(v_idx));
+    v_idx->attrs &= (uint8_t)~RAY_ATTR_HAS_NULLS;
     TEST_ASSERT_FALSE(RAY_IS_ERR(ray_index_attach_sort(&v_idx)));
 
     ray_t* r_idx = distinct_vec_eager(v_idx);

--- a/test/test_vec.c
+++ b/test/test_vec.c
@@ -28,7 +28,9 @@
 #include "vec/embedding.h"
 #include "table/sym.h"
 #include "core/platform.h"
+#include "store/serde.h"
 #include <string.h>
+#include <math.h>
 
 /* ---- Setup / Teardown -------------------------------------------------- */
 
@@ -2150,6 +2152,76 @@ static test_result_t test_vec_from_raw_sym(void) {
     PASS();
 }
 
+/* ---- from_raw: sentinel nulls in raw input must set HAS_NULLS ---------- */
+
+static test_result_t test_vec_from_raw_sentinel_nulls(void) {
+    /* #445: a binding passing INT64_MIN through from_raw got a vector whose
+     * payload held the null sentinel while HAS_NULLS stayed clear, so
+     * ray_vec_is_null (gated on the attr for numeric types) denied the null
+     * and it rendered as -9223372036854775808 — including after an IPC
+     * round trip.  Construction must scan the raw payload. */
+    int64_t iv[] = { 1, NULL_I64, 3 };
+    ray_t* v = ray_vec_from_raw(RAY_I64, iv, 3);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(v));
+    TEST_ASSERT_TRUE(v->attrs & RAY_ATTR_HAS_NULLS);
+    TEST_ASSERT_FALSE(ray_vec_is_null(v, 0));
+    TEST_ASSERT_TRUE(ray_vec_is_null(v, 1));
+
+    /* Serialize/deserialize keeps both the flag and the null. */
+    ray_t* wire = ray_ser(v);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(wire));
+    ray_t* back = ray_de(wire);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(back));
+    TEST_ASSERT_TRUE(back->attrs & RAY_ATTR_HAS_NULLS);
+    TEST_ASSERT_TRUE(ray_vec_is_null(back, 1));
+    ray_release(back);
+    ray_release(wire);
+    ray_release(v);
+
+    /* F64: any NaN bit pattern is the sentinel. */
+    double fv[] = { 1.5, (double)NAN, 3.5 };
+    ray_t* f = ray_vec_from_raw(RAY_F64, fv, 3);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(f));
+    TEST_ASSERT_TRUE(f->attrs & RAY_ATTR_HAS_NULLS);
+    TEST_ASSERT_TRUE(ray_vec_is_null(f, 1));
+    ray_t* fwire = ray_ser(f);
+    ray_t* fback = ray_de(fwire);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(fback));
+    TEST_ASSERT_TRUE(ray_vec_is_null(fback, 1));
+    ray_release(fback);
+    ray_release(fwire);
+    ray_release(f);
+
+    /* I32/DATE width, I16, and GUID all-zero sentinel. */
+    int32_t dv[] = { 100, NULL_I32 };
+    ray_t* d = ray_vec_from_raw(RAY_DATE, dv, 2);
+    TEST_ASSERT_TRUE(d->attrs & RAY_ATTR_HAS_NULLS);
+    TEST_ASSERT_TRUE(ray_vec_is_null(d, 1));
+    ray_release(d);
+
+    int16_t sv[] = { 7, NULL_I16 };
+    ray_t* s = ray_vec_from_raw(RAY_I16, sv, 2);
+    TEST_ASSERT_TRUE(s->attrs & RAY_ATTR_HAS_NULLS);
+    TEST_ASSERT_TRUE(ray_vec_is_null(s, 1));
+    ray_release(s);
+
+    uint8_t gv[32];
+    memset(gv, 0xAB, 16);
+    memset(gv + 16, 0, 16);
+    ray_t* g = ray_vec_from_raw(RAY_GUID, gv, 2);
+    TEST_ASSERT_TRUE(g->attrs & RAY_ATTR_HAS_NULLS);
+    TEST_ASSERT_FALSE(ray_vec_is_null(g, 0));
+    TEST_ASSERT_TRUE(ray_vec_is_null(g, 1));
+    ray_release(g);
+
+    /* Clean input must NOT pick up the flag. */
+    int64_t cv[] = { 1, 2, 3 };
+    ray_t* c = ray_vec_from_raw(RAY_I64, cv, 3);
+    TEST_ASSERT_FALSE(c->attrs & RAY_ATTR_HAS_NULLS);
+    ray_release(c);
+    PASS();
+}
+
 /* ---- slice: NULL/error passthrough + zero-length ----------------------- */
 
 static test_result_t test_vec_slice_guards(void) {
@@ -2247,6 +2319,7 @@ const test_entry_t vec_entries[] = {
     { "vec/insert_many_atom", test_vec_insert_many_atom, vec_setup, vec_teardown },
     { "vec/insert_many_guards", test_vec_insert_many_guards, vec_setup, vec_teardown },
     { "vec/from_raw_sym", test_vec_from_raw_sym, vec_setup, vec_teardown },
+    { "vec/from_raw_sentinel_nulls", test_vec_from_raw_sentinel_nulls, vec_setup, vec_teardown },
     { "vec/slice_guards", test_vec_slice_guards, vec_setup, vec_teardown },
     { NULL, NULL, NULL, NULL },
 };


### PR DESCRIPTION
Closes #445.

`ray_vec_from_raw` scanned only SYM input for its canonical null. A raw numeric payload carrying a sentinel — the reporter's OCaml binding passes `Int64.min_value` for an absent DBN quantity — produced a vector whose payload held the documented null representation while `HAS_NULLS` stayed clear. Since `ray_vec_is_null` gates numeric/temporal/GUID types on the attr, the null rendered as `-9223372036854775808`, survived IPC that way, and fed aggregation fast paths as ordinary data.

The construction scan now covers every sentinel-nullable type (`F64`/`F32` NaN, `NULL_I64` for I64/TIMESTAMP, `NULL_I32` for I32/DATE/TIME, `NULL_I16`, all-zero GUID) through `sentinel_is_null` — the same predicate `ray_vec_is_null` reads — so the flag and the payload can't disagree at this producer. The sentinel remains the source of truth; the scan stops at the first hit.

Two existing tests (`exec/expr_binary_range_f64_nan_branches`, `idx_route/distinct_f64_nan_no_null_attr`) used from_raw's old behavior as the way to craft *unflagged*-NaN vectors; they now strip the attr explicitly, keeping their actual subject — tolerance of legacy/flag-dropped vectors — intact.

Regression test covers construction + `ray_vec_is_null` + ser/de round-trip for I64 and F64, plus DATE/I16/GUID flagging and a clean-input no-flag check.

Known adjacent gap, left out deliberately: `ray_vec_set`/`ray_vec_append` also flag only SYM when a raw element happens to be a sentinel — but `ray_vec_set_null_checked` is the intended null-writing API there, and scanning per-append is a hot-path cost; can be discussed separately.

## Verification
- Full suite: 3723/3723 pass (UBSan fatal).
- New test fails on the parent commit (`HAS_NULLS` absent after I64 construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8TdSm4JwxHB37kiaKxgTN