### PR TITLE
fix(parse): reject a leaf token glued to a quote, colon or name character

### DIFF
--- a/docs/docs/language/syntax.md
+++ b/docs/docs/language/syntax.md
@@ -39,6 +39,8 @@ false       ; boolean false
 
 Symbols are interned identifiers used for column names, dictionary keys, and categorical data. Prefix with a single quote to create a literal symbol.
 
+A symbol literal runs over letters, digits, `_`, `.` and `-`. A symbol, keyword, name or number cannot be directly followed by a quote, a colon, or another name or number character: `['a:1]` is a parse error rather than the two symbols `a` and `1`, and `0Na` is not `0` followed by `Na`. A symbol that must contain a colon is built from a string, `(as 'symbol "a:1")`.
+
 ```lisp
 'AAPL       ; symbol atom
 'price      ; used as column reference

--- a/src/lang/parse.c
+++ b/src/lang/parse.c
@@ -852,6 +852,7 @@ static ray_t* parse_expr_inner(ray_parser_t *p) {
     int32_t sl = p->line, sc = p->col;
     const char *before = p->pos;
     ray_t *result;
+    bool leaf = true;   /* symbol / keyword / name / number: must end at a delimiter */
 
     switch (PA(*p->pos)) {
         case PA_END:    return ray_error("parse", NULL);
@@ -863,11 +864,11 @@ static ray_t* parse_expr_inner(ray_parser_t *p) {
                 result = parse_name(p);  /* standalone '-' or '-name' */
             break;
         case PA_ALPHA:  result = parse_name(p); break;
-        case PA_STRING: result = parse_string(p); break;
+        case PA_STRING: result = parse_string(p); leaf = false; break;
         case PA_QUOTE:  result = parse_symbol(p); break;
-        case PA_LPAREN: result = parse_list(p); break;
-        case PA_LBRACK: result = parse_vector(p); break;
-        case PA_LBRACE: result = parse_dict(p); break;
+        case PA_LPAREN: result = parse_list(p);   leaf = false; break;
+        case PA_LBRACK: result = parse_vector(p); leaf = false; break;
+        case PA_LBRACE: result = parse_dict(p);   leaf = false; break;
         case PA_RPAREN: return ray_error("parse", NULL);
         case PA_RBRACK: return ray_error("parse", NULL);
         case PA_RBRACE: return ray_error("parse", NULL);
@@ -887,6 +888,26 @@ static ray_t* parse_expr_inner(ray_parser_t *p) {
             break;
         }
         default:        result = parse_name(p); break;  /* operators like +, *, etc. */
+    }
+
+    /* A leaf token must not be glued to another: a quote, a colon, or a
+     * name/number character directly after a symbol, keyword, name or
+     * number is a parse error.  Without this, nothing separated adjacent
+     * tokens, so `['a:1]` lexed as the symbol `a` followed by the keyword
+     * symbol `:1` (a two-element vector printed as `[a 1]`), and `(+ 1'a)`
+     * or `0Na` quietly became something other than what was written.
+     * Brackets and strings stay self-delimiting on both sides: `fn[x]`,
+     * `gds(take ..)`, `(f x)(g y)` and `(list "A""B")` are established
+     * usage. */
+    if (leaf && result && !RAY_IS_ERR(result)) {
+        char c = *p->pos;
+        bool glued = c == '\'' || c == ':' || PA(c) == PA_ALPHA || PA(c) == PA_DIGIT ||
+                     c == '_' || c == '.' || c == '-' || c == '?' || c == '!';
+        if (glued) {
+            ray_release(result);
+            fixup_pos(p, before);
+            return ray_error("parse", "unexpected '%c' directly after a token; separate tokens with whitespace", c);
+        }
     }
 
     /* Fixup line/col: leaf parsers advance pos without updating line/col.

--- a/test/rfl/lang/parse_branch_cov.rfl
+++ b/test/rfl/lang/parse_branch_cov.rfl
@@ -104,16 +104,17 @@
 ;; 3.  BARE-0N IDENTIFIER-CONTINUATION GUARDS  (parse_number :214-218)
 ;; ════════════════════════════════════════════════════════════════════
 ;; `0N` followed by a letter/digit/underscore that is NOT a suffix is
-;; *not* a null — the digit `0` is taken and the continuation parsed as a
-;; separate trailing name, so `(do 0 <name>)` evaluates to the name value.
+;; *not* a null — the digit `0` is taken, and what follows is a second
+;; token glued to it, which is a parse error since #484 (before, it was
+;; silently read as `(do 0 <name>)` and evaluated to the name's value).
 (set Na 7)
-0Na -- 7
+0Na !- parse
 (set Nz 9)
-0Nz -- 9
+0Nz !- parse
 (set N3 3)
-0N3 -- 3
+0N3 !- parse
 (set N_x 11)
-0N_x -- 11
+0N_x !- parse
 
 ;; ════════════════════════════════════════════════════════════════════
 ;; 4.  FLOAT / EXPONENT / INTEGER-OVERFLOW PROMOTION  (parse_number)
@@ -164,13 +165,13 @@
 ;; time without sub-second fraction is still valid; eval pins the value.
 (type (parse "12:30:45")) -- 'time
 (eval (parse "12:30:45")) -- 12:30:45.000
-;; 2-digit + colon where try_parse_time fails → fall through to number,
-;; then the remainder is re-lexed (parse_number :281-289, try_parse_time
-;; NULL at MM :151, at MM-colon :157, at SS digits).  Each yields
-;; `(do 12 <keyword>)` whose value is the trailing keyword sym.
-(eval (parse "12:3x")) -- '3x
-(eval (parse "12:30x")) -- '30x
-(eval (parse "12:30:4x")) -- '4x
+;; 2-digit + colon where try_parse_time fails → fall through to number
+;; (parse_number, try_parse_time NULL at MM / MM-colon / SS digits); the
+;; remainder is then a second token glued to the number, a parse error
+;; since #484 (before, each re-lexed to `(do 12 <keyword>)`).
+(parse "12:3x") !- parse
+(parse "12:30x") !- parse
+(parse "12:30:4x") !- parse
 ;; timestamp YYYY.MM.DDDhh:mm:ss.nnnnnnnnn
 2024.01.15D12:30:45.000000000 -- 2024.01.15D12:30:45.000000000
 (type 2024.01.15D12:30:45.000000000) -- 'timestamp

--- a/test/rfl/lang/parse_token_boundary.rfl
+++ b/test/rfl/lang/parse_token_boundary.rfl
@@ -1,0 +1,54 @@
+;; parse_token_boundary.rfl — a leaf token cannot be glued to another (#484).
+;;
+;; Regression: nothing required a delimiter between tokens, so `['a:1]`
+;; lexed as the symbol `a` followed by the keyword symbol `:1` — a
+;; two-element symbol vector that printed as `[a 1]` — and `(+ 1'a)` or
+;; `0Na` quietly became something else.  A symbol, keyword, name or
+;; number directly followed by a quote, a colon, or another name/number
+;; character is now a parse error at that position.  Brackets and strings
+;; stay self-delimiting on both sides: `fn[x]`, `gds(take ..)`,
+;; `(f x)(g y)` and `(list "A""B")` still parse as before.
+
+;; ── the reported case and its relatives ──
+(count ['a:1]) !- parse
+['a:1] !- parse
+[a:1] !- parse
+(list 'a:1) !- parse
+['a'b] !- parse
+[1'a] !- parse
+(+ 1'a) !- parse
+(nil?'a) !- parse
+:a:b !- parse
+0Na !- parse
+1x !- parse
+(parse "12:3x") !- parse
+
+;; ── a colon inside a symbol is spelled through a cast ──
+(count (list (as 'symbol "a:1"))) -- 1
+(type (as 'symbol "a:1")) -- 'sym
+
+;; ── everything delimited stays as it was ──
+(count ['a 'b]) -- 2
+['a :b] -- [a b]
+(count [1 2 3]) -- 3
+(+ 1 2) -- 3
+{a: 1} -- {a:1}
+{a:1} -- {a:1}
+(at {a: 1} 'a) -- 1
+(list "A""B""C") -- (list "A" "B" "C")
+((fn [x] x) 5) -- 5
+(set _tb 1)(+ _tb 1) -- 2
+(count (list [1 2]3)) -- 2
+(count (list 1[2])) -- 2
+((fn[x] x) 5) -- 5
+(count (list [1 2] [3 4])) -- 2
+(count [2024.01.02D01:02:03.004005006 0Np]) -- 2
+(nil? ') -- true
+-1 -- -1
+(- 5 2) -- 3
+[1 -2] -- [1 -2]
+(count (quote (+ 1 2))) -- 3
+'a' -- "a"
+'\n' -- "\n"
+;; a comment right after a token is a delimiter too
+(+ 1 2);; trailing comment


### PR DESCRIPTION
## Summary

`['a:1]` parsed as two symbols, `a` and `1`, because nothing required a delimiter between tokens: a symbol literal ended at the colon (not in its character class) and `:1` was re-lexed as a keyword symbol. The same gap made `(+ 1'a)` an addition of `1` and `'a`, and `0Na` evaluate to the variable `Na`.

A symbol, keyword, name or number directly followed by a quote, a colon, or another name/number character is now a parse error naming the character:

```
['a:1]
error: parse: unexpected ':' directly after a token; separate tokens with whitespace
```

Brackets and strings remain self-delimiting on both sides, deliberately: `fn[x]`, `gds(take …)`, `(f x)(g y)` on one line and `(list "A""B")` all occur in the suite and still parse. A symbol that must contain a colon is built from a string, `(as 'symbol "a:1")`, as the reporter noted.

## Tests

`test/rfl/lang/parse_token_boundary.rfl` pins the rejected forms (`['a:1]`, `[a:1]`, `['a'b]`, `[1'a]`, `(nil?'a)`, `:a:b`, `0Na`, `1x`, `12:3x`) and the forms that must keep parsing (delimited symbols and keywords, `{a:1}`, adjacent strings, `fn[x]`, `1[2]`, `[1 2]3`, char and escape literals, a trailing comment as delimiter). `parse_branch_cov.rfl` had pinned the old re-lexing for `0N<name>` and malformed times; those lines now expect the parse error. Full `make test`: 3753 of 3753, no sanitizer output. Docs updated in `syntax.md`.

Closes #484

https://claude.ai/code/session_01J4QKJW3RbRP8TQoquJtARg
