### PR TITLE
perf(join): route heavy-null build sides to the chained path upfront

### DIFF
--- a/src/ops/internal.h
+++ b/src/ops/internal.h
@@ -788,6 +788,7 @@ extern bool     ray_join_force_dup_fallback;
 /* perf-gate bypass: disable the auto dup-fallback to measure the pre-fix O(dup²) build */
 extern bool     ray_join_no_dup_fallback;
 extern uint64_t ray_join_dup_fallbacks;
+extern uint64_t ray_join_null_fallbacks;
 extern bool     ray_agg_engine_v2; /* route OP_GROUP through v2 agg engine; default off */
 void ray_expr_stats_init(void);
 

--- a/src/ops/join.c
+++ b/src/ops/join.c
@@ -41,6 +41,9 @@ bool ray_join_force_dup_fallback = false;
 bool ray_join_no_dup_fallback = false;
 /* Diagnostic: radix joins that fell back due to pathological key duplication. */
 uint64_t ray_join_dup_fallbacks = 0;
+/* Diagnostic: radix joins routed to the chained path upfront because the
+ * build side carries more all-null key rows than RADIX_DUP_RUN_MAX (#458). */
+uint64_t ray_join_null_fallbacks = 0;
 
 static int join_store_key_cell(ray_t* dst, int64_t dst_row,
                                ray_t* src, int64_t src_row) {
@@ -1188,6 +1191,38 @@ static ray_t* exec_join_flat(ray_graph_t* g, ray_op_t* op, ray_t* left_table, ra
         ray_t**  probe_keys = swap ? r_key_vecs : l_key_vecs;
         uint8_t radix_bits = radix_join_bits(build_rows);
         uint32_t n_rparts = (uint32_t)1 << radix_bits;
+
+        /* #458: every null key cell hashes to the one canonical null value,
+         * so a build side with more all-null key rows than RADIX_DUP_RUN_MAX
+         * is GUARANTEED to trip the dup-run abort mid-build and re-run the
+         * whole join chained — full hash/partition/HT work discarded, every
+         * execution.  Massive duplication is the chained HT's job either way
+         * (O(dup) build vs the open table's O(dup²)), so detect the case
+         * upfront and go there directly.  The scan runs only when a key
+         * column advertises HAS_NULLS, uses the same null predicate as
+         * hash_row_keys (so it counts exactly what would form the run), and
+         * stops at the threshold. */
+        {
+            bool any_nullable = false;
+            for (uint32_t k = 0; k < n_keys && !any_nullable; k++)
+                if (build_keys[k] && (build_keys[k]->attrs & RAY_ATTR_HAS_NULLS))
+                    any_nullable = true;
+            if (any_nullable) {
+                int64_t null_rows = 0;
+                for (int64_t r = 0; r < build_rows; r++) {
+                    bool all_null = true;
+                    for (uint32_t k = 0; k < n_keys; k++) {
+                        ray_t* col = build_keys[k];
+                        if (!col || !ray_vec_is_null(col, r)) { all_null = false; break; }
+                    }
+                    if (all_null && ++null_rows > RADIX_DUP_RUN_MAX) break;
+                }
+                if (null_rows > RADIX_DUP_RUN_MAX) {
+                    ray_join_null_fallbacks++;
+                    goto chained_ht_fallback;
+                }
+            }
+        }
 
         /* Pre-compute hashes for both sides (once, reused by histogram+scatter) */
         ray_t* r_hash_hdr = NULL;

--- a/test/test_join_buildside.c
+++ b/test/test_join_buildside.c
@@ -928,6 +928,61 @@ static test_result_t test_jb_trip_boundary(void) {
     return rr;
 }
 
+/* ── Null-run upfront fallback (#458) ──────────────────────────────────────
+ * Every null key cell hashes to one canonical value, so >RADIX_DUP_RUN_MAX
+ * build-side nulls used to START the radix build and then discard it on the
+ * dup-run abort.  Now the null count routes the join to the chained path
+ * upfront: the null-fallback counter advances, the dup-abort counter does
+ * NOT (nothing was built and thrown away), and the answer still matches the
+ * forced-chained oracle — nulls pairing with nulls included.
+ * ──────────────────────────────────────────────────────────────────────── */
+static test_result_t test_jb_null_run_upfront_fallback(void) {
+    ray_heap_init();
+    (void)ray_sym_init();
+
+    int64_t n_r = RAY_PARALLEL_THRESHOLD + 5000;
+    int64_t n_l = 4000;
+    int64_t* rv = malloc((size_t)n_r * sizeof(int64_t));
+    int64_t* lv = malloc((size_t)n_l * sizeof(int64_t));
+    TEST_ASSERT(rv && lv, "malloc key arrays");
+
+    /* Build side: low per-key duplication (~35/key, below the dup trip) plus
+     * 600 nulls — above RADIX_DUP_RUN_MAX, so only the null gate can fire.
+     * Probe side: a couple of nulls to exercise null==null output. */
+    for (int64_t i = 0; i < n_r; i++) rv[i] = (i % 100 == 0 && i < 60000) ? NULL_I64 : i % 2000;
+    for (int64_t i = 0; i < n_l; i++) lv[i] = (i == 7 || i == 4001 - 2000) ? NULL_I64 : i % 2000;
+
+    ray_join_no_build_swap = true;                            /* build = right */
+
+    uint64_t null_before = ray_join_null_fallbacks;
+    uint64_t dup_before  = ray_join_dup_fallbacks;
+    ray_t* rt = jb_table1("rk", rv, n_r);
+    ray_t* lt = jb_table1("lk", lv, n_l);
+    test_result_t rr = jb_diff_dup(lt, "lk", rt, "rk", /*join_type=*/0, /*expect_trip=*/false);
+    if (rr.status == TEST_PASS && ray_join_null_fallbacks == null_before)
+        rr = (test_result_t){ TEST_FAIL, "expected the null-run upfront fallback to fire" };
+    if (rr.status == TEST_PASS && ray_join_dup_fallbacks != dup_before)
+        rr = (test_result_t){ TEST_FAIL, "dup-run abort fired — radix work was built and discarded" };
+    ray_release(lt); ray_release(rt);
+
+    /* Few nulls (< RADIX_DUP_RUN_MAX): the gate must NOT fire. */
+    if (rr.status == TEST_PASS) {
+        for (int64_t i = 0; i < n_r; i++) rv[i] = (i < 100) ? NULL_I64 : i % 2000;
+        uint64_t nb2 = ray_join_null_fallbacks;
+        ray_t* rt2 = jb_table1("rk", rv, n_r);
+        ray_t* lt2 = jb_table1("lk", lv, n_l);
+        rr = jb_diff_dup(lt2, "lk", rt2, "rk", /*join_type=*/0, /*expect_trip=*/false);
+        if (rr.status == TEST_PASS && ray_join_null_fallbacks != nb2)
+            rr = (test_result_t){ TEST_FAIL, "null gate fired below its threshold" };
+        ray_release(lt2); ray_release(rt2);
+    }
+
+    ray_join_no_build_swap = false;                           /* reset */
+    free(lv); free(rv);
+    ray_sym_destroy(); ray_heap_destroy();
+    return rr;
+}
+
 /* ── Not sticky ────────────────────────────────────────────────────────────
  * The pathological flag is per-join (reset each exec_join), not a sticky
  * global.  Run a tripping join then a non-tripping join in the SAME heap
@@ -1037,5 +1092,6 @@ const test_entry_t join_buildside_entries[] = {
     { "join_buildside/trip_boundary", test_jb_trip_boundary, NULL, NULL },
     { "join_buildside/not_sticky", test_jb_not_sticky, NULL, NULL },
     { "join_buildside/mixed_type_radix", test_jb_mixed_type_radix, NULL, NULL },
+    { "join_buildside/null_run_upfront_fallback", test_jb_null_run_upfront_fallback, NULL, NULL },
     { NULL, NULL, NULL, NULL },
 };


### PR DESCRIPTION
Closes #458.

Since #449, all nulls in a key column share one canonical hash. A build side with more than `RADIX_DUP_RUN_MAX` (512) all-null key rows therefore formed a same-hash run that was *guaranteed* to trip the pathological-duplication abort mid-build — the radix path's hash/partition/HT work was built and discarded, then the whole join re-ran on the chained path, every execution. (Pre-#449 this didn't happen only because nulls had unique per-row hashes — which also made the answers wrong, so the abort was the cost of correctness, not a regression to unwind.)

The chained HT is the right home for massive duplication either way — O(dup) linked build vs the open-addressing table's O(dup²) — so the fix counts the build side's all-null key rows *before* any radix work and routes straight to the chained path when they exceed the threshold:

- The scan runs only when a key column advertises `HAS_NULLS` (zero cost on null-free keys), uses the same null predicate as `hash_row_keys` (so it counts exactly the rows that would form the run), and stops as soon as the threshold is crossed.
- `ray_join_null_fallbacks` counts the upfront routings, next to the existing `ray_join_dup_fallbacks` diagnostic.

## Test

`join_buildside/null_run_upfront_fallback`: a radix-scale build side with 600 nulls (per-key duplication otherwise below the dup trip) — asserts the null gate fires, the dup-run abort does **not** (nothing built and discarded), and the result multiset-matches the forced-chained oracle, null==null pairs included; then the same shape with 100 nulls asserts the gate stays quiet below its threshold. Full suite: 3727/3727 (ASan + fatal UBSan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8TdSm4JwxHB37kiaKxgTN