### PR TITLE
fix(types): index ray_type_sizes by uint8_t to avoid an out-of-bounds read on atom tags

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -39,8 +39,12 @@
 /* Type sizes lookup table (defined in types.c) */
 extern const uint8_t ray_type_sizes[256];
 
-/* Element size for a given type tag */
-#define ray_elem_size(t)  (ray_type_sizes[(t)])
+/* Element size for a given type tag.  Cast to uint8_t so a negative (atom)
+ * type tag indexes the upper, zero-filled half of the 256-entry table rather
+ * than reading out of bounds — ray_type_sizes[(int8_t)-1] is an OOB read (UB).
+ * Non-vector/atom tags legitimately have no element size and read back 0, and
+ * this matches the (uint8_t) indexing already used in vec.c. */
+#define ray_elem_size(t)  (ray_type_sizes[(uint8_t)(t)])
 
 static inline int64_t ray_cast_f64_to_i64_null(double v) {
     if (v != v) return NULL_I64;

--- a/test/test_types.c
+++ b/test/test_types.c
@@ -67,6 +67,16 @@ static test_result_t test_elem_size_macro(void) {
     TEST_ASSERT_EQ_U(ray_elem_size(RAY_BOOL), 1);
     TEST_ASSERT_EQ_U(ray_elem_size(RAY_GUID), 16);
 
+    /* Negative (atom) type tags must index the zero-filled upper half of the
+     * 256-entry table, not read out of bounds: ray_type_sizes[(int8_t)-1] is
+     * an OOB read (UBSan `index -1 out of bounds`).  Atoms carry no element
+     * size in this table, so the well-defined answer is 0.  -RAY_BOOL == -1 is
+     * the tag that hit this via ray_sym_elem_size in the query path. */
+    TEST_ASSERT_EQ_U(ray_elem_size((int8_t)-RAY_BOOL), 0);
+    TEST_ASSERT_EQ_U(ray_elem_size((int8_t)-RAY_I64), 0);
+    TEST_ASSERT_EQ_U(ray_elem_size((int8_t)-RAY_SYM), 0);
+    TEST_ASSERT_EQ_U(ray_elem_size((int8_t)-1), 0);
+
     PASS();
 }
 


### PR DESCRIPTION
## How it looks from the user's side

`ray_elem_size(tag)` indexes a `const uint8_t[256]` table by the type tag. Atom tags are **negative** (a BOOL atom is `-RAY_BOOL == -1`), and the SYM-column read path reaches the macro through `ray_sym_elem_size`, which falls through to `ray_elem_size` for any non-SYM tag. So for an atom tag the lookup is `ray_type_sizes[-1]` — a read one element *before* the table.

On a sanitizer build (the debug / CI flavour) it is caught as undefined behaviour:

**Before**

    runtime error: index -1 out of bounds for type 'const uint8_t[256]'
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/core/types.h

**After** — the tag reads back a well-defined 0 (atoms carry no element size in this table), no out-of-bounds access:

    types/elem_size_macro                                 PASS
    === full make test: 3753 of 3754 passed (1 skipped, 0 failed) ===

In a release build there is no diagnostic, but the read still lands out of bounds and returns whatever byte precedes the table — a garbage element size that then feeds `memcpy` / allocation sizing on that path.

## Root cause

    #define ray_elem_size(t)  (ray_type_sizes[(t)])   // t is an int8_t tag

A negative (atom) tag indexes before the array. The table is `[256]`, and its upper half (indices 128–255, where a negative int8 tag lands once read as unsigned) is zero-filled — so the *intended* answer for a tag that carries no element size is already 0; it was simply being reached by an out-of-bounds read.

## Fix

    #define ray_elem_size(t)  (ray_type_sizes[(uint8_t)(t)])

Cast the tag to `uint8_t` so a negative atom tag wraps into the zero-filled upper half instead of reading before the table. This matches the `(uint8_t)` indexing `vec.c` already uses; vector (positive) tags are unchanged.

## Tests

`test_types.c`'s `elem_size_macro` gains assertions that `ray_elem_size` of negative / atom tags (`-RAY_BOOL`, `-RAY_I64`, `-RAY_SYM`, `-1`) returns 0. Full `make test`: 3753/3754 pass (1 pre-existing skip), no sanitizer output.
