### PR TITLE
fix(store): reject calendar-impossible date partition directories

### DIFF
--- a/src/store/part.c
+++ b/src/store/part.c
@@ -33,6 +33,7 @@
 #include "store/splay.h"
 #include "table/sym.h"
 #include "table/domain.h"
+#include "lang/cal.h"   /* MONTHDAYS, date_leap_year — calendar-date validation */
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,8 +41,11 @@
 #include <dirent.h>
 #include <sys/stat.h>
 
-/* Validate YYYY.MM.DD format: exactly 10 chars, dots at pos 4/7,
- * month 01-12, day 01-31. */
+/* Validate YYYY.MM.DD format: exactly 10 chars, dots at pos 4/7, and a real
+ * calendar date.  A blanket day 01-31 check let calendar-impossible names like
+ * 2024.02.31 through; parse_date_dir then silently normalised them into a
+ * different real day (2024.03.02) — a mislabelled partition key.  Validate the
+ * day against the leap-aware length of its month instead. */
 static bool is_date_dir(const char* name) {
     if (strlen(name) != 10) return false;
     if (name[4] != '.' || name[7] != '.') return false;
@@ -49,9 +53,14 @@ static bool is_date_dir(const char* name) {
         if (i == 4 || i == 7) continue;
         if (name[i] < '0' || name[i] > '9') return false;
     }
+    int year  = (name[0]-'0')*1000 + (name[1]-'0')*100 +
+                (name[2]-'0')*10   + (name[3]-'0');
     int month = (name[5] - '0') * 10 + (name[6] - '0');
     int day   = (name[8] - '0') * 10 + (name[9] - '0');
-    return month >= 1 && month <= 12 && day >= 1 && day <= 31;
+    if (month < 1 || month > 12 || day < 1) return false;
+    int leap = date_leap_year(year);
+    int dim  = (int)(MONTHDAYS[leap][month] - MONTHDAYS[leap][month - 1]);
+    return day <= dim;
 }
 
 /* Check if string is a pure integer (digits only, possibly with leading minus). */

--- a/test/rfl/system/part.rfl
+++ b/test/rfl/system/part.rfl
@@ -393,5 +393,35 @@
 (at (at (at Rnested 'n) 1) 0) -- 9.0
 (.sys.exec "rm -rf /tmp/rfl_part_nested")
 
+;; ────── calendar-impossible date dirs are not date partitions ──────
+;; is_date_dir accepted any day 01-31, so a shaped-but-impossible dir like
+;; 2024.02.31 classified as RAY_MC_DATE and parse_date_dir silently normalised
+;; it to a real but WRONG day (2024.03.02).  It must fail date validation: the
+;; set then drops to RAY_MC_SYM (partition-key column 'part, keys kept literal)
+;; instead of masquerading as a mislabelled date.
+(.sys.exec "rm -rf /tmp/rfl_part_badcal /tmp/rfl_part_leap")
+(set BC-A (table [v] (list [1 2 3])))
+(set BC-B (table [v] (list [4 5])))
+(.db.splayed.set "/tmp/rfl_part_badcal/2024.02.28/t/" BC-A)
+(.db.splayed.set "/tmp/rfl_part_badcal/2024.02.31/t/" BC-B)
+(set Pbad (.db.parted.get "/tmp/rfl_part_badcal/" 't))
+;; not 'date: the impossible Feb 31 defeats the all-date classification
+(first (key Pbad)) -- 'part
+(key Pbad) -- ['part 'v]
+(count Pbad) -- 5
+(sum (at Pbad 'v)) -- 15
+;; The impossible day is kept LITERAL, not remapped: the partition-key column
+;; holds the exact directory names.  On dev this column is 'date and Feb 31's
+;; rows read back 2024.03.02 — the silent mislabel this fix removes.
+(at Pbad 'part) -- (as 'sym ["2024.02.28" "2024.02.28" "2024.02.28" "2024.02.31" "2024.02.31"])
+;; No over-rejection: 2024 is a leap year, so the real leap day 2024.02.29
+;; still classifies as a date partition ('date column).
+(set LP (table [v] (list [7 8])))
+(.db.splayed.set "/tmp/rfl_part_leap/2024.02.29/t/" LP)
+(set Pleap (.db.parted.get "/tmp/rfl_part_leap/" 't))
+(first (key Pleap)) -- 'date
+(sum (at Pleap 'v)) -- 15
+(.sys.exec "rm -rf /tmp/rfl_part_badcal /tmp/rfl_part_leap")
+
 ;; ────────────── teardown ──────────────
 (.sys.exec "rm -rf /tmp/rfl_part_date /tmp/rfl_part_int /tmp/rfl_part_sym /tmp/rfl_part_single /tmp/rfl_part_empty /tmp/rfl_part_missing /tmp/rfl_part_three /tmp/rfl_part_cd /tmp/rfl_part_cd_sym /tmp/rfl_part_minute /tmp/rfl_part_like /tmp/rfl_part_mc /tmp/rfl_part_mb")


### PR DESCRIPTION
## How it looks from the user's side

A partitioned table on disk has a directory whose name is shaped like a date but is not a real one — `2024.02.31` (February has no 31st) — next to a valid one:

    db/2024.02.28/t/
    db/2024.02.31/t/

Loading it with `(.db.parted.get "db/" 't)`:

**Before** — `is_date_dir` accepts any day 01–31, so the impossible name is classified as a date partition and `parse_date_dir` normalises it through the civil-calendar formula into a *different real day*. The partition key silently points at the wrong date:

    partition-key column : date
    schema               : [date v]
    partition-key values : [2024.02.28 2024.02.28 2024.02.28 2024.03.02 2024.03.02]
                                                              ^^^^^^^^^^ 2024.02.31 became 2024.03.02

**After** — the impossible day fails date validation, so the set is not treated as date-partitioned; the directory name is kept literal instead of masquerading as a wrong date:

    partition-key column : part
    schema               : [part v]
    partition-key values : [2024.02.28 2024.02.28 2024.02.28 2024.02.31 2024.02.31]

A real leap day (`2024.02.29`) still classifies as a date, so valid dates are unaffected.

## Root cause

`is_date_dir` gated partition directory names with a blanket `day 01–31` check:

    return month >= 1 && month <= 12 && day >= 1 && day <= 31;

so a shaped-but-impossible name like `2024.02.31` passed as a date. `parse_date_dir` then ran it through the civil-calendar formula, which normalises the overflow into a different real day (2024-03-02), silently mislabelling that partition's key.

## Fix

Validate the day against the leap-aware length of its month, reusing `cal.h`'s `MONTHDAYS` / `date_leap_year` — the shared calendar tables the engine already uses for date decode. An impossible name now fails date classification, so `infer_mc_type` falls through to symbol partitioning and the directory name is kept literal.

## Tests

`part.rfl` adds a mixed valid/impossible date set (`2024.02.28` + `2024.02.31`) and asserts it classifies as `'part` (sym) with the partition keys kept **literal** — not `'date` with `2024.02.31` silently read back as `2024.03.02` — plus a real leap day (`2024.02.29`) that must still classify as `'date` so the tightened check does not over-reject. Full `make test`: 3753/3754 pass (1 pre-existing skip).
