### PR TITLE
fix(repl): read piped stdin through the poll loop, and stay for pending timers

### DIFF
--- a/docs/docs/namespaces/time.md
+++ b/docs/docs/namespaces/time.md
@@ -1,6 +1,6 @@
 # `.time.*` — clock and timers
 
-Monotonic clock access plus a recurring-callback scheduler. Timers integrate into the runtime's poll loop — they only fire when control is back in `ray_poll_run`, i.e. between REPL inputs, between IPC requests, or while idling in server-only mode. A long-running synchronous evaluation will defer pending timers until it returns.
+Monotonic clock access plus a recurring-callback scheduler. Timers integrate into the runtime's poll loop — they only fire when control is back in the loop, i.e. between REPL inputs (interactive or piped: both read stdin through the loop), between IPC requests, or while idling in server-only mode. A long-running synchronous evaluation will defer pending timers until it returns. A script, or a piped session that reached end of input, stays alive until its pending timers are spent, so a one-shot timer set by a script fires before the process exits; a periodic timer keeps it running until the script ends the process itself. An open client handle does not keep a script alive.
 
 The clock is the same `CLOCK_MONOTONIC` source the scheduler uses for its deadlines, so `(.time.now)` is directly comparable to the `ms` argument passed to `.time.timer.set`. Wall-clock time is intentionally not exposed here: a host sleep / resume must not retroactively shift a scheduled deadline.
 

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -282,7 +282,14 @@ int main(int argc, char** argv) {
     /* Load script if specified */
     if (file) {
         rc = ray_repl_run_file(file);
-        if (!interactive && !(port > 0)) goto done;
+        if (!interactive && !(port > 0)) {
+            /* A script that armed timers means to run them: stay until
+             * they are spent (a one-shot fires once, a periodic one until
+             * the script ends the process).  Nothing else keeps a script
+             * alive — a client handle it left open is not a reason. */
+            if (poll) ray_poll_drain_timers(poll);
+            goto done;
+        }
     }
 
     /* REPL or pure server mode.

--- a/src/app/repl.c
+++ b/src/app/repl.c
@@ -32,6 +32,7 @@
 #include "app/term.h"
 #include "core/ipc.h"
 #include "core/poll.h"
+#include "core/timer.h"
 #include "core/pool.h"
 #include "lang/env.h"
 #include "lang/eval.h"
@@ -58,6 +59,7 @@
 #define STDIN_FD 0
 #else
 #include <unistd.h>
+#include <errno.h>
 #include <sys/ioctl.h>
 #define STDIN_FD STDIN_FILENO
 #endif
@@ -1180,13 +1182,111 @@ static int32_t count_unmatched(const char* s, size_t len) {
     return d > 0 ? d : 0;
 }
 
+/* ── Piped stdin, read through the poll loop ──────────────────────────
+ * fgets() on a pipe blocks outside the poll loop, so while a producer
+ * held the pipe open nothing else ran: no timer fired, no IPC request
+ * was served, until the writer closed (#493).  The piped REPL now reads
+ * stdin through a small line reader: when it needs bytes and a poll
+ * exists, stdin is a registered selector whose read_fn pumps the pipe
+ * into the reader's buffer, and the reader waits in bounded poll passes
+ * — which fire due timers and serve every other selector.  Without a
+ * poll it reads directly, as before. */
+typedef struct {
+    ray_repl_t* repl;
+    char        buf[PIPE_BUF_SIZE * 2];
+    size_t      head, tail;
+    bool        eof;
+    int64_t     sel_id;          /* -1 once deregistered (EOF) or never registered */
+} pipe_rd_t;
+
+static ray_t* piped_pump(ray_poll_t* poll, ray_selector_t* sel) {
+    pipe_rd_t* rd = (pipe_rd_t*)sel->data;
+    if (rd->tail >= sizeof(rd->buf)) return NULL;   /* consumer drains first */
+    ssize_t n = read(STDIN_FD, rd->buf + rd->tail, sizeof(rd->buf) - rd->tail);
+    if (n > 0) { rd->tail += (size_t)n; return NULL; }
+    if (n < 0 && (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)) return NULL;
+    rd->eof = true;
+    ray_poll_deregister(poll, sel->id);      /* close_fn clears sel_id */
+    return NULL;
+}
+
+/* The poller deregisters a selector on hangup after serving its last
+ * readable event, without another read_fn call — a pipe's data and its
+ * hangup arrive in one event.  Mark the reader so it stops waiting on
+ * the poll and drains whatever the pipe still holds with direct reads
+ * (which never block once the writer is gone). */
+static void piped_closed(ray_poll_t* poll, ray_selector_t* sel) {
+    (void)poll;
+    pipe_rd_t* rd = (pipe_rd_t*)sel->data;
+    if (rd) rd->sel_id = -1;
+}
+
+/* fgets semantics over the reader: returns `line` holding up to size-1
+ * bytes including a trailing newline when one was seen, or NULL at EOF
+ * with nothing left.  A line longer than size-1 comes back in pieces,
+ * exactly as fgets hands it out. */
+static char* piped_fgets(pipe_rd_t* rd, char* line, size_t size) {
+    for (;;) {
+        size_t avail = rd->tail - rd->head;
+        size_t maxn  = size - 1 < avail ? size - 1 : avail;
+        char* nl = maxn ? memchr(rd->buf + rd->head, '\n', maxn) : NULL;
+        if (nl) {
+            size_t n = (size_t)(nl - (rd->buf + rd->head)) + 1;
+            memcpy(line, rd->buf + rd->head, n); line[n] = '\0';
+            rd->head += n;
+            return line;
+        }
+        if (avail >= size - 1) {
+            memcpy(line, rd->buf + rd->head, size - 1); line[size - 1] = '\0';
+            rd->head += size - 1;
+            return line;
+        }
+        if (rd->eof) {
+            if (avail == 0) return NULL;
+            memcpy(line, rd->buf + rd->head, avail); line[avail] = '\0';
+            rd->head = rd->tail;
+            return line;
+        }
+        if (rd->head > 0) {                      /* compact, then refill */
+            memmove(rd->buf, rd->buf + rd->head, avail);
+            rd->head = 0; rd->tail = avail;
+        }
+        ray_poll_t* poll = rd->repl ? rd->repl->poll : NULL;
+        if (poll && rd->sel_id >= 0) {
+            if (ray_poll_run_for(poll, 1000) < 0 || poll->code >= 0) {
+                /* The loop was told to exit (an IPC hook, a callback):
+                 * stop reading, let run_piped wind down. */
+                rd->eof = true;
+            }
+        } else {
+            ssize_t n = read(STDIN_FD, rd->buf + rd->tail, sizeof(rd->buf) - rd->tail);
+            if (n > 0) rd->tail += (size_t)n;
+            else if (n < 0 && errno == EINTR) continue;
+            else rd->eof = true;
+        }
+    }
+}
+
 static void run_piped(ray_repl_t* repl) {
     char line[PIPE_BUF_SIZE];
     char accum[PIPE_BUF_SIZE];
     size_t accum_len = 0;
     bool mid_line = false;
 
-    while (fgets(line, PIPE_BUF_SIZE, stdin)) {
+    pipe_rd_t rd = { .repl = repl, .head = 0, .tail = 0, .eof = false, .sel_id = -1 };
+    if (repl->poll) {
+        ray_poll_reg_t reg = {0};
+        reg.fd      = STDIN_FD;
+        reg.type    = RAY_SEL_STDIN;
+        reg.read_fn  = piped_pump;
+        reg.close_fn = piped_closed;
+        reg.data     = &rd;
+        rd.sel_id = ray_poll_register(repl->poll, &reg);
+        /* A registration failure (an fd the poller cannot watch) falls
+         * back to direct reads, exactly the old behaviour. */
+    }
+
+    while (piped_fgets(&rd, line, PIPE_BUF_SIZE)) {
         size_t len = strlen(line);
         bool had_newline = (len > 0 && line[len - 1] == '\n');
         if (had_newline) line[--len] = '\0';
@@ -1226,7 +1326,7 @@ static void run_piped(ray_repl_t* repl) {
             accum_len = 0;
             mid_line = false;
             while (!had_newline) {
-                if (!fgets(line, PIPE_BUF_SIZE, stdin)) break;
+                if (!piped_fgets(&rd, line, PIPE_BUF_SIZE)) break;
                 len = strlen(line);
                 had_newline = (len > 0 && line[len - 1] == '\n');
                 if (had_newline) {
@@ -1236,7 +1336,7 @@ static void run_piped(ray_repl_t* repl) {
                 depth += bracket_delta_s(line, len, &bs);
             }
             while (depth > 0) {
-                if (!fgets(line, PIPE_BUF_SIZE, stdin)) break;
+                if (!piped_fgets(&rd, line, PIPE_BUF_SIZE)) break;
                 len = strlen(line);
                 had_newline = (len > 0 && line[len - 1] == '\n');
                 if (had_newline) {
@@ -1245,7 +1345,7 @@ static void run_piped(ray_repl_t* repl) {
                 }
                 depth += bracket_delta_s(line, len, &bs);
                 while (!had_newline) {
-                    if (!fgets(line, PIPE_BUF_SIZE, stdin)) break;
+                    if (!piped_fgets(&rd, line, PIPE_BUF_SIZE)) break;
                     len = strlen(line);
                     had_newline = (len > 0 && line[len - 1] == '\n');
                     if (had_newline) {
@@ -1275,9 +1375,16 @@ static void run_piped(ray_repl_t* repl) {
         eval_and_print(NULL, accum, false, repl->timeit);
     }
 
-    /* If poll has registered selectors (IPC server), enter poll_run after stdin */
-    if (repl->poll && repl->poll->n_sels > 0)
-        ray_poll_run(repl->poll);
+    if (repl->poll) {
+        if (rd.sel_id >= 0) ray_poll_deregister(repl->poll, rd.sel_id);
+        /* After stdin: a listener or connections keep the process serving
+         * (as before, now counting live selectors rather than slots);
+         * with none, stay only until pending timers are spent. */
+        if (repl->poll->n_live > 0)
+            ray_poll_run(repl->poll);
+        else
+            ray_poll_drain_timers(repl->poll);
+    }
 }
 
 void ray_repl_run(ray_repl_t* repl) {

--- a/src/core/epoll.c
+++ b/src/core/epoll.c
@@ -160,6 +160,7 @@ int64_t ray_poll_register(ray_poll_t* poll, ray_poll_reg_t* reg)
         return -1;
     }
 
+    poll->n_live++;
     if (sel->open_fn) sel->open_fn(poll, sel);
     return id;
 }
@@ -186,6 +187,7 @@ void ray_poll_deregister(ray_poll_t* poll, int64_t id)
     ray_poll_buf_free(sel->tx.buf);
     ray_sys_free(sel);
     poll->sels[id] = NULL;
+    if (poll->n_live > 0) poll->n_live--;
 }
 
 int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
@@ -204,6 +206,11 @@ int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
             if (remaining > INT_MAX) remaining = INT_MAX;
             wait_ms = (int)remaining;
         }
+
+        /* Nothing registered and nothing scheduled: an unbounded loop
+         * would block here forever.  Return instead, so a process that
+         * stayed only for its timers can end once they are spent. */
+        if (!bounded && ray_poll_idle(poll)) return 0;
 
         if (poll->timers) {
             int64_t deadline = ray_timers_next_deadline_ms(

--- a/src/core/kqueue.c
+++ b/src/core/kqueue.c
@@ -166,6 +166,7 @@ int64_t ray_poll_register(ray_poll_t* poll, ray_poll_reg_t* reg)
         return -1;
     }
 
+    poll->n_live++;
     if (sel->open_fn) sel->open_fn(poll, sel);
     return id;
 }
@@ -187,6 +188,7 @@ void ray_poll_deregister(ray_poll_t* poll, int64_t id)
     ray_poll_buf_free(sel->tx.buf);
     ray_sys_free(sel);
     poll->sels[id] = NULL;
+    if (poll->n_live > 0) poll->n_live--;
 }
 
 int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
@@ -204,6 +206,11 @@ int64_t ray_poll_run_for(ray_poll_t* poll, int timeout_ms)
             if (remaining < 0) remaining = 0;
             wait_ms = remaining;
         }
+
+        /* Nothing registered and nothing scheduled: an unbounded loop
+         * would block here forever.  Return instead, so a process that
+         * stayed only for its timers can end once they are spent. */
+        if (!bounded && ray_poll_idle(poll)) return 0;
 
         if (poll->timers) {
             int64_t deadline = ray_timers_next_deadline_ms(

--- a/src/core/poll.c
+++ b/src/core/poll.c
@@ -22,6 +22,7 @@
  */
 
 #include "core/poll.h"
+#include "core/timer.h"
 #include "mem/sys.h"
 #include <errno.h>
 
@@ -42,6 +43,25 @@ ray_selector_t* ray_poll_get(ray_poll_t* poll, int64_t id)
     if (!poll || id < 0 || (uint32_t)id >= poll->n_sels)
         return NULL;
     return poll->sels[id];
+}
+
+bool ray_poll_idle(ray_poll_t* poll)
+{
+    if (!poll) return true;
+    if (poll->n_live > 0) return false;
+    if (!poll->timers) return true;
+    return ray_timers_next_deadline_ms((ray_timers_t*)poll->timers) == INT64_MAX;
+}
+
+void ray_poll_drain_timers(ray_poll_t* poll)
+{
+    if (!poll) return;
+    while (poll->code < 0 && poll->timers &&
+           ray_timers_next_deadline_ms((ray_timers_t*)poll->timers) != INT64_MAX) {
+        /* One bounded pass: wakes for the next deadline (the loop trims
+         * the wait to it) or for any selector event, fires what is due. */
+        if (ray_poll_run_for(poll, 1000) < 0) break;
+    }
 }
 
 ray_poll_buf_t* ray_poll_buf_new(int64_t size)

--- a/src/core/poll.h
+++ b/src/core/poll.h
@@ -115,7 +115,8 @@ struct ray_poll {
      * compiler hoist the load out of the loop. */
     _Atomic int64_t  code;     /* exit code (-1 = running) */
     ray_selector_t** sels;     /* selector array */
-    uint32_t         n_sels;
+    uint32_t         n_sels;   /* slots (deregistered slots stay NULL) */
+    uint32_t         n_live;   /* registered selectors right now */
     uint32_t         sel_cap;
     char             auth_secret[256]; /* password from -u/-U, empty = no auth */
     bool             restricted;       /* true if -U (read-only IPC mode) */
@@ -127,6 +128,14 @@ struct ray_poll {
 /* ===== API ===== */
 
 ray_poll_t*     ray_poll_create(void);
+/* True when the loop has nothing to wait for: no registered selector and
+ * no pending timer.  ray_poll_run returns instead of blocking forever. */
+bool            ray_poll_idle(ray_poll_t* poll);
+/* Run bounded passes until no timer is pending (or the loop was told to
+ * exit).  Serves whatever selectors exist meanwhile, but does not stay
+ * for them: a script's lingering client handle must not keep the
+ * process alive once its timers are spent. */
+void            ray_poll_drain_timers(ray_poll_t* poll);
 void            ray_poll_destroy(ray_poll_t* poll);
 void            ray_poll_set_restricted(ray_poll_t* poll, bool restricted);
 int64_t         ray_poll_register(ray_poll_t* poll, ray_poll_reg_t* reg);

--- a/test/rfl/system/piped_timers.rfl
+++ b/test/rfl/system/piped_timers.rfl
@@ -1,0 +1,39 @@
+;; piped_timers.rfl — timers keep firing while a piped (non-TTY) stdin is
+;; held open, and a process stays for its pending timers after input ends
+;; (#493, the narrowed report).
+;;
+;; Regression: run_piped blocked in fgets(), so with a producer holding
+;; the pipe open a 100 ms timer fired only when the writer closed; and at
+;; EOF the poll loop was entered only for registered selectors, so a
+;; timer-only run printed the timer id and exited without firing it.
+;;
+;; Each case runs ./rayforce as a subprocess.  The callback exits with a
+;; distinctive code, so the exit code says whether it ran; the wall clock
+;; says whether it ran before the producer let go.  Process substitution
+;; keeps the write end open in the background without making the shell
+;; wait for it, so the elapsed time is rayforce's alone.
+(.sys.exec "rm -f /tmp/rfl_pt.sh /tmp/rfl_pt.rfl")
+(.sys.exec "printf '%s\n' '(.time.timer.set 100 1 (fn [t] (exit 7)))' > /tmp/rfl_pt.rfl")
+(.sys.exec "printf '%s\n' 's=$(date +%s)' 'exec 3< <(printf \"(.time.timer.set 100 1 (fn [t] (exit 7)))\\n\"; sleep 4)' './rayforce -i <&3; rc=$?' 'exec 3<&-' 'e=$(date +%s)' '[ $rc -eq 7 ] && [ $((e-s)) -le 1 ]' > /tmp/rfl_pt.sh")
+
+;; pipe held open for 4 s: the callback runs at 100 ms, not at close
+(.sys.exec "bash /tmp/rfl_pt.sh") -- 0
+
+;; the same with a listener: IPC is served while stdin is open, and the
+;; timer still fires early
+(.sys.exec "sed -i.bak 's#./rayforce -i#./rayforce -i -p 19973#' /tmp/rfl_pt.sh; bash /tmp/rfl_pt.sh") -- 0
+
+;; timer-only input that reaches EOF at once: the process stays for the
+;; timer instead of exiting 0 with it unfired
+(.sys.exec "./rayforce -i < /tmp/rfl_pt.rfl; [ $? -eq 7 ]") -- 0
+
+;; a script file that armed a one-shot timer, no listener: same
+(.sys.exec "./rayforce /tmp/rfl_pt.rfl </dev/null; [ $? -eq 7 ]") -- 0
+
+;; a script with no timers still exits promptly with its own status
+(.sys.exec "s=$(date +%s); printf '(+ 1 1)\n' | ./rayforce -i; rc=$?; e=$(date +%s); [ $rc -eq 0 ] && [ $((e-s)) -le 1 ]") -- 0
+
+;; a script that opened a client handle and set no timer still exits
+(.sys.exec "printf '%s\n' '(set h (.ipc.open \"127.0.0.1:19972\" 200))' > /tmp/rfl_pt2.rfl; s=$(date +%s); ./rayforce /tmp/rfl_pt2.rfl </dev/null >/dev/null 2>&1; e=$(date +%s); [ $((e-s)) -le 1 ]") -- 0
+
+(.sys.exec "rm -f /tmp/rfl_pt.sh /tmp/rfl_pt.sh.bak /tmp/rfl_pt.rfl /tmp/rfl_pt2.rfl")

--- a/test/test_runtime.c
+++ b/test/test_runtime.c
@@ -744,6 +744,51 @@ static test_result_t test_poll_run_for_fires_timer(void) {
     PASS();
 }
 
+/* An unbounded ray_poll_run with nothing registered and nothing scheduled
+ * returns instead of blocking forever, and one that has only a pending
+ * timer returns once the timer has fired (#493: a script or a piped
+ * session stays for its timers, then ends).  ray_poll_drain_timers is the
+ * bounded form used by main.c and the piped REPL. */
+static test_result_t test_poll_run_returns_when_idle(void) {
+    ray_poll_t* poll = (ray_poll_t*)ray_runtime_get_poll();
+    TEST_ASSERT_NOT_NULL(poll);
+    TEST_ASSERT_EQ_U(poll->n_live, 0u);
+    TEST_ASSERT_TRUE(ray_poll_idle(poll));
+
+    int64_t t0 = ray_time_now_ms();
+    TEST_ASSERT_EQ_I(ray_poll_run(poll), 0);        /* nothing to wait for */
+    TEST_ASSERT_TRUE(ray_time_now_ms() - t0 < 500);
+
+    ray_t* r = ray_eval_str("(set idle_timer_fired 0)"
+                            "(.time.timer.set 20 1 (fn [t] (set idle_timer_fired 1)))");
+    TEST_ASSERT_NOT_NULL(r);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(r));
+    ray_release(r);
+    TEST_ASSERT_FALSE(ray_poll_idle(poll));
+
+    t0 = ray_time_now_ms();
+    TEST_ASSERT_EQ_I(ray_poll_run(poll), 0);        /* fires, then idle */
+    TEST_ASSERT_TRUE(ray_time_now_ms() - t0 < 2000);
+    ray_t* f = ray_eval_str("idle_timer_fired");
+    TEST_ASSERT_NOT_NULL(f);
+    TEST_ASSERT_EQ_I(f->i64, 1);
+    ray_release(f);
+    TEST_ASSERT_TRUE(ray_poll_idle(poll));
+
+    r = ray_eval_str("(set idle_timer_fired 0)"
+                     "(.time.timer.set 20 1 (fn [t] (set idle_timer_fired 2)))");
+    TEST_ASSERT_NOT_NULL(r);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(r));
+    ray_release(r);
+    ray_poll_drain_timers(poll);
+    f = ray_eval_str("idle_timer_fired");
+    TEST_ASSERT_NOT_NULL(f);
+    TEST_ASSERT_EQ_I(f->i64, 2);
+    ray_release(f);
+    TEST_ASSERT_TRUE(ray_poll_idle(poll));
+    PASS();
+}
+
 /* ─── timer.c deep coverage (heap helpers + edge paths) ───────
  *
  * The static heap helpers (heap_less, heap_swap, heap_up sift body,
@@ -1202,6 +1247,7 @@ const test_entry_t runtime_entries[] = {
     { "runtime/syscov_time_timer_set_del",   test_syscov_time_timer_set_del,   sys_setup_with_poll, sys_teardown_with_poll },
     { "runtime/syscov_time_timer_fires",     test_syscov_time_timer_fires,     sys_setup_with_poll, sys_teardown_with_poll },
     { "runtime/poll_run_for_fires_timer",    test_poll_run_for_fires_timer,    sys_setup_with_poll, sys_teardown_with_poll },
+    { "runtime/poll_run_returns_when_idle",    test_poll_run_returns_when_idle,    sys_setup_with_poll, sys_teardown_with_poll },
     { "runtime/timer_heap_grow_past_initial_cap", test_timer_heap_grow_past_initial_cap, sys_setup_with_poll, sys_teardown_with_poll },
     { "runtime/timer_next_deadline_ms",      test_timer_next_deadline_ms,      sys_setup_with_poll, sys_teardown_with_poll },
     { "runtime/timer_heap_sift_paths",       test_timer_heap_sift_paths,       sys_setup_with_poll, sys_teardown_with_poll },


### PR DESCRIPTION
## Summary

The reporter's follow-up on #493 narrowed it to the piped (non-TTY) REPL, and both cases reproduced: `run_piped` blocked in `fgets()`, so a 100 ms timer fired only when the pipe's writer closed at 1.0 s; and a timer-only run at EOF exited 0 with the timer unfired.

- **Piped stdin is read through the poll loop.** A line reader with `fgets` semantics replaces the six `fgets` calls. With a poll, stdin is a registered selector whose read callback pumps the pipe, and the reader waits in bounded poll passes that fire due timers and serve every other selector, so a `-p` server also answers IPC while piped input is open. A close callback handles the pipe's data and hangup arriving in one event (the poller drops the selector itself on hangup), after which the reader drains the pipe with direct reads. Without a poll it reads directly as before.
- **A process with pending timers stays until they are spent.** After a script, or at piped EOF with nothing else registered, `ray_poll_drain_timers` runs bounded passes while a deadline exists. A live listener or connection keeps the loop as before, now counted by `n_live` rather than array slots. A lingering client handle does not keep a script alive: all sockets share one selector type, and a script's open handle must not turn into a hang.
- **The unbounded loop returns when idle** (no selectors, no timers) in both pollers instead of blocking forever.

Reporter's command on this branch:

```
{ printf '(.time.timer.set 100 1 (fn [t] (exit 7)))\n'; sleep 1; } | ./rayforce -i -p 19126
→ exit 7 at 0.0 s   (was: exit 7 at 1.00 s, when the pipe closed)
printf '(.time.timer.set 100 1 (fn [t] (exit 7)))\n' | ./rayforce -i
→ exit 7            (was: exit 0, timer unfired)
```

## Tests

`test/rfl/system/piped_timers.rfl` drives the real binary: pipe held open 4 s with and without a listener (exit 7 within 1 s), timer-only EOF and a script file (exit 7), a script with no timers exits promptly, and a script that left a client handle open still exits. `runtime/poll_run_returns_when_idle` covers the idle exit and the drain helper. Docs in `time.md` say when timers fire and what keeps a process alive. Full `make test`: 3761 of 3761, no sanitizer output; the 93 REPL tests are unchanged.

Fixes #493

https://claude.ai/code/session_01J4QKJW3RbRP8TQoquJtARg
