### PR TITLE
feat(ipc): make the per-connection transmit backlog configurable

### DIFF
--- a/docs/docs/reference/all-functions.md
+++ b/docs/docs/reference/all-functions.md
@@ -726,7 +726,8 @@ TCP-based IPC for connecting to remote Rayforce instances. Uses binary serializa
 | `.ipc.open` | variadic | restricted | Open TCP connection to host:port (optional connect timeout in ms), returns handle | `(.ipc.open "localhost:5000" 2000)` |
 | `.ipc.close` | unary | restricted | Close an IPC connection handle | `(.ipc.close h)` |
 | `.ipc.send` | binary | restricted | Send a value over an IPC handle (sync request) | `(.ipc.send h "(sum (til 100))")` |
-| `.ipc.handle` | variadic | — | Current connection handle inside any `.ipc.on.*` hook, `-1` outside | `(.ipc.handle)` |
+| `.ipc.handle` | variadic | — | Current connection handle inside any `.ipc.on.*` hook, `-1` outside; given a live connection handle, that connection's transmit-queue view (`limit_bytes`, `limit_frames`, `queued_bytes`, `queued_frames`, `hwm_bytes`) | `(.ipc.handle)`, `(.ipc.handle h)` |
+| `.ipc.txlimit` | variadic | restricted | Transmit backlog policy: `()` reads the process default, `(bytes [frames])` sets it, `(h bytes frames)` overrides one connection; a frame that would exceed a connection's limit is refused and a multicast subscriber is dropped and closed | `(.ipc.txlimit 8388608 64)` |
 | `.ipc.on.open` | hook | user-settable | Fires after inbound connection completes handshake; arg = handle | `(set .ipc.on.open (fn [h] ...))` |
 | `.ipc.on.close` | hook | user-settable | Fires before inbound connection teardown; arg = handle | `(set .ipc.on.close (fn [h] ...))` |
 | `.ipc.on.sync` | hook | user-settable | Intercepts sync messages; return value becomes the response | `(set .ipc.on.sync (fn [m] (eval (parse m))))` |

--- a/docs/docs/storage/ipc.md
+++ b/docs/docs/storage/ipc.md
@@ -175,6 +175,20 @@ The query is assembled as data: while the `(list ...)` is built, `(quote price)`
 !!! note "Message types"
     `.ipc.send` uses synchronous messaging — it blocks until the server returns a result. For asynchronous (fire-and-forget) messaging, use `.ipc.post`, which sends without waiting for a response (the C equivalent is `ray_ipc_send_async`).
 
+### .ipc.txlimit
+
+Every connection queues outbound bytes the socket cannot take immediately (asynchronous `.ipc.post` sends and multicast fan-out). The queue is bounded per connection: a frame that would push the backlog past the limit is refused, and for a multicast subscriber that means it is dropped from the topic and closed, so a lagging consumer learns of the loss explicitly instead of silently missing updates.
+
+```lisp
+(.ipc.txlimit)                 ; {bytes:268435456 frames:0} — the process default
+(.ipc.txlimit 8388608)         ; 8 MiB per connection, frames unlimited
+(.ipc.txlimit 8388608 64)      ; at most 8 MiB or 64 queued frames, whichever first
+(.ipc.txlimit h 67108864 0)    ; one connection may hold 64 MiB
+(.ipc.handle h)                ; {handle limit_bytes limit_frames queued_bytes queued_frames hwm_bytes}
+```
+
+The default is 256 MiB with no frame cap; the minimum is 4 KiB, and `frames` of `0` means unlimited. Changing the default applies to every connection without an override, including ones already open. `.mc.stats` reports the default as `tx_limit_bytes` / `tx_limit_frames` and the largest backlog any connection has held as `tx_hwm_bytes`. `.ipc.txlimit` is restricted: it decides when a peer is dropped.
+
 ## Connection Hooks
 
 The server side exposes the inbound connection lifecycle to Rayfall code through five user-installable lambdas under `.ipc.on.*` — `open`, `close`, `sync`, `async`, and `auth` — plus the `(.ipc.handle)` accessor that returns the current connection's handle inside any hook. See [IPC Connection Hooks](ipc-hooks.md) for the full reference: signatures, install / clear semantics, the reserved-namespace carve-out, per-hook error handling, and the restricted-mode interaction.

--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -167,7 +167,12 @@ size_t ray_ipc_decompress(const uint8_t* src, size_t clen,
 #define RAY_IPC_PHASE_HEADER    1
 #define RAY_IPC_PHASE_PAYLOAD   2
 #define RAY_IPC_PHASE_CREDS     3
-#define RAY_IPC_TX_MAX_BYTES    (256LL * 1024LL * 1024LL)
+/* Hard cap on a single wire frame; the backlog a connection may hold is
+ * the separately configurable transmit limit (ray_ipc_tx_limit_set). */
+#define RAY_IPC_FRAME_MAX_BYTES (256LL * 1024LL * 1024LL)
+
+static int64_t g_tx_limit_bytes  = RAY_IPC_TX_DEFAULT_BYTES;
+static int64_t g_tx_limit_frames = 0;   /* unlimited */
 
 /* Constant-time comparison — prevents timing side-channel on password. */
 static bool ct_eq(const void* a, const void* b, size_t len) {
@@ -1606,7 +1611,7 @@ static ray_poll_frame_t* conn_frame_msg(ray_t* msg, uint8_t msgtype,
     };
 
     size_t total = sizeof(hdr) + send_len;
-    if (total > (size_t)RAY_IPC_TX_MAX_BYTES) {
+    if (total > (size_t)RAY_IPC_FRAME_MAX_BYTES) {
         ray_sys_free(send_buf);
         if (payload) ray_sys_free(payload);
         if (err_out) *err_out = RAY_ERR_IO;
@@ -1915,32 +1920,48 @@ ray_err_t ray_ipc_send_async(int64_t handle, ray_t* msg)
     return rc;
 }
 
-static int64_t conn_tx_pending(ray_selector_t* sel)
+static void conn_tx_limits(ray_selector_t* sel, int64_t* bytes, int64_t* frames)
 {
-    int64_t pending = 0;
+    *bytes  = (sel && sel->tx.limit_bytes  > 0) ? sel->tx.limit_bytes  : g_tx_limit_bytes;
+    *frames = (sel && sel->tx.limit_frames > 0) ? sel->tx.limit_frames : g_tx_limit_frames;
+}
+
+/* Bytes still to be written across the queue, and the number of queued
+ * frames.  Saturates at INT64_MAX rather than overflowing. */
+static int64_t conn_tx_pending(ray_selector_t* sel, int64_t* frames_out)
+{
+    int64_t pending = 0, frames = 0;
     for (ray_poll_buf_t* b = sel ? sel->tx.buf : NULL; b; b = b->next) {
         if (b->size > b->offset) {
             int64_t rem = b->size - b->offset;
-            if (pending > RAY_IPC_TX_MAX_BYTES - rem)
-                return RAY_IPC_TX_MAX_BYTES + 1;
-            pending += rem;
+            pending = (pending > INT64_MAX - rem) ? INT64_MAX : pending + rem;
+            frames++;
         }
     }
+    if (frames_out) *frames_out = frames;
     return pending;
 }
 
-static int conn_tx_append(ray_selector_t* sel, ray_poll_buf_t* frame)
+/* Admit `frame` to the queue if the configured backlog allows it. */
+static int conn_tx_append(ray_poll_t* poll, ray_selector_t* sel, ray_poll_buf_t* frame)
 {
     if (!sel || !frame || frame->offset > frame->size) return -1;
 
     int64_t add = frame->size - frame->offset;
-    int64_t pending = conn_tx_pending(sel);
-    if (add < 0 || pending < 0 || pending > RAY_IPC_TX_MAX_BYTES - add)
-        return -1;
+    int64_t limit_bytes, limit_frames;
+    conn_tx_limits(sel, &limit_bytes, &limit_frames);
+    int64_t frames = 0;
+    int64_t pending = conn_tx_pending(sel, &frames);
+    if (add < 0 || pending > limit_bytes - add) return -1;
+    if (limit_frames > 0 && frames + 1 > limit_frames) return -1;
 
     ray_poll_buf_t** tail = &sel->tx.buf;
     while (*tail) tail = &(*tail)->next;
     *tail = frame;
+
+    int64_t now = pending + add;
+    if (now > sel->tx.hwm_bytes) sel->tx.hwm_bytes = now;
+    if (poll && now > poll->tx_hwm_bytes) poll->tx_hwm_bytes = now;
     return 0;
 }
 
@@ -2006,7 +2027,7 @@ ray_err_t ray_ipc_try_send_frame(int64_t handle, ray_poll_frame_t* frame)
     if (rc == 0) {
         ray_poll_buf_free(node);
     } else if (rc > 0) {
-        if (conn_tx_append(sel, node) < 0) {
+        if (conn_tx_append(poll, sel, node) < 0) {
             ray_poll_buf_free(node);
             return RAY_ERR_IO;
         }
@@ -2015,6 +2036,48 @@ ray_err_t ray_ipc_try_send_frame(int64_t handle, ray_poll_frame_t* frame)
         ray_poll_buf_free(node);
     }
     return rc >= 0 ? RAY_OK : RAY_ERR_IO;
+}
+
+void ray_ipc_tx_limit_get(int64_t* bytes, int64_t* frames)
+{
+    if (bytes)  *bytes  = g_tx_limit_bytes;
+    if (frames) *frames = g_tx_limit_frames;
+}
+
+ray_err_t ray_ipc_tx_limit_set(int64_t bytes, int64_t frames)
+{
+    if (bytes < RAY_IPC_TX_MIN_BYTES || frames < 0) return RAY_ERR_DOMAIN;
+    g_tx_limit_bytes  = bytes;
+    g_tx_limit_frames = frames;
+    return RAY_OK;
+}
+
+ray_err_t ray_ipc_tx_limit_set_handle(int64_t handle, int64_t bytes, int64_t frames)
+{
+    if (bytes < RAY_IPC_TX_MIN_BYTES || frames < 0) return RAY_ERR_DOMAIN;
+    ray_poll_t* poll;
+    ray_selector_t* sel = conn_resolve(&poll, handle);
+    if (!sel) return RAY_ERR_IO;
+    sel->tx.limit_bytes  = bytes;
+    sel->tx.limit_frames = frames;
+    return RAY_OK;
+}
+
+ray_err_t ray_ipc_tx_info(int64_t handle, ray_ipc_tx_info_t* out)
+{
+    if (!out) return RAY_ERR_TYPE;
+    ray_poll_t* poll;
+    ray_selector_t* sel = conn_resolve(&poll, handle);
+    if (!sel) return RAY_ERR_IO;
+    conn_tx_limits(sel, &out->limit_bytes, &out->limit_frames);
+    out->queued_bytes = conn_tx_pending(sel, &out->queued_frames);
+    out->hwm_bytes    = sel->tx.hwm_bytes;
+    return RAY_OK;
+}
+
+int64_t ray_ipc_tx_hwm_bytes(ray_poll_t* poll)
+{
+    return poll ? poll->tx_hwm_bytes : 0;
 }
 
 ray_err_t ray_ipc_try_send_async(int64_t handle, ray_t* msg)

--- a/src/core/ipc.h
+++ b/src/core/ipc.h
@@ -141,6 +141,28 @@ ray_err_t ray_ipc_try_send_async(int64_t handle, ray_t* msg);
 ray_err_t ray_ipc_frame_async(ray_t* msg, ray_poll_frame_t** out);
 ray_err_t ray_ipc_try_send_frame(int64_t handle, ray_poll_frame_t* frame);
 
+/* Transmit backlog (#486).  A connection's queue admits a frame only while
+ * the bytes and frames already queued stay under its limit; a frame that
+ * would exceed it is refused (RAY_ERR_IO), which multicast turns into an
+ * explicit drop-and-close of that subscriber.  The process default applies
+ * to every connection without an override.  frames == 0 means unlimited. */
+#define RAY_IPC_TX_DEFAULT_BYTES  (256LL * 1024LL * 1024LL)
+#define RAY_IPC_TX_MIN_BYTES      4096LL
+
+typedef struct {
+    int64_t limit_bytes;    /* effective limit on this connection */
+    int64_t limit_frames;
+    int64_t queued_bytes;   /* backlog right now */
+    int64_t queued_frames;
+    int64_t hwm_bytes;      /* largest backlog ever queued here */
+} ray_ipc_tx_info_t;
+
+void      ray_ipc_tx_limit_get(int64_t* bytes, int64_t* frames);
+ray_err_t ray_ipc_tx_limit_set(int64_t bytes, int64_t frames);       /* process default */
+ray_err_t ray_ipc_tx_limit_set_handle(int64_t handle, int64_t bytes, int64_t frames);
+ray_err_t ray_ipc_tx_info(int64_t handle, ray_ipc_tx_info_t* out);   /* RAY_ERR_IO: not a live connection */
+int64_t   ray_ipc_tx_hwm_bytes(ray_poll_t* poll);
+
 /* Remote-REPL helper: send a SYNC message with RAY_IPC_FLAG_VERBOSE
  * set, returning a 2-element list [captured_str, result] where
  * captured_str is whatever the server's eval wrote to stdout/stderr

--- a/src/core/mcast.c
+++ b/src/core/mcast.c
@@ -343,8 +343,8 @@ ray_t* ray_mcast_stats(ray_poll_t* poll) {
             subs += mc->topics[i].n_subs;
     }
 
-    ray_t* keys = ray_sym_vec_new(RAY_SYM_W64, 6);
-    ray_t* vals = ray_list_new(6);
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W64, 9);
+    ray_t* vals = ray_list_new(9);
     if (!keys || RAY_IS_ERR(keys) || !vals || RAY_IS_ERR(vals)) {
         if (keys && !RAY_IS_ERR(keys)) ray_release(keys);
         if (vals && !RAY_IS_ERR(vals)) ray_release(vals);
@@ -376,6 +376,21 @@ ray_t* ray_mcast_stats(ray_poll_t* poll) {
     k = ray_sym_intern("framed", 6);      keys = ray_vec_append(keys, &k);
     if (RAY_IS_ERR(keys)) { ray_release(vals); return keys; }
     v = ray_i64(mc ? mc->framed : 0);     vals = ray_list_append(vals, v); ray_release(v);
+    if (RAY_IS_ERR(vals)) { ray_release(keys); return vals; }
+    /* Backlog policy in force and the largest backlog seen (#486). */
+    int64_t lim_bytes = 0, lim_frames = 0;
+    ray_ipc_tx_limit_get(&lim_bytes, &lim_frames);
+    k = ray_sym_intern("tx_limit_bytes", 14); keys = ray_vec_append(keys, &k);
+    if (RAY_IS_ERR(keys)) { ray_release(vals); return keys; }
+    v = ray_i64(lim_bytes);               vals = ray_list_append(vals, v); ray_release(v);
+    if (RAY_IS_ERR(vals)) { ray_release(keys); return vals; }
+    k = ray_sym_intern("tx_limit_frames", 15); keys = ray_vec_append(keys, &k);
+    if (RAY_IS_ERR(keys)) { ray_release(vals); return keys; }
+    v = ray_i64(lim_frames);              vals = ray_list_append(vals, v); ray_release(v);
+    if (RAY_IS_ERR(vals)) { ray_release(keys); return vals; }
+    k = ray_sym_intern("tx_hwm_bytes", 12); keys = ray_vec_append(keys, &k);
+    if (RAY_IS_ERR(keys)) { ray_release(vals); return keys; }
+    v = ray_i64(ray_ipc_tx_hwm_bytes(poll)); vals = ray_list_append(vals, v); ray_release(v);
     if (RAY_IS_ERR(vals)) { ray_release(keys); return vals; }
     return ray_dict_new(keys, vals);
 }

--- a/src/core/poll.h
+++ b/src/core/poll.h
@@ -79,7 +79,13 @@ struct ray_selector {
     ray_event_fn     error_fn;
     ray_poll_data_fn      data_fn;
     struct { ray_poll_buf_t* buf; ray_io_fn recv_fn; ray_read_fn read_fn; } rx;
-    struct { ray_poll_buf_t* buf; ray_io_fn send_fn; }                      tx;
+    struct {
+        ray_poll_buf_t* buf;
+        ray_io_fn       send_fn;
+        int64_t         limit_bytes;   /* per-connection backlog override; 0 = process default */
+        int64_t         limit_frames;  /* idem; 0 = process default (which may be unlimited) */
+        int64_t         hwm_bytes;     /* largest backlog ever queued on this connection */
+    } tx;
 };
 
 /* ===== Registration ===== */
@@ -115,6 +121,7 @@ struct ray_poll {
     bool             restricted;       /* true if -U (read-only IPC mode) */
     void*            timers;           /* opaque ray_timers_t*; lazily allocated */
     void*            mcast;            /* opaque ray_mcast_t*; lazily allocated */
+    int64_t          tx_hwm_bytes;     /* largest backlog ever queued on any connection */
 };
 
 /* ===== API ===== */

--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -3400,6 +3400,9 @@ static void ray_register_builtins(void) {
     /* Current connection handle inside any `.ipc.on.*` hook, -1 otherwise.
      * Variadic for the `(.ipc.handle)` / `(.ipc.handle 0)` convention. */
     register_vary(  ".ipc.handle", RAY_FN_NONE,       ray_ipc_handle_fn);
+    /* Transmit backlog policy: read, set the process default, or override
+     * one connection.  Privileged — it decides when a peer is dropped. */
+    register_vary(  ".ipc.txlimit", RAY_FN_RESTRICTED, ray_ipc_txlimit_fn);
 
     /* Multicast/pub-sub over IPC.  Subscriptions are allowed under
      * restricted IPC; publishing stays privileged. */

--- a/src/lang/internal.h
+++ b/src/lang/internal.h
@@ -645,6 +645,7 @@ ray_t* ray_hclose_fn(ray_t* x);
 ray_t* ray_hsend_fn(ray_t* handle, ray_t* msg);
 ray_t* ray_hpost_fn(ray_t* handle, ray_t* msg);
 ray_t* ray_ipc_handle_fn(ray_t** args, int64_t n);
+ray_t* ray_ipc_txlimit_fn(ray_t** args, int64_t n);
 ray_t* ray_mc_sub_fn(ray_t** args, int64_t n);
 ray_t* ray_mc_unsub_fn(ray_t* topic);
 ray_t* ray_mc_pub_fn(ray_t* topic, ray_t* payload);

--- a/src/ops/system.c
+++ b/src/ops/system.c
@@ -1518,9 +1518,100 @@ ray_t* ray_hpost_fn(ray_t* handle, ray_t* msg) {
  * hook, or -1 outside any hook.  Registered variadic so both
  * `(.ipc.handle)` (no args) and `(.ipc.handle 0)` (one arg, ignored)
  * work — matches the convention of `.sys.gc` / `.sys.info`. */
+/* Build {handle limit_bytes limit_frames queued_bytes queued_frames hwm_bytes}
+ * for a live connection. */
+static ray_t* ipc_tx_info_dict(int64_t h, const ray_ipc_tx_info_t* ti) {
+    static const char* const names[6] = { "handle", "limit_bytes", "limit_frames",
+                                          "queued_bytes", "queued_frames", "hwm_bytes" };
+    int64_t vals_i[6] = { h, ti->limit_bytes, ti->limit_frames,
+                          ti->queued_bytes, ti->queued_frames, ti->hwm_bytes };
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W64, 6);
+    ray_t* vals = ray_list_new(6);
+    if (!keys || RAY_IS_ERR(keys) || !vals || RAY_IS_ERR(vals)) {
+        if (keys && !RAY_IS_ERR(keys)) ray_release(keys);
+        if (vals && !RAY_IS_ERR(vals)) ray_release(vals);
+        return ray_error("oom", NULL);
+    }
+    for (int i = 0; i < 6; i++) {
+        int64_t k = ray_sym_intern(names[i], strlen(names[i]));
+        keys = ray_vec_append(keys, &k);
+        if (RAY_IS_ERR(keys)) { ray_release(vals); return keys; }
+        ray_t* v = make_i64(vals_i[i]);
+        vals = ray_list_append(vals, v); ray_release(v);
+        if (RAY_IS_ERR(vals)) { ray_release(keys); return vals; }
+    }
+    return ray_dict_new(keys, vals);
+}
+
+static bool ipc_arg_i64(ray_t* x, int64_t* out) {
+    if (!x || !ray_is_atom(x)) return false;
+    if (x->type == -RAY_I64) { *out = x->i64; return true; }
+    if (x->type == -RAY_I32) { *out = x->i32; return true; }
+    return false;
+}
+
+/* `(.ipc.handle)` (no args) and `(.ipc.handle 0)` (one arg, ignored)
+ * answer the current connection's handle, -1 outside a hook.  Given a
+ * LIVE connection handle, `(.ipc.handle h)` instead returns that
+ * connection's transmit-queue view (#486): its effective backlog limits,
+ * the bytes and frames queued right now, and its high-water mark. */
 ray_t* ray_ipc_handle_fn(ray_t** args, int64_t n) {
-    (void)args; (void)n;
+    int64_t h;
+    if (n == 1 && ipc_arg_i64(args[0], &h)) {
+        ray_ipc_tx_info_t ti;
+        if (ray_ipc_tx_info(h, &ti) == RAY_OK) return ipc_tx_info_dict(h, &ti);
+    }
     return make_i64(ray_ipc_current_handle());
+}
+
+static ray_t* ipc_txlimit_dict(int64_t bytes, int64_t frames) {
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W64, 2);
+    ray_t* vals = ray_list_new(2);
+    if (!keys || RAY_IS_ERR(keys) || !vals || RAY_IS_ERR(vals)) {
+        if (keys && !RAY_IS_ERR(keys)) ray_release(keys);
+        if (vals && !RAY_IS_ERR(vals)) ray_release(vals);
+        return ray_error("oom", NULL);
+    }
+    int64_t k = ray_sym_intern("bytes", 5);  keys = ray_vec_append(keys, &k);
+    if (RAY_IS_ERR(keys)) { ray_release(vals); return keys; }
+    k = ray_sym_intern("frames", 6);         keys = ray_vec_append(keys, &k);
+    if (RAY_IS_ERR(keys)) { ray_release(vals); return keys; }
+    ray_t* v = make_i64(bytes);  vals = ray_list_append(vals, v); ray_release(v);
+    if (RAY_IS_ERR(vals)) { ray_release(keys); return vals; }
+    v = make_i64(frames);        vals = ray_list_append(vals, v); ray_release(v);
+    if (RAY_IS_ERR(vals)) { ray_release(keys); return vals; }
+    return ray_dict_new(keys, vals);
+}
+
+/* (.ipc.txlimit)                 -> {bytes frames}: the process default
+ * (.ipc.txlimit bytes [frames])  -> set the default; frames 0 = unlimited
+ * (.ipc.txlimit h bytes frames)  -> override one live connection
+ * Every form answers with the limits now in force for its target. */
+ray_t* ray_ipc_txlimit_fn(ray_t** args, int64_t n) {
+    if (n > 3) return ray_error("rank", ".ipc.txlimit takes 0 to 3 arguments, got %lld", (long long)n);
+    int64_t a[3] = {0, 0, 0};
+    for (int64_t i = 0; i < n; i++)
+        if (!ipc_arg_i64(args[i], &a[i]))
+            return ray_error("type", ".ipc.txlimit expects integer arguments, got %s", ray_type_name(args[i]->type));
+    int64_t bytes, frames;
+    if (n == 0) {
+        ray_ipc_tx_limit_get(&bytes, &frames);
+        return ipc_txlimit_dict(bytes, frames);
+    }
+    if (n == 3) {
+        ray_err_t rc = ray_ipc_tx_limit_set_handle(a[0], a[1], a[2]);
+        if (rc == RAY_ERR_DOMAIN)
+            return ray_error("domain", ".ipc.txlimit: bytes must be >= %lld and frames >= 0", (long long)RAY_IPC_TX_MIN_BYTES);
+        if (rc != RAY_OK)
+            return ray_error("domain", ".ipc.txlimit: %lld is not a live connection handle", (long long)a[0]);
+        return ipc_txlimit_dict(a[1], a[2]);
+    }
+    ray_ipc_tx_limit_get(&bytes, &frames);
+    bytes = a[0];
+    if (n == 2) frames = a[1];
+    if (ray_ipc_tx_limit_set(bytes, frames) != RAY_OK)
+        return ray_error("domain", ".ipc.txlimit: bytes must be >= %lld and frames >= 0", (long long)RAY_IPC_TX_MIN_BYTES);
+    return ipc_txlimit_dict(bytes, frames);
 }
 
 ray_t* ray_mc_sub_fn(ray_t** args, int64_t n) {

--- a/test/rfl/system/ipc_txlimit.rfl
+++ b/test/rfl/system/ipc_txlimit.rfl
@@ -1,0 +1,22 @@
+;; ipc_txlimit.rfl — the per-connection transmit backlog is configurable
+;; at runtime (#486).  (.ipc.txlimit) reads the process default,
+;; (.ipc.txlimit bytes [frames]) sets it, (.ipc.txlimit h bytes frames)
+;; overrides one live connection.  The overflow behaviour itself is
+;; exercised with real sockets in test/test_mcast.c.
+(at (.ipc.txlimit) 'bytes) -- 268435456
+(at (.ipc.txlimit) 'frames) -- 0
+(at (.ipc.txlimit 1048576) 'bytes) -- 1048576
+(at (.ipc.txlimit 1048576) 'frames) -- 0
+(at (.ipc.txlimit 2097152 8) 'frames) -- 8
+(at (.ipc.txlimit) 'bytes) -- 2097152
+;; bounds: at least one 4 KiB frame, frames >= 0 (0 = unlimited)
+(.ipc.txlimit 0) !- domain
+(.ipc.txlimit 1024) !- domain
+(.ipc.txlimit 65536 -1) !- domain
+(.ipc.txlimit "x") !- type
+(.ipc.txlimit 1 2 3 4) !- rank
+;; a per-connection override needs a live connection handle
+(.ipc.txlimit 12345 65536 0) !- domain
+(.ipc.handle 12345) -- -1
+;; restore the built-in default
+(at (.ipc.txlimit 268435456 0) 'bytes) -- 268435456

--- a/test/rfl/system/reserved_namespace.rfl
+++ b/test/rfl/system/reserved_namespace.rfl
@@ -27,8 +27,8 @@
 ;; getenv, setenv
 (count .fs) -- 2
 ;; size, list
-(count .ipc) -- 5
-;; open, close, send, post, handle
+(count .ipc) -- 6
+;; open, close, send, post, handle, txlimit
 (count .csv) -- 4
 ;; read, splayed, parted, write
 ;; .db.* — three-level reserved namespace for storage I/O.  The

--- a/test/test_mcast.c
+++ b/test/test_mcast.c
@@ -764,6 +764,136 @@ static test_result_t test_mcast_shared_frame_across_subscribers(void) {
     PASS();
 }
 
+/* Configurable transmit backlog (#486): a subscriber whose queue would
+ * exceed the process default is dropped and closed at admission, while a
+ * subscriber with a per-connection override large enough to hold the
+ * frame keeps receiving.  The active limits and the high-water mark are
+ * readable from .mc.stats and per handle from (.ipc.handle h). */
+static test_result_t test_mcast_txlimit_overflow_disconnects(void) {
+    ray_t* r = ray_eval_str(
+        "(set _mc_count 0)"
+        "(set _mc_close_count 0)"
+        "(set _mc_handles [])"
+        "(set upd (fn [topic seq payload] (set _mc_count (+ _mc_count 1))))"
+        "(set .ipc.on.open (fn [h] (set _mc_handles (concat _mc_handles h))))"
+        "(set .ipc.on.close (fn [h] (set _mc_close_count (+ _mc_close_count 1))))");
+    TEST_ASSERT_NOT_NULL(r);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(r));
+    if (r != RAY_NULL_OBJ) ray_release(r);
+
+    ray_poll_t* poll;
+    ray_vm_t* vm;
+    uint16_t port;
+    ray_thread_t tid;
+    test_result_t sr = start_server(&poll, &port, &vm, &tid);
+    if (sr.status != TEST_PASS) return sr;
+
+    int64_t h1 = ray_ipc_connect("127.0.0.1", port, NULL, NULL, 0);
+    int64_t h2 = ray_ipc_connect("127.0.0.1", port, NULL, NULL, 0);
+    int64_t hp = ray_ipc_connect("127.0.0.1", port, NULL, NULL, 0);
+    TEST_ASSERT((h1) >= (0), "h1 connected");
+    TEST_ASSERT((h2) >= (0), "h2 connected");
+    TEST_ASSERT((hp) >= (0), "publisher connected");
+    for (int i = 0; i < 2; i++) {
+        ray_t* msg = ray_str("(.mc.sub \"cap\" null)", strlen("(.mc.sub \"cap\" null)"));
+        ray_t* sub = ray_ipc_send(i == 0 ? h1 : h2, msg);
+        ray_release(msg);
+        TEST_ASSERT_NOT_NULL(sub);
+        TEST_ASSERT_FALSE(RAY_IS_ERR(sub));
+        ray_release(sub);
+    }
+
+    ray_t* server_hs = ray_env_get(ray_sym_intern("_mc_handles", 11));
+    TEST_ASSERT_NOT_NULL(server_hs);
+    TEST_ASSERT((ray_len(server_hs)) >= (2), "two server-side subscriber handles");
+    int64_t s1 = ((int64_t*)ray_data(server_hs))[0];
+    int64_t s2 = ((int64_t*)ray_data(server_hs))[1];
+#ifndef RAY_OS_WINDOWS
+    for (int i = 0; i < 2; i++) {
+        ray_selector_t* ssel = ray_poll_get(poll, i == 0 ? s1 : s2);
+        TEST_ASSERT_NOT_NULL(ssel);
+        int sndbuf = 4096;
+        setsockopt((ray_sock_t)ssel->fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf));
+    }
+#endif
+
+    /* Process default: 64 KiB.  h2 alone may hold 4 MiB. */
+    ray_t* msg = ray_str("(.ipc.txlimit 65536 0)", strlen("(.ipc.txlimit 65536 0)"));
+    ray_t* lim = ray_ipc_send(hp, msg);
+    ray_release(msg);
+    TEST_ASSERT_NOT_NULL(lim);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(lim));
+    TEST_ASSERT_EQ_I(dict_i64(lim, "bytes"), 65536);
+    TEST_ASSERT_EQ_I(dict_i64(lim, "frames"), 0);
+    ray_release(lim);
+    char src[96];
+    int n = snprintf(src, sizeof(src), "(.ipc.txlimit %lld 4194304 0)", (long long)s2);
+    TEST_ASSERT((n) > (0) && (size_t)n < sizeof(src), "format override");
+    msg = ray_str(src, (size_t)n);
+    lim = ray_ipc_send(hp, msg);
+    ray_release(msg);
+    TEST_ASSERT_NOT_NULL(lim);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(lim));
+    TEST_ASSERT_EQ_I(dict_i64(lim, "bytes"), 4194304);
+    ray_release(lim);
+
+    /* ~800 KiB on the wire: over h1's 64 KiB, under h2's 4 MiB. */
+    const char* pub_src = "(.mc.pub \"cap\" (+ (* (til 100000) 1103515245) 12345))";
+    msg = ray_str(pub_src, strlen(pub_src));
+    ray_t* pub = ray_ipc_send(hp, msg);
+    ray_release(msg);
+    TEST_ASSERT_NOT_NULL(pub);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(pub));
+    ray_release(pub);
+
+    TEST_ASSERT_TRUE(pump_until_env_i64_at_least("_mc_count", 9, 1, 2000));
+    TEST_ASSERT_TRUE(pump_until_env_i64_at_least("_mc_close_count", 15, 1, 2000));
+    ray_t* c = ray_env_get(ray_sym_intern("_mc_count", 9));
+    TEST_ASSERT_NOT_NULL(c);
+    TEST_ASSERT_EQ_I(c->i64, 1);              /* only h2 received it */
+
+    msg = ray_str("(.mc.stats)", strlen("(.mc.stats)"));
+    ray_t* st = ray_ipc_send(hp, msg);
+    ray_release(msg);
+    TEST_ASSERT_NOT_NULL(st);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(st));
+    TEST_ASSERT_EQ_I(dict_i64(st, "subscriptions"), 1);
+    TEST_ASSERT_EQ_I(dict_i64(st, "delivered"), 1);
+    TEST_ASSERT_EQ_I(dict_i64(st, "dropped"), 1);
+    TEST_ASSERT_EQ_I(dict_i64(st, "tx_limit_bytes"), 65536);
+    TEST_ASSERT_EQ_I(dict_i64(st, "tx_limit_frames"), 0);
+    TEST_ASSERT((dict_i64(st, "tx_hwm_bytes")) > (65536), "the override let a larger backlog form");
+    TEST_ASSERT((dict_i64(st, "tx_hwm_bytes")) <= (4194304), "never past the override");
+    ray_release(st);
+
+    n = snprintf(src, sizeof(src), "(.ipc.handle %lld)", (long long)s2);
+    msg = ray_str(src, (size_t)n);
+    ray_t* info = ray_ipc_send(hp, msg);
+    ray_release(msg);
+    TEST_ASSERT_NOT_NULL(info);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(info));
+    TEST_ASSERT_EQ_I(dict_i64(info, "handle"), s2);
+    TEST_ASSERT_EQ_I(dict_i64(info, "limit_bytes"), 4194304);
+    TEST_ASSERT_EQ_I(dict_i64(info, "limit_frames"), 0);
+    TEST_ASSERT((dict_i64(info, "hwm_bytes")) > (65536), "per-handle high-water mark");
+    TEST_ASSERT((dict_i64(info, "queued_bytes")) >= (0), "queue drained or draining");
+    ray_release(info);
+
+    /* Restore the process default so later tests see the built-in limit. */
+    msg = ray_str("(.ipc.txlimit 268435456 0)", strlen("(.ipc.txlimit 268435456 0)"));
+    lim = ray_ipc_send(hp, msg);
+    ray_release(msg);
+    TEST_ASSERT_NOT_NULL(lim);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(lim));
+    ray_release(lim);
+
+    ray_ipc_close(h1);
+    ray_ipc_close(h2);
+    ray_ipc_close(hp);
+    stop_server(poll, port, vm, tid);
+    PASS();
+}
+
 static test_result_t test_mcast_failed_send_defers_close(void) {
     ray_t* r = ray_eval_str(
         "(set _mc_count 0)"
@@ -975,5 +1105,6 @@ const test_entry_t mcast_entries[] = {
     { "mcast/sync_reply_after_queued",    test_mcast_sync_reply_after_queued_frame, mcast_setup, mcast_teardown },
     { "mcast/failed_send_defers_close",   test_mcast_failed_send_defers_close,   mcast_setup, mcast_teardown },
     { "mcast/shared_frame_across_subs",   test_mcast_shared_frame_across_subscribers, mcast_setup, mcast_teardown },
+    { "mcast/txlimit_overflow_disconnects", test_mcast_txlimit_overflow_disconnects, mcast_setup, mcast_teardown },
     { NULL, NULL, NULL, NULL },
 };


### PR DESCRIPTION
## Summary

Stacked on #490 (shared frames); the diff shown here includes that PR until it merges.

The per-connection transmit backlog was the compiled-in 256 MiB `RAY_IPC_TX_MAX_BYTES`. It is now a process default with a per-connection override, checked at queue admission:

```lisp
(.ipc.txlimit)                 ; {bytes:268435456 frames:0}
(.ipc.txlimit 8388608 64)      ; default: 8 MiB or 64 frames per connection
(.ipc.txlimit h 67108864 0)    ; one connection may hold 64 MiB
(.ipc.handle h)                ; {handle limit_bytes limit_frames queued_bytes queued_frames hwm_bytes}
```

- A frame that would exceed the effective limit is refused; a multicast subscriber is then dropped from the topic and closed, as today. Nothing is dropped silently.
- `.mc.stats` gains `tx_limit_bytes`, `tx_limit_frames`, `tx_hwm_bytes` (largest backlog any connection has held); `(.ipc.handle h)` gives the per-connection view, and keeps its old meaning for `()` and `(0)`.
- Minimum 4 KiB, `frames` 0 = unlimited, default unchanged. `.ipc.txlimit` is restricted. The old constant remains only as a hard cap on a single wire frame.
- Not included: a maximum age for the oldest queued frame. It needs a timestamp per node and a timer to enforce it while a connection is idle; worth its own change if wanted.

## Tests

`mcast/txlimit_overflow_disconnects`: default set to 64 KiB, one subscriber overridden to 4 MiB, both with 4 KiB socket buffers; an ~800 KiB publication drops and closes the first (the `.ipc.on.close` hook fires, `dropped` = 1) while the second receives it, and the stats and per-handle views show the limits and a high-water mark between the two. `test/rfl/system/ipc_txlimit.rfl` covers the argument forms and bounds. Full `make test`: 3757 of 3757, no sanitizer output. Docs in `storage/ipc.md` and `all-functions.md`.

Closes #486

https://claude.ai/code/session_01J4QKJW3RbRP8TQoquJtARg
