### PR TITLE
test(pool): drop racy main-thread-participation assert in zero_workers

### DIFF
--- a/test/test_pool.c
+++ b/test/test_pool.c
@@ -634,10 +634,13 @@ static test_result_t test_pool_zero_workers(void) {
     TEST_ASSERT_EQ_I(atomic_load(&ctx.calls), 3);
     TEST_ASSERT_EQ_I(atomic_load(&ctx.elem_sum), 8192LL * 3);
 
-    /* Worker 0 (main) must have participated; worker 1 may or may not have
-     * picked up tasks depending on scheduling — at least worker 0 is set. */
-    uint32_t mask = atomic_load(&ctx.saw_worker);
-    TEST_ASSERT_TRUE((mask & 0x1u) != 0);  /* main thread always = worker 0 */
+    /* No per-id participation assert, for the reason workers_participate
+     * gives: which claimant wins is pure scheduling.  With one worker and
+     * three tasks the worker can drain all three before main enters its
+     * claim loop, leaving bit 0 unset — observed on macOS CI.  Completion
+     * is asserted exactly above; some bit is necessarily set once
+     * calls == 3. */
+    TEST_ASSERT_TRUE(atomic_load(&ctx.saw_worker) != 0);
 
     ray_pool_free(&pool);
     ray_heap_destroy();


### PR DESCRIPTION
Same race that 069c27a4 removed from `workers_participate`: `pool/zero_workers` asserted that the main thread (bit 0 of `saw_worker`) took part, while conceding that the worker's participation depends on scheduling. With one worker and three tasks the worker can drain all three before main enters its claim loop. Observed on the macOS debug job of #477, a change that does not touch the pool. Completion is already asserted exactly; the test now asserts only that some participant recorded itself.

https://claude.ai/code/session_01J4QKJW3RbRP8TQoquJtARg