### PR TITLE
fix(serde): round-trip builtins by full registered name

### DIFF
--- a/src/lang/env.c
+++ b/src/lang/env.c
@@ -114,6 +114,20 @@ static struct {
 int32_t ray_env_scope_depth(void) { return __VM ? __VM->scope_depth : 0; }
 int32_t ray_env_global_count(void) { return g_env.count; }
 
+/* Reverse-map a builtin function object to the symbol it is bound under in the
+ * global environment.  Builtins inline only the first 13 bytes of their name
+ * (see fn_set_name / ray_fn_name), so serialization — which must round-trip the
+ * full name — cannot read it off the object.  Every builtin, dotted reserved
+ * names included, is also bound flat in g_env (see reg_bind's ray_env_bind_flat
+ * call), so a pointer scan recovers the full name.  Returns the sym_id, or -1
+ * if `fn` is not a registered global builtin. */
+int64_t ray_env_builtin_sym(const ray_t* fn) {
+    if (!fn) return -1;
+    for (int32_t i = 0; i < g_env.count; i++)
+        if (g_env.vals[i] == fn) return g_env.keys[i];
+    return -1;
+}
+
 /* Query scopes are synthetic and must not eclipse a caller's lexical
  * parameter/let binding.  Other query frames are deliberately ignored so
  * an inner query can bind a same-named column over an outer query column.

--- a/src/lang/env.h
+++ b/src/lang/env.h
@@ -132,6 +132,12 @@ int32_t ray_env_list_user(int64_t* sym_ids, ray_t** vals, int32_t max_entries);
  * user).  Useful for sizing buffers before ray_env_list. */
 int32_t ray_env_global_count(void);
 
+/* Reverse-map a builtin function object to the sym_id it is bound under in the
+ * global env, or -1 if it is not a registered global builtin.  Serialization
+ * uses this to recover a builtin's full name, which the object only inlines to
+ * 13 bytes (ray_fn_name). */
+int64_t ray_env_builtin_sym(const ray_t* fn);
+
 /* Local scope stack for lexical binding (let, do, lambda) */
 ray_err_t ray_env_push_scope(void);
 ray_err_t ray_env_push_query_scope(void);

--- a/src/store/serde.c
+++ b/src/store/serde.c
@@ -131,6 +131,26 @@ static int64_t ser_schema_names(uint8_t* buf, ray_t* schema) {
     return c;
 }
 
+/* Builtins inline only the first 13 bytes of their name (ray_fn_name), so a
+ * longer registered name cannot be read off the object.  Recover the full name
+ * from the global-env binding; the returned pointer is borrowed from the sym
+ * table (stable through the read-only serialization phase — no release).  Sets
+ * *nlen to the byte length and returns the bytes.  Falls back to the object's
+ * inline name for anything not found as a registered global builtin. */
+static const char* serde_builtin_name(ray_t* obj, size_t* nlen) {
+    int64_t sym = ray_env_builtin_sym(obj);
+    if (sym >= 0) {
+        ray_t* s = ray_sym_str(sym);
+        if (s && !RAY_IS_ERR(s)) {
+            *nlen = ray_str_len(s);
+            return ray_str_ptr(s);
+        }
+    }
+    const char* name = ray_fn_name(obj);
+    *nlen = strlen(name);
+    return name;
+}
+
 /* --------------------------------------------------------------------------
  * ray_serde_size — calculate serialized size (excluding IPC header)
  * -------------------------------------------------------------------------- */
@@ -239,9 +259,12 @@ int64_t ray_serde_size(ray_t* obj) {
     case RAY_UNARY:
     case RAY_BINARY:
     case RAY_VARY: {
-        /* Serialize by name (null-terminated string in aux) */
-        const char* name = ray_fn_name(obj);
-        size_t nlen = strlen(name); if (nlen > 15) nlen = 15;
+        /* Serialize by name: type + full NUL-terminated name.  The name comes
+         * from the env binding (serde_builtin_name), not the object's 13-byte
+         * inline copy, so a long builtin name round-trips instead of resolving
+         * to a truncated, non-existent name on decode. */
+        size_t nlen;
+        (void)serde_builtin_name(obj, &nlen);
         return 1 + (int64_t)nlen + 1; /* type + name + null terminator */
     }
     case RAY_ERROR:
@@ -487,9 +510,12 @@ int64_t ray_ser_raw(uint8_t* buf, ray_t* obj) {
     case RAY_UNARY:
     case RAY_BINARY:
     case RAY_VARY: {
-        /* Serialize builtin by name (null-terminated) */
-        const char* name = ray_fn_name(obj);
-        size_t nlen = strlen(name); if (nlen > 15) nlen = 15;
+        /* Serialize builtin by its full NUL-terminated name, recovered from the
+         * env binding (the object only inlines 13 bytes).  ray_serde_size
+         * reserves 1 + nlen + 1 the same way; the decoder resolves the name in
+         * the global environment. */
+        size_t nlen;
+        const char* name = serde_builtin_name(obj, &nlen);
         memcpy(buf, name, nlen);
         buf[nlen] = 0;
         return 1 + (int64_t)nlen + 1;

--- a/test/rfl/system/serde.rfl
+++ b/test/rfl/system/serde.rfl
@@ -33,3 +33,14 @@
 ;; columns, dict keys-vs-values) is covered in test/test_store.c
 ;; (store/serde_container_count_mismatch), which builds frames via
 ;; sizeof(ray_ipc_header_t) rather than hard-coding the wire layout.
+
+;; ────────────── builtins serialize by their FULL name ──────────────
+;; Regression: the encoder capped builtin names at 15 bytes, so any longer
+;; name was written truncated and failed to resolve on decode.  Both of these
+;; registered builtins exceed 15 chars and must survive a round-trip.
+(de (ser .db.parted.tables))    -- .db.parted.tables
+(de (ser .sys.querylog.enable)) -- .sys.querylog.enable
+;; Identity, not just "some builtin": the decoded value is the real function,
+;; so calling it still raises its own argument error.  Before the fix the
+;; truncated name failed to resolve during decode (a 'name error) instead.
+((de (ser .db.parted.tables)) 123) !- type

--- a/test/rfl/system/serde.rfl
+++ b/test/rfl/system/serde.rfl
@@ -35,12 +35,14 @@
 ;; sizeof(ray_ipc_header_t) rather than hard-coding the wire layout.
 
 ;; ────────────── builtins serialize by their FULL name ──────────────
-;; Regression: the encoder capped builtin names at 15 bytes, so any longer
-;; name was written truncated and failed to resolve on decode.  Both of these
-;; registered builtins exceed 15 chars and must survive a round-trip.
-(de (ser .db.parted.tables))    -- .db.parted.tables
-(de (ser .sys.querylog.enable)) -- .sys.querylog.enable
-;; Identity, not just "some builtin": the decoded value is the real function,
-;; so calling it still raises its own argument error.  Before the fix the
-;; truncated name failed to resolve during decode (a 'name error) instead.
-((de (ser .db.parted.tables)) 123) !- type
+;; Regression: the encoder capped builtin names at 15 bytes, so a longer name
+;; was written truncated and failed to resolve on decode.  Both of these
+;; registered builtins exceed 15 chars.  Prove the round-trip BEHAVIOURALLY —
+;; the decoded value is the real function, so calling it reaches that
+;; function's own argument check; before the fix decode raised a 'name error.
+;; A `-- .db.parted.tables` golden could NOT prove this: the formatter renders
+;; a builtin through ray_fn_name's 13-byte inline copy, so both sides would
+;; read `.db.parted.ta` and match on dev too.  Pointer identity is asserted at
+;; the C level in test_store.c (store/serde_builtin_name_roundtrip).
+((de (ser .db.parted.tables)) 123)    !- type
+((de (ser .sys.querylog.enable)) 1 2) !- domain

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -2709,6 +2709,54 @@ static test_result_t test_serde_function_types(void) {
     PASS();
 }
 
+/* ---- test_serde_builtin_name_roundtrip ---------------------------------- */
+
+static test_result_t test_serde_builtin_name_roundtrip(void) {
+    /* Regression: builtins serialize by name, but the encoder capped the name
+     * at 15 bytes.  A builtin whose registered name is longer was written
+     * truncated and could not be resolved on decode, so (de (ser fn)) raised a
+     * name error instead of round-tripping.  test_serde_function_types only
+     * exercises short names (neg, +, list), so it never caught this. */
+    ray_runtime_t* rt = ray_runtime_create(0, NULL);
+    TEST_ASSERT_NOT_NULL(rt);
+
+    static const char* const long_names[] = {
+        ".db.parted.tables",    /* 17 bytes, RAY_VARY */
+        ".sys.querylog.enable", /* 20 bytes           */
+    };
+
+    for (size_t i = 0; i < sizeof(long_names) / sizeof(long_names[0]); i++) {
+        const char* name = long_names[i];
+        TEST_ASSERT(strlen(name) > 15, "test name must exceed the old 15-byte cap");
+
+        /* Borrowed: ray_env_get returns the env-owned object, do not release. */
+        ray_t* orig = ray_env_get(ray_sym_intern(name, strlen(name)));
+        TEST_ASSERT_NOT_NULL(orig);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(orig));
+
+        ray_t* wire = ray_ser(orig);
+        TEST_ASSERT_NOT_NULL(wire);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(wire));
+
+        ray_t* back = ray_de(wire);
+        TEST_ASSERT_NOT_NULL(back);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(back));
+
+        /* The decoder resolves the full name in the global env, so it returns
+         * the very same builtin — identity is the strongest proof and implies
+         * the name survived intact.  A truncated name would either miss or
+         * resolve to a different entry. */
+        TEST_ASSERT_EQ_PTR(back, orig);
+        TEST_ASSERT_EQ_I(back->type, orig->type);
+
+        ray_release(back);
+        ray_release(wire);
+    }
+
+    ray_runtime_destroy(rt);
+    PASS();
+}
+
 /* ---- serde coverage: ERROR object roundtrip ------------------------------ */
 
 static test_result_t test_serde_error_roundtrip(void) {
@@ -5509,6 +5557,7 @@ const test_entry_t store_entries[] = {
     { "store/serde_de_error_paths",       test_serde_de_error_paths,       store_setup, store_teardown },
     { "store/serde_list_null_elem",       test_serde_list_with_null_elem,  store_setup, store_teardown },
     { "store/serde_function_types",       test_serde_function_types,       NULL,        NULL           },
+    { "store/serde_builtin_name_roundtrip", test_serde_builtin_name_roundtrip, NULL,     NULL           },
     { "store/serde_error_roundtrip",      test_serde_error_roundtrip,      store_setup, store_teardown },
     { "store/serde_large_null_vec",       test_serde_large_null_vec,       store_setup, store_teardown },
     { "store/serde_f32_atom",             test_serde_f32_atom_and_edge_cases, store_setup, store_teardown },


### PR DESCRIPTION
## How it looks from the user's side

A user serializes and deserializes a long-named builtin function:

    (de (ser .db.parted.tables))

Before, the encoder wrote only the truncated builtin display name, so decode could not resolve it:

    test/rfl/system/serde_builtin_name_repro.rfl:1: LHS eval error: error: name  -- src: (de (ser .db.parted.tables))

After, deserialize resolves the original builtin. Calling the decoded value now reaches the builtin's own argument validation instead of failing with `name`:

    ((de (ser .db.parted.tables)) 123)
    error: type: .db.parted.tables expects a string db root path, got i64

## Root cause

Builtin function objects inline only the first 13 bytes of their display name. Serde used that inline name for builtin serialization, so long registered names like `.db.parted.tables` and `.sys.querylog.enable` were serialized truncated and could not be looked up during decode.

## Fix

Add an env reverse lookup from builtin object pointer to symbol id and use that in serde so both the size and write passes serialize the full registered env name.

## Tests

- `make test TEST_FILTER=serde_builtin_name_roundtrip`
- `make test TEST_FILTER=serde`
- `make test` (3747/3748 passed, 1 pre-existing skip)
