### PR TITLE
fix(query): handle guid membership predicates

### DIFF
--- a/src/ops/collection.c
+++ b/src/ops/collection.c
@@ -1224,6 +1224,25 @@ ray_t* ray_distinct_fn(ray_t* x) {
 ray_t* ray_in_fn(ray_t* val, ray_t* vec) {
     if (ray_is_lazy(val)) val = ray_lazy_materialize(val);
     if (ray_is_lazy(vec)) vec = ray_lazy_materialize(vec);
+    /* Parted columns store segment pointers where vector paths expect flat
+     * cells: reading a parted GUID column through ray_data() yields segment
+     * pointers, not 16-byte guids, so membership silently matched nothing.
+     * Flatten first, then run the normal path.  This mirrors distinct/except/
+     * sect, which already flatten via parted_to_flat_vec. */
+    if (val && RAY_IS_PARTED(val->type)) {
+        ray_t* fv = parted_to_flat_vec(val);
+        if (!fv || RAY_IS_ERR(fv)) return fv ? fv : ray_error("oom", NULL);
+        ray_t* r = ray_in_fn(fv, vec);
+        ray_release(fv);
+        return r;
+    }
+    if (vec && RAY_IS_PARTED(vec->type)) {
+        ray_t* fs = parted_to_flat_vec(vec);
+        if (!fs || RAY_IS_ERR(fs)) return fs ? fs : ray_error("oom", NULL);
+        ray_t* r = ray_in_fn(val, fs);
+        ray_release(fs);
+        return r;
+    }
     /* STR in STR: for each char of val, check membership in vec string */
     if (ray_is_atom(val) && (-val->type) == RAY_STR && ray_is_atom(vec) && (-vec->type) == RAY_STR) {
         const char* vp = ray_str_ptr(val);

--- a/src/ops/collection.c
+++ b/src/ops/collection.c
@@ -1225,22 +1225,27 @@ ray_t* ray_in_fn(ray_t* val, ray_t* vec) {
     if (ray_is_lazy(val)) val = ray_lazy_materialize(val);
     if (ray_is_lazy(vec)) vec = ray_lazy_materialize(vec);
     /* Parted columns store segment pointers where vector paths expect flat
-     * cells: reading a parted GUID column through ray_data() yields segment
-     * pointers, not 16-byte guids, so membership silently matched nothing.
-     * Flatten first, then run the normal path.  This mirrors distinct/except/
-     * sect, which already flatten via parted_to_flat_vec. */
+     * cells.  Flatten both operands before membership; distinct uses the same
+     * helper, while except/sect still reject parted input. */
+    ray_t* flat_val = NULL;
+    ray_t* flat_vec = NULL;
     if (val && RAY_IS_PARTED(val->type)) {
-        ray_t* fv = parted_to_flat_vec(val);
-        if (!fv || RAY_IS_ERR(fv)) return fv ? fv : ray_error("oom", NULL);
-        ray_t* r = ray_in_fn(fv, vec);
-        ray_release(fv);
-        return r;
+        flat_val = parted_to_flat_vec(val);
+        if (!flat_val || RAY_IS_ERR(flat_val)) return flat_val ? flat_val : ray_error("oom", NULL);
+        val = flat_val;
     }
     if (vec && RAY_IS_PARTED(vec->type)) {
-        ray_t* fs = parted_to_flat_vec(vec);
-        if (!fs || RAY_IS_ERR(fs)) return fs ? fs : ray_error("oom", NULL);
-        ray_t* r = ray_in_fn(val, fs);
-        ray_release(fs);
+        flat_vec = parted_to_flat_vec(vec);
+        if (!flat_vec || RAY_IS_ERR(flat_vec)) {
+            if (flat_val) ray_release(flat_val);
+            return flat_vec ? flat_vec : ray_error("oom", NULL);
+        }
+        vec = flat_vec;
+    }
+    if (flat_val || flat_vec) {
+        ray_t* r = ray_in_fn(val, vec);
+        if (flat_val) ray_release(flat_val);
+        if (flat_vec) ray_release(flat_vec);
         return r;
     }
     /* STR in STR: for each char of val, check membership in vec string */

--- a/src/ops/exec.c
+++ b/src/ops/exec.c
@@ -1100,18 +1100,64 @@ ray_t* ray_in_vec_exec(ray_t* col, ray_t* set, bool negate) {
     return out;
 }
 
+static ray_t* flatten_parted_col(ray_t* col);
+
 /* GUID membership fallback: the typed `in` kernel bails on guid operands
  * (16-byte cells it can't compare), so route them through the general
  * ray_in_fn path, which builds a guid-aware hashset.  `col` is a materialized
  * column vector, so ray_in_fn returns a fresh RAY_BOOL vector we own and may
  * invert in place for not-in. */
 static ray_t* exec_in_guid_fallback(ray_t* col, ray_t* set, bool negate) {
-    ray_t* r = ray_in_fn(col, set);
-    if (!r || RAY_IS_ERR(r)) return r;
-    if (negate && r->type == RAY_BOOL) {
-        uint8_t* b = (uint8_t*)ray_data(r);
-        for (int64_t i = 0; i < r->len; i++) b[i] = (uint8_t)!b[i];
+    ray_t* input = col;
+    bool owns_input = false;
+    if (RAY_IS_PARTED(col->type) || col->type == RAY_MAPCOMMON) {
+        input = flatten_parted_col(col);
+        if (!input || RAY_IS_ERR(input)) return input ? input : ray_error("oom", NULL);
+        owns_input = true;
     }
+
+    ray_t* r = ray_in_fn(input, set);
+    if (!r || RAY_IS_ERR(r)) {
+        if (owns_input) ray_release(input);
+        return r;
+    }
+
+    /* ray_in_fn returns a scalar for a scalar GUID subject.  Normalize it to
+     * the vector contract of exec_in before applying not-in. */
+    if (ray_is_atom(r) && r->type == -RAY_BOOL) {
+        ray_t* out = ray_vec_new(RAY_BOOL, 1);
+        if (!out || RAY_IS_ERR(out)) {
+            ray_release(r);
+            return out ? out : ray_error("oom", NULL);
+        }
+        out->len = 1;
+        ((uint8_t*)ray_data(out))[0] = r->b8;
+        ray_release(r);
+        r = out;
+    }
+
+    if (r->type == RAY_BOOL) {
+        uint8_t* b = (uint8_t*)ray_data(r);
+        if (negate)
+            for (int64_t i = 0; i < r->len; i++) b[i] = (uint8_t)!b[i];
+
+        /* Mask after inversion: null rows must remain false for both IN and
+         * NOT_IN, while the underlying membership helper may match null. */
+        if (ray_is_atom(col)) {
+            if (RAY_ATOM_IS_NULL(col)) b[0] = 0;
+        } else if (input->type == RAY_GUID) {
+            /* GUID nulls are all-zero cells; older table construction paths
+             * may omit HAS_NULLS even though the sentinel is present. */
+            static const uint8_t null_guid[16] = {0};
+            const uint8_t* data = (const uint8_t*)ray_data(input);
+            for (int64_t i = 0; i < r->len; i++)
+                if (memcmp(data + i * 16, null_guid, 16) == 0) b[i] = 0;
+        } else if (col->attrs & RAY_ATTR_HAS_NULLS) {
+            for (int64_t i = 0; i < r->len; i++)
+                if (ray_vec_is_null(input, i)) b[i] = 0;
+        }
+    }
+    if (owns_input) ray_release(input);
     return r;
 }
 

--- a/src/ops/exec.c
+++ b/src/ops/exec.c
@@ -870,6 +870,12 @@ static in_ctx_status_t in_build_worker_ctx(ray_t* col, ray_t* set, bool negate,
     if (RAY_IS_PARTED(st)) st = (int8_t)RAY_PARTED_BASETYPE(st);
 
     if (ct == RAY_STR || st == RAY_STR) return IN_CTX_UNSUPPORTED;
+    /* GUID cells are 16-byte blobs; the typed kernel's READ_I64/IN_READ_I64
+     * loops have no guid case and read them at the wrong width (every cell
+     * decodes to 0, so membership silently matched everything).  Bail so the
+     * caller routes to the guid-aware hashset path, mirroring how RAY_STR bails
+     * above and the guid == fix. */
+    if (ct == RAY_GUID || st == RAY_GUID) return IN_CTX_UNSUPPORTED;
 
     /* Classify each side: 0=int-family, 1=float-family, 2=sym. */
     #define CLASSIFY(t)                                                    \
@@ -1094,6 +1100,30 @@ ray_t* ray_in_vec_exec(ray_t* col, ray_t* set, bool negate) {
     return out;
 }
 
+/* GUID membership fallback: the typed `in` kernel bails on guid operands
+ * (16-byte cells it can't compare), so route them through the general
+ * ray_in_fn path, which builds a guid-aware hashset.  `col` is a materialized
+ * column vector, so ray_in_fn returns a fresh RAY_BOOL vector we own and may
+ * invert in place for not-in. */
+static ray_t* exec_in_guid_fallback(ray_t* col, ray_t* set, bool negate) {
+    ray_t* r = ray_in_fn(col, set);
+    if (!r || RAY_IS_ERR(r)) return r;
+    if (negate && r->type == RAY_BOOL) {
+        uint8_t* b = (uint8_t*)ray_data(r);
+        for (int64_t i = 0; i < r->len; i++) b[i] = (uint8_t)!b[i];
+    }
+    return r;
+}
+
+/* True when either operand is a guid column/atom (parted base included). */
+static bool in_is_guid(ray_t* col, ray_t* set) {
+    int8_t ct = ray_is_atom(col) ? (int8_t)(-col->type) : col->type;
+    int8_t st = ray_is_atom(set) ? (int8_t)(-set->type) : set->type;
+    if (RAY_IS_PARTED(ct)) ct = (int8_t)RAY_PARTED_BASETYPE(ct);
+    if (RAY_IS_PARTED(st)) st = (int8_t)RAY_PARTED_BASETYPE(st);
+    return ct == RAY_GUID || st == RAY_GUID;
+}
+
 static ray_t* exec_in(ray_graph_t* g, ray_op_t* op, ray_t* col, ray_t* set) {
     (void)g;
     bool negate = (op->opcode == OP_NOT_IN);
@@ -1122,8 +1152,11 @@ static ray_t* exec_in(ray_graph_t* g, ray_op_t* op, ray_t* col, ray_t* set) {
     in_ctx_status_t st = in_build_worker_ctx(col, set, negate,
                                              svf_stack, svi_stack,
                                              &in_ctx, &sv_hdr, &lut_hdr);
-    if (st == IN_CTX_UNSUPPORTED)
+    if (st == IN_CTX_UNSUPPORTED) {
+        if (in_is_guid(col, set))
+            return exec_in_guid_fallback(col, set, negate);
         return ray_error("nyi", "OP_IN on RAY_STR not yet implemented");
+    }
     if (st == IN_CTX_OOM)
         return ray_error("oom", NULL);
 

--- a/test/rfl/query/guid_like_predicates.rfl
+++ b/test/rfl/query/guid_like_predicates.rfl
@@ -24,6 +24,18 @@
 ;; ordering on guid operands is undefined — loud, not silent
 (select {from: t where: (< g g1)}) !- type
 
+;; GUID membership: the typed `in` kernel read guid cells at the wrong width
+;; (every cell decoded to 0), so `in`/`not-in` silently matched everything.
+;; The kernel now bails guid to the guid-aware hashset path.
+(set gsub (at gs [0 2]))
+(in gs gsub) -- [true false true]
+(not (in gs gsub)) -- [false true false]
+(get (select {from: t where: (in g gsub)}) 'v) -- [10 30]
+(get (select {from: t where: (not (in g gsub))}) 'v) -- [20]
+(at (get (select {from: t where: (in g gsub) s: (sum v)}) 's) 0) -- 40
+;; membership against an empty set matches nothing (no all-true collapse)
+(in gs (at gs [])) -- [false false false]
+
 ;; like over a string column inside select-where (table construction
 ;; normalizes the list to a STR column; the real list-of-atoms shape —
 ;; a legacy STRL splayed load — is covered by legacy_strl_predicates.rfl)
@@ -56,3 +68,7 @@
 (count (get (select {from: PT where: (!= g pg1)}) 'v)) -- 4
 ;; ordering stays loud on parted guids too
 (select {from: PT where: (< g pg1)}) !- type
+
+;; partitioned guid columns take the same in/not-in fallback
+(get (select {from: PT where: (in g (at PG1 [0 1]))}) 'v) -- [10 20]
+(get (select {from: PT where: (not (in g (at PG1 [0 1])))}) 'v) -- [30 40 50]

--- a/test/rfl/query/guid_like_predicates.rfl
+++ b/test/rfl/query/guid_like_predicates.rfl
@@ -35,6 +35,14 @@
 (at (get (select {from: t where: (in g gsub) s: (sum v)}) 's) 0) -- 40
 ;; membership against an empty set matches nothing (no all-true collapse)
 (in gs (at gs [])) -- [false false false]
+;; Scalar subjects retain builtin scalar semantics; query predicates normalize
+;; their result to a row-aligned BOOL vector and keep nulls false.
+(set gn (as 'guid "00000000-0000-0000-0000-000000000000"))
+(in gn gs) -- false
+(not (in gn gs)) -- true
+(set gns (list gn (at gs 0)))
+(in gns gs) -- [false true]
+(not (in gns gs)) -- [true false]
 
 ;; like over a string column inside select-where (table construction
 ;; normalizes the list to a STR column; the real list-of-atoms shape —

--- a/test/test_lang.c
+++ b/test/test_lang.c
@@ -870,6 +870,31 @@ static test_result_t test_eval_in(void) {
     PASS();
 }
 
+/* ---- Test: GUID OP_NOT_IN preserves null semantics ---------------------- */
+static test_result_t test_eval_select_where_in_guid_nulls(void) {
+    ray_t* table = ray_eval_str(
+        "(do (set g (guid 2)) "
+        "(set probe (as 'guid \"00000000-0000-0000-0000-000000000000\")) "
+        "(set t (table ['g 'v] (list g [10 20]))) t)");
+    TEST_ASSERT_NOT_NULL(table);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(table));
+
+    ray_t* col = ray_table_get_col(table, ray_sym_intern("g", 1));
+    TEST_ASSERT_NOT_NULL(col);
+    TEST_ASSERT_EQ_I(col->type, RAY_GUID);
+    ray_vec_set_null(col, 0, true);
+
+    ray_t* result = ray_eval_str(
+        "(select {from: t where: (not-in g probe)})");
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    TEST_ASSERT_EQ_I(ray_table_nrows(result), 1);
+
+    ray_release(result);
+    ray_release(table);
+    PASS();
+}
+
 /* ---- Test: except ---- */
 static test_result_t test_eval_except(void) {
     ray_t* result = ray_eval_str("(except [1 2 3] [2])");
@@ -8907,6 +8932,7 @@ const test_entry_t lang_entries[] = {
     { "lang/eval/apply", test_eval_apply, lang_setup, lang_teardown },
     { "lang/eval/distinct", test_eval_distinct, lang_setup, lang_teardown },
     { "lang/eval/in", test_eval_in, lang_setup, lang_teardown },
+    { "lang/eval/select_where_in_guid_nulls", test_eval_select_where_in_guid_nulls, lang_setup, lang_teardown },
     { "lang/eval/except", test_eval_except, lang_setup, lang_teardown },
     { "lang/eval/union", test_eval_union, lang_setup, lang_teardown },
     { "lang/eval/sect", test_eval_sect, lang_setup, lang_teardown },


### PR DESCRIPTION
## How it looks from the user's side

A user filters a GUID column with `in` or `not-in`:

```rfl
(select {from: trades where: (not-in guid_col target_guids)})
```

Before, GUID membership could silently produce incorrect matches. In particular, a GUID atom used as the subject could return a scalar with the wrong `not-in` result, and null GUID rows could pass `not-in` because the all-zero GUID matched the fallback hashset and was inverted.

After, GUID membership compares the complete 16-byte values, returns a row-aligned BOOL vector from the query execution path, and null GUID rows remain excluded from both `in` and `not-in` predicates.

## Root Cause

The typed `in` worker only supports numeric and SYM readers, so GUID operands must use the GUID-aware fallback. The fallback previously assumed vector-shaped results and applied negation without preserving the typed null semantics used by the worker. Parted operands also exposed segment pointers to generic membership code instead of flat GUID cells.

## Fix

- Route GUID operands through the GUID-aware fallback.
- Normalize scalar fallback results to a one-row BOOL vector for `exec_in`.
- Apply `not-in` before masking canonical all-zero GUID null cells, so null rows stay false.
- Flatten parted operands through a shared path before membership checks.
- Correct the parted-membership comment to describe only the operation that actually shares this flattening behavior.

## Tests

- `RAYFORCE_CORES=2 ./rayforce.test -f rfl/query/guid_like_predicates`
- `./rayforce.test -f lang/eval/select_where_in_guid_nulls`
- `make debug`

The two targeted tests pass. A full local `make test` reaches the end but currently reports unrelated IPC/stress/system failures in the local test environment; the GUID regression tests themselves pass.
