### PR TITLE
fix(journal): reject explicit writes during auto-journaled eval

### DIFF
--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -259,6 +259,18 @@ static void ipc_ctx_set(int64_t handle, ray_poll_t* poll) {
     __VM->ipc_poll   = poll;
 }
 
+static _Thread_local bool g_auto_journal_eval = false;
+
+bool ray_ipc_auto_journal_eval(void) {
+    return g_auto_journal_eval;
+}
+
+#ifdef DEBUG
+void ray_ipc_set_auto_journal_eval_for_test(bool enabled) {
+    g_auto_journal_eval = enabled;
+}
+#endif
+
 ray_poll_t* ray_ipc_active_poll(void) {
     ray_poll_t* p = ipc_ctx_poll();
     return p ? p : (ray_poll_t*)ray_runtime_get_poll();
@@ -512,6 +524,7 @@ static ray_t* eval_payload_core(uint8_t* payload, size_t payload_len,
      * behaviour: "the message has not been logged so we cannot
      * accept it".  Silently evaluating un-logged mutations defeats
      * the entire durability premise of `-l`/`-L`. */
+    bool auto_journaled = false;
     if (ray_journal_is_open() && hdr->msgtype == RAY_IPC_MSG_SYNC) {
         ray_ipc_header_t log_hdr = *hdr;
         if (ray_eval_get_restricted())
@@ -521,6 +534,7 @@ static ray_t* eval_payload_core(uint8_t* payload, size_t payload_len,
             fprintf(stderr, "log: ERROR  journal write failed (rc=%d) — refusing to evaluate\n", (int)je);
             return ray_error("io", "journal write failed; mutation refused");
         }
+        auto_journaled = true;
     }
 
     /* Query-statistics ring: bracket the eval so the server records one
@@ -552,6 +566,8 @@ static ray_t* eval_payload_core(uint8_t* payload, size_t payload_len,
     }
 
     ray_t* result = NULL;
+    bool prev_auto_journal_eval = g_auto_journal_eval;
+    if (auto_journaled) g_auto_journal_eval = true;
     if (msg && !RAY_IS_ERR(msg)) {
         if (msg->type == RAY_LIST) {
             ray_t** elems = (ray_t**)ray_data(msg);
@@ -598,6 +614,7 @@ static ray_t* eval_payload_core(uint8_t* payload, size_t payload_len,
             ray_release(msg);
         }
     }
+    g_auto_journal_eval = prev_auto_journal_eval;
     /* A lazy result is an internal deferred-DAG representation that cannot
      * be serialized — force it to a concrete value before it reaches the
      * wire.  The direct ray_eval(msg) path (non-STR payloads, e.g. an

--- a/src/core/ipc.h
+++ b/src/core/ipc.h
@@ -74,6 +74,10 @@ size_t ray_ipc_decompress(const uint8_t* src, size_t clen,
 int64_t ray_ipc_current_handle(void);
 ray_poll_t* ray_ipc_active_poll(void);
 ray_poll_t* ray_ipc_context_poll(void);
+bool ray_ipc_auto_journal_eval(void);
+#ifdef DEBUG
+void ray_ipc_set_auto_journal_eval_for_test(bool enabled);
+#endif
 
 /* ===== Poll-based IPC (new API) ===== */
 

--- a/src/ops/journal.c
+++ b/src/ops/journal.c
@@ -91,6 +91,8 @@ ray_t* ray_log_open_fn(ray_t** args, int64_t n) {
 ray_t* ray_log_write_fn(ray_t* expr) {
     if (!ray_journal_is_open())
         return ray_error("noopen", ".log.write: no journal open (start with -l/-L)");
+    if (ray_ipc_auto_journal_eval())
+        return ray_error("domain", ".log.write is disabled inside auto-journaled IPC eval");
     if (!expr) return ray_error("type", ".log.write expects an argument");
 
     bool owned = false;

--- a/test/rfl/system/log_journal_advanced.rfl
+++ b/test/rfl/system/log_journal_advanced.rfl
@@ -8,7 +8,7 @@
 ;; Phase C: per-entry eval error in log warns-and-continues, doesn't
 ;;          abort replay (commit message documents this; basic test
 ;;          only exercises framing badtail)
-;; Phase D: .log.write manual escape hatch round-trips via replay
+;; Phase D: .log.write is rejected inside auto-journaled IPC eval
 
 ;; ── IPC connect with handshake-level retry ──────────────────────────
 ;; A /dev/tcp probe reports ready the instant the server calls listen(),
@@ -130,11 +130,11 @@
 (.sys.exec "rm -f /tmp/rftest_jerr*")
 
 ;; ════════════════════════════════════════════════════════════════════
-;; Phase D — .log.write manual entry round-trips via replay
+;; Phase D — .log.write inside auto-journaled IPC eval is rejected
 ;; ════════════════════════════════════════════════════════════════════
-;; The escape hatch lets a Rayfall handler journal an arbitrary
-;; expression out-of-band.  Currently zero coverage — a regression
-;; that broke the API would only surface for users.
+;; A journaled server logs every SYNC IPC payload before evaluation.
+;; Letting the payload call .log.write as well would persist nested
+;; writes in addition to the already-logged outer request.
 
 (.sys.exec "pkill -KILL -f '[r]ayforce -l /tmp/rftest_jwr' 2>/dev/null; true")
 (.sys.exec "rm -f /tmp/rftest_jwr*")
@@ -142,18 +142,9 @@
 (.sys.exec "for i in $(seq 30); do bash -c '(echo > /dev/tcp/127.0.0.1/19994) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
 
 (set hD (wait_ipc "127.0.0.1:19994" 50))
-;; Journal a string-eval entry manually.  On replay this string will
-;; be re-evaluated (string payloads go through ray_eval_str), binding d1.
-(.ipc.send hD "(.log.write \"(set d1 999)\")")
+(.ipc.send hD "(.log.write \"(set d1 999)\")") !- domain
 (.ipc.close hD)
 (.sys.exec "pkill -TERM -f '[r]ayforce -l /tmp/rftest_jwr -p 19994' 2>/dev/null; true")
 (.sys.exec "for i in $(seq 30); do pgrep -f '[r]ayforce -l /tmp/rftest_jwr -p 19994' >/dev/null || exit 0; sleep 0.1; done; exit 1") -- 0
-
-(.sys.exec "./rayforce -l /tmp/rftest_jwr -p 19994 </dev/null >/dev/null 2>&1 &")
-(.sys.exec "for i in $(seq 30); do bash -c '(echo > /dev/tcp/127.0.0.1/19994) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
-
-(set hD2 (wait_ipc "127.0.0.1:19994" 50))
-(.ipc.send hD2 "d1") -- 999
-(.ipc.close hD2)
 (.sys.exec "pkill -KILL -f '[r]ayforce -l /tmp/rftest_jwr' 2>/dev/null; true")
 (.sys.exec "rm -f /tmp/rftest_jwr*")

--- a/test/test_journal.c
+++ b/test/test_journal.c
@@ -1993,7 +1993,30 @@ static test_result_t test_ops_write_noopen(void) {
     PASS();
 }
 
-/* 22q. ray_log_write_fn: pay_size <= 0 (lines 100-103).
+/* 22q. ray_log_write_fn: reject explicit writes from auto-journaled IPC eval. */
+static test_result_t test_ops_write_rejects_auto_journal_eval(void) {
+    char base[256]; make_base(base, sizeof(base), "ops_auto_eval");
+
+    TEST_ASSERT_EQ_I(ray_journal_open(base, RAY_JOURNAL_ASYNC), RAY_OK);
+
+    ray_t* expr = ray_i64(42);
+    TEST_ASSERT_NOT_NULL(expr);
+    ray_ipc_set_auto_journal_eval_for_test(true);
+    ray_t* r = ray_log_write_fn(expr);
+    ray_ipc_set_auto_journal_eval_for_test(false);
+    ray_release(expr);
+
+    TEST_ASSERT_NOT_NULL(r);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(r));
+    TEST_ASSERT_STR_EQ(ray_err_code(r), "domain");
+    ray_error_free(r);
+
+    TEST_ASSERT_EQ_I(ray_journal_close(), RAY_OK);
+    cleanup_base(base);
+    PASS();
+}
+
+/* 22r. ray_log_write_fn: pay_size <= 0 (lines 100-103).
  *
  *  ray_serde_size returns 0 for object types not in its switch (any type
  *  value that is not a known atom/vector/container type).  We manufacture
@@ -2407,6 +2430,7 @@ const test_entry_t journal_entries[] = {
     { "journal/ops_open_sync_mode",        test_ops_open_sync_mode,               jrn_setup, jrn_teardown },
     { "journal/ops_write_null_expr",       test_ops_write_null_expr,              jrn_setup, jrn_teardown },
     { "journal/ops_write_noopen",          test_ops_write_noopen,                 jrn_setup, jrn_teardown },
+    { "journal/ops_write_auto_journal_eval", test_ops_write_rejects_auto_journal_eval, jrn_setup, jrn_teardown },
     { "journal/ops_write_serde_size_zero", test_ops_write_serde_size_zero,        jrn_setup, jrn_teardown },
     /* End-to-end RFL round-trip */
     { "journal/replay_symbol_head_both_forms", test_journal_replay_symbol_head_both_forms, jrn_setup, jrn_teardown },


### PR DESCRIPTION
## Summary
- reject `.log.write` while evaluating an IPC SYNC message that was already captured by auto-journal
- add test coverage for the explicit-write guard

## Tests
- `make test TEST_FILTER=journal/ops_write_auto_journal_eval DEBUG_CFLAGS='-fPIC -Wall -Wextra -Werror -Wstrict-prototypes -Wno-unused-parameter -std=c17 -g -O0 -march=native -DDEBUG -fno-omit-frame-pointer' DEBUG_LDFLAGS=''`
