### PR TITLE
feat(ipc): fire .ipc.on.close for outbound connections, report direction in .ipc.handle

### DIFF
--- a/docs/docs/reference/all-functions.md
+++ b/docs/docs/reference/all-functions.md
@@ -726,10 +726,10 @@ TCP-based IPC for connecting to remote Rayforce instances. Uses binary serializa
 | `.ipc.open` | variadic | restricted | Open TCP connection to host:port (optional connect timeout in ms), returns handle | `(.ipc.open "localhost:5000" 2000)` |
 | `.ipc.close` | unary | restricted | Close an IPC connection handle | `(.ipc.close h)` |
 | `.ipc.send` | binary | restricted | Send a value over an IPC handle (sync request) | `(.ipc.send h "(sum (til 100))")` |
-| `.ipc.handle` | variadic | — | Current connection handle inside any `.ipc.on.*` hook, `-1` outside; given a live connection handle, that connection's transmit-queue view (`limit_bytes`, `limit_frames`, `queued_bytes`, `queued_frames`, `hwm_bytes`) | `(.ipc.handle)`, `(.ipc.handle h)` |
+| `.ipc.handle` | variadic | — | Current connection handle inside any `.ipc.on.*` hook, `-1` outside; given a live connection handle, that connection's view (`inbound`, `limit_bytes`, `limit_frames`, `queued_bytes`, `queued_frames`, `hwm_bytes`) | `(.ipc.handle)`, `(.ipc.handle h)` |
 | `.ipc.txlimit` | variadic | restricted | Transmit backlog policy: `()` reads the process default, `(bytes [frames])` sets it, `(h bytes frames)` overrides one connection; a frame that would exceed a connection's limit is refused and a multicast subscriber is dropped and closed | `(.ipc.txlimit 8388608 64)` |
 | `.ipc.on.open` | hook | user-settable | Fires after inbound connection completes handshake; arg = handle | `(set .ipc.on.open (fn [h] ...))` |
-| `.ipc.on.close` | hook | user-settable | Fires before inbound connection teardown; arg = handle | `(set .ipc.on.close (fn [h] ...))` |
+| `.ipc.on.close` | hook | user-settable | Fires once before an established connection is torn down, inbound or outbound, on any cause; arg = handle | `(set .ipc.on.close (fn [h] ...))` |
 | `.ipc.on.sync` | hook | user-settable | Intercepts sync messages; return value becomes the response | `(set .ipc.on.sync (fn [m] (eval (parse m))))` |
 | `.ipc.on.async` | hook | user-settable | Intercepts async messages; return value ignored | `(set .ipc.on.async (fn [m] ...))` |
 | `.ipc.on.auth` | hook | user-settable | Narrows `-u`/`-U` auth; truthy = accept, falsy = reject | `(set .ipc.on.auth (fn [u p] (!= u "ban")))` |

--- a/docs/docs/storage/ipc-hooks.md
+++ b/docs/docs/storage/ipc-hooks.md
@@ -2,7 +2,7 @@
 
 Five user-installable lambdas under `.ipc.on.*` that intercept the server-side connection lifecycle, plus the `.ipc.handle` accessor for the current connection's handle.
 
-The handle a hook receives is a first-class connection handle — the same namespace `.ipc.open` allocates from. Pass it to `.ipc.post` (async push to the connected client), `.ipc.send` (sync round-trip), or `.ipc.close` (kick the client), from inside the hook or any time later. Lifecycle hooks fire for **inbound** connections only; connections the process itself opened via `.ipc.open` never trigger `on.open`/`on.close`.
+The handle a hook receives is a first-class connection handle — the same namespace `.ipc.open` allocates from. Pass it to `.ipc.post` (async push to the connected client), `.ipc.send` (sync round-trip), or `.ipc.close` (kick the client), from inside the hook or any time later. `on.open`, `on.sync`, `on.async` and `on.auth` fire for **inbound** connections only. `on.close` fires for **both** directions: a connection the process opened with `.ipc.open` reports its close too, so a receive-only client (a multicast subscriber, say) learns that the peer went away without probing. `(at (.ipc.handle h) 'inbound)` tells the two apart inside the hook.
 
 !!! note "See also"
     The [IPC & Serialization](ipc.md) page documents the client-side `.ipc.open` / `.ipc.send` / `.ipc.close` and the wire format. Hooks live on the server and fire in response to inbound connections.
@@ -14,7 +14,7 @@ The server side exposes the inbound connection lifecycle to Rayfall code through
 | Name | Signature | Fires | Return value |
 |---|---|---|---|
 | `.ipc.on.open` | `(fn [h] ...)` | Inbound connection fully handshaked (and authed when `-u`/`-U` is on), just before the first header read. | Ignored. |
-| `.ipc.on.close` | `(fn [h] ...)` | Inbound connection about to close, before its socket is closed and per-conn state is freed. Pairs 1-to-1 with `.ipc.on.open` — never fires for connections that died mid-handshake. | Ignored. |
+| `.ipc.on.close` | `(fn [h] ...)` | An established connection, inbound or outbound, about to close, before its socket is closed and per-conn state is freed. Fires exactly once per connection on any teardown: the peer's close or reset, a socket error, a local `.ipc.close`, or a multicast eviction seen from the subscriber's side. Never fires for a connection that died mid-handshake. Inbound closes pair 1-to-1 with `.ipc.on.open`; outbound ones have no open event. | Ignored. |
 | `.ipc.on.sync` | `(fn [m] ...)` | Inbound sync request, after the payload is deserialised into `m`. Replaces the default in-process `eval`. | Serialised and shipped to the client as the response. |
 | `.ipc.on.async` | `(fn [m] ...)` | Inbound async message. Same dispatch point as `on.sync`, but the wire produces no response. | Ignored (errors are logged to stderr). |
 | `.ipc.on.auth` | `(fn [u p] ...)` | After the constant-time secret compare in `-u`/`-U` auth passes. Servers started without auth never reach this hook. | Truthy = accept connection, falsy / error = reject and close. |
@@ -86,3 +86,13 @@ Inside any hook, `(.ipc.handle)` returns the handle of the connection that trigg
 The argument `h` passed to `on.open` / `on.close` always equals `(.ipc.handle)` at the moment the hook fires — the builtin is the only way to reach the handle from `on.sync` / `on.async` / `on.auth`, whose signatures don't include it directly.
 
 A handle read here stays valid for the connection's lifetime: store it and `.ipc.post` to it later (publish/subscribe), or `.ipc.close` it to drop the client. After the connection closes, the integer may be reused by a future connection — don't cache handles across `on.close`.
+
+Inside `on.close` the handle still resolves — `(.ipc.handle h)` answers, with `inbound` saying which direction closed — but the peer is gone or going, so sending on it is pointless. The hook runs inside the poller's teardown of that connection; reconnect from a timer (`.time.timer.set`) rather than from inside the hook.
+
+```lisp
+;; a subscriber that notices its publisher dropped it
+(set .ipc.on.close (fn [h]
+  (if (not (at (.ipc.handle h) 'inbound))
+      (.time.timer.set 1000 1 (fn [t] (reconnect-and-resubscribe)))
+      null)))
+```

--- a/docs/docs/storage/ipc.md
+++ b/docs/docs/storage/ipc.md
@@ -184,14 +184,14 @@ Every connection queues outbound bytes the socket cannot take immediately (async
 (.ipc.txlimit 8388608)         ; 8 MiB per connection, frames unlimited
 (.ipc.txlimit 8388608 64)      ; at most 8 MiB or 64 queued frames, whichever first
 (.ipc.txlimit h 67108864 0)    ; one connection may hold 64 MiB
-(.ipc.handle h)                ; {handle limit_bytes limit_frames queued_bytes queued_frames hwm_bytes}
+(.ipc.handle h)                ; {handle inbound limit_bytes limit_frames queued_bytes queued_frames hwm_bytes}
 ```
 
 The default is 256 MiB with no frame cap; the minimum is 4 KiB, and `frames` of `0` means unlimited. Changing the default applies to every connection without an override, including ones already open. `.mc.stats` reports the default as `tx_limit_bytes` / `tx_limit_frames` and the largest backlog any connection has held as `tx_hwm_bytes`. `.ipc.txlimit` is restricted: it decides when a peer is dropped.
 
 ## Connection Hooks
 
-The server side exposes the inbound connection lifecycle to Rayfall code through five user-installable lambdas under `.ipc.on.*` — `open`, `close`, `sync`, `async`, and `auth` — plus the `(.ipc.handle)` accessor that returns the current connection's handle inside any hook. See [IPC Connection Hooks](ipc-hooks.md) for the full reference: signatures, install / clear semantics, the reserved-namespace carve-out, per-hook error handling, and the restricted-mode interaction.
+The server side exposes the inbound connection lifecycle to Rayfall code through five user-installable lambdas under `.ipc.on.*` — `open`, `close`, `sync`, `async`, and `auth` — plus the `(.ipc.handle)` accessor that returns the current connection's handle inside any hook. `close` also fires on the client side for a connection opened with `.ipc.open`, so a subscriber sees its publisher go away. See [IPC Connection Hooks](ipc-hooks.md) for the full reference: signatures, install / clear semantics, the reserved-namespace carve-out, per-hook error handling, and the restricted-mode interaction.
 
 ## Serialization with `ser`
 

--- a/src/core/ipc.c
+++ b/src/core/ipc.c
@@ -1068,17 +1068,20 @@ static void ipc_on_close(ray_poll_t* poll, ray_selector_t* sel)
      * before the listener's own close path (which would otherwise also
      * route through here) runs the hook with a stale fd.  Guard on:
      *   - sel->data: the listener itself has no conn data.
-     *   - listener_id ≥ 0: lifecycle hooks pair with inbound on.open
-     *     only — outbound conns (ray_ipc_connect) never fired on.open,
-     *     so they must not fire on.close either.
-     *   - phase ≥ HEADER: the connection actually completed handshake
-     *     (otherwise no matching on.open was fired, so on.close must
-     *     also stay silent to keep the pair balanced for the user). */
+     *   - phase ≥ HEADER: the connection actually completed handshake.
+     *     An inbound one that died mid-handshake never fired on.open;
+     *     an outbound one is registered after its handshake, so it
+     *     always qualifies.
+     * The hook fires for both directions (#503): a receive-only client —
+     * every multicast subscriber — otherwise learns of the peer's close
+     * only by probing.  It fires once per established connection on any
+     * teardown (peer EOF, socket error, local .ipc.close, eviction);
+     * on.open stays inbound-only, and (.ipc.handle h) reports `inbound`
+     * so one handler can tell the direction. */
     if (sel->data) {
         ray_ipc_conn_data_t* cd = (ray_ipc_conn_data_t*)sel->data;
-        if (cd->listener_id >= 0 &&
-            (cd->phase == RAY_IPC_PHASE_HEADER ||
-             cd->phase == RAY_IPC_PHASE_PAYLOAD)) {
+        if (cd->phase == RAY_IPC_PHASE_HEADER ||
+            cd->phase == RAY_IPC_PHASE_PAYLOAD) {
             hook_call_lifecycle(poll, IPC_HOOK_CLOSE, sel->id);
         }
         /* A RESP deposited for a sync wait that never consumed it
@@ -1780,7 +1783,7 @@ int64_t ray_ipc_connect(const char* host, uint16_t port,
     if (!cd) { ray_sock_close(fd); return -1; }
     memset(cd, 0, sizeof(*cd));
     cd->phase       = RAY_IPC_PHASE_HEADER;
-    cd->listener_id = -1;               /* outbound — no lifecycle hooks */
+    cd->listener_id = -1;               /* outbound: on.open never fires, on.close does */
     cd->restricted  = poll->restricted; /* -U narrows pushed evals too */
 
     ray_sock_set_nonblocking(fd);
@@ -2089,6 +2092,8 @@ ray_err_t ray_ipc_tx_info(int64_t handle, ray_ipc_tx_info_t* out)
     conn_tx_limits(sel, &out->limit_bytes, &out->limit_frames);
     out->queued_bytes = conn_tx_pending(sel, &out->queued_frames);
     out->hwm_bytes    = sel->tx.hwm_bytes;
+    out->inbound      = sel->data &&
+                        ((ray_ipc_conn_data_t*)sel->data)->listener_id >= 0;
     return RAY_OK;
 }
 

--- a/src/core/ipc.h
+++ b/src/core/ipc.h
@@ -159,6 +159,7 @@ typedef struct {
     int64_t queued_bytes;   /* backlog right now */
     int64_t queued_frames;
     int64_t hwm_bytes;      /* largest backlog ever queued here */
+    bool    inbound;        /* accepted by a listener here (true) or opened by .ipc.open (false) */
 } ray_ipc_tx_info_t;
 
 void      ray_ipc_tx_limit_get(int64_t* bytes, int64_t* frames);

--- a/src/ops/system.c
+++ b/src/ops/system.c
@@ -1521,22 +1521,23 @@ ray_t* ray_hpost_fn(ray_t* handle, ray_t* msg) {
 /* Build {handle limit_bytes limit_frames queued_bytes queued_frames hwm_bytes}
  * for a live connection. */
 static ray_t* ipc_tx_info_dict(int64_t h, const ray_ipc_tx_info_t* ti) {
-    static const char* const names[6] = { "handle", "limit_bytes", "limit_frames",
+    static const char* const names[7] = { "handle", "inbound", "limit_bytes", "limit_frames",
                                           "queued_bytes", "queued_frames", "hwm_bytes" };
-    int64_t vals_i[6] = { h, ti->limit_bytes, ti->limit_frames,
+    int64_t vals_i[7] = { h, ti->inbound ? 1 : 0, ti->limit_bytes, ti->limit_frames,
                           ti->queued_bytes, ti->queued_frames, ti->hwm_bytes };
-    ray_t* keys = ray_sym_vec_new(RAY_SYM_W64, 6);
-    ray_t* vals = ray_list_new(6);
+    ray_t* keys = ray_sym_vec_new(RAY_SYM_W64, 7);
+    ray_t* vals = ray_list_new(7);
     if (!keys || RAY_IS_ERR(keys) || !vals || RAY_IS_ERR(vals)) {
         if (keys && !RAY_IS_ERR(keys)) ray_release(keys);
         if (vals && !RAY_IS_ERR(vals)) ray_release(vals);
         return ray_error("oom", NULL);
     }
-    for (int i = 0; i < 6; i++) {
+    for (int i = 0; i < 7; i++) {
         int64_t k = ray_sym_intern(names[i], strlen(names[i]));
         keys = ray_vec_append(keys, &k);
         if (RAY_IS_ERR(keys)) { ray_release(vals); return keys; }
-        ray_t* v = make_i64(vals_i[i]);
+        /* `inbound` is the direction: accepted here, or opened by .ipc.open */
+        ray_t* v = (i == 1) ? ray_bool(vals_i[i] != 0) : make_i64(vals_i[i]);
         vals = ray_list_append(vals, v); ray_release(v);
         if (RAY_IS_ERR(vals)) { ray_release(keys); return vals; }
     }

--- a/test/test_ipc.c
+++ b/test/test_ipc.c
@@ -1845,7 +1845,9 @@ static test_result_t test_ipc_hooks_lifecycle(void) {
     ray_sys_free(srv_vm);
 
     /* Read counters back through the global env.  on.open + on.sync
-     * + on.close each fired exactly once.  `_hook_sync_handle` records
+     * fired exactly once; on.close fired twice — once on the client for
+     * its own outbound handle (ray_ipc_close, #503) and once on the
+     * server for the inbound one.  `_hook_sync_handle` records
      * `.ipc.handle` as seen INSIDE the sync hook — must equal the
      * legacy server's conn-array index (0 for the only active conn). */
     int64_t sym_open  = ray_sym_intern("_hook_open",        strlen("_hook_open"));
@@ -1859,7 +1861,7 @@ static test_result_t test_ipc_hooks_lifecycle(void) {
     ray_t* v_msg   = ray_env_get(sym_msg);    TEST_ASSERT_NOT_NULL(v_msg);
 
     TEST_ASSERT_EQ_I(v_open->i64,  1);
-    TEST_ASSERT_EQ_I(v_close->i64, 1);
+    TEST_ASSERT_EQ_I(v_close->i64, 2);
     TEST_ASSERT_EQ_I(v_msg->i64,   1);
     TEST_ASSERT_EQ_I(v_h->i64,     0);
 

--- a/test/test_mcast.c
+++ b/test/test_mcast.c
@@ -879,7 +879,10 @@ static test_result_t test_mcast_txlimit_overflow_disconnects(void) {
     ray_release(pub);
 
     TEST_ASSERT_TRUE(pump_until_env_i64_at_least("_mc_count", 9, 1, 2000));
-    TEST_ASSERT_TRUE(pump_until_env_i64_at_least("_mc_close_count", 15, 1, 2000));
+    /* Two closes: the server dropping h1 (inbound), and h1's own side
+     * seeing the EOF (outbound, #503) — the signal a subscriber needs
+     * to notice it was evicted and reconnect. */
+    TEST_ASSERT_TRUE(pump_until_env_i64_at_least("_mc_close_count", 15, 2, 2000));
     ray_t* c = ray_env_get(ray_sym_intern("_mc_count", 9));
     TEST_ASSERT_NOT_NULL(c);
     TEST_ASSERT_EQ_I(c->i64, 1);              /* only h2 received it */
@@ -922,6 +925,114 @@ static test_result_t test_mcast_txlimit_overflow_disconnects(void) {
     ray_ipc_close(h1);
     ray_ipc_close(h2);
     ray_ipc_close(hp);
+    stop_server(poll, port, vm, tid);
+    PASS();
+}
+
+/* .ipc.on.close fires for outbound connections too (#503), once per
+ * established connection on any teardown: the peer's orderly close, a
+ * peer reset, and a local .ipc.close.  .ipc.on.open stays inbound-only,
+ * and (.ipc.handle h) reports `inbound` so one handler can tell the two
+ * apart.  The hook lambda is shared by the server thread (inbound
+ * closes) and the client poll (outbound closes), so it records the
+ * direction it saw rather than bare handle ids, which the two polls
+ * number independently. */
+static test_result_t test_ipc_outbound_close_hook(void) {
+    ray_t* r = ray_eval_str(
+        "(set _oc_in 0)"
+        "(set _oc_out 0)"
+        "(set _oc_open 0)"
+        "(set _oc_srv [])"
+        "(set .ipc.on.open (fn [h] (do (set _oc_open (+ _oc_open 1)) (set _oc_srv (concat _oc_srv h)))))"
+        "(set .ipc.on.close (fn [h] "
+        "  (if (at (.ipc.handle h) 'inbound) (set _oc_in (+ _oc_in 1)) (set _oc_out (+ _oc_out 1)))))");
+    TEST_ASSERT_NOT_NULL(r);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(r));
+    if (r != RAY_NULL_OBJ) ray_release(r);
+
+    ray_poll_t* poll;
+    ray_vm_t* vm;
+    uint16_t port;
+    ray_thread_t tid;
+    test_result_t sr = start_server(&poll, &port, &vm, &tid);
+    if (sr.status != TEST_PASS) return sr;
+
+    int64_t h1 = ray_ipc_connect("127.0.0.1", port, NULL, NULL, 0);
+    int64_t h2 = ray_ipc_connect("127.0.0.1", port, NULL, NULL, 0);
+    int64_t h3 = ray_ipc_connect("127.0.0.1", port, NULL, NULL, 0);
+    int64_t hc = ray_ipc_connect("127.0.0.1", port, NULL, NULL, 0);   /* control */
+    TEST_ASSERT((h1) >= (0) && (h2) >= (0) && (h3) >= (0) && (hc) >= (0), "connected");
+    pump_client();
+
+    /* open fired once per inbound connection and never for an outbound one */
+    ray_t* op = ray_env_get(ray_sym_intern("_oc_open", 8));
+    TEST_ASSERT_NOT_NULL(op);
+    TEST_ASSERT_EQ_I(op->i64, 4);
+
+    /* direction is visible on both sides */
+    ray_t* msg = ray_str("(at (.ipc.handle (.ipc.handle)) 'inbound)", strlen("(at (.ipc.handle (.ipc.handle)) 'inbound)"));
+    ray_t* inb = ray_ipc_send(hc, msg);
+    ray_release(msg);
+    TEST_ASSERT_NOT_NULL(inb);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(inb));
+    TEST_ASSERT_EQ_I(inb->type, -RAY_BOOL);
+    TEST_ASSERT_TRUE(inb->b8);
+    ray_release(inb);
+    {
+        ray_ipc_tx_info_t ti;
+        TEST_ASSERT_EQ_I(ray_ipc_tx_info(h1, &ti), RAY_OK);
+        TEST_ASSERT_FALSE(ti.inbound);
+    }
+
+    ray_t* srv = ray_env_get(ray_sym_intern("_oc_srv", 7));
+    TEST_ASSERT_NOT_NULL(srv);
+    TEST_ASSERT((ray_len(srv)) >= (3), "server-side handles captured");
+    int64_t s1 = ((int64_t*)ray_data(srv))[0];
+    int64_t s2 = ((int64_t*)ray_data(srv))[1];
+
+    /* A: the peer closes h1 in an orderly way (server-side .ipc.close) */
+    char src[96];
+    int n = snprintf(src, sizeof(src), "(.ipc.close %lld)", (long long)s1);
+    msg = ray_str(src, (size_t)n);
+    ray_t* cr = ray_ipc_send(hc, msg);
+    ray_release(msg);
+    TEST_ASSERT_NOT_NULL(cr);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(cr));
+    ray_release(cr);
+    TEST_ASSERT_TRUE(pump_until_env_i64_at_least("_oc_out", 7, 1, 1000));
+
+    /* B: the peer resets h2 (linger zero, then close → RST) */
+#ifndef RAY_OS_WINDOWS
+    {
+        ray_selector_t* ssel = ray_poll_get(poll, s2);
+        TEST_ASSERT_NOT_NULL(ssel);
+        struct linger lg = { 1, 0 };
+        setsockopt((ray_sock_t)ssel->fd, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg));
+    }
+#endif
+    n = snprintf(src, sizeof(src), "(.ipc.close %lld)", (long long)s2);
+    msg = ray_str(src, (size_t)n);
+    cr = ray_ipc_send(hc, msg);
+    ray_release(msg);
+    TEST_ASSERT_NOT_NULL(cr);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(cr));
+    ray_release(cr);
+    TEST_ASSERT_TRUE(pump_until_env_i64_at_least("_oc_out", 7, 2, 1000));
+
+    /* C: local close of h3 fires the hook too — one rule for any teardown */
+    ray_ipc_close(h3);
+    TEST_ASSERT_TRUE(pump_until_env_i64_at_least("_oc_out", 7, 3, 1000));
+
+    /* exactly once each; the inbound side saw its own three closes */
+    ray_t* out = ray_env_get(ray_sym_intern("_oc_out", 7));
+    TEST_ASSERT_NOT_NULL(out);
+    TEST_ASSERT_EQ_I(out->i64, 3);
+    sleep_ms(50);
+    ray_t* in = ray_env_get(ray_sym_intern("_oc_in", 6));
+    TEST_ASSERT_NOT_NULL(in);
+    TEST_ASSERT((in->i64) >= (3), "inbound closes observed on the server");
+
+    ray_ipc_close(hc);
     stop_server(poll, port, vm, tid);
     PASS();
 }
@@ -1139,5 +1250,6 @@ const test_entry_t mcast_entries[] = {
     { "mcast/failed_send_defers_close",   test_mcast_failed_send_defers_close,   mcast_setup, mcast_teardown },
     { "mcast/shared_frame_across_subs",   test_mcast_shared_frame_across_subscribers, mcast_setup, mcast_teardown },
     { "mcast/txlimit_overflow_disconnects", test_mcast_txlimit_overflow_disconnects, mcast_setup, mcast_teardown },
+    { "ipc/outbound_close_hook",          test_ipc_outbound_close_hook,          mcast_setup, mcast_teardown },
     { NULL, NULL, NULL, NULL },
 };


### PR DESCRIPTION
## Summary

`.ipc.on.close` fired for inbound connections only, so a receive-only client (every multicast subscriber) got no event when its peer closed, reset, or evicted it. It now fires for both directions, with one rule:

- **Once per established connection, on any teardown**: peer close or reset, socket error, local `.ipc.close`, or a multicast eviction seen from the subscriber's side as EOF. Never for a connection that died mid-handshake.
- **`.ipc.on.open` stays inbound-only.** The pairing becomes a documented asymmetry, the same shape as q's `.z.po` / `.z.pc`.
- **`(.ipc.handle h)` gains `inbound`** so a single handler tells the direction in one line; the hook fires before teardown, so the handle resolves inside it. Reconnect from a timer, not from inside the hook (it runs in the poller's deregister path).

Code-wise it is the removal of the `listener_id >= 0` guard in `ipc_on_close`, one field in `ray_ipc_tx_info_t`, and one dict key. Behaviour change to flag: a server that also opens outbound connections now sees their closes in `.ipc.on.close`; a subscription-cleanup handler is unaffected, a client counter needs the `inbound` branch. The lifecycle test that pinned one close per client round-trip now expects two (client-side outbound, server-side inbound).

```lisp
;; a subscriber that notices its publisher dropped it
(set .ipc.on.close (fn [h]
  (if (not (at (.ipc.handle h) 'inbound))
      (.time.timer.set 1000 1 (fn [t] (reconnect-and-resubscribe)))
      null)))
```

## Tests

`ipc/outbound_close_hook`: a client-side handler counting closes by direction through `(.ipc.handle h)`; the peer's orderly close, a linger-zero reset, and a local `.ipc.close` each fire exactly once for the outbound handle, `on.open` fires only for the four inbound accepts, and `inbound` reads true on the server and false on the client. `mcast/txlimit_overflow_disconnects` now also asserts the evicted subscriber's own side sees the close. Docs updated in `ipc-hooks.md`, `ipc.md` and `all-functions.md`. Full `make test`: 3767 of 3767, no sanitizer output.

Observation, not addressed here: on the pre-fix code the first draft of the new test crashed once in the server thread inside `ipc_hook_syms_ensure` (a symbol-table read during `ray_sym_intern` from the hook lookup) while the main thread was mid-`ray_ipc_send`. It did not reproduce on the fixed code in repeated runs, nor in the existing hook tests, but the two-poll test harness shares one symbol table across threads, and that path may deserve a look on its own.

Closes #503

https://claude.ai/code/session_01J4QKJW3RbRP8TQoquJtARg
