### PR TITLE
fix(app): a failed startup script under -p is fatal when not interactive

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -199,7 +199,10 @@ int main(int argc, char** argv) {
                 "  and stderr to a file/journal — anything (println ...)\n"
                 "  prints from the server side goes there.  Example:\n"
                 "    nohup rayforce -p 5000 > rayforce.log 2>&1 &\n"
-                "    systemd:  StandardOutput=journal StandardError=journal\n",
+                "    systemd:  StandardOutput=journal StandardError=journal\n"
+                "  With -p and a script, a script that fails to parse or\n"
+                "  evaluate is fatal: the listener closes and the process\n"
+                "  exits non-zero (with -i the REPL stays up instead).\n",
                 argv[0]);
             ray_runtime_destroy(rt);
             return 0;
@@ -282,6 +285,18 @@ int main(int argc, char** argv) {
     /* Load script if specified */
     if (file) {
         rc = ray_repl_run_file(file);
+        /* The listener is already up (so the script may use it), which
+         * means a failed startup script would otherwise leave a port
+         * that accepts connections in front of an empty workspace: a
+         * supervisor's port check passes and Restart=on-failure never
+         * fires.  Non-interactively, a script that fails to parse or
+         * evaluate is fatal; the listener goes down with the process.
+         * With -i the REPL stays up for the user to look around. */
+        if (rc != 0 && !interactive && port > 0) {
+            fprintf(stderr, "startup script %s failed; closing listener on %s:%u and exiting\n",
+                    file, bind_host[0] ? bind_host : "*", port);
+            goto done;
+        }
         if (!interactive && !(port > 0)) {
             /* A script that armed timers means to run them: stay until
              * they are spent (a one-shot fires once, a periodic one until

--- a/test/rfl/system/startup_script_fatal.rfl
+++ b/test/rfl/system/startup_script_fatal.rfl
@@ -1,0 +1,14 @@
+;; startup_script_fatal.rfl — a failing startup script under -p is fatal
+;; non-interactively (#507).
+;;
+;; Regression: -p opened the listener before the script, and when the
+;; script failed the process printed the error and kept serving the port
+;; with none of the script's definitions installed.  A supervisor's port
+;; check passed and Restart=on-failure never fired.
+(.sys.exec "rm -rf /tmp/rfl_ssf && mkdir -p /tmp/rfl_ssf && printf '(load \"does-not-exist.rfl\")\n' > /tmp/rfl_ssf/bad.rfl && printf '(set ok 1)\n' > /tmp/rfl_ssf/good.rfl")
+;; bad script: exits 1 within a second and leaves nothing listening
+(.sys.exec "s=$(date +%s); ./rayforce -p 19969 /tmp/rfl_ssf/bad.rfl </dev/null >/tmp/rfl_ssf/out 2>&1; rc=$?; e=$(date +%s); grep -q 'error: io' /tmp/rfl_ssf/out && grep -q 'startup script /tmp/rfl_ssf/bad.rfl failed' /tmp/rfl_ssf/out && [ $rc -eq 1 ] && [ $((e-s)) -le 1 ]") -- 0
+(.sys.exec "bash -c '(echo > /dev/tcp/127.0.0.1/19969) 2>/dev/null' && exit 1; exit 0") -- 0
+;; good script: still serves after the script (killed by pid once up)
+(.sys.exec "./rayforce -p 19969 /tmp/rfl_ssf/good.rfl </dev/null >/dev/null 2>&1 & echo $! > /tmp/rfl_ssf/pid; for i in $(seq 50); do bash -c '(echo > /dev/tcp/127.0.0.1/19969) 2>/dev/null' && exit 0; sleep 0.1; done; exit 1") -- 0
+(.sys.exec "kill $(cat /tmp/rfl_ssf/pid) 2>/dev/null; rm -rf /tmp/rfl_ssf; true")


### PR DESCRIPTION
## Summary

With `-p` and a script, the listener opens first (so the script can use it), and a script that failed to parse or evaluate left the process serving the port in front of an empty workspace. A supervisor's port check passed and `Restart=on-failure` never fired.

Non-interactively, a failing startup script is now fatal: the diagnostic names the script and the listener, and the process exits with the script's status through the normal teardown, which closes the listener.

```
$ rayforce -p 19999 bad.rfl </dev/null; echo rc=$?
listening on *:19999
error: io: load "does-not-exist.rfl": No such file or directory   (message from #508)
startup script bad.rfl failed; closing listener on *:19999 and exiting
rc=1
```

With `-i` the REPL stays up as before. The listener still opens before the script; opening it after would change what scripts can do at startup (register handlers, publish on their own port) and is not needed once failure closes it. No strict flag: a failing startup script is not a state a service should keep running in.

## Test

`test/rfl/system/startup_script_fatal.rfl`: the bad script exits 1 within a second with both lines on stderr and nothing left listening; a good script still serves after it runs.

Closes #507

https://claude.ai/code/session_01J4QKJW3RbRP8TQoquJtARg