### PR TITLE
fix(mcast): accept bare subscribe calls

### DIFF
--- a/docs/multicast-usage.md
+++ b/docs/multicast-usage.md
@@ -21,7 +21,8 @@ It does not yet provide durable replay, topic filters, wildcard topics, ACLs, pe
 ## API
 
 ```clj
-(.mc.sub topic null)       ;; subscribe the current IPC handle to topic
+(.mc.sub topic)            ;; subscribe the current IPC handle to topic
+(.mc.sub topic null)       ;; explicit no-filter form
 (.mc.unsub topic)          ;; unsubscribe the current IPC handle from topic
 (.mc.pub topic payload)    ;; publish payload to all current subscribers
 (.mc.stats)                ;; return aggregate multicast stats
@@ -30,6 +31,7 @@ It does not yet provide durable replay, topic filters, wildcard topics, ACLs, pe
 `topic` can be a string or a symbol:
 
 ```clj
+(.mc.sub "ticks")
 (.mc.sub "ticks" null)
 (.mc.sub 'ticks null)
 
@@ -37,9 +39,10 @@ It does not yet provide durable replay, topic filters, wildcard topics, ACLs, pe
 (.mc.pub 'ticks (dict ['sym 'price] (list 'AAPL 185.5)))
 ```
 
-Filters are reserved for later work. For now, pass `null`:
+Filters are reserved for later work. For now, omit the filter or pass `null`:
 
 ```clj
+(.mc.sub "ticks")          ;; ok
 (.mc.sub "ticks" null)     ;; ok
 (.mc.sub "ticks" 1)        ;; nyi
 ```

--- a/src/ops/system.c
+++ b/src/ops/system.c
@@ -1615,11 +1615,12 @@ ray_t* ray_ipc_txlimit_fn(ray_t** args, int64_t n) {
 }
 
 ray_t* ray_mc_sub_fn(ray_t** args, int64_t n) {
-    if (n != 2)
-        return ray_error("domain", ".mc.sub expects 2 arguments");
+    if (n < 1 || n > 2)
+        return ray_error("domain", ".mc.sub expects 1 or 2 arguments");
     if (!ray_ipc_context_poll())
         return ray_error("domain", ".mc.sub requires a poll IPC context");
-    return ray_mcast_sub(ray_ipc_active_poll(), ray_ipc_current_handle(), args[0], args[1]);
+    ray_t* filter = (n == 2) ? args[1] : RAY_NULL_OBJ;
+    return ray_mcast_sub(ray_ipc_active_poll(), ray_ipc_current_handle(), args[0], filter);
 }
 
 ray_t* ray_mc_unsub_fn(ray_t* topic) {

--- a/test/test_mcast.c
+++ b/test/test_mcast.c
@@ -520,6 +520,38 @@ static test_result_t test_mcast_no_subscribers_and_api_errors(void) {
     PASS();
 }
 
+static test_result_t test_mcast_bare_subscribe_shorthand(void) {
+    ray_poll_t* poll;
+    ray_vm_t* vm;
+    uint16_t port;
+    ray_thread_t tid;
+    test_result_t sr = start_server(&poll, &port, &vm, &tid);
+    if (sr.status != TEST_PASS) return sr;
+
+    int64_t h = ray_ipc_connect("127.0.0.1", port, NULL, NULL, 0);
+    TEST_ASSERT((h) >= (0), "client connected");
+
+    ray_t* msg = ray_str("(.mc.sub \"bare\")", strlen("(.mc.sub \"bare\")"));
+    ray_t* sub = ray_ipc_send(h, msg);
+    ray_release(msg);
+    TEST_ASSERT_NOT_NULL(sub);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(sub));
+    TEST_ASSERT_EQ_I(sub->i64, 1);
+    ray_release(sub);
+
+    msg = ray_str("(.mc.sub)", strlen("(.mc.sub)"));
+    ray_t* err = ray_ipc_send(h, msg);
+    ray_release(msg);
+    TEST_ASSERT_NOT_NULL(err);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(err));
+    TEST_ASSERT_STR_EQ(ray_err_code(err), "domain");
+    ray_error_free(err);
+
+    ray_ipc_close(h);
+    stop_server(poll, port, vm, tid);
+    PASS();
+}
+
 static test_result_t test_mcast_restricted_sub_but_not_pub(void) {
     ray_poll_t* poll;
     ray_vm_t* vm;
@@ -1099,6 +1131,7 @@ const test_entry_t mcast_entries[] = {
     { "mcast/duplicate_sub_idempotent",   test_mcast_duplicate_sub_is_idempotent, mcast_setup, mcast_teardown },
     { "mcast/multi_topic_routing",        test_mcast_multi_topic_routing,        mcast_setup, mcast_teardown },
     { "mcast/no_subscribers_api_errors",  test_mcast_no_subscribers_and_api_errors, mcast_setup, mcast_teardown },
+    { "mcast/bare_sub_shorthand",         test_mcast_bare_subscribe_shorthand, mcast_setup, mcast_teardown },
     { "mcast/restricted_sub_not_pub",     test_mcast_restricted_sub_but_not_pub, mcast_setup, mcast_teardown },
     { "mcast/sub_requires_ipc_context",   test_mcast_requires_ipc_context_for_sub, mcast_setup, mcast_teardown },
     { "mcast/large_payload_queues",       test_mcast_large_payload_queues_until_writable, mcast_setup, mcast_teardown },


### PR DESCRIPTION
## Summary
- allow `.mc.sub topic` as shorthand for `.mc.sub topic null`
- keep explicit filter rejection unchanged
- document the shorthand form

## Tests
- `make test TEST_FILTER=mcast/sub_requires_ipc_context DEBUG_CFLAGS='-fPIC -Wall -Wextra -Werror -Wstrict-prototypes -Wno-unused-parameter -std=c17 -g -O0 -march=native -DDEBUG -fno-omit-frame-pointer' DEBUG_LDFLAGS=''`

Note: the new shorthand assertion is in the socket-backed multicast test; the full local mcast socket subset is blocked in this environment by `ray_ipc_listen(poll, 0)` failing before multicast behavior runs.
