### PR TITLE
fix(group): hash null keys identically on rehash and lookup

### DIFF
--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -4163,15 +4163,25 @@ static inline uint64_t hash_keys_inline(const int64_t* keys, const int8_t* key_t
                                          uint16_t n_keys, void* const* key_data,
                                          const ght_layout_t* ly,
                                          const void* const* key_pool) {
+    /* A null key is stored as a zeroed slot with its null-mask bit set, and
+     * every phase-1 builder hashes it as ray_hash_i64(0) REGARDLESS of the
+     * key's type.  Consult the mask before reading the slot back by type:
+     * a zeroed inline-STR descriptor would otherwise hash as the empty
+     * string, and a zeroed wide (GUID) slot as source row 0 — neither is
+     * what the entry was created under, so after the first rehash the group
+     * would sit under a hash no probe computes and never be found again. */
     if (ly->any_inline_str) {
         /* Inline-STR layout: key offsets are shifted by 16-byte descriptors,
          * so address every key via key_off[k] and hash the inline descriptor. */
         uint64_t h = 0;
+        const int64_t* nullw = (const int64_t*)((const char*)keys + ly->key_off[n_keys]);
+        const bool nullable = ly->null_words != 0;
         for (uint32_t k = 0; k < n_keys; k++) {
-            uint64_t kh = inline_layout_key_hash(ly, k, key_types, keys, key_data, key_pool);
+            uint64_t kh = (nullable && ((uint64_t)nullw[k >> 6] >> (k & 63)) & 1u)
+                        ? ray_hash_i64(0)
+                        : inline_layout_key_hash(ly, k, key_types, keys, key_data, key_pool);
             h = (k == 0) ? kh : ray_hash_combine(h, kh);
         }
-        const int64_t* nullw = (const int64_t*)((const char*)keys + ly->key_off[n_keys]);
         return ght_hash_null_words(h, nullw, ly->null_words);
     }
     /* Packed tuple: one avalanche over the whole key region.  MUST stay in
@@ -4180,10 +4190,15 @@ static inline uint64_t hash_keys_inline(const int64_t* keys, const int8_t* key_t
     if (ly->packed_key)
         return ght_hash_lanes(keys, (uint32_t)n_keys + ly->null_words);
     const uint8_t* const kflags = ly->key_flags;
+    const bool nullable = ly->null_words != 0;
     uint64_t h = 0;
     for (uint32_t k = 0; k < n_keys; k++) {
         uint64_t kh;
-        if (kflags[k] & GHT_KEYF_WIDE) {
+        if (nullable && ((uint64_t)keys[n_keys + (k >> 6)] >> (k & 63)) & 1u) {
+            /* Null key (see above): the builder stored 0 and hashed
+             * ray_hash_i64(0), whatever the key type. */
+            kh = ray_hash_i64(0);
+        } else if (kflags[k] & GHT_KEYF_WIDE) {
             /* Wide key: keys[k] is the source row index.  Resolve + hash the
              * actual bytes (GUID fixed / STR SSO via pool). */
             kh = wide_key_hash_at(ly, k, key_data, key_pool, keys[k]);

--- a/test/rfl/group/null_str_key_rehash.rfl
+++ b/test/rfl/group/null_str_key_rehash.rfl
@@ -1,0 +1,67 @@
+;; null_str_key_rehash.rfl — a null key must hash identically wherever the
+;; hash is computed (#466).
+;;
+;; Regression: every phase-1 key builder stores a null key as a zeroed slot
+;; plus a null-mask bit and hashes it as ray_hash_i64(0).  hash_keys_inline
+;; (rehash / lookup / partial-table merge) read the stored slot back BY TYPE:
+;; a zeroed inline-STR descriptor hashed as the empty string and a zeroed
+;; wide (GUID) slot as source row 0.  After the table's first growth the
+;; rehashed group sat under a hash no probe computes, so every later row
+;; with the same keys opened a fresh group — one group per null-keyed row,
+;; silently wrong aggregates, no error.
+
+;; ─── the reported shape: long STR keys beside an all-null STR column ────
+(set G1 "c0f1979caacf5d1021f8cc8fbd5a67aea133f9851c4100e1f6939baf939901cf")
+(set KA "5e3ceb01534e06c927d06cb03492aafca56057df49937395af4f6ad7a4763c4c")
+(set KB "971723c2bc887c9f7b67f8f399a05944f31a6c7f9010ee9232d8a80478c4f37a")
+(set PAD (take (enlist "") 3))
+(set R (table [g1 g2 g3 v] (list (list G1 G1 G1) (list KA KB KB) PAD [1 2 3])))
+(set Q (select {n: (count v) from: R by: [g1 g2 g3]}))
+(count Q) -- 2
+(sum (at Q 'n)) -- 3
+(max (at Q 'n)) -- 2
+;; the same rows in the other order fold too
+(set Rb (table [g1 g2 g3 v] (list (list G1 G1 G1) (list KB KB KA) PAD [2 3 1])))
+(count (select {n: (count v) from: Rb by: [g1 g2 g3]})) -- 2
+;; two keys, null column second
+(count (select {n: (count v) from: R by: [g2 g3]})) -- 2
+;; the null column alone, and without the null column — unchanged
+(count (select {n: (count v) from: R by: g3})) -- 1
+(count (select {n: (count v) from: R by: [g1 g2]})) -- 2
+
+;; ─── short (SSO) strings behave the same ─────────────────────────────
+(set Rs (table [g1 g2 g3 v] (list (list "x" "x" "x") (list "a" "b" "b") PAD [1 2 3])))
+(count (select {n: (count v) from: Rs by: [g1 g2 g3]})) -- 2
+
+;; ─── sorted keys and a copying select take the same path ─────────────
+(count (select {n: (count v) from: (xasc R [g1 g2 g3]) by: [g1 g2 g3]})) -- 2
+(set Rc (select {g1: g1 g2: g2 g3: g3 v: v from: R}))
+(count (select {n: (count v) from: Rc by: [g1 g2 g3]})) -- 2
+
+;; ─── one null among real values in the second key ────────────────────
+(set Rm (table [g1 g2 v] (list (list "x" "x" "x" "x") (list "" "" "x" "") [1 2 3 4])))
+(set Qm (select {n: (count v) from: Rm by: [g1 g2]}))
+(count Qm) -- 2
+(max (at Qm 'n)) -- 3
+
+;; ─── many rows: several rehashes between equal null-keyed rows ───────
+;; 20000 rows over 300 distinct (I64, STR) pairs; the STR key is null on
+;; every third row so a third of the groups carry a null key.
+(set N 20000)
+(set Kn (as 'I64 (% (til N) 300)))
+(set Ks (take (list "" "a" "b") N))
+(set Rbig (table [k s v] (list Kn Ks (as 'I64 (til N)))))
+(set Qbig (select {n: (count v) from: Rbig by: [k s]}))
+(count Qbig) -- 300
+(sum (at Qbig 'n)) -- 20000
+(min (at Qbig 'n)) -- 66
+(max (at Qbig 'n)) -- 67
+;; STR key first, so it is key 0 in the layout
+(count (select {n: (count v) from: Rbig by: [s k]})) -- 300
+
+;; ─── a null GUID key beside a STR key (wide slot must not read as row 0) ─
+(set Gg (as 'GUID (list "00000000-0000-0000-0000-000000000001" "" "" "00000000-0000-0000-0000-000000000001")))
+(set Rg (table [g s v] (list Gg (list "a" "a" "a" "a") [1 2 3 4])))
+(set Qg (select {n: (count v) from: Rg by: [g s]}))
+(count Qg) -- 2
+(max (at Qg 'n)) -- 2


### PR DESCRIPTION
## What & why

Fixes #466. A multi-key `select … by:` whose key columns include a STR column carrying nulls returned one group per null-keyed row once the group hash table had grown. Every phase-1 key builder stores a null key as a zeroed slot with its null-mask bit set and hashes it as `ray_hash_i64(0)`, but `hash_keys_inline` (used by rehash, lookup and the partial-table merge) re-read the stored slot by type: a zeroed inline-STR descriptor hashed as the empty string, and a zeroed wide GUID slot as source row 0. After the first rehash the group sat under a hash no probe computes, so later equal rows opened fresh groups.

`hash_keys_inline` now checks the null-mask word before reading a key slot and hashes a null key as `ray_hash_i64(0)` regardless of type, in both the inline-STR and generic layouts. The packed layout already hashed the whole key region (values plus mask words) on both sides and is untouched.

Regression test `test/rfl/group/null_str_key_rehash.rfl` covers the reported shape (long and short strings, both row orders, sorted and copied tables, one null among values), a 20k-row table that rehashes several times, and a null GUID key beside a STR key. It fails on `dev` (`expected "2", got "3"`) and passes with the fix.

## Checklist

- [x] PR targets `dev` (not `master`)
- [x] Commits follow Conventional Commits (`feat:` / `fix:` / `perf:` / `docs:` / …)
- [x] `make` builds cleanly (no new warnings)
- [x] `make test` passes; tests added/updated for behaviour changes

https://claude.ai/code/session_01XbNM4pZe3wCS7V1m5zUUSW
