### PR TITLE
fix(timer): skip missed intervals on overrun and print the callback error message

### DIFF
--- a/docs/docs/namespaces/time.md
+++ b/docs/docs/namespaces/time.md
@@ -44,7 +44,9 @@ Errors:
 - `type` — non-`i64` `ms` / `num`, or `fn` not a lambda.
 - `oom` — heap allocation failed.
 
-The callback's return value is released and discarded — timers are side-effecting procedures. If the callback raises an error, the error is printed to `stderr` (prefixed `timer <id>:`) and the timer continues as if the call had succeeded; one fire is still counted toward `num`.
+The callback's return value is released and discarded — timers are side-effecting procedures. If the callback raises an error, the error is printed to `stderr` as `timer <id>: error: <code>: <message>` (the same line the REPL would print) and the timer continues as if the call had succeeded; one fire is still counted toward `num`.
+
+A callback that overruns its period does not replay the fires it missed. After each fire the timer re-arms at its next scheduled deadline, or one period from now if that deadline has already passed, so a periodic timer fires at most once per `ms` and the poll loop gets back to serving I/O between fires.
 
 ```lisp
 ;; Print "tick" every second, three times

--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -29,6 +29,7 @@
 #endif
 
 #include "core/timer.h"
+#include "core/runtime.h"   /* ray_error_msg */
 #include "lang/internal.h"
 #include "mem/sys.h"
 #include <stdio.h>
@@ -191,30 +192,32 @@ uint32_t ray_timers_fire_expired(ray_timers_t* t) {
         ray_release(arg);
         if (result) {
             if (RAY_IS_ERR(result)) {
-                ray_t* msg = ray_fmt(result, 0);
-                if (msg && ray_str_ptr(msg)) {
-                    fprintf(stderr, "timer %lld: %.*s\n",
-                            (long long)timer->id,
-                            (int)ray_str_len(msg),
-                            ray_str_ptr(msg));
-                }
-                if (msg) ray_release(msg);
+                /* An error formats as its code alone; the message lives
+                 * in the runtime's last-error slot.  Print both, as the
+                 * REPL does, so a failing poll names its peer and cause. */
+                char code[8] = {0};
+                memcpy(code, result->sdata, result->slen < 7 ? result->slen : 7);
+                const char* detail = ray_error_msg();
+                fprintf(stderr, "timer %lld: error: %s%s%s\n",
+                        (long long)timer->id, code,
+                        detail ? ": " : "", detail ? detail : "");
                 ray_error_free(result);
             } else {
                 ray_release(result);
             }
         }
 
-        /* Re-schedule or free. */
-        if (timer->num == 0) {
-            /* Forever: re-push. */
+        /* Re-schedule or free.  Re-arm from the schedule, so the cadence
+         * stays exact while callbacks are cheap, but never into the past:
+         * a callback that overran its period would otherwise leave the
+         * timer T/tic deadlines behind, and this loop would fire it that
+         * many times back-to-back before the poll loop served any I/O.
+         * Missed intervals are skipped, not replayed. */
+        if (timer->num == 0 || timer->num > 1) {
+            if (timer->num > 1) timer->num--;
+            now = ray_time_now_ms();
             timer->exp_ms += timer->tic_ms;
-            t->heap[t->n] = timer;
-            heap_up(t->heap, t->n);
-            t->n++;
-        } else if (timer->num > 1) {
-            timer->num--;
-            timer->exp_ms += timer->tic_ms;
+            if (timer->exp_ms <= now) timer->exp_ms = now + timer->tic_ms;
             t->heap[t->n] = timer;
             heap_up(t->heap, t->n);
             t->n++;

--- a/test/rfl/system/timer_overrun.rfl
+++ b/test/rfl/system/timer_overrun.rfl
@@ -1,0 +1,23 @@
+;; timer_overrun.rfl — a periodic timer does not replay missed intervals,
+;; and a failing callback's line carries the message (#474).
+;;
+;; Regression 1: a forever timer was re-pushed with exp += tic and the
+;; firing loop ran while exp <= now, so a callback that overran by T
+;; fired T/tic more times back-to-back before the poll loop served any
+;; I/O.  Regression 2: the error arm printed ray_fmt(err), which is the
+;; code alone (`timer 0: error: io`), dropping the message.
+;;
+;; Timers only fire inside ray_poll_run, so both halves run a server
+;; subprocess for a bounded time (backgrounded and killed by pid, since
+;; macOS has no `timeout`) and read its output.  A 100 ms timer
+;; whose first fire sleeps 1 s: with replay the ten missed fires land
+;; back-to-back (about 23 fires in 2.4 s); without, it resumes its cadence
+;; after the sleep (about 13).  Bounds are wide for slow builds.
+(.sys.exec "printf '%s\n' '(set N 0)' '(.time.timer.set 100 0 (fn [t] (do (set N (+ N 1)) (if (== N 1) (.sys.exec \"sleep 1\") 0) (println \"fire\"))))' > /tmp/rfl_timer_ov.rfl")
+(.sys.exec "./rayforce -p 19979 /tmp/rfl_timer_ov.rfl </dev/null >/tmp/rfl_timer_ov.out 2>/dev/null & p=$!; sleep 2.4; kill $p; wait $p 2>/dev/null; n=$(grep -c ^fire /tmp/rfl_timer_ov.out); [ \"$n\" -ge 4 ] && [ \"$n\" -le 17 ]") -- 0
+
+;; the error line names the cause, not just the code
+(.sys.exec "printf '%s\n' '(.time.timer.set 50 1 (fn [t] (.ipc.open \"127.0.0.1:19974\" 200)))' > /tmp/rfl_timer_err.rfl")
+(.sys.exec "./rayforce -p 19979 /tmp/rfl_timer_err.rfl </dev/null >/tmp/rfl_timer_err.out 2>&1 & p=$!; sleep 1.5; kill $p; wait $p 2>/dev/null; grep -q 'timer 0: error: io: connection refused: 127.0.0.1:19974' /tmp/rfl_timer_err.out") -- 0
+
+(.sys.exec "rm -f /tmp/rfl_timer_ov.rfl /tmp/rfl_timer_err.rfl /tmp/rfl_timer_ov.out /tmp/rfl_timer_err.out; true")


### PR DESCRIPTION
## Summary

Two fixes to the timer loop in `src/core/timer.c`.

**Missed intervals are skipped, not replayed.** A forever timer was re-pushed with `exp_ms += tic_ms`, and the firing loop runs while `heap[0]->exp_ms <= now`, so a callback that overran its period by T fired T/tic more times back-to-back before the poll loop served any I/O. The timer now re-arms at its next scheduled deadline, or one period from now when that deadline has already passed. Cadence stays exact while callbacks are cheap; under overrun a periodic timer fires at most once per period. One-shot timers are unaffected.

With the issue's reproducer (100 ms timer, first fire sleeps 1 s, 2.4 s run): about 23 fires before, 13 after, and the cadence resumes immediately after the sleep instead of after a storm.

**The error line carries the message.** The error arm printed `ray_fmt(err)`, which renders an error as its code alone (`timer 0: error: io`). It now prints `timer <id>: error: <code>: <message>`, the same line the REPL prints.

`docs/docs/namespaces/time.md` documents both.

## Test

`test/rfl/system/timer_overrun.rfl` runs a server subprocess for a bounded time (timers only fire inside the poll loop) and counts fires with wide bounds, then checks that a callback raising `.ipc.open` against a dead port prints `timer 0: error: io: connection refused: 127.0.0.1:19991`.

Fixes #474

https://claude.ai/code/session_01J4QKJW3RbRP8TQoquJtARg
