### PR TITLE
feat(builtins): make nil? element-wise over vectors and lists

### DIFF
--- a/docs/docs/language/syntax.md
+++ b/docs/docs/language/syntax.md
@@ -124,9 +124,18 @@ sentinel for their type:
 
 Symbols have no typed null literal (there is no `0Ns`).
 
-Inside `select` and `update` expressions, `(nil? col)` lowers to the DAG
-null-check opcode and returns a boolean per row, so it can be used directly in
-`where:` predicates and projections.
+`nil?` is element-wise: given a vector or a list it returns a `B8` vector with
+one entry per element, so `(where (nil? v))` and `(sum (as 'I64 (nil? v)))`
+work without a `map`. An atom answers for itself, and so does any other
+container (a table or a dict is never null). Inside `select` and `update`
+expressions, `(nil? col)` lowers to the DAG null-check opcode, which gives the
+same per-row answer and can be used directly in `where:` predicates and
+projections.
+
+```lisp
+(nil? [1 0N 3])   ; [false true false]
+(nil? [a ' b])    ; [false true false]  — the empty symbol is SYM's null
+```
 
 ## Vectors
 

--- a/docs/docs/reference/all-functions.md
+++ b/docs/docs/reference/all-functions.md
@@ -585,7 +585,7 @@ Type checking, casting, null testing, and object inspection.
 |---|---|---|---|---|
 | `type` | unary | — | Get the type name of a value | `(type 42)` → `i64` |
 | `as` | binary | — | Cast value to another type | `(as 'i64 "42")` → `42` |
-| `nil?` | unary | DAG in queries | Test if value is null; element-wise in query expressions | `(nil? 0Ni)` → `true` |
+| `nil?` | unary | DAG in queries | Test for null; element-wise over vectors and lists (a `B8` per element), the same in and out of queries | `(nil? [1 0N 3])` → `[false true false]` |
 | `rc` | unary | — | Get reference count of an object | `(rc x)` → `1` |
 | `guid` | unary | — | Generate a vector of N GUIDs (`(guid 0)` → `[]`) | `(guid 1)` |
 

--- a/src/ops/builtins.c
+++ b/src/ops/builtins.c
@@ -2334,11 +2334,36 @@ ray_t* ray_dict_fn(ray_t* keys, ray_t* vals) {
     return ray_dict_new(keys, vlist);
 }
 
-/* (nil? x) -> true if x is null */
+/* (nil? x) -> true if x is null.
+ *
+ * Element-wise over a vector or a boxed list: one BOOL per element, the
+ * same answer the query path's OP_ISNULL gives per row, so `nil?` means
+ * the same thing inside and outside a query (#485).  Nulls are in-band
+ * (sentinels, the empty symbol, the empty string), so ray_vec_is_null
+ * decides per element regardless of the HAS_NULLS hint.  A list element
+ * that is not an atom is not null.  Atoms, the null object, and any
+ * other container (a table, a dict) answer for the object itself. */
 ray_t* ray_nil_fn(ray_t* x) {
     RAY_ASSERT_VALUE(x);
     if (RAY_IS_NULL(x)) return ray_bool(true);
-    if (ray_is_atom(x) && RAY_ATOM_IS_NULL(x)) return ray_bool(true);
+    if (ray_is_atom(x)) return ray_bool(RAY_ATOM_IS_NULL(x));
+    if (ray_is_vec(x) || x->type == RAY_LIST) {
+        int64_t n = ray_len(x);
+        ray_t* out = ray_vec_new(RAY_BOOL, n);
+        if (!out || RAY_IS_ERR(out)) return out ? out : ray_error("oom", NULL);
+        uint8_t* o = (uint8_t*)ray_data(out);
+        if (x->type == RAY_LIST) {
+            ray_t** e = (ray_t**)ray_data(x);
+            for (int64_t i = 0; i < n; i++)
+                o[i] = (uint8_t)(!e[i] || RAY_IS_NULL(e[i]) ||
+                                 (ray_is_atom(e[i]) && RAY_ATOM_IS_NULL(e[i])));
+        } else {
+            for (int64_t i = 0; i < n; i++)
+                o[i] = (uint8_t)ray_vec_is_null(x, i);
+        }
+        out->len = n;
+        return out;
+    }
     return ray_bool(false);
 }
 

--- a/test/rfl/expr/cast_unary.rfl
+++ b/test/rfl/expr/cast_unary.rfl
@@ -76,9 +76,9 @@
 
 ;; ===================================================================
 ;; ISNULL over I64 vec (exec_elementwise_unary lines 1320-1327)
-;; Non-null vec: result is all false
+;; Non-null vec: result is all false — one bool per element (#485)
 ;; ===================================================================
-(nil? (til 5))   -- false
+(nil? (til 5))   -- [false false false false false]
 (map nil? (til 3)) -- [false false false]
 
 ;; ISNULL on nullable vector detects null positions

--- a/test/rfl/null/nil_elementwise.rfl
+++ b/test/rfl/null/nil_elementwise.rfl
@@ -1,0 +1,53 @@
+;; nil_elementwise.rfl — `nil?` is element-wise over vectors and lists
+;; everywhere, not only inside queries (#485).
+;;
+;; Before: outside a query `nil?` tested whether the argument OBJECT was
+;; null, so `(nil? [1 0N 3])` was `false` while `(select {n: (nil? v)})`
+;; gave one bool per row.  Now a vector or list argument yields a BOOL
+;; vector, one entry per element, agreeing with the query opcode.  Atoms
+;; and the null object answer as before.
+
+;; ── atoms and the null object: unchanged ──
+(nil? 0Nl) -- true
+(nil? 1) -- false
+(nil? 0Nf) -- true
+(nil? 1.5) -- false
+(nil? ') -- true
+(nil? 'a) -- false
+(nil? "") -- true
+(nil? "x") -- false
+(nil? null) -- true
+
+;; ── typed vectors: one bool per element, B8 result ──
+(nil? [1 0N 3]) -- [false true false]
+(type (nil? [1 0N 3])) -- 'B8
+(nil? [1.5 0Nf 2.5]) -- [false true false]
+(nil? [1i 0Ni]) -- [false true]
+(nil? [2024.01.01 0Nd]) -- [false true]
+(nil? [2000.01.01D00:00:00.000000001 0Np]) -- [false true]
+(nil? [a ' b]) -- [false true false]
+(nil? (list "x" "" "y")) -- [false true false]
+(nil? [true false]) -- [false false]
+(nil? [1 2 3]) -- [false false false]
+(nil? (as 'I64 [])) -- (as 'B8 [])
+;; sentinel is the truth, whatever the HAS_NULLS hint says
+(nil? (concat [1 0N] [0N 2])) -- [false true true false]
+
+;; ── boxed lists: null atoms are null, anything else is not ──
+(nil? (list 1 0N "x" [1 2])) -- [false true false false]
+(nil? (list (list 0N))) -- [false]
+(nil? (list)) -- (as 'B8 [])
+
+;; ── the result composes without a cast ──
+(where (nil? [1 0N 3 0N])) -- [1 3]
+(count (where (nil? [0N 0N 1]))) -- 2
+(sum (as 'I64 (nil? [1 0N 3]))) -- 1
+
+;; ── containers other than vectors and lists are whole objects, as before ──
+(nil? (table [a] (list [1]))) -- false
+(nil? (dict ['a] [1])) -- false
+
+;; ── the query path answers the same ──
+(set t (table [v] (list [1 0N 3])))
+(at (select {n: (nil? v) from: t}) 'n) -- (nil? (at t 'v))
+(count (select {from: t where: (nil? v)})) -- 1

--- a/test/rfl/query/width_matrix.rfl
+++ b/test/rfl/query/width_matrix.rfl
@@ -1041,7 +1041,8 @@
 ;; reflect how the vector's own consumers (sum, the DA accumulator)
 ;; treat it: they gate on the VECTOR's HAS_NULLS attribute first, which
 ;; is correctly unset here.
-(nil? wm5_va) -- false
+;; (element-wise since #485: no element is null)
+(nil? wm5_va) -- [false false false false]
 (sum wm5_va) -- -2147483518
 (at wm5_va 1) -- 100
 (set wm5_vf [7i 7i 3i 3i])

--- a/test/rfl/system/system_branch_cov2.rfl
+++ b/test/rfl/system/system_branch_cov2.rfl
@@ -13,7 +13,8 @@
 (quote 42) -- 42
 (quote 'hello) -- 'hello
 (quote [1 2 3]) -- [1 2 3]
-(nil? (quote (+ 1 2))) -- false
+;; a quoted form is a 3-element list; nil? is element-wise over it (#485)
+(nil? (quote (+ 1 2))) -- [false false false]
 
 ;; ══════════════════════════════════════════════════════════════════════
 ;; ray_return_fn  (lines 590-593)


### PR DESCRIPTION
## Summary

`nil?` is now element-wise everywhere. Outside a query it tested whether the argument object was null, so `(nil? [1 0N 3])` was `false` while the same call inside `select`/`update`/`where` gave one bool per row. The vector answer was never useful, and the workaround `(map nil? v)` returns a boxed list that needs `(as 'BOOL …)` before `where` or arithmetic can use it.

| call | before | after |
|---|---|---|
| `(nil? [1 0N 3])` | `false` | `[false true false]` (B8) |
| `(nil? [a ' b])` | `false` | `[false true false]` |
| `(nil? (list 1 0N "x" [1 2]))` | `false` | `[false true false false]` |
| `(nil? 0Nl)`, `(nil? null)`, `(nil? 1)` | unchanged | unchanged |
| `(nil? table)`, `(nil? dict)` | `false` | `false` |
| `(select {n: (nil? v) …})` | per row | per row, same answer |

Implemented inside `ray_nil_fn` rather than by flagging the builtin atomic: the vector path loops `ray_vec_is_null` into a B8 vector with no per-element atom, a list yields a B8 vector rather than a list, and the evaluator's carve-out for the null object is untouched. Nulls are in-band (sentinels, empty symbol, empty string), so the per-element answer does not depend on the `HAS_NULLS` hint.

Behaviour change only for calls that passed a vector or list, which always answered `false` before. Three coverage tests pinned that answer (`cast_unary.rfl`, `width_matrix.rfl`, `system_branch_cov2.rfl`); they now expect the per-element result, and are the only callers in the suite that did.

## Tests

`test/rfl/null/nil_elementwise.rfl` covers atoms and the null object, every nullable vector type plus BOOL and empty vectors, a concat whose hint may be stale, lists with nested non-atoms, composition with `where`/`sum`, containers, and agreement with the query path. Full `make test`: all passed, no sanitizer output. Docs updated in `syntax.md` and `all-functions.md`.

Closes #485

https://claude.ai/code/session_01J4QKJW3RbRP8TQoquJtARg
