### PR TITLE
fix(ipc): report a wire-handshake timeout as timed out, not refused

### DIFF
--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -1489,7 +1489,8 @@ static int64_t recv_full(ray_sock_t fd, void* buf, size_t len) {
     size_t total = 0;
     while (total < len) {
         int64_t n = ray_sock_recv(fd, (uint8_t*)buf + total, len - total);
-        if (n <= 0) return -1;
+        if (n == 0) { errno = ECONNRESET; return -1; }   /* peer closed: not a timeout */
+        if (n < 0) return -1;
         total += (size_t)n;
     }
     return (int64_t)total;
@@ -1641,6 +1642,27 @@ static int64_t conn_write_msg(ray_sock_t fd, ray_t* msg, uint8_t msgtype,
     return rc < 0 ? -1 : 0;
 }
 
+/* Classify a failed connect or handshake step by errno.  The connect
+ * and the two-byte wire handshake share one budget: ray_sock_connect
+ * installs it as SO_RCVTIMEO / SO_SNDTIMEO once the connect completes,
+ * so a handshake that the peer never answers surfaces as EAGAIN /
+ * EWOULDBLOCK — a server that is alive and listening but inside a long
+ * evaluation.  That must not read as "refused", which is what a dead
+ * port says, instantly.
+ *   -5  no answer within the budget (ETIMEDOUT, EAGAIN, EWOULDBLOCK)
+ *   -1  ECONNREFUSED
+ *   -6  anything else; errno is left holding it for the caller's
+ *       strerror. */
+static int64_t connect_fail_code(int err) {
+    if (err == ETIMEDOUT || err == EAGAIN) return -5;
+#if defined(EWOULDBLOCK) && EWOULDBLOCK != EAGAIN
+    if (err == EWOULDBLOCK) return -5;
+#endif
+    if (err == ECONNREFUSED) return -1;
+    errno = err;
+    return -6;
+}
+
 int64_t ray_ipc_connect(const char* host, uint16_t port,
                          const char* user, const char* password,
                          int timeout_ms)
@@ -1655,18 +1677,20 @@ int64_t ray_ipc_connect(const char* host, uint16_t port,
      * no explicit timeout, matching the long-standing handshake timeout. */
     int connect_to = timeout_ms > 0 ? timeout_ms : 5000;
     ray_sock_t fd = ray_sock_connect(host, port, connect_to);
-    if (fd == RAY_INVALID_SOCK) return (errno == ETIMEDOUT) ? -5 : -1;
+    if (fd == RAY_INVALID_SOCK) return connect_fail_code(errno);
 
     uint8_t hs[2] = { RAY_SERDE_WIRE_VERSION, 0x00 };
     if (ray_sock_send(fd, hs, 2) < 0) {
+        int e = errno;                  /* close() may clobber it */
         ray_sock_close(fd);
-        return -1;
+        return connect_fail_code(e);
     }
 
     uint8_t resp[2];
     if (recv_full(fd, resp, 2) < 0) {
+        int e = errno;
         ray_sock_close(fd);
-        return -1;
+        return connect_fail_code(e);
     }
 
     /* Refuse a peer that speaks a different wire version.  This gives

--- a/src/core/sock.c
+++ b/src/core/sock.c
@@ -173,8 +173,10 @@ ray_sock_t ray_sock_connect(const char* host, uint16_t port, int timeout_ms)
     char port_str[8];
     snprintf(port_str, sizeof(port_str), "%u", (unsigned)port);
 
-    if (getaddrinfo(host, port_str, &hints, &res) != 0 || !res)
+    if (getaddrinfo(host, port_str, &hints, &res) != 0 || !res) {
+        errno = EHOSTUNREACH;           /* not a refusal, and not a timeout */
         return RAY_INVALID_SOCK;
+    }
 
     /* Try every resolved address in turn, not just the first.  `localhost`
      * commonly resolves to BOTH ::1 (IPv6, often first) and 127.0.0.1; a

--- a/src/ops/system.c
+++ b/src/ops/system.c
@@ -1469,7 +1469,9 @@ ray_t* ray_hopen_fn(ray_t** args, int64_t n) {
     int64_t h = ray_ipc_connect(host, (uint16_t)port, us_ptr, pw_ptr, timeout_ms);
     if (h == -2) return ray_error("access", "server requires authentication");
     if (h == -3) return ray_error("access", "authentication failed");
+    if (h == -4) return ray_error("io", "wire version mismatch: %s:%d", host, port);
     if (h == -5) return ray_error("io", "connection timed out: %s:%d", host, port);
+    if (h == -6) return ray_error("io", "connect failed: %s:%d: %s", host, port, strerror(errno));
     if (h < 0) return ray_error("io", "connection refused: %s:%d", host, port);
 
     return make_i64(h);

--- a/test/rfl/system/ipc_open_errors.rfl
+++ b/test/rfl/system/ipc_open_errors.rfl
@@ -1,0 +1,36 @@
+;; ipc_open_errors.rfl — `.ipc.open` names the failure it actually hit.
+;;
+;; Regression (#472): the connect and the wire handshake share one budget,
+;; installed as SO_RCVTIMEO/SO_SNDTIMEO after the connect.  A server that
+;; is alive and listening but inside a long evaluation completes the TCP
+;; handshake in the kernel and never answers the wire handshake, so the
+;; recv timed out — and ray_ipc_connect returned the generic -1 that
+;; `.ipc.open` printed as "connection refused", byte-identical to a dead
+;; port that fails instantly.
+;;
+;; Server lifecycle is shell-driven like ipc_diff.rfl (by pid, so no pattern
+;; can match the shell that runs it): a second rayforce
+;; on port 19976 whose script sleeps, so the listener is up (-p binds
+;; before the script runs) and nobody serves the handshake.
+(.sys.exec "[ -f /tmp/rfl_ipc_deaf.pid ] && kill $(cat /tmp/rfl_ipc_deaf.pid) 2>/dev/null; rm -f /tmp/rfl_ipc_deaf.pid; true")
+(.sys.exec "printf '(.sys.exec \"sleep 6\")\n' > /tmp/rfl_ipc_deaf.rfl")
+(.sys.exec "./rayforce -p 19976 /tmp/rfl_ipc_deaf.rfl </dev/null >/dev/null 2>&1 & echo $! > /tmp/rfl_ipc_deaf.pid")
+;; the kernel accepts into the backlog even though nobody answers
+(.sys.exec "for i in $(seq 50); do bash -c '(echo > /dev/tcp/127.0.0.1/19976) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
+
+(.sys.exec "printf '(println (.ipc.open \"127.0.0.1:19976\" 300))\n' > /tmp/rfl_ipc_c1.rfl")
+(.sys.exec "printf '(println (.ipc.open \"127.0.0.1:19975\" 300))\n' > /tmp/rfl_ipc_c2.rfl")
+(.sys.exec "printf '(println (.ipc.open \"no-such-host.invalid:19975\" 300))\n' > /tmp/rfl_ipc_c3.rfl")
+
+;; listening but not answering: the budget expires, and the line says so
+(.ipc.open "127.0.0.1:19976" 300) !- io
+(.sys.exec "./rayforce /tmp/rfl_ipc_c1.rfl </dev/null 2>&1 | grep -q 'error: io: connection timed out: 127.0.0.1:19976'") -- 0
+
+;; nothing bound: refused, and instantly
+(.ipc.open "127.0.0.1:19975" 300) !- io
+(.sys.exec "./rayforce /tmp/rfl_ipc_c2.rfl </dev/null 2>&1 | grep -q 'error: io: connection refused: 127.0.0.1:19975'") -- 0
+
+;; a host that does not resolve is neither
+(.sys.exec "./rayforce /tmp/rfl_ipc_c3.rfl </dev/null 2>&1 | grep -q 'error: io: connect failed: no-such-host.invalid:19975: '") -- 0
+
+(.sys.exec "kill $(cat /tmp/rfl_ipc_deaf.pid) 2>/dev/null; for i in $(seq 50); do bash -c '(echo > /dev/tcp/127.0.0.1/19976) 2>/dev/null' || break; sleep 0.1; done; rm -f /tmp/rfl_ipc_deaf.pid /tmp/rfl_ipc_deaf.rfl /tmp/rfl_ipc_c1.rfl /tmp/rfl_ipc_c2.rfl /tmp/rfl_ipc_c3.rfl; true")


### PR DESCRIPTION
## Summary

`.ipc.open` against a server that is alive and listening but inside a long evaluation failed after its budget with `connection refused`, the same text a dead port produces instantly. The connect phase already distinguished a timeout (`-5`); the wire-handshake send/recv did not, returning the generic `-1`.

Failed steps are now classified by errno:

| cause | before | after |
|---|---|---|
| handshake not answered within the budget (`EAGAIN`/`EWOULDBLOCK`/`ETIMEDOUT`) | `connection refused` | `connection timed out: HOST:PORT` |
| nothing bound (`ECONNREFUSED`) | `connection refused` | `connection refused` |
| any other errno | `connection refused` | `connect failed: HOST:PORT: <strerror>` |
| wire version mismatch (`-4`) | `connection refused` | `wire version mismatch: HOST:PORT` |

Two supporting details: `recv_full` sets `ECONNRESET` on EOF so a peer closing mid-handshake cannot inherit a stale `EAGAIN`, and an unresolvable host sets `EHOSTUNREACH` instead of leaving errno as it was. The default budget is unchanged.

## Test

`test/rfl/system/ipc_open_errors.rfl` spawns a second rayforce whose script sleeps (`-p` binds before the script runs), so the port is listening and nobody serves the handshake, and checks the three lines through a client subprocess's stderr. Verified by hand: 700 ms budget against the deaf server fails in 0.76 s with `connection timed out`.

Fixes #472

https://claude.ai/code/session_01J4QKJW3RbRP8TQoquJtARg
