### PR TITLE
fix(app): a -p that cannot bind is fatal

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -265,11 +265,18 @@ int main(int argc, char** argv) {
     /* Start IPC server if port specified */
     if (port > 0) {
         const char* bh = bind_host[0] ? bind_host : NULL;
-        if (poll && ray_ipc_listen_at(poll, bh, port) >= 0)
+        if (poll && ray_ipc_listen_at(poll, bh, port) >= 0) {
             fprintf(stderr, "listening on %s:%u\n", bh ? bh : "*", port);
-        else
+        } else {
+            /* The process was asked to serve.  Carrying on would run the
+             * script and exit 0 (or sit on its timers) with no listener,
+             * and a supervisor would learn of it from the first client's
+             * ECONNREFUSED.  Fail like every other server does. */
             fprintf(stderr, "failed to listen on %s:%u: %s\n",
                     bh ? bh : "*", port, strerror(errno));
+            rc = 1;
+            goto done;
+        }
     }
 
     /* Load script if specified */

--- a/test/rfl/system/listen_fatal.rfl
+++ b/test/rfl/system/listen_fatal.rfl
@@ -1,0 +1,25 @@
+;; listen_fatal.rfl — a `-p` that cannot bind is fatal (#473).
+;;
+;; Regression: when ray_ipc_listen_at failed, main printed
+;; `failed to listen on HOST:PORT: ...` and carried on — loaded the
+;; script, ran it, and exited 0 (or kept running its timers with no
+;; listener).  A supervisor that asked for a server got a process that
+;; was not one, with a zero exit code.
+;;
+;; A first rayforce holds port 19978 (server-only, started by pid so the
+;; cleanup cannot match any shell); a second one asked for the same port
+;; must exit non-zero without running its script.
+(.sys.exec "[ -f /tmp/rfl_lf.pid ] && kill $(cat /tmp/rfl_lf.pid) 2>/dev/null; rm -f /tmp/rfl_lf.pid; true")
+(.sys.exec "./rayforce -p 19978 </dev/null >/dev/null 2>&1 & echo $! > /tmp/rfl_lf.pid")
+(.sys.exec "for i in $(seq 50); do bash -c '(echo > /dev/tcp/127.0.0.1/19978) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
+(.sys.exec "printf '(println \"script ran\")\n' > /tmp/rfl_lf_plain.rfl")
+
+;; the second process must exit 1 with the diagnostic and without running
+;; its script (.sys.exec returns the raw wait status, so fold to 0/1 here)
+(.sys.exec "./rayforce -p 19978 /tmp/rfl_lf_plain.rfl </dev/null >/tmp/rfl_lf.out 2>&1; rc=$?; grep -q 'script ran' /tmp/rfl_lf.out && exit 99; grep -q 'failed to listen on \\*:19978' /tmp/rfl_lf.out || exit 98; [ $rc -eq 1 ]") -- 0
+
+;; the same script on a free port still runs (the process then serves, so
+;; it is started in the background and killed by pid once the marker shows)
+(.sys.exec "./rayforce -p 19977 /tmp/rfl_lf_plain.rfl </dev/null >/tmp/rfl_lf2.out 2>&1 & p=$!; for i in $(seq 50); do grep -q 'script ran' /tmp/rfl_lf2.out && break; sleep 0.1; done; kill $p; grep -q 'script ran' /tmp/rfl_lf2.out") -- 0
+
+(.sys.exec "kill $(cat /tmp/rfl_lf.pid) 2>/dev/null; rm -f /tmp/rfl_lf.pid /tmp/rfl_lf_plain.rfl /tmp/rfl_lf.out /tmp/rfl_lf2.out; true")


### PR DESCRIPTION
## Summary

`-p PORT` that fails to bind printed `failed to listen on HOST:PORT: <strerror>` and carried on: the script ran, and the process exited 0 (or sat on the script's timers with no listener). A supervisor that asked for a server got a process that was not one, and found out from the first client's `ECONNREFUSED`.

The bind failure is now fatal: diagnostic, no script, exit 1 through the normal teardown (`done:`), so the journal is still closed cleanly.

```
$ ./rayforce -p 127.0.0.1:7798 plain.rfl; echo rc=$?     # port held by another engine
failed to listen on 127.0.0.1:7798: Address already in use
rc=1
```

## Test

`test/rfl/system/listen_fatal.rfl` holds a port with a server-only rayforce (tracked by pid), then starts a second one on the same port with a script that prints a marker: it must exit 1 with the diagnostic and without the marker. The same script on a free port still runs and exits 0.

Fixes #473

https://claude.ai/code/session_01J4QKJW3RbRP8TQoquJtARg
