### PR TITLE
fix(format): pad table cells by display width, not byte length

### DIFF
--- a/src/lang/format.c
+++ b/src/lang/format.c
@@ -738,9 +738,24 @@ static int32_t fmt_utf8_width(const char* s, int32_t slen) {
         }
         if (!ok) { w += 1; i += 1; continue; }
         i += cont + 1;
-        if ((cp >= 0x0300 && cp <= 0x036F) ||       /* combining marks */
+        if ((cp >= 0x0300 && cp <= 0x036F) ||       /* Latin combining marks */
+            (cp >= 0x0483 && cp <= 0x0489) ||       /* Cyrillic combining */
+            (cp >= 0x0591 && cp <= 0x05BD) ||       /* Hebrew points (niqqud) */
+            cp == 0x05BF || cp == 0x05C1 || cp == 0x05C2 ||
+            cp == 0x05C4 || cp == 0x05C5 || cp == 0x05C7 ||
+            (cp >= 0x0610 && cp <= 0x061A) ||       /* Arabic marks */
+            (cp >= 0x064B && cp <= 0x065F) ||       /* Arabic harakat */
+            cp == 0x0670 ||
+            (cp >= 0x06D6 && cp <= 0x06DC) ||
+            (cp >= 0x0E31 && cp <= 0x0E3A) ||       /* Thai vowels above/below */
+            (cp >= 0x0E47 && cp <= 0x0E4E) ||
             (cp >= 0x200B && cp <= 0x200F) ||       /* zero-width spaces */
-            (cp >= 0xFE00 && cp <= 0xFE0F))         /* variation selectors */
+            (cp >= 0x202A && cp <= 0x202E) ||       /* bidi embedding/override */
+            (cp >= 0x2060 && cp <= 0x2064) ||       /* word joiner, invisibles */
+            (cp >= 0x2066 && cp <= 0x2069) ||       /* bidi isolates */
+            (cp >= 0xFE00 && cp <= 0xFE0F) ||       /* variation selectors */
+            (cp >= 0xFE20 && cp <= 0xFE2F) ||       /* combining half marks */
+            cp == 0xFEFF)                           /* BOM / zero-width nbsp */
             continue;                               /* width 0 */
         if ((cp >= 0x1100  && cp <= 0x115F)  ||     /* Hangul jamo */
             (cp >= 0x2E80  && cp <= 0xA4CF)  ||     /* CJK radicals..Yi */

--- a/src/lang/format.c
+++ b/src/lang/format.c
@@ -711,9 +711,57 @@ static void fmt_dict(fmt_buf_t* b, ray_t* dict, int mode) {
 
 /* ===== Table formatter helpers ===== */
 
+/* Terminal display width of a UTF-8 string.  Byte length overstates the
+ * width of any multi-byte cell (a 3-byte CJK char renders as 2 columns,
+ * not 3), which skewed every pad computed from it and tore the table
+ * borders.  Coarse East-Asian-Width classification: wide/fullwidth CJK,
+ * Hangul, fullwidth forms and emoji count 2; zero-width marks count 0;
+ * everything else, malformed bytes included, counts 1 — so a bad
+ * sequence can never desync more than its own cell. */
+static int32_t fmt_utf8_width(const char* s, int32_t slen) {
+    int32_t w = 0;
+    for (int32_t i = 0; i < slen;) {
+        uint8_t c = (uint8_t)s[i];
+        if (c < 0x80) { w += 1; i += 1; continue; }
+        uint32_t cp;
+        int32_t  cont;
+        if      ((c & 0xE0) == 0xC0) { cp = c & 0x1Fu; cont = 1; }
+        else if ((c & 0xF0) == 0xE0) { cp = c & 0x0Fu; cont = 2; }
+        else if ((c & 0xF8) == 0xF0) { cp = c & 0x07u; cont = 3; }
+        else                         { w += 1; i += 1; continue; }
+        if (i + cont >= slen) { w += 1; i += 1; continue; }
+        bool ok = true;
+        for (int32_t k = 1; k <= cont; k++) {
+            uint8_t cc = (uint8_t)s[i + k];
+            if ((cc & 0xC0) != 0x80) { ok = false; break; }
+            cp = (cp << 6) | (cc & 0x3Fu);
+        }
+        if (!ok) { w += 1; i += 1; continue; }
+        i += cont + 1;
+        if ((cp >= 0x0300 && cp <= 0x036F) ||       /* combining marks */
+            (cp >= 0x200B && cp <= 0x200F) ||       /* zero-width spaces */
+            (cp >= 0xFE00 && cp <= 0xFE0F))         /* variation selectors */
+            continue;                               /* width 0 */
+        if ((cp >= 0x1100  && cp <= 0x115F)  ||     /* Hangul jamo */
+            (cp >= 0x2E80  && cp <= 0xA4CF)  ||     /* CJK radicals..Yi */
+            (cp >= 0xAC00  && cp <= 0xD7A3)  ||     /* Hangul syllables */
+            (cp >= 0xF900  && cp <= 0xFAFF)  ||     /* CJK compat ideographs */
+            (cp >= 0xFE30  && cp <= 0xFE4F)  ||     /* CJK compat forms */
+            (cp >= 0xFF00  && cp <= 0xFF60)  ||     /* fullwidth forms */
+            (cp >= 0xFFE0  && cp <= 0xFFE6)  ||     /* fullwidth signs */
+            (cp >= 0x1F300 && cp <= 0x1FAFF) ||     /* emoji */
+            (cp >= 0x20000 && cp <= 0x3FFFD))       /* CJK ext B+ */
+            w += 2;
+        else
+            w += 1;
+    }
+    return w;
+}
+
 static void fmt_centered(fmt_buf_t* b, const char* s, int32_t slen, int32_t width) {
-    int32_t left  = (width - slen) / 2;
-    int32_t right = width - slen - left;
+    int32_t dlen  = fmt_utf8_width(s, slen);
+    int32_t left  = (width - dlen) / 2;
+    int32_t right = width - dlen - left;
     for (int32_t i = 0; i < left; i++)  fmt_putc(b, ' ');
     fmt_putn(b, s, slen);
     for (int32_t i = 0; i < right; i++) fmt_putc(b, ' ');
@@ -851,8 +899,9 @@ static void fmt_table(fmt_buf_t* b, ray_t* tbl, int mode) {
         col_types[ci]     = tname;
         col_type_lens[ci] = (int32_t)strlen(tname);
 
-        /* Start with max of name and type lengths */
-        int32_t max_w = col_name_lens[ci];
+        /* Start with max of name and type DISPLAY widths (a multi-byte
+         * name still writes its full byte length, padded to this). */
+        int32_t max_w = fmt_utf8_width(col_names[ci], col_name_lens[ci]);
         if (col_type_lens[ci] > max_w) max_w = col_type_lens[ci];
 
         int64_t col_len = col_vec ? ray_len(col_vec) : 0;
@@ -874,7 +923,8 @@ static void fmt_table(fmt_buf_t* b, ray_t* tbl, int mode) {
                 memcpy(cell->str, "NA", 3);
                 cell->len = 2;
             }
-            if (cell->len > max_w) max_w = cell->len;
+            int32_t cell_dw = fmt_utf8_width(cell->str, cell->len);
+            if (cell_dw > max_w) max_w = cell_dw;
         }
 
         /* Format second half (tail rows) */
@@ -899,7 +949,8 @@ static void fmt_table(fmt_buf_t* b, ray_t* tbl, int mode) {
                 memcpy(cell->str, "NA", 3);
                 cell->len = 2;
             }
-            if (cell->len > max_w) max_w = cell->len;
+            int32_t cell_dw = fmt_utf8_width(cell->str, cell->len);
+            if (cell_dw > max_w) max_w = cell_dw;
         }
 
         col_widths[ci] = max_w + 2; /* +2 for padding (1 space each side) */
@@ -1008,7 +1059,7 @@ static void fmt_table(fmt_buf_t* b, ray_t* tbl, int mode) {
             fmt_cell_t* cell = &cells[ci * table_height + ri];
             fmt_putc(b, ' ');
             fmt_putn(b, cell->str, cell->len);
-            int32_t pad = col_widths[ci] - cell->len - 1;
+            int32_t pad = col_widths[ci] - fmt_utf8_width(cell->str, cell->len) - 1;
             for (int32_t p = 0; p < pad; p++)
                 fmt_putc(b, ' ');
             fmt_puts(b, G_V);

--- a/test/test_format.c
+++ b/test/test_format.c
@@ -541,6 +541,45 @@ static test_result_t test_fmt_table_utf8_width(void) {
     ray_release(col_s);
     ray_release(col_v);
     ray_release(tbl);
+
+    /* Combining marks are width 0: bare and pointed Hebrew are the same
+     * four letters and must occupy the same four columns, so their data
+     * lines differ by exactly the marks' byte count. */
+    const char* heb_bare   = "\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d";  /* שלום */
+    const char* heb_marked = "\xd7\xa9\xd7\x81\xd6\xb8"           /* ש + dot + qamats */
+                             "\xd7\x9c\xd7\x95\xd6\xb9\xd7\x9d";  /* ל, ו + holam, ם */
+    ray_t* tbl2 = ray_table_new(1);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(tbl2));
+    int64_t hids[] = {
+        ray_sym_intern(heb_bare, (int64_t)strlen(heb_bare)),
+        ray_sym_intern(heb_marked, (int64_t)strlen(heb_marked)),
+    };
+    ray_t* col_h = ray_vec_from_raw(RAY_SYM, hids, 2);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(col_h));
+    tbl2 = ray_table_add_col(tbl2, ray_sym_intern("h", 1), col_h);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(tbl2));
+
+    ray_t* result2 = ray_fmt(tbl2, 1);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result2));
+    const char* s2 = ray_str_ptr(result2);
+    const char* bare_line   = strstr(s2, heb_bare);
+    const char* marked_line = strstr(s2, heb_marked);
+    TEST_ASSERT_NOT_NULL(bare_line);
+    TEST_ASSERT_NOT_NULL(marked_line);
+    /* strstr(heb_bare) can land on the marked row if the marked bytes embed
+     * the bare sequence — they don't (marks interleave), but anchor to line
+     * starts to be safe. */
+    while (bare_line > s2 && bare_line[-1] != '\n') bare_line--;
+    while (marked_line > s2 && marked_line[-1] != '\n') marked_line--;
+    TEST_ASSERT_TRUE(bare_line != marked_line);
+    size_t bare_len   = strcspn(bare_line, "\n");
+    size_t marked_len = strcspn(marked_line, "\n");
+    int64_t mark_bytes = (int64_t)strlen(heb_marked) - (int64_t)strlen(heb_bare);
+    TEST_ASSERT_EQ_I((int64_t)marked_len, (int64_t)bare_len + mark_bytes);
+
+    ray_release(result2);
+    ray_release(col_h);
+    ray_release(tbl2);
     PASS();
 }
 

--- a/test/test_format.c
+++ b/test/test_format.c
@@ -498,6 +498,52 @@ static test_result_t test_fmt_raw_elem_list_null(void) {
 }
 
 /* ---- Test: table with short col that triggers NA in head half ---- */
+/* #454: cell padding must use DISPLAY width, not byte length.  A CJK char
+ * is 3 UTF-8 bytes but renders 2 terminal columns, so byte-based padding
+ * tore the table borders on any row holding a multi-byte symbol. */
+static test_result_t test_fmt_table_utf8_width(void) {
+    ray_t* tbl = ray_table_new(2);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(tbl));
+
+    /* "ab牛来": 8 bytes, 6 display columns.  "abcd": 4 bytes, 4 columns. */
+    const char* wide_sym = "ab\xe7\x89\x9b\xe6\x9d\xa5";
+    int64_t ids[] = { ray_sym_intern(wide_sym, 8), ray_sym_intern("abcd", 4) };
+    int64_t vals[] = { 1, 2 };
+    ray_t* col_s = ray_vec_from_raw(RAY_SYM, ids, 2);
+    ray_t* col_v = ray_vec_from_raw(RAY_I64, vals, 2);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(col_s));
+    TEST_ASSERT_FALSE(RAY_IS_ERR(col_v));
+    tbl = ray_table_add_col(tbl, ray_sym_intern("s", 1), col_s);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(tbl));
+    tbl = ray_table_add_col(tbl, ray_sym_intern("v", 1), col_v);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(tbl));
+
+    ray_t* result = ray_fmt(tbl, 1);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(result));
+    const char* s = ray_str_ptr(result);
+
+    const char* wide_line  = strstr(s, wide_sym);
+    const char* ascii_line = strstr(s, "abcd");
+    TEST_ASSERT_NOT_NULL(wide_line);
+    TEST_ASSERT_NOT_NULL(ascii_line);
+    while (wide_line > s && wide_line[-1] != '\n') wide_line--;
+    while (ascii_line > s && ascii_line[-1] != '\n') ascii_line--;
+    size_t wide_len  = strcspn(wide_line, "\n");
+    size_t ascii_len = strcspn(ascii_line, "\n");
+
+    /* Equal display width means the wide row carries exactly the byte
+     * surplus of its wide chars: 2 CJK chars x (3 bytes - 2 columns)
+     * = +2 bytes over the ASCII row.  Byte-based padding rendered the
+     * two rows byte-EQUAL (and visually torn), which this catches. */
+    TEST_ASSERT_EQ_I((int64_t)wide_len, (int64_t)ascii_len + 2);
+
+    ray_release(result);
+    ray_release(col_s);
+    ray_release(col_v);
+    ray_release(tbl);
+    PASS();
+}
+
 static test_result_t test_fmt_table_na_head(void) {
     /* With nrows=5 (half=2), a col of len=1 has ri=0 hit, ri=1 miss -> NA in head */
     int64_t nrows = 5;
@@ -1762,5 +1808,6 @@ const test_entry_t format_entries[] = {
     { "format/table/wide_tall", test_fmt_table_wide_and_tall, fmt_setup, fmt_teardown },
     { "format/table/list_col_null", test_fmt_raw_elem_list_null, fmt_setup, fmt_teardown },
     { "format/table/na_head", test_fmt_table_na_head, fmt_setup, fmt_teardown },
+    { "format/table/utf8_width", test_fmt_table_utf8_width, fmt_setup, fmt_teardown },
     { NULL, NULL, NULL, NULL },
 };


### PR DESCRIPTION
Closes #454.

The table formatter measured and padded cells by **byte length**. A CJK character is 3 UTF-8 bytes but renders 2 terminal columns, so any row holding a multi-byte symbol (the issue's `牛来USDT`) got its padding short by one column per wide char and the box borders tore.

The fix adds `fmt_utf8_width` — terminal display width with a coarse East-Asian-Width classification (CJK ranges, Hangul, fullwidth forms, emoji → 2 columns; combining marks / zero-width spaces / variation selectors → 0; everything else, malformed bytes included, → 1, so a truncated or bad sequence can never desync more than its own cell). Column-width measurement (cells and column names), data-row padding, and header/type centering all use display width now; the cell bytes are still written verbatim.

Before/after on the issue's shape:

```
│ 牛来USDT │      →    │ 牛来USDT   │
│ XLMUSDT    │    →    │ XLMUSDT    │
```

## Tests

`format/table/utf8_width`: renders a table with `ab牛来` and `abcd` sym cells and asserts the wide row is exactly its wide chars' byte surplus (+2) longer than the ASCII row — equal display width. Fails on the parent commit (rows come out byte-equal, i.e. visually torn), passes with the fix. Full suite: 3725/3725 (ASan + fatal UBSan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8TdSm4JwxHB37kiaKxgTN