### PR TITLE
fix(ipc): restrict server-state mutators under -U restricted IPC

### DIFF
--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -3335,7 +3335,7 @@ static void ray_register_builtins(void) {
     register_unary("guid",       RAY_FN_NONE, ray_guid_fn);
 
     /* In-place mutation */
-    register_vary("alter",       RAY_FN_SPECIAL_FORM, ray_alter_fn);
+    register_vary("alter",       RAY_FN_SPECIAL_FORM | RAY_FN_RESTRICTED, ray_alter_fn);
 
     /* Pattern matching */
     register_binary("like",      RAY_FN_NONE, ray_like_fn);
@@ -3490,8 +3490,8 @@ static void ray_register_builtins(void) {
     /* Programmatic Datalog API */
     register_vary("dl-program",    RAY_FN_NONE, ray_dl_program_fn);
     register_vary("dl-add-edb",    RAY_FN_RESTRICTED, ray_dl_add_edb_fn);
-    register_unary("dl-stratify",  RAY_FN_NONE, ray_dl_stratify_fn);
-    register_unary("dl-eval",      RAY_FN_NONE, ray_dl_eval_fn);
+    register_unary("dl-stratify",  RAY_FN_RESTRICTED, ray_dl_stratify_fn);
+    register_unary("dl-eval",      RAY_FN_RESTRICTED, ray_dl_eval_fn);
     register_binary("dl-query",    RAY_FN_NONE, ray_dl_query_fn);
     register_binary("dl-provenance", RAY_FN_NONE, ray_dl_provenance_fn);
     register_unary("dl-free",      RAY_FN_RESTRICTED, ray_dl_free_fn);

--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -3417,7 +3417,7 @@ static void ray_register_builtins(void) {
      * startup; these builtins expose the same machinery to Rayfall code
      * for manual control (open from a script, snapshot on demand, etc). */
     register_vary(".log.open",     RAY_FN_RESTRICTED, ray_log_open_fn);
-    register_unary(".log.write",   RAY_FN_NONE,       ray_log_write_fn);
+    register_unary(".log.write",   RAY_FN_RESTRICTED, ray_log_write_fn);
     register_unary(".log.replay",  RAY_FN_RESTRICTED, ray_log_replay_fn);
     register_unary(".log.validate",RAY_FN_NONE,       ray_log_validate_fn);
     register_vary(".log.roll",     RAY_FN_RESTRICTED, ray_log_roll_fn);
@@ -3484,17 +3484,17 @@ static void ray_register_builtins(void) {
     register_vary("pull",          RAY_FN_NONE, ray_pull_fn);
 
     /* Datalog */
-    register_vary("rule",         RAY_FN_SPECIAL_FORM, ray_rule_fn);
+    register_vary("rule",         RAY_FN_SPECIAL_FORM | RAY_FN_RESTRICTED, ray_rule_fn);
     register_vary("query",        RAY_FN_SPECIAL_FORM, ray_query_fn);
 
     /* Programmatic Datalog API */
     register_vary("dl-program",    RAY_FN_NONE, ray_dl_program_fn);
-    register_vary("dl-add-edb",    RAY_FN_NONE, ray_dl_add_edb_fn);
+    register_vary("dl-add-edb",    RAY_FN_RESTRICTED, ray_dl_add_edb_fn);
     register_unary("dl-stratify",  RAY_FN_NONE, ray_dl_stratify_fn);
     register_unary("dl-eval",      RAY_FN_NONE, ray_dl_eval_fn);
     register_binary("dl-query",    RAY_FN_NONE, ray_dl_query_fn);
     register_binary("dl-provenance", RAY_FN_NONE, ray_dl_provenance_fn);
-    register_unary("dl-free",      RAY_FN_NONE, ray_dl_free_fn);
+    register_unary("dl-free",      RAY_FN_RESTRICTED, ray_dl_free_fn);
 
     /* Vector similarity / embeddings / HNSW */
     register_binary("cos-dist",    RAY_FN_NONE, ray_cos_dist_fn);
@@ -3504,7 +3504,7 @@ static void ray_register_builtins(void) {
     register_vary  ("knn",         RAY_FN_NONE, ray_knn_fn);
     register_vary  ("hnsw-build",  RAY_FN_NONE, ray_hnsw_build_fn);
     register_vary  ("ann",         RAY_FN_NONE, ray_ann_fn);
-    register_unary ("hnsw-free",   RAY_FN_NONE, ray_hnsw_free_fn);
+    register_unary ("hnsw-free",   RAY_FN_RESTRICTED, ray_hnsw_free_fn);
     register_binary("hnsw-save",   RAY_FN_RESTRICTED, ray_hnsw_save_fn);
     register_unary ("hnsw-load",   RAY_FN_RESTRICTED, ray_hnsw_load_fn);
     register_unary ("hnsw-info",   RAY_FN_NONE, ray_hnsw_info_fn);
@@ -3536,7 +3536,7 @@ static void ray_register_builtins(void) {
      * Lifecycle handles auto-free on rc→0 (see RAY_ATTR_GRAPH branch in
      * src/mem/heap.c). */
     register_vary (".graph.build",         RAY_FN_NONE, ray_graph_build_fn);
-    register_unary(".graph.free",          RAY_FN_NONE, ray_graph_free_fn);
+    register_unary(".graph.free",          RAY_FN_RESTRICTED, ray_graph_free_fn);
     register_unary(".graph.info",          RAY_FN_NONE, ray_graph_info_fn);
     register_vary (".graph.pagerank",      RAY_FN_NONE, ray_graph_pagerank_fn);
     register_vary (".graph.connected",     RAY_FN_NONE, ray_graph_connected_fn);

--- a/test/test_lang.c
+++ b/test/test_lang.c
@@ -6530,11 +6530,16 @@ static test_result_t test_eval_restricted_lambda_bypass(void) {
  * error; dummy handles are deliberate — the restricted gate fires at the
  * invocation boundary, before the body validates its arguments. */
 static test_result_t test_eval_restricted_server_state_ops(void) {
+    /* alter can bypass the restricted `set` path and mutate a global vector. */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access("(alter 'x set 0 1)"));
     /* #44: global Datalog rule registration (a restricted special form). */
     TEST_ASSERT_TRUE(restricted_expr_returns_access(
         "(rule (__rf_restr_probe ?x) (?x :tag 1))"));
     /* #49: mutate a Datalog program with a new EDB relation. */
     TEST_ASSERT_TRUE(restricted_expr_returns_access("(dl-add-edb 0 'rel 0 2)"));
+    /* Stratification and evaluation rewrite a Datalog program in place. */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access("(dl-stratify 0)"));
+    TEST_ASSERT_TRUE(restricted_expr_returns_access("(dl-eval 0)"));
     /* #48: free a Datalog program handle. */
     TEST_ASSERT_TRUE(restricted_expr_returns_access("(dl-free 0)"));
     /* #46: free a server graph handle. */

--- a/test/test_lang.c
+++ b/test/test_lang.c
@@ -6522,6 +6522,45 @@ static test_result_t test_eval_restricted_lambda_bypass(void) {
     PASS();
 }
 
+/* #41/#44/#46-#49: mutating or destroying server-side state over restricted
+ * (-U) IPC is privilege escalation.  These builtins were registered without
+ * RAY_FN_RESTRICTED, so a restricted client could free graph/HNSW/Datalog
+ * handles, mutate a Datalog program, register a global rule, or persist WAL
+ * work that replays unrestricted.  Each must now be refused with an `access`
+ * error; dummy handles are deliberate — the restricted gate fires at the
+ * invocation boundary, before the body validates its arguments. */
+static test_result_t test_eval_restricted_server_state_ops(void) {
+    /* #44: global Datalog rule registration (a restricted special form). */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access(
+        "(rule (__rf_restr_probe ?x) (?x :tag 1))"));
+    /* #49: mutate a Datalog program with a new EDB relation. */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access("(dl-add-edb 0 'rel 0 2)"));
+    /* #48: free a Datalog program handle. */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access("(dl-free 0)"));
+    /* #46: free a server graph handle. */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access("(.graph.free 0)"));
+    /* #47: free a server HNSW index handle. */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access("(hnsw-free 0)"));
+    /* #41: persist WAL work that would replay outside restricted mode. */
+    TEST_ASSERT_TRUE(restricted_expr_returns_access(
+        "(.log.write (list 'set '__rf_restr_wal 1))"));
+
+    /* The gate is scoped to restricted eval, not a blanket ban: in normal mode
+     * the same call reaches its body and fails for a non-access reason (a bogus
+     * handle), proving read-only mode is what changed, not the verb itself. */
+    ray_t* normal = ray_eval_str("(dl-free 0)");
+    TEST_ASSERT_NOT_NULL(normal);
+    if (RAY_IS_ERR(normal)) {
+        TEST_ASSERT(!ray_err_code(normal) ||
+                    strcmp(ray_err_code(normal), "access") != 0,
+                    "dl-free must not be an access denial outside restricted mode");
+        ray_error_free(normal);
+    } else {
+        ray_release(normal);
+    }
+    PASS();
+}
+
 /* --- self-recursive lambda via recursion (tests op_calls path) --- */
 static test_result_t test_eval_self_recursion_direct(void) {
     /* Direct recursion using named function — compiler may use op_calls */
@@ -9166,6 +9205,7 @@ const test_entry_t lang_entries[] = {
     { "lang/eval/cond_and_branches", test_eval_cond_and_branches, lang_setup, lang_teardown },
     { "lang/eval/restricted_fn", test_eval_restricted_fn, lang_setup, lang_teardown },
     { "lang/eval/restricted_lambda_bypass", test_eval_restricted_lambda_bypass, lang_setup, lang_teardown },
+    { "lang/eval/restricted_server_state_ops", test_eval_restricted_server_state_ops, lang_setup, lang_teardown },
     { "lang/eval/self_recursion_direct", test_eval_self_recursion_direct, lang_setup, lang_teardown },
     { "lang/eval/nested_lambda_calls", test_eval_nested_lambda_calls, lang_setup, lang_teardown },
     { "lang/eval/vm_empty_ret", test_eval_vm_empty_ret, lang_setup, lang_teardown },


### PR DESCRIPTION
## How it looks from the user's side

An operator runs a server in restricted mode so untrusted clients get read-only access. The server keeps live vectors, graph/HNSW handles, and Datalog program handles in globals.

Before this fix, a restricted client could send calls such as `(alter 'g set 0 999)`, `(.graph.free g)`, `(hnsw-free h)`, `(dl-add-edb p ...)`, `(dl-stratify p)`, `(dl-eval p)`, `(dl-free p)`, `(rule ...)`, or `(.log.write ...)`. The server accepted these calls, so the client could overwrite global data, destroy live handles, mutate or recompute server-held Datalog state, register a global rule, or persist WAL work.

After this fix, the same calls return an `access` error during restricted evaluation. The server-side values and handles remain unchanged; normal local evaluation, startup scripts, and WAL replay continue to work.

## Root cause

A `-U` restricted IPC client's evaluations run with `__VM->restricted` set, and `fn_is_restricted` blocks builtins carrying `RAY_FN_RESTRICTED`. Nine mutating or destructive registrations were missing that flag:

| builtin | protected state |
|---|---|
| `alter` | global vectors/lists |
| `rule` | global Datalog rules |
| `dl-add-edb` | Datalog program relations |
| `dl-stratify` | Datalog program strata |
| `dl-eval` | Datalog program IDB results |
| `dl-free` | Datalog program handles |
| `.graph.free` | graph handles |
| `hnsw-free` | HNSW handles |
| `.log.write` | WAL entries replayed outside restricted mode |

## Fix

Add `RAY_FN_RESTRICTED` to all nine registrations. Special forms retain their existing `RAY_FN_SPECIAL_FORM` attribute. The gate only fires while `__VM->restricted` is set.

## Tests

`lang/eval/restricted_server_state_ops` now checks all nine verbs return an `access` error under restricted evaluation, while normal-mode behavior remains available. Full `make test`: 3729/3730 pass (1 skipped).