### PR TITLE
fix(query): accept SYM/STR HAS_NULLS segments on parted insert

### DIFF
--- a/src/ops/query.c
+++ b/src/ops/query.c
@@ -12605,9 +12605,14 @@ static bool parted_segment_attrs_valid(int8_t base, uint8_t attrs) {
     if (base == RAY_SYM) allowed |= RAY_SYM_W_MASK;
     if (base == RAY_I32 || base == RAY_I64)
         allowed |= RAY_ATTR_HAS_LINK;
+    /* SYM/STR nulls (the empty symbol / empty string) are in-band — the bit
+     * only marks their presence, the payload is unchanged — and the store
+     * carries it across a save, so every mapped partition holding one blank
+     * cell arrives here with it set. */
     if (base == RAY_I16 || base == RAY_I32 || base == RAY_I64 ||
         base == RAY_F32 || base == RAY_F64 || base == RAY_DATE ||
-        base == RAY_TIME || base == RAY_TIMESTAMP || base == RAY_GUID)
+        base == RAY_TIME || base == RAY_TIMESTAMP || base == RAY_GUID ||
+        base == RAY_SYM || base == RAY_STR)
         allowed |= RAY_ATTR_HAS_NULLS;
     return (attrs & (uint8_t)~allowed) == 0;
 }

--- a/test/rfl/store/parted_insert_symstr_nulls.rfl
+++ b/test/rfl/store/parted_insert_symstr_nulls.rfl
@@ -1,0 +1,56 @@
+;; parted_insert_symstr_nulls.rfl — a live `insert` into a parted table must
+;; accept SYM/STR segments carrying HAS_NULLS (#465).
+;;
+;; Regression: since the empty symbol / empty string became their types'
+;; canonical nulls, the store carries RAY_ATTR_HAS_NULLS for them across a
+;; save, so every mapped partition holding one blank SYM/STR cell arrives with
+;; the bit set.  parted_segment_attrs_valid (src/ops/query.c) allowed the bit
+;; only for the numeric, temporal and GUID bases, so the whole insert was
+;; refused as `corrupt: insert: segment metadata/length/type mismatch`.
+;; The null is in-band — the payload is what it always was — so nothing about
+;; the append changes.
+(.sys.exec "rm -rf /tmp/rfl_pins_nulls")
+
+;; ─── 1. same process: first batch into a NEW day holds a blank ───────────
+;; one clean day on disk so the parted root exists
+(.db.splayed.set "/tmp/rfl_pins_nulls/a/2026.01.01/t/" (table ['d 's 'x 'n] (list [2026.01.01] (as 'SYM ['a]) (list "p") [1])))
+(.db.parted.fill "/tmp/rfl_pins_nulls/a/")
+(set W (.db.parted.get "/tmp/rfl_pins_nulls/a/" 't))
+;; first live batch into a new day, blank STR — materialises the partition,
+;; which maps back with HAS_NULLS set
+(insert 'W 2026.01.02 (table ['d 's 'x 'n] (list [2026.01.02] (as 'SYM ['a]) (list "") [2])))
+;; the day's second batch (no blanks at all) was the one refused
+(insert 'W 2026.01.02 (table ['d 's 'x 'n] (list [2026.01.02] (as 'SYM ['b]) (list "r") [3])))
+;; and a blank SYM in a later batch
+(insert 'W 2026.01.02 (table ['d 's 'x 'n] (list [2026.01.02] (as 'SYM [']) (list "q") [4])))
+(insert 'W 2026.01.02 (table ['d 's 'x 'n] (list [2026.01.02] (as 'SYM ['c]) (list "s") [5])))
+(count (select {from: W})) -- 5
+(sum (at (select {from: W}) 'n)) -- 15
+(count (select {from: W where: (== x "")})) -- 1
+(count (select {from: W where: (nil? s)})) -- 1
+(first (at (select {from: W where: (== n 3)}) 'x)) -- "r"
+
+;; ─── 2. across a reopen: a day saved with a blank, then inserted into ─────
+(.db.splayed.set "/tmp/rfl_pins_nulls/sym/2026.01.01/t/" (table ['d 's 'x 'n] (list [2026.01.01 2026.01.01] (as 'SYM ['a ']) (list "p" "q") [1 2])))
+(.db.parted.fill "/tmp/rfl_pins_nulls/sym/")
+(set Vs (.db.parted.get "/tmp/rfl_pins_nulls/sym/" 't))
+(insert 'Vs 2026.01.01 (table ['d 's 'x 'n] (list [2026.01.01] (as 'SYM ['z]) (list "zz") [9])))
+(count (select {from: Vs})) -- 3
+(sum (at (select {from: Vs}) 'n)) -- 12
+(count (select {from: Vs where: (nil? s)})) -- 1
+
+(.db.splayed.set "/tmp/rfl_pins_nulls/str/2026.01.01/t/" (table ['d 's 'x 'n] (list [2026.01.01 2026.01.01] (as 'SYM ['a 'b]) (list "p" "") [1 2])))
+(.db.parted.fill "/tmp/rfl_pins_nulls/str/")
+(set Vx (.db.parted.get "/tmp/rfl_pins_nulls/str/" 't))
+(insert 'Vx 2026.01.01 (table ['d 's 'x 'n] (list [2026.01.01] (as 'SYM ['z]) (list "zz") [9])))
+(count (select {from: Vx})) -- 3
+(sum (at (select {from: Vx}) 'n)) -- 12
+(count (select {from: Vx where: (== x "")})) -- 1
+
+;; ─── 3. the numeric-null case that always worked stays accepted ───────────
+(.db.splayed.set "/tmp/rfl_pins_nulls/i64/2026.01.01/t/" (table ['d 's 'x 'n] (list [2026.01.01 2026.01.01] (as 'SYM ['a 'b]) (list "p" "q") [1 0Nl])))
+(.db.parted.fill "/tmp/rfl_pins_nulls/i64/")
+(set Vn (.db.parted.get "/tmp/rfl_pins_nulls/i64/" 't))
+(insert 'Vn 2026.01.01 (table ['d 's 'x 'n] (list [2026.01.01] (as 'SYM ['z]) (list "zz") [9])))
+(count (select {from: Vn})) -- 3
+(.sys.exec "rm -rf /tmp/rfl_pins_nulls") -- 0


### PR DESCRIPTION
## What & why

Fixes #465. A live `insert` into a parted table was refused with `corrupt: insert: segment metadata/length/type mismatch` once a SYM or STR segment of the target day carried `HAS_NULLS`. Since v2.6.0 the store carries that bit for the empty symbol / empty string across a save, so every mapped partition holding one blank cell arrives with it set, but `parted_segment_attrs_valid` in `src/ops/query.c` admitted the bit only for the numeric, temporal and GUID bases.

SYM/STR nulls are in-band, so the payload the append sees is unchanged by the bit. The validator now allows `HAS_NULLS` for `RAY_SYM` and `RAY_STR` as well.

Regression test `test/rfl/store/parted_insert_symstr_nulls.rfl` covers both reported paths: a first batch into a new day holding a blank STR followed by further batches (including a blank SYM), and a day saved with a blank SYM or STR reopened via `.db.parted.get` and inserted into. It also keeps the numeric-null case that always worked. On `dev` the second insert fails with `corrupt`; with the fix it passes and the rows read back correctly.

## Checklist

- [x] PR targets `dev` (not `master`)
- [x] Commits follow Conventional Commits (`feat:` / `fix:` / `perf:` / `docs:` / …)
- [x] `make` builds cleanly (no new warnings)
- [x] `make test` passes; tests added/updated for behaviour changes

https://claude.ai/code/session_01XbNM4pZe3wCS7V1m5zUUSW
