### PR TITLE
feat(ipc): bind a listener to a given address — loopback-only listeners

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -81,6 +81,7 @@ int main(int argc, char** argv) {
     int interactive = 0;
     const char* file = NULL;
     uint16_t port = 0;
+    char bind_host[64] = "";   /* -p HOST:PORT bind address; empty = all interfaces */
     int n_cores = -1;      /* total execution cores; -1 = leave pool lazy */
     int timeit_init = 0;   /* -t N: enable profiler at startup */
     int qlog_init = 0;     /* -Q N: enable query-statistics logging at startup */
@@ -91,7 +92,7 @@ int main(int argc, char** argv) {
 
     /* Parse args. Supported flags:
      *   -f FILE          run script file
-     *   -p PORT          IPC listen port
+     *   -p PORT|HOST:PORT  IPC listen port, optionally bound to HOST
      *   -c N             total execution cores, main included (0 = auto)
      *   -t N             enable timeit at startup (N != 0 turns on)
      *   -Q N             enable query-statistics logging (N != 0 turns on)
@@ -103,8 +104,32 @@ int main(int argc, char** argv) {
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "-i") == 0 || strcmp(argv[i], "--interactive") == 0)
             interactive = 1;
-        else if ((strcmp(argv[i], "-p") == 0 || strcmp(argv[i], "--port") == 0) && i + 1 < argc)
-            port = (uint16_t)atoi(argv[++i]);
+        else if ((strcmp(argv[i], "-p") == 0 || strcmp(argv[i], "--port") == 0) && i + 1 < argc) {
+            /* PORT binds all interfaces; HOST:PORT confines the listener
+             * to one IPv4 address (#427).  Strict digits-only port — a
+             * silently truncated "65536x" listener is worse than exiting. */
+            const char* parg  = argv[++i];
+            const char* colon = strchr(parg, ':');
+            const char* pstr  = parg;
+            if (colon) {
+                size_t hlen = (size_t)(colon - parg);
+                if (hlen == 0 || hlen >= sizeof(bind_host)) {
+                    fprintf(stderr, "bad -p bind address: %s\n", parg);
+                    return 2;
+                }
+                memcpy(bind_host, parg, hlen);
+                bind_host[hlen] = '\0';
+                pstr = colon + 1;
+            }
+            char* endp;
+            errno = 0;
+            long pv = strtol(pstr, &endp, 10);
+            if (endp == pstr || *endp != '\0' || errno == ERANGE || pv <= 0 || pv > 65535) {
+                fprintf(stderr, "bad -p port (must be 1..65535): %s\n", parg);
+                return 2;
+            }
+            port = (uint16_t)pv;
+        }
         else if ((strcmp(argv[i], "-c") == 0 || strcmp(argv[i], "--cores") == 0) && i + 1 < argc) {
             int v = atoi(argv[++i]);
             if (v < 0) v = 0;
@@ -151,7 +176,8 @@ int main(int argc, char** argv) {
                 "usage: %s [-f file] [-p port] [-c cores] [-t 0|1] [-i]"
                 " [-u PW | -U PW] [-l BASE | -L BASE] [-m SIZE] [file.rfl] [-- app args]\n"
                 "  -f, --file FILE     run script file (or pass as a positional arg)\n"
-                "  -p, --port PORT     listen for IPC clients on PORT\n"
+                "  -p, --port PORT     listen for IPC clients on PORT (all interfaces)\n"
+                "      --port HOST:PORT  bind the listener to HOST only (e.g. 127.0.0.1:7701)\n"
                 "  -c, --cores N       total execution cores, main included (0 = auto)\n"
                 "  -t, --timeit N      enable profiler at startup (N != 0)\n"
                 "  -i, --interactive   start the REPL even after running a file\n"
@@ -238,11 +264,12 @@ int main(int argc, char** argv) {
 
     /* Start IPC server if port specified */
     if (port > 0) {
-        if (poll && ray_ipc_listen(poll, port) >= 0)
-            fprintf(stderr, "listening on port %u\n", port);
+        const char* bh = bind_host[0] ? bind_host : NULL;
+        if (poll && ray_ipc_listen_at(poll, bh, port) >= 0)
+            fprintf(stderr, "listening on %s:%u\n", bh ? bh : "*", port);
         else
-            fprintf(stderr, "failed to listen on port %u: %s\n",
-                    port, strerror(errno));
+            fprintf(stderr, "failed to listen on %s:%u: %s\n",
+                    bh ? bh : "*", port, strerror(errno));
     }
 
     /* Load script if specified */

--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -1018,12 +1018,12 @@ static void ipc_on_close(ray_poll_t* poll, ray_selector_t* sel)
     ray_sock_close((ray_sock_t)sel->fd);
 }
 
-int64_t ray_ipc_listen(ray_poll_t* poll, uint16_t port)
+int64_t ray_ipc_listen_at(ray_poll_t* poll, const char* host, uint16_t port)
 {
     if (!poll) return -1;
     ipc_install_oob_cancel();   /* enable client Ctrl-C → SIGURG query cancel */
 
-    ray_sock_t fd = ray_sock_listen(port);
+    ray_sock_t fd = ray_sock_listen_at(host, port);
     if (fd == RAY_INVALID_SOCK) return -1;
     ray_sock_set_nonblocking(fd);
 
@@ -1039,6 +1039,11 @@ int64_t ray_ipc_listen(ray_poll_t* poll, uint16_t port)
         return -1;
     }
     return id;
+}
+
+int64_t ray_ipc_listen(ray_poll_t* poll, uint16_t port)
+{
+    return ray_ipc_listen_at(poll, NULL, port);
 }
 
 /* ======================================================================
@@ -1224,10 +1229,10 @@ static void conn_on_readable(ray_ipc_server_t* srv, ray_ipc_conn_t* c)
     }
 }
 
-ray_err_t ray_ipc_server_init(ray_ipc_server_t* srv, uint16_t port)
+ray_err_t ray_ipc_server_init_at(ray_ipc_server_t* srv, const char* host, uint16_t port)
 {
     memset(srv, 0, sizeof(*srv));
-    srv->listen_fd = ray_sock_listen(port);
+    srv->listen_fd = ray_sock_listen_at(host, port);
     if (srv->listen_fd == RAY_INVALID_SOCK) return RAY_ERR_IO;
     ray_sock_set_nonblocking(srv->listen_fd);
 
@@ -1254,6 +1259,11 @@ ray_err_t ray_ipc_server_init(ray_ipc_server_t* srv, uint16_t port)
 
     srv->running = true;
     return RAY_OK;
+}
+
+ray_err_t ray_ipc_server_init(ray_ipc_server_t* srv, uint16_t port)
+{
+    return ray_ipc_server_init_at(srv, NULL, port);
 }
 
 void ray_ipc_server_destroy(ray_ipc_server_t* srv)

--- a/src/core/ipc.h
+++ b/src/core/ipc.h
@@ -77,6 +77,8 @@ int64_t ray_ipc_current_handle(void);
 
 /* Register IPC listener on poll. Returns selector id or -1. */
 int64_t ray_ipc_listen(ray_poll_t* poll, uint16_t port);
+/* Bind to a specific IPv4 address; host NULL/empty means INADDR_ANY (#427). */
+int64_t ray_ipc_listen_at(ray_poll_t* poll, const char* host, uint16_t port);
 
 /* ===== Legacy server API (wraps poll internally for tests) ===== */
 
@@ -100,6 +102,7 @@ typedef struct ray_ipc_server {
 } ray_ipc_server_t;
 
 ray_err_t ray_ipc_server_init(ray_ipc_server_t* srv, uint16_t port);
+ray_err_t ray_ipc_server_init_at(ray_ipc_server_t* srv, const char* host, uint16_t port);
 void      ray_ipc_server_destroy(ray_ipc_server_t* srv);
 int       ray_ipc_poll(ray_ipc_server_t* srv, int timeout_ms);
 

--- a/src/core/sock.c
+++ b/src/core/sock.c
@@ -48,8 +48,22 @@
 
 /* ===== Socket Implementation ===== */
 
-ray_sock_t ray_sock_listen(uint16_t port)
+ray_sock_t ray_sock_listen_at(const char* host, uint16_t port)
 {
+    /* NULL/empty host keeps the historical INADDR_ANY bind.  A host that
+     * does not parse as an IPv4 address is a loud bind failure — never a
+     * silent fallback to all interfaces, which would defeat the point of
+     * asking for a confined listener. */
+    struct in_addr bind_addr;
+    if (host && *host) {
+        if (inet_pton(AF_INET, host, &bind_addr) != 1) {
+            errno = EINVAL;
+            return RAY_INVALID_SOCK;
+        }
+    } else {
+        bind_addr.s_addr = htonl(INADDR_ANY);
+    }
+
     ray_sock_t fd = (ray_sock_t)socket(AF_INET, SOCK_STREAM, 0);
     if (fd == RAY_INVALID_SOCK) return RAY_INVALID_SOCK;
 
@@ -59,7 +73,7 @@ ray_sock_t ray_sock_listen(uint16_t port)
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(addr));
     addr.sin_family      = AF_INET;
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_addr        = bind_addr;
     addr.sin_port        = htons(port);
 
     if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
@@ -71,6 +85,11 @@ ray_sock_t ray_sock_listen(uint16_t port)
         return RAY_INVALID_SOCK;
     }
     return fd;
+}
+
+ray_sock_t ray_sock_listen(uint16_t port)
+{
+    return ray_sock_listen_at(NULL, port);
 }
 
 ray_sock_t ray_sock_accept(ray_sock_t srv)

--- a/src/core/sock.h
+++ b/src/core/sock.h
@@ -37,6 +37,9 @@
 #endif
 
 ray_sock_t ray_sock_listen(uint16_t port);
+/* Bind to a specific IPv4 address; host NULL/empty means INADDR_ANY.  An
+ * unparseable host fails the listen (errno EINVAL), never falls back. */
+ray_sock_t ray_sock_listen_at(const char* host, uint16_t port);
 ray_sock_t ray_sock_accept(ray_sock_t srv);
 /* Connect to host:port.  timeout_ms > 0 bounds the connect: the socket
  * connects non-blocking and waits at most timeout_ms for completion (a

--- a/src/lang/syscmd.c
+++ b/src/lang/syscmd.c
@@ -130,19 +130,53 @@ static ray_t* h_listen(ray_t* arg, ray_syscmd_ctx_t* ctx) {
     (void)arg;
     return ray_error("restricted", "listen disabled under fuzzing");
 #endif
-    int err = 0;
-    int64_t port = arg_as_i64(arg, &err);
-    if (err) return ray_error("type", "listen expects a port number");
+    /* Two forms: a port number binds INADDR_ANY (unchanged), and a
+     * "HOST:PORT" string confines the listener to one IPv4 address
+     * (#427) — e.g. (.sys.listen "127.0.0.1:7701") for loopback-only. */
+    char host[64];
+    const char* bind_host = NULL;
+    int64_t port;
+    const char* s    = (arg && arg->type == -RAY_STR) ? ray_str_ptr(arg) : NULL;
+    size_t      slen = s ? ray_str_len(arg) : 0;
+    const char* colon = s ? memchr(s, ':', slen) : NULL;
+    if (colon) {
+        if (colon == s || (size_t)(colon - s) >= sizeof(host))
+            return ray_error("type", "listen expects a port number or \"HOST:PORT\"");
+        memcpy(host, s, (size_t)(colon - s));
+        host[colon - s] = '\0';
+        bind_host = host;
+        /* Strict digits-only port, the .ipc.open rule: "1abc" is a
+         * malformed port, not port 1. */
+        char pbuf[16];
+        size_t plen = slen - (size_t)(colon - s) - 1;
+        if (plen == 0 || plen >= sizeof(pbuf))
+            return ray_error("domain", "listen: port out of range (1..65535)");
+        memcpy(pbuf, colon + 1, plen);
+        pbuf[plen] = '\0';
+        char* endp;
+        errno = 0;
+        long pv = strtol(pbuf, &endp, 10);
+        if (endp == pbuf || *endp != '\0' || errno == ERANGE)
+            return ray_error("domain", "listen: port must be numeric 1..65535, got \"%s\"", pbuf);
+        port = (int64_t)pv;
+    } else {
+        /* Port-only form: an i64/int atom, or (via the .sys.cmd string
+         * dispatcher) a numeric string — arg_as_i64 handles both. */
+        int err = 0;
+        port = arg_as_i64(arg, &err);
+        if (err) return ray_error("type", "listen expects a port number or \"HOST:PORT\"");
+    }
     if (port <= 0 || port > 65535) return ray_error("domain", "listen: port out of range (1..65535)");
 
     ray_poll_t* poll = (ray_poll_t*)ray_runtime_get_poll();
     if (!poll) return ray_error("nyi", "listen: no main event loop attached");
 
-    int64_t id = ray_ipc_listen(poll, (uint16_t)port);
+    int64_t id = ray_ipc_listen_at(poll, bind_host, (uint16_t)port);
     if (id < 0) {
         int e = errno;
-        return ray_error("io", "listen: bind to port %lld failed: %s",
-                         (long long)port, strerror(e ? e : EADDRINUSE));
+        return ray_error("io", "listen: bind to %s port %lld failed: %s",
+                         bind_host ? bind_host : "*", (long long)port,
+                         strerror(e ? e : EADDRINUSE));
     }
     return ray_i64(id);
 }
@@ -241,7 +275,7 @@ static const ray_syscmd_t TABLE[] = {
     { "timeit", "t",  h_timeit, 0,                                "Toggle profiling on/off (or :t 0|1)."     },
     { "env",    NULL, h_env,    0,                                "List defined globals."                    },
     { "clear",  NULL, h_clear,  RAY_SYSCMD_REPL_ONLY,            "Clear the screen."                        },
-    { "listen", NULL, h_listen, RAY_SYSCMD_RESTRICTED,           "Start IPC listener on PORT."              },
+    { "listen", NULL, h_listen, RAY_SYSCMD_RESTRICTED,           "Start IPC listener on PORT or \"HOST:PORT\"." },
     { "q",      NULL, h_quit,   RAY_SYSCMD_REPL_ONLY,            "Exit the REPL."                           },
     { "quit",   NULL, h_quit,   RAY_SYSCMD_REPL_ONLY,            "Exit the REPL."                           },
 };

--- a/test/rfl/system/syscmd_coverage.rfl
+++ b/test/rfl/system/syscmd_coverage.rfl
@@ -78,6 +78,14 @@
 (.sys.timeit 3.14)   !- type
 (.sys.listen 1.5)    !- type
 (.sys.listen 3.14)   !- type
+
+;; ────────────── listen "HOST:PORT" form (#427): argument guards ─────
+;; All of these fail before any socket is touched.
+(.sys.listen ":123")             !- type
+(.sys.listen "127.0.0.1:")       !- domain
+(.sys.listen "127.0.0.1:1abc")   !- domain
+(.sys.listen "127.0.0.1:70000")  !- domain
+(.sys.listen "127.0.0.1:0")      !- domain
 ;; State should be untouched by the failed timeit calls above (the
 ;; type guard runs before the profiler flag is poked).  Confirm by
 ;; toggling and reading back.

--- a/test/test_ipc.c
+++ b/test/test_ipc.c
@@ -165,6 +165,27 @@ static void sleep_ms(long ms) {
     nanosleep(&ts, NULL);
 }
 
+/* ---- bind address (#427) ------------------------------------------------- */
+
+/* A listener confined to loopback binds and accepts a loopback connect;
+ * an unparseable host is a loud io failure, never a silent INADDR_ANY. */
+static test_result_t test_ipc_listen_bind_addr(void) {
+    ray_ipc_server_t srv;
+    TEST_ASSERT_EQ_I(ray_ipc_server_init_at(&srv, "127.0.0.1", 0), RAY_OK);
+    uint16_t port = get_listen_port(srv.listen_fd);
+    TEST_ASSERT(port > 0, "port > 0");
+    ray_ipc_server_destroy(&srv);
+
+    /* NULL host keeps the historical all-interfaces bind. */
+    TEST_ASSERT_EQ_I(ray_ipc_server_init_at(&srv, NULL, 0), RAY_OK);
+    ray_ipc_server_destroy(&srv);
+
+    ray_ipc_server_t bad;
+    TEST_ASSERT_EQ_I(ray_ipc_server_init_at(&bad, "not-an-address", 0), RAY_ERR_IO);
+    TEST_ASSERT_EQ_I(ray_ipc_server_init_at(&bad, "999.9.9.9", 0), RAY_ERR_IO);
+    PASS();
+}
+
 /* ---- test_ipc_send_verbose ----------------------------------------------- */
 /*
  * Exercise ray_ipc_send_verbose — covers the entire function (lines 1212-1274)
@@ -2119,6 +2140,7 @@ static test_result_t test_ipc_server_push(void) {
 /* ---- Registry ------------------------------------------------------------ */
 
 const test_entry_t ipc_entries[] = {
+    { "ipc/listen_bind_addr",           test_ipc_listen_bind_addr,               ipc_setup, ipc_teardown },
     { "ipc/send_verbose",               test_ipc_send_verbose,                   ipc_setup, ipc_teardown },
     { "ipc/send_verbose_captures",      test_ipc_send_verbose_captures_output,   ipc_setup, ipc_teardown },
     { "ipc/eval_non_string_msg",        test_ipc_eval_non_string_msg,            ipc_setup, ipc_teardown },


### PR DESCRIPTION
Closes #427, following the issue's shape exactly — additive at every layer, every existing form keeps binding `INADDR_ANY`:

- **C**: `ray_sock_listen_at(host, port)`, `ray_ipc_listen_at(poll, host, port)`, `ray_ipc_server_init_at(srv, host, port)`; `host == NULL`/empty ≡ today. A host that doesn't parse as an IPv4 address fails the listen with `EINVAL` — never a silent fallback to all interfaces. The port-only functions become one-line wrappers.
- **Rayfall**: `(.sys.listen PORT)` unchanged (including numeric strings via the `.sys.cmd` dispatcher); `(.sys.listen "HOST:PORT")` confines the listener. Errors stay in `h_listen`'s voice (`type`/`domain`/`io`), with the strict digits-only port rule from `.ipc.open` (#440).
- **CLI**: `-p HOST:PORT` binds to HOST; `-p PORT` unchanged in behavior but now **strictly parsed** — closing the #440 follow-up where `rayforce -p 65536x` silently listened on a truncated port; it now exits with a clear message.

Verified end-to-end: `ss` shows `-p 127.0.0.1:19877` binding `127.0.0.1`, not `0.0.0.0`; `-p 65536x` exits with `bad -p port`; `-p bad.host:19877` fails loudly with `Invalid argument`.

## Tests

- `ipc/listen_bind_addr`: loopback bind succeeds, NULL host keeps the historical bind, `"not-an-address"` and `"999.9.9.9"` fail with `RAY_ERR_IO`.
- `syscmd_coverage.rfl`: the `"HOST:PORT"` argument guards (`":123"`, trailing-empty port, `"1abc"`, out-of-range, port 0) all error before any socket is touched; the existing float/`.sys.cmd` string forms keep their assertions.

Full suite: 3727/3727 (ASan + fatal UBSan). IPv4 only, per the issue ("loopback is the need"); `AF_INET6` can follow the same `_at` seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8TdSm4JwxHB37kiaKxgTN