### PR TITLE
fix(vec): a slice inherits its parent's HAS_NULLS; a saved column derives it from the payload

### DIFF
--- a/src/mem/heap.h
+++ b/src/mem/heap.h
@@ -58,7 +58,8 @@
  *   Bit  0x10       vectors:         RAY_ATTR_SLICE
  *   Bit  0x20       -RAY_SYM:        ATTR_QUOTED (quoted/literal symbol; default = name reference)
  *   Bit  0x20       vectors:         RAY_ATTR_SORTED (non-descending order marker)
- *   Bit  0x40       vectors:         RAY_ATTR_HAS_NULLS (sentinel-encoded; payload is truth)
+ *   Bit  0x40       vectors:         RAY_ATTR_HAS_NULLS (sentinel-encoded; payload is truth;
+ *                                    a slice inherits its parent's bit)
  *   Bit  0x80       all types:       RAY_ATTR_ARENA (arena-allocated, no refcount)
  *
  * Overlapping bit values are safe because consumers always check the type tag

--- a/src/store/col.c
+++ b/src/store/col.c
@@ -732,6 +732,45 @@ ray_err_t ray_col_append_index(const char* path, const void* ix_v,
     return RAY_OK;
 }
 
+/* Does the payload hold the type's null sentinel anywhere?  Sequential
+ * read with an early return on the first hit; resolves a slice through
+ * its parent like every other reader.  Types without a sentinel (BOOL,
+ * U8, SYM, STR, GUID, LIST) answer false — their null state is in-band
+ * or absent, and the bit means nothing to them on disk. */
+static bool col_payload_has_nulls(ray_t* vec) {
+    int64_t n = vec->len;
+    if (n <= 0) return false;
+    const void* p = ray_data(vec);
+    switch (vec->type) {
+        case RAY_F64: {
+            const double* d = (const double*)p;
+            for (int64_t i = 0; i < n; i++) if (d[i] != d[i]) return true;
+            return false;
+        }
+        case RAY_F32: {
+            const float* d = (const float*)p;
+            for (int64_t i = 0; i < n; i++) if (d[i] != d[i]) return true;
+            return false;
+        }
+        case RAY_I64: case RAY_TIMESTAMP: {
+            const int64_t* d = (const int64_t*)p;
+            for (int64_t i = 0; i < n; i++) if (d[i] == NULL_I64) return true;
+            return false;
+        }
+        case RAY_I32: case RAY_DATE: case RAY_TIME: {
+            const int32_t* d = (const int32_t*)p;
+            for (int64_t i = 0; i < n; i++) if (d[i] == NULL_I32) return true;
+            return false;
+        }
+        case RAY_I16: {
+            const int16_t* d = (const int16_t*)p;
+            for (int64_t i = 0; i < n; i++) if (d[i] == NULL_I16) return true;
+            return false;
+        }
+        default: return false;
+    }
+}
+
 static ray_err_t col_save_impl(ray_t* vec, const char* path, bool durable) {
     if (!vec || RAY_IS_ERR(vec)) return RAY_ERR_TYPE;
     if (!path) return RAY_ERR_IO;
@@ -849,8 +888,21 @@ static ray_err_t col_save_impl(ray_t* vec, const char* path, bool durable) {
             memset(header.aux + 8, 0, 8);
         }
 
-        /* Clear slice flag — slices are materialized on save. */
-        header.attrs &= (uint8_t)~RAY_ATTR_SLICE;
+        /* Clear slice flag — slices are materialized on save.  A slice's
+         * aux holds the parent pointer and window offset, which must
+         * never reach disk. */
+        if (vec->attrs & RAY_ATTR_SLICE) {
+            header.attrs &= (uint8_t)~RAY_ATTR_SLICE;
+            memset(header.aux, 0, 16);
+        }
+        /* The persisted HAS_NULLS bit is load-bearing for every reader
+         * (nothing rescans on load), so derive it from the payload rather
+         * than trust the producer: a column that holds a sentinel is
+         * written with the bit set whatever the in-memory header said
+         * (#495).  Only ever sets — a spurious set costs a slow path, a
+         * missing one costs the answer. */
+        if (!(header.attrs & RAY_ATTR_HAS_NULLS) && col_payload_has_nulls(vec))
+            header.attrs |= RAY_ATTR_HAS_NULLS;
         if (!(header.attrs & RAY_ATTR_HAS_NULLS))
             memset(header.aux, 0, 16);
 

--- a/src/vec/vec.c
+++ b/src/vec/vec.c
@@ -435,7 +435,13 @@ ray_t* ray_vec_slice(ray_t* vec, int64_t offset, int64_t len) {
     if (!s || RAY_IS_ERR(s)) return s;
 
     s->type = parent->type;
-    s->attrs = RAY_ATTR_SLICE | (parent->attrs & RAY_SYM_W_MASK);
+    /* A slice inherits the parent's HAS_NULLS hint: it is a window onto
+     * the same sentinel-encoded payload, and every fast-path gate that
+     * reads the bit (aggregates, raze, the morsel null bitmap, the save
+     * path) would otherwise read a window with nulls as null-free and
+     * fold the sentinel in as a value (#495).  Over-approximation when
+     * the window happens to hold no null is the bit's documented role. */
+    s->attrs = RAY_ATTR_SLICE | (parent->attrs & (RAY_SYM_W_MASK | RAY_ATTR_HAS_NULLS));
     s->len = len;
     s->slice_parent = parent;
     s->slice_offset = parent_offset;

--- a/test/rfl/null/slice_has_nulls.rfl
+++ b/test/rfl/null/slice_has_nulls.rfl
@@ -1,0 +1,60 @@
+;; slice_has_nulls.rfl — a slice sees its parent's nulls, in memory and on
+;; disk (#495).
+;;
+;; Regression: ray_vec_slice built the slice header without the parent's
+;; RAY_ATTR_HAS_NULLS hint, and every fast-path gate that trusts the hint
+;; (sum/min/max/avg, raze, the save path) read a window holding a null
+;; sentinel as null-free — folding INT64_MIN into a sum, materialising it
+;; as a plain number through raze, and persisting the column with the bit
+;; clear so every later reader was wrong too.  (take D <range>) on a dict
+;; slices the key vector, so three ordinary verbs produced one.
+
+;; ── in memory: the slice answers what the whole vector answers ──
+(set D (dict (as 'I64 [1 0N 3 4]) [10 20 30 40]))
+(set W (key D))
+(set S (key (take D [0 3])))
+(format "%s" S) -- "[1 0Nl 3]s"
+(sum S) -- 4
+(sum (take W 3)) -- 4
+(min S) -- 1
+(max S) -- 3
+(avg S) -- 2.0
+(nil? S) -- [false true false]
+(count (where (nil? S))) -- 1
+
+;; ── raze keeps the null, whichever path it takes ──
+(set R (raze (enlist S)))
+(format "%s" R) -- "[1 0Nl 3]s"
+(sum R) -- 4
+(sum (raze (list S S))) -- 8
+(sum (concat S (take S 0))) -- 4
+(sum (at S (til 3))) -- 4
+
+;; ── the same through F64 and a nested slice ──
+(set DF (dict (as 'F64 [1.5 0Nf 2.5 4.0]) [10 20 30 40]))
+(set SF (key (take DF [0 3])))
+(sum SF) -- 4.0
+(min SF) -- 1.5
+(sum (take SF 2)) -- 1.5
+(sum (raze (enlist SF))) -- 4.0
+
+;; a slice whose window holds no null still answers correctly
+(set S2 (key (take D [2 4])))
+(sum S2) -- 7
+(nil? S2) -- [false false]
+
+;; ── on disk: the persisted bit is derived from the payload ──
+(.sys.exec "rm -rf /tmp/rfl_slice_nulls")
+(set G (as 'I64 [1 0N 3]))
+(.db.splayed.set "/tmp/rfl_slice_nulls/good/" (table ['x] (list G)))
+(.db.splayed.set "/tmp/rfl_slice_nulls/slice/" (table ['x] (list S)))
+(.db.splayed.set "/tmp/rfl_slice_nulls/razed/" (table ['x] (list R)))
+(.db.splayed.set "/tmp/rfl_slice_nulls/f64/" (table ['x] (list SF)))
+(sum (at (.db.splayed.get "/tmp/rfl_slice_nulls/good/") 'x)) -- 4
+(sum (at (.db.splayed.get "/tmp/rfl_slice_nulls/slice/") 'x)) -- 4
+(sum (at (.db.splayed.get "/tmp/rfl_slice_nulls/razed/") 'x)) -- 4
+(format "%s" (at (.db.splayed.get "/tmp/rfl_slice_nulls/razed/") 'x)) -- "[1 0Nl 3]s"
+(sum (at (.db.splayed.get "/tmp/rfl_slice_nulls/f64/") 'x)) -- 4.0
+;; the header byte itself: 0x40 (HAS_NULLS) on every one of them
+(.sys.exec "for d in good slice razed f64; do [ \"$(xxd -s 19 -l 1 -p /tmp/rfl_slice_nulls/$d/x)\" = 40 ] || exit 1; done") -- 0
+(.sys.exec "rm -rf /tmp/rfl_slice_nulls")

--- a/test/test_index.c
+++ b/test/test_index.c
@@ -517,7 +517,9 @@ static test_result_t test_index_aux_helper_slice(void) {
     ray_t* s = ray_vec_slice(v, 2, 4);
     TEST_ASSERT_FALSE(RAY_IS_ERR(s));
     TEST_ASSERT_TRUE(s->attrs & RAY_ATTR_SLICE);
-    TEST_ASSERT_FALSE(s->attrs & RAY_ATTR_HAS_NULLS);
+    /* A slice inherits the parent's HAS_NULLS hint (#495): the gates
+     * that read the bit would otherwise treat the window as null-free. */
+    TEST_ASSERT_TRUE(s->attrs & RAY_ATTR_HAS_NULLS);
 
     /* ray_vec_is_null still works correctly on the slice. */
     TEST_ASSERT_FALSE(ray_vec_is_null(s, 0));   /* parent row 2 — not null */

--- a/test/test_lang.c
+++ b/test/test_lang.c
@@ -5716,13 +5716,14 @@ static test_result_t test_temporal_extract_slice_nulls(void) {
     TEST_ASSERT_TRUE((v->attrs & RAY_ATTR_HAS_NULLS) != 0);
     TEST_ASSERT_TRUE(ray_vec_is_null(v, 2));
 
-    /* Slice [1..4): {2s, null, 4s}.  Slice itself does not carry
-     * HAS_NULLS; only the parent does. */
+    /* Slice [1..4): {2s, null, 4s}.  Since #495 the slice header carries
+     * the parent's HAS_NULLS hint too, so the bit-only gates see it; the
+     * slice-aware detection below is still what reads the cell. */
     ray_t* s = ray_vec_slice(v, 1, 3);
     TEST_ASSERT_NOT_NULL(s);
     TEST_ASSERT_FALSE(RAY_IS_ERR(s));
     TEST_ASSERT_TRUE((s->attrs & RAY_ATTR_SLICE) != 0);
-    TEST_ASSERT_FALSE((s->attrs & RAY_ATTR_HAS_NULLS) != 0);
+    TEST_ASSERT_TRUE((s->attrs & RAY_ATTR_HAS_NULLS) != 0);
     TEST_ASSERT_TRUE(ray_vec_is_null(s, 1));
 
     /* Extract seconds.  Without slice-aware null detection this path

--- a/test/test_store.c
+++ b/test/test_store.c
@@ -73,6 +73,48 @@ static void store_teardown(void) {
     ray_heap_destroy();
 }
 
+/* ---- test_col_save_derives_has_nulls ----------------------------------- */
+
+/* The on-disk HAS_NULLS bit is load-bearing and nothing rescans on load,
+ * so the save path derives it from the payload (#495): a column whose
+ * producer left the bit clear while writing a sentinel is persisted with
+ * the bit set, on both the read and the mmap loader. */
+static test_result_t test_col_save_derives_has_nulls(void) {
+    int64_t raw[] = {1, NULL_I64, 3};
+    ray_t* vec = ray_vec_from_raw(RAY_I64, raw, 3);
+    TEST_ASSERT_NOT_NULL(vec);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(vec));
+    vec->attrs &= (uint8_t)~RAY_ATTR_HAS_NULLS;   /* the forgetful producer */
+
+    TEST_ASSERT_EQ_I(ray_col_save(vec, TMP_COL_PATH), RAY_OK);
+
+    ray_t* loaded = ray_col_load(TMP_COL_PATH);
+    TEST_ASSERT_NOT_NULL(loaded);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(loaded));
+    TEST_ASSERT_TRUE((loaded->attrs & RAY_ATTR_HAS_NULLS) != 0);
+    TEST_ASSERT_TRUE(ray_vec_is_null(loaded, 1));
+    ray_release(loaded);
+
+    ray_t* mapped = ray_col_mmap(TMP_COL_PATH);
+    TEST_ASSERT_NOT_NULL(mapped);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(mapped));
+    TEST_ASSERT_TRUE((mapped->attrs & RAY_ATTR_HAS_NULLS) != 0);
+    TEST_ASSERT_TRUE(ray_vec_is_null(mapped, 1));
+    ray_release(mapped);
+
+    /* A null-free column stays null-free: the scan only ever sets. */
+    int64_t clean[] = {1, 2, 3};
+    ray_t* cvec = ray_vec_from_raw(RAY_I64, clean, 3);
+    TEST_ASSERT_EQ_I(ray_col_save(cvec, TMP_COL_PATH), RAY_OK);
+    ray_t* cl = ray_col_load(TMP_COL_PATH);
+    TEST_ASSERT_NOT_NULL(cl);
+    TEST_ASSERT_TRUE((cl->attrs & RAY_ATTR_HAS_NULLS) == 0);
+    ray_release(cl);
+    ray_release(cvec);
+    ray_release(vec);
+    PASS();
+}
+
 /* ---- test_col_mmap_i64 ------------------------------------------------- */
 
 static test_result_t test_col_mmap_i64(void) {
@@ -5479,6 +5521,7 @@ static test_result_t test_col_save_nyi_type(void) {
 
 const test_entry_t store_entries[] = {
     { "store/col_mmap_i64", test_col_mmap_i64, store_setup, store_teardown },
+    { "store/col_save_derives_has_nulls", test_col_save_derives_has_nulls, store_setup, store_teardown },
     { "store/col_mmap_f64", test_col_mmap_f64, store_setup, store_teardown },
     { "store/col_mmap_f32", test_col_mmap_f32, store_setup, store_teardown },
     { "store/col_mmap_cow", test_col_mmap_cow, store_setup, store_teardown },


### PR DESCRIPTION
## Summary

`ray_vec_slice` dropped the parent's `RAY_ATTR_HAS_NULLS`, so every gate that trusts the bit (the aggregate reduction, `raze`'s memcpy path, the morsel null bitmap, the column save header) read a window holding a null sentinel as null-free. `(take D <range>)` on a dict slices the key vector, which is how three ordinary verbs produced a wrong `sum`, a materialised sentinel through `raze`, and a persisted column with attrs 0.

Two changes, narrower than the three sites the issue proposes:

1. **A slice inherits the parent's `HAS_NULLS` hint.** One line in `ray_vec_slice`. It corrects `sum`/`min`/`max`/`avg` over any slice, sends a null-bearing slice down `raze`'s concat path (no change to `raze` needed), and makes the save header right. Over-approximation when the window holds no null is the bit's documented role; the slice-aware readers are untouched.
2. **The save path derives the bit from the payload** (set-only, one sequential read with early exit, for the sentinel types) so no producer that forgets the bit can write a blind column, and a slice's `aux` (parent pointer, offset) is zeroed before it reaches disk. Both `ray_col_save` and `ray_col_save_bulk` go through it.

Issue's reproducers on this branch, in memory and on disk:

```
slice  sum    4        (was -9223372036854775804)
slice  min    1        (was 0Nl)
razed  render [1 0Nl 3]   (was [1 -9223372036854775808 3])
good/slice/razed attrs byte 19: 40 40 40   (was 40 00 00)
```

Not done, deliberately: validating the bit on load, which would defeat lazy mmap with a full scan per column; and the `.attr` repair verbs the issue mentions. A hand-zeroed header can still be believed by `by:` grouping (the `agg_engine.c:217` abort the issue notes); with saves now self-consistent that needs a corrupted file to reach.

## Tests

`test/rfl/null/slice_has_nulls.rfl`: I64 and F64 slices through `sum`/`min`/`max`/`avg`/`nil?`/`where`, `raze` and `concat` and `at` of a slice, a nested slice, a null-free window, and the splayed round trip with the header byte checked at 0x40. `store/col_save_derives_has_nulls`: a column whose producer left the bit clear is persisted with it set, seen by both loaders, and a null-free column stays clear. Two existing C tests asserted the old "a slice never carries the bit" and now assert the inverse. Full `make test` green apart from those two before their update; null, store, index and lang groups green after.

Fixes #495

https://claude.ai/code/session_01J4QKJW3RbRP8TQoquJtARg
