### PR TITLE
fix(csv): infer Rayfall temporal forms

### DIFF
--- a/src/io/csv.c
+++ b/src/io/csv.c
@@ -504,14 +504,15 @@ RAY_INLINE int32_t civil_to_days(int y, int m, int d) {
     return (int32_t)(era * 146097 + doe - 719468 - 10957);
 }
 
-/* Strict YYYY-MM-DD: exactly 10 chars, '-' separators at offsets 4/7, and
- * digits in every field.  Mirrors detect_type() and csv_write_date() so that
- * typed .csv.read [DATE] round-trips the writer's output while rejecting
- * malformed separators or trailing garbage (e.g. "2024/01/02", "2024x01x02",
- * "2024-01-02junk") as null instead of silently coercing them to a bogus
- * date.  fast_timestamp() reuses this on the leading date (passing len 10). */
+/* Strict date parser: exactly 10 chars, either YYYY-MM-DD (CSV writer output)
+ * or YYYY.MM.DD (Rayfall display form), with matching separators at offsets
+ * 4/7 and digits in every field.  Reject malformed separators or trailing
+ * garbage (e.g. "2024/01/02", "2024x01x02", "2024-01-02junk") as null instead
+ * of silently coercing them to a bogus date.  fast_timestamp() reuses this on
+ * the leading date (passing len 10). */
 RAY_INLINE int32_t fast_date(const char* p, size_t len, bool* is_null) {
-    if (RAY_UNLIKELY(len != 10 || p[4] != '-' || p[7] != '-')) { *is_null = true; return 0; }
+    bool sep_ok = len == 10 && (p[4] == '-' || p[4] == '.') && p[7] == p[4];
+    if (RAY_UNLIKELY(!sep_ok)) { *is_null = true; return 0; }
     if (RAY_UNLIKELY((unsigned)(p[0]-'0') > 9u || (unsigned)(p[1]-'0') > 9u ||
                      (unsigned)(p[2]-'0') > 9u || (unsigned)(p[3]-'0') > 9u ||
                      (unsigned)(p[5]-'0') > 9u || (unsigned)(p[6]-'0') > 9u ||
@@ -662,10 +663,15 @@ RAY_INLINE bool parse_tz_offset(const char* p, size_t len, int64_t* out_ns, size
 }
 
 RAY_INLINE int64_t fast_timestamp(const char* p, size_t len, bool* is_null) {
-    /* Require "YYYY-MM-DD" + 'T'|'t'|' ' separator + "HH:MM:SS" (>=19 chars),
-     * matching detect_type() and csv_write_timestamp().  A malformed date/time
-     * separator (e.g. "2024x01x02D01:02:03") is rejected as null. */
-    if (RAY_UNLIKELY(len < 19 || (p[10] != 'T' && p[10] != 't' && p[10] != ' '))) { *is_null = true; return 0; }
+    /* Require a strict date + separator + "HH:MM:SS" (>=19 chars).  Accept the
+     * CSV writer's ISO-ish separators ('T'|'t'|' ') and Rayfall display's
+     * dotted-date + 'D' form.  Malformed date/time separators (e.g.
+     * "2024x01x02D01:02:03" or "2024-01-02D01:02:03") reject as null. */
+    if (RAY_UNLIKELY(len < 19)) { *is_null = true; return 0; }
+    bool rayfall_sep = (p[10] == 'D');
+    bool dt_sep_ok = p[10] == 'T' || p[10] == 't' || p[10] == ' ' ||
+                     (rayfall_sep && p[4] == '.');
+    if (RAY_UNLIKELY(!dt_sep_ok)) { *is_null = true; return 0; }
     *is_null = false;
     int32_t days = fast_date(p, 10, is_null);
     if (*is_null) return 0;

--- a/src/io/csv.c
+++ b/src/io/csv.c
@@ -666,7 +666,13 @@ RAY_INLINE int64_t fast_timestamp(const char* p, size_t len, bool* is_null) {
     /* Require a strict date + separator + "HH:MM:SS" (>=19 chars).  Accept the
      * CSV writer's ISO-ish separators ('T'|'t'|' ') and Rayfall display's
      * dotted-date + 'D' form.  Malformed date/time separators (e.g.
-     * "2024x01x02D01:02:03" or "2024-01-02D01:02:03") reject as null. */
+     * "2024x01x02D01:02:03" or "2024-01-02D01:02:03") reject as null.
+     *
+     * Grammar note: 'T'|'t'|' ' are accepted after either date form, so a
+     * dotted date paired with one of them ("2024.01.02T01:02:03") also infers
+     * TIMESTAMP even though no writer emits that mixed shape; only 'D' is tied
+     * to the dotted date.  This is deliberate leniency on input, not a form we
+     * produce. */
     if (RAY_UNLIKELY(len < 19)) { *is_null = true; return 0; }
     bool rayfall_sep = (p[10] == 'D');
     bool dt_sep_ok = p[10] == 'T' || p[10] == 't' || p[10] == ' ' ||

--- a/test/rfl/io/csv_rayfall_temporal.rfl
+++ b/test/rfl/io/csv_rayfall_temporal.rfl
@@ -1,0 +1,9 @@
+;; CSV type inference must recognize Rayfall's display temporal forms.
+;; These are the forms users see when DATE/TIMESTAMP values are printed.
+(.sys.exec "printf 'd,ts\n2024.01.02,2024.01.02D01:02:03.004005006\n' > rf_test_csv_rayfall_temporal.csv") -- 0
+(set T (.csv.read "rf_test_csv_rayfall_temporal.csv"))
+(type (at T 'd)) -- 'DATE
+(type (at T 'ts)) -- 'TIMESTAMP
+(at (at T 'd) 0) -- 2024.01.02
+(at (at T 'ts) 0) -- 2024.01.02D01:02:03.004005006
+(.sys.exec "rm -f rf_test_csv_rayfall_temporal.csv") -- 0


### PR DESCRIPTION
## How it looks from the user's side

A user has a CSV containing temporal values in the same forms Rayfall prints:

    d,ts
    2024.01.02,2024.01.02D01:02:03.004005006

and reads it without an explicit schema:

    (set T (.csv.read "rf_test_csv_rayfall_temporal.csv"))
    (type (at T 'd))
    (type (at T 'ts))

**Before** - the date column was inferred as a symbol instead of DATE:

    test/rfl/io/csv_rayfall_temporal_repro.rfl:3: expected "DATE", got "SYM"  -- src: (type (at T 'd))

**After** - the same values infer and parse as temporal columns:

    (type (at T 'd)) -- 'DATE
    (type (at T 'ts)) -- 'TIMESTAMP
    (at (at T 'd) 0) -- 2024.01.02
    (at (at T 'ts) 0) -- 2024.01.02D01:02:03.004005006

## Root cause / fix

CSV temporal inference now shares the strict typed-ingest parsers. Those parsers accepted the CSV writer's `YYYY-MM-DD` and `YYYY-MM-DDT...` forms, but rejected Rayfall display forms using dotted dates and the `D` timestamp separator.

This keeps the strict full-consumption parser path, but lets `fast_date` accept `YYYY.MM.DD` alongside `YYYY-MM-DD`, and lets `fast_timestamp` accept Rayfall's dotted-date + `D` separator form.

## Tests

    make test TEST_FILTER=csv_rayfall_temporal
    make test TEST_FILTER=csv_types
    make test TEST_FILTER=csv
    make test
