### PR TITLE
fix(datalog): audit correctness fixes (recursion, negation, types, leak, arithmetic)

### DIFF
--- a/docs/docs/guides/datalog-reference.md
+++ b/docs/docs/guides/datalog-reference.md
@@ -226,12 +226,15 @@ Use `_` to match any value without binding it to a variable:
 
 ### How queries compile to the DAG
 
-Under the hood, each query compiles to Rayforce's DAG execution pipeline:
-
-- Each triple pattern `(?e :attr ?v)` becomes a `ray_scan` + `ray_filter` on the datoms table
-- Shared variables across patterns become `ray_join` operations
-- The `find` clause becomes a final projection selecting the requested columns
-- The optimizer applies predicate pushdown, filter reorder, and fusion — the same passes used for `select`
+Under the hood each rule is evaluated by materialisation: every positive body
+atom is filtered on its constants and repeated variables, joined with the
+accumulated result on shared variables (hash join, morsel-parallel), then
+negations, comparisons, assignments and aggregates are applied in declared
+order, and the head projection is de-duplicated and merged into the derived
+relation. Recursive rules run to fixpoint with semi-naive evaluation. Joins
+execute on the same operators as `select`, but a whole rule is not planned as
+one DAG: body atoms are joined in the order written, and comparisons are
+applied after the joins that bind their variables.
 
 ## Negation
 
@@ -459,7 +462,52 @@ Every Datalog concept compiles down to existing Rayforce DAG operations. The Dat
 
 !!! note "Performance"
 
-    Because Datalog compiles to the same DAG as `select`/`update`, queries benefit from all optimizer passes: predicate pushdown, filter reorder, fusion, and morsel-parallel execution with SIMD.
+    Joins and distinct inside a rule use the parallel `select` operators. Rule-level
+    join ordering, predicate pushdown across atoms and plan reuse between queries are
+    not performed; write the most selective atom first.
+
+## Constants in patterns
+
+In a `where` clause or rule body, a quoted symbol (`'Alice`) or keyword
+(`:name`) is a literal; a bare unquoted symbol (`sid`) is evaluated as a
+variable reference to a bound value (integer, float, symbol or string). Head
+arguments still treat a bare symbol as a literal constant.
+
+## Arithmetic
+
+Integer expressions in `(= ?y (+ ?x 1))` and comparisons are 64-bit and checked:
+overflow, division by zero, `INT64_MIN / -1` and any null operand produce the
+null integer `0Nl`. Float expressions follow IEEE 754 (division by zero gives
+`0Nf`). The error code surfaced for a failed query evaluation is `domain`.
+
+## Limits
+
+| Limit | Value | On overflow |
+|---|---|---|
+| Variables in `find` | 16 | error `find supports at most 16 variables` |
+| Arity of a relation | 16 | error at rule or EDB registration |
+| Body literals per rule | 16 | error `too many body literals` |
+| Rules per program | 128 | error `too many rules` |
+| Relations per program | 64 | error |
+| Strata | 16 | error |
+| Group keys in an aggregate | 8 | error |
+
+An unknown relation name in a body is an error (`unknown relation 'name'`),
+not an empty result.
+
+## Symbol storage
+
+`assert-fact` stores symbol values in the `v` column with a type tag, so the
+symbol `'Alice` and the integer equal to its intern id are different values.
+Query results, `pull` and `scan-eav` return the plain intern id; use `sym-name`
+to read it back. Inspecting the raw datoms table shows the tagged encoding.
+
+A datoms table whose `v` column is a real symbol vector (hand-built or
+loaded) is also recognised as holding symbols. A legacy table whose `v`
+column holds bare integer intern ids is not — those integers stay integers
+and are not matched against a symbol or keyword literal. Positive integer
+values of 2^61 and above cannot be stored in the `v` column or returned
+from a query without being masked; this is a limit of the tag encoding.
 
 ## Complete Example
 

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -73,6 +73,8 @@ void dl_program_free(dl_program_t* prog) {
         if (prog->rels[i].prov_src_data && !RAY_IS_ERR(prog->rels[i].prov_src_data))
             ray_release(prog->rels[i].prov_src_data);
     }
+    for (int i = 0; i < prog->n_rules; i++)
+        dl_rule_free_exprs(&prog->rules[i]);
     ray_free(dl_prog_block(prog));
 }
 
@@ -245,6 +247,7 @@ int dl_add_rule(dl_program_t* prog, const dl_rule_t* rule) {
     int idx = prog->n_rules++;
     memcpy(&prog->rules[idx], rule, sizeof(dl_rule_t));
     prog->rules[idx].stratum = -1;
+    if (dl_rule_clone_exprs(&prog->rules[idx]) < 0) { prog->n_rules--; return -1; }
 
     /* Ensure IDB relation exists for the head predicate */
     dl_ensure_idb(prog, rule->head_pred, rule->head_arity);
@@ -433,6 +436,59 @@ dl_expr_t* dl_expr_binop(int op, dl_expr_t* left, dl_expr_t* right) {
     e->left = left;
     e->right = right;
     return e;
+}
+
+/* dl_expr_alloc allocates a ray_alloc block whose ray_data() is the
+ * dl_expr_t node; recover the block header to free it. */
+static inline ray_t* dl_expr_block(dl_expr_t* e) { return (ray_t*)((char*)e - 32); }
+
+void dl_expr_free(dl_expr_t* e) {
+    if (!e) return;
+    dl_expr_free(e->left);
+    dl_expr_free(e->right);
+    ray_free(dl_expr_block(e));
+}
+
+dl_expr_t* dl_expr_clone(const dl_expr_t* e) {
+    if (!e) return NULL;
+    dl_expr_t* c = dl_expr_alloc();
+    if (!c) return NULL;
+    *c = *e;
+    c->left = c->right = NULL;
+    if (e->left)  { c->left  = dl_expr_clone(e->left);  if (!c->left)  { dl_expr_free(c); return NULL; } }
+    if (e->right) { c->right = dl_expr_clone(e->right); if (!c->right) { dl_expr_free(c); return NULL; } }
+    return c;
+}
+
+void dl_rule_free_exprs(dl_rule_t* rule) {
+    if (!rule) return;
+    for (int i = 0; i < rule->n_body; i++) {
+        dl_body_t* b = &rule->body[i];
+        dl_expr_free(b->assign_expr);  b->assign_expr  = NULL;
+        dl_expr_free(b->cmp_lhs_expr); b->cmp_lhs_expr = NULL;
+        dl_expr_free(b->cmp_rhs_expr); b->cmp_rhs_expr = NULL;
+    }
+}
+
+int dl_rule_clone_exprs(dl_rule_t* rule) {
+    for (int i = 0; i < rule->n_body; i++) {
+        dl_body_t* b = &rule->body[i];
+        dl_expr_t* a = dl_expr_clone(b->assign_expr);
+        dl_expr_t* l = dl_expr_clone(b->cmp_lhs_expr);
+        dl_expr_t* r = dl_expr_clone(b->cmp_rhs_expr);
+        if ((b->assign_expr && !a) || (b->cmp_lhs_expr && !l) || (b->cmp_rhs_expr && !r)) {
+            dl_expr_free(a); dl_expr_free(l); dl_expr_free(r);
+            /* Detach the shared originals so a later free of this copy
+             * cannot touch the caller's trees, then free what we cloned. */
+            for (int j = 0; j < rule->n_body; j++) {
+                if (j < i) { dl_expr_free(rule->body[j].assign_expr); dl_expr_free(rule->body[j].cmp_lhs_expr); dl_expr_free(rule->body[j].cmp_rhs_expr); }
+                rule->body[j].assign_expr = rule->body[j].cmp_lhs_expr = rule->body[j].cmp_rhs_expr = NULL;
+            }
+            return -1;
+        }
+        b->assign_expr = a; b->cmp_lhs_expr = l; b->cmp_rhs_expr = r;
+    }
+    return 0;
 }
 
 /* ========================================================================
@@ -4136,9 +4192,15 @@ ray_t* ray_rule_fn(ray_t** args, int64_t n) {
     dl_var_map_t vars;
     memset(&vars, 0, sizeof(vars));
     dl_rule_t rule;
+    /* dl_parse_rule_from_head_and_body can fail before its own dl_rule_init
+     * runs (e.g. malformed head); zero rule up front so n_body == 0 in that
+     * case and dl_rule_free_exprs below is always safe. */
+    memset(&rule, 0, sizeof(rule));
     ray_t* perr = dl_parse_rule_from_head_and_body(&rule, args[0], &args[1], n - 1, &vars, NULL);
-    if (perr) return perr;
+    if (perr) { dl_rule_free_exprs(&rule); return perr; }
 
+    /* Success: rule's trees move into g_dl_rules, which owns them until
+     * ray_dl_reset_rules — no clone/free here. */
     memcpy(&g_dl_rules[g_dl_n_rules++], &rule, sizeof(dl_rule_t));
     return ray_bool(true);
 }
@@ -4253,7 +4315,7 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
     /* Parse body clauses into the query rule */
     for (int64_t i = 1; i < where_len; i++) {
         ray_t* err = dl_parse_body_clause(&qrule, where_elems[i], &vars, NULL);
-        if (err) { ray_release(db); return err; }
+        if (err) { dl_rule_free_exprs(&qrule); ray_release(db); return err; }
     }
     qrule.n_vars = vars.n;
 
@@ -4300,25 +4362,41 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
         int64_t rlen = ray_len(rules_clause);
         for (int64_t i = 1; i < rlen; i++) {
             dl_rule_t irule;
+            /* dl_parse_inline_rule can fail before its own dl_rule_init runs
+             * (e.g. malformed head); zero irule up front so n_body == 0 in
+             * that case and dl_rule_free_exprs below is always safe. */
+            memset(&irule, 0, sizeof(irule));
             ray_t* rerr = dl_parse_inline_rule(&irule, re[i], prog);
             if (rerr) {
+                dl_rule_free_exprs(&irule);
+                dl_rule_free_exprs(&qrule);
                 dl_program_free(prog);
                 ray_release(db);
                 return rerr;
             }
             if (dl_add_rule(prog, &irule) < 0) {
+                dl_rule_free_exprs(&irule);
+                dl_rule_free_exprs(&qrule);
                 dl_program_free(prog);
                 ray_release(db);
                 return ray_error("domain", "query: too many rules");
             }
+            dl_rule_free_exprs(&irule);
         }
     } else {
         for (int i = 0; i < g_dl_n_rules; i++)
             dl_add_rule(prog, &g_dl_rules[i]);
     }
 
-    /* Add the synthetic query rule */
-    dl_add_rule(prog, &qrule);
+    /* Add the synthetic query rule. dl_add_rule deep-clones the trees into
+     * prog, so qrule's own trees must be freed here on every path below. */
+    if (dl_add_rule(prog, &qrule) < 0) {
+        dl_rule_free_exprs(&qrule);
+        dl_program_free(prog);
+        ray_release(db);
+        return ray_error("memory", "query: cannot add query rule");
+    }
+    dl_rule_free_exprs(&qrule);
 
     /* Auto-register env-bound EDB tables referenced from rule bodies.
      *
@@ -4654,5 +4732,7 @@ ray_t* ray_dl_free_fn(ray_t* x) {
 
 /* Reset global Datalog rule storage (called from ray_lang_destroy) */
 void ray_dl_reset_rules(void) {
+    for (int i = 0; i < g_dl_n_rules; i++)
+        dl_rule_free_exprs(&g_dl_rules[i]);
     g_dl_n_rules = 0;
 }

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -1044,6 +1044,45 @@ static bool dl_col_eq_row(ray_t* col, int64_t row, int64_t value,
     return false;
 }
 
+/* Copy the rows of tbl where keep[r] != 0 (count = number of such rows)
+ * into a new table with identical schema (SYM width/domain preserved).
+ * keep == NULL with count == 0 builds the empty table of the same schema.
+ * Returns an owned table or RAY_ERROR. */
+static ray_t* dl_table_take_mask(ray_t* tbl, const uint8_t* keep, int64_t count) {
+    int64_t nrows = ray_table_nrows(tbl);
+    int64_t ncols = ray_table_ncols(tbl);
+    ray_t* out = ray_table_new((int)ncols);
+    if (!out) return ray_error("memory", "dl_table_take_mask: table_new");
+    if (RAY_IS_ERR(out)) return out;
+    for (int64_t c = 0; c < ncols; c++) {
+        ray_t* src = ray_table_get_col_idx(tbl, c);
+        if (!src) { ray_release(out); return ray_error("domain", "dl_table_take_mask: missing source column"); }
+        ray_t* dst = (src->type == RAY_SYM)
+            ? ray_sym_vec_new(src->attrs & RAY_SYM_W_MASK, count)
+            : ray_vec_new(src->type, count);
+        if (!dst) { ray_release(out); return ray_error("memory", "dl_table_take_mask: vec_new"); }
+        if (RAY_IS_ERR(dst)) { ray_error_free(dst); ray_release(out); return ray_error("memory", "dl_table_take_mask: vec_new"); }
+        dst->len = count;
+        if (src->type == RAY_SYM) ray_sym_vec_adopt_domain(dst, src);
+        uint8_t esz = ray_sym_elem_size(src->type, src->attrs);
+        const uint8_t* src_b = (const uint8_t*)ray_data(src);
+        uint8_t* dst_b = (uint8_t*)ray_data(dst);
+        int64_t j = 0;
+        for (int64_t r = 0; keep && r < nrows; r++) {
+            if (!keep[r]) continue;
+            memcpy(dst_b + (size_t)j * esz, src_b + (size_t)r * esz, (size_t)esz);
+            j++;
+        }
+        if (src->type == RAY_STR) col_propagate_str_pool(dst, src);
+        ray_t* next = ray_table_add_col(out, ray_table_col_name(tbl, c), dst);
+        ray_release(dst);
+        if (!next) { ray_release(out); return ray_error("memory", "dl_table_take_mask: add_col"); }
+        if (RAY_IS_ERR(next)) { ray_release(out); return next; }
+        out = next;
+    }
+    return out;
+}
+
 static ray_t* dl_filter_eq(ray_t* tbl, int col_idx, int64_t value,
                            int8_t const_type) {
     /* Contract: always return an owned reference (rc bumped) so the
@@ -1080,63 +1119,74 @@ static ray_t* dl_filter_eq(ray_t* tbl, int col_idx, int64_t value,
     }
 
     int64_t nrows = ray_table_nrows(tbl);
-    int64_t ncols = ray_table_ncols(tbl);
 
-    /* Count matching rows — type-aware read for RAY_SYM adaptive width. */
+    /* Compute the keep mask — type-aware read for RAY_SYM adaptive width. */
+    ray_t* keep_block = ray_alloc((size_t)nrows);
+    if (!keep_block || RAY_IS_ERR(keep_block)) return ray_error("memory", "dl_filter_eq: mask alloc");
+    uint8_t* keep = (uint8_t*)ray_data(keep_block);
     int64_t count = 0;
-    for (int64_t r = 0; r < nrows; r++)
-        if (dl_col_eq_row(col, r, value, const_type)) count++;
+    for (int64_t r = 0; r < nrows; r++) {
+        keep[r] = dl_col_eq_row(col, r, value, const_type) ? 1 : 0;
+        count += keep[r];
+    }
 
-    if (count == nrows) { ray_retain(tbl); return tbl; }
+    if (count == nrows) { ray_free(keep_block); ray_retain(tbl); return tbl; }
 
     /* Build filtered table.  Each surviving column is allocated with
      * its source's element-size (via ray_sym_elem_size) so narrow-SYM
      * stays narrow rather than being silently widened to W64. */
-    ray_t* out = ray_table_new((int)ncols);
-    if (!out) return ray_error("memory", "dl_filter_eq: table_new");
-    if (RAY_IS_ERR(out)) return out;
-    for (int64_t c = 0; c < ncols; c++) {
-        ray_t* src = ray_table_get_col_idx(tbl, c);
-        if (!src) {
-            ray_release(out);
-            return ray_error("domain", "dl_filter_eq: missing source column");
-        }
-        ray_t* dst = (src->type == RAY_SYM)
-            ? ray_sym_vec_new(src->attrs & RAY_SYM_W_MASK, count)
-            : ray_vec_new(src->type, count);
-        if (!dst) { ray_release(out); return ray_error("memory", "dl_filter_eq: vec_new"); }
-        if (RAY_IS_ERR(dst)) { ray_error_free(dst); ray_release(out); return ray_error("memory", "dl_filter_eq: vec_new"); }
-        dst->len = count;
-        /* raw SYM cell-id copies resolve over the source's dictionary */
-        if (src->type == RAY_SYM) ray_sym_vec_adopt_domain(dst, src);
-        uint8_t esz = ray_sym_elem_size(src->type, src->attrs);
-        const uint8_t* src_b = (const uint8_t*)ray_data(src);
-        uint8_t* dst_b = (uint8_t*)ray_data(dst);
-        int64_t j = 0;
-        for (int64_t r = 0; r < nrows; r++) {
-            if (dl_col_eq_row(col, r, value, const_type)) {
-                memcpy(dst_b + (size_t)j * esz,
-                       src_b + (size_t)r * esz,
-                       (size_t)esz);
-                j++;
-            }
-        }
-        if (src->type == RAY_STR) col_propagate_str_pool(dst, src);
-        ray_t* next = ray_table_add_col(out, ray_table_col_name(tbl, c), dst);
-        ray_release(dst);
-        /* ray_table_add_col does not release `out` on failure, so we
-         * must release the partially-built table before bailing out. */
-        if (!next) {
-            ray_release(out);
-            return ray_error("memory", "dl_filter_eq: add_col");
-        }
-        if (RAY_IS_ERR(next)) {
-            ray_release(out);
-            return next;
-        }
-        out = next;
-    }
+    ray_t* out = dl_table_take_mask(tbl, keep, count);
+    ray_free(keep_block);
     return out;
+}
+
+static int64_t dl_cell_i64(ray_t* col, int64_t row) {
+    if (col->type == RAY_SYM)
+        return ray_read_sym(ray_data(col), row, col->type, col->attrs);
+    return ((int64_t*)ray_data(col))[row];
+}
+
+/* Rows where column c1 == column c2 (I64/SYM cells read as int64).
+ * Owned result; retains and returns tbl unchanged when all rows match. */
+static ray_t* dl_filter_col_eq(ray_t* tbl, int c1, int c2) {
+    if (!tbl || RAY_IS_ERR(tbl)) { if (tbl) ray_retain(tbl); return tbl; }
+    int64_t nrows = ray_table_nrows(tbl);
+    if (nrows == 0) { ray_retain(tbl); return tbl; }
+    ray_t* a = ray_table_get_col_idx(tbl, c1);
+    ray_t* b = ray_table_get_col_idx(tbl, c2);
+    if (!a || !b) return ray_error("domain", "datalog: repeated-variable filter on missing column");
+    if ((a->type != RAY_I64 && a->type != RAY_SYM) || (b->type != RAY_I64 && b->type != RAY_SYM))
+        return ray_error("type", "datalog: repeated variable over unsupported column type %s",
+                         ray_type_name(a->type != RAY_I64 && a->type != RAY_SYM ? a->type : b->type));
+    ray_t* keep_block = ray_alloc((size_t)nrows);
+    if (!keep_block || RAY_IS_ERR(keep_block)) return ray_error("memory", "datalog: mask alloc");
+    uint8_t* keep = (uint8_t*)ray_data(keep_block);
+    int64_t count = 0;
+    for (int64_t r = 0; r < nrows; r++) {
+        keep[r] = dl_cell_i64(a, r) == dl_cell_i64(b, r);
+        count += keep[r];
+    }
+    ray_t* out;
+    if (count == nrows) { ray_retain(tbl); out = tbl; }
+    else out = dl_table_take_mask(tbl, keep, count);
+    ray_free(keep_block);
+    return out;
+}
+
+/* Apply dl_filter_col_eq for every pair of positions in body sharing a
+ * variable. Consumes tbl, returns an owned table or RAY_ERROR/NULL. */
+static ray_t* dl_filter_repeated_vars(ray_t* tbl, const dl_body_t* body) {
+    for (int i = 0; i < body->arity && tbl && !RAY_IS_ERR(tbl); i++) {
+        if (body->vars[i] == DL_CONST) continue;
+        for (int j = i + 1; j < body->arity; j++) {
+            if (body->vars[j] != body->vars[i]) continue;
+            ray_t* f = dl_filter_col_eq(tbl, i, j);
+            ray_release(tbl);
+            tbl = f;
+            if (!tbl || RAY_IS_ERR(tbl)) return tbl;
+        }
+    }
+    return tbl;
 }
 
 /* Helper: build a fully-owned broadcast column for a constant head slot.
@@ -1383,6 +1433,15 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
             }
         }
 
+        body_tbl = dl_filter_repeated_vars(body_tbl, body);
+        if (!body_tbl) { if (accum) ray_release(accum); prog->eval_err = true; return NULL; }
+        if (RAY_IS_ERR(body_tbl)) {
+            ray_error_free(body_tbl);
+            if (accum) ray_release(accum);
+            prog->eval_err = true;
+            return NULL;
+        }
+
         if (accum == NULL) {
             /* First body atom: accum = body_tbl */
             accum = body_tbl;
@@ -1540,6 +1599,15 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
                     }
                     neg_tbl = filtered;
                 }
+            }
+
+            neg_tbl = dl_filter_repeated_vars(neg_tbl, body);
+            if (!neg_tbl) { ray_release(accum); prog->eval_err = true; return NULL; }
+            if (RAY_IS_ERR(neg_tbl)) {
+                ray_error_free(neg_tbl);
+                ray_release(accum);
+                prog->eval_err = true;
+                return NULL;
             }
 
             int lkeys[DL_MAX_ARITY], rkeys[DL_MAX_ARITY];

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -1182,7 +1182,13 @@ static ray_t* dl_untag_i64_col(ray_t* col) {
     int64_t n = col->len;
     const int64_t* d = (const int64_t*)ray_data(col);
     int64_t i = 0;
-    while (i < n && !(d[i] & DL_DATOM_TAG_MASK)) i++;
+    /* Same v >= 0 guard as dl_datom_untag: a negative cell can never be a
+     * genuine tag (sign extension spuriously sets the tag bits), so the
+     * pre-scan must not treat it as one -- otherwise a column that is all
+     * plain, untagged, possibly-negative integers would still take the
+     * (needlessly allocating, and for negatives previously corrupting)
+     * per-cell path below instead of the no-op retain. */
+    while (i < n && !(d[i] >= 0 && (d[i] & DL_DATOM_TAG_MASK))) i++;
     if (i == n) { ray_retain(col); return col; }
     ray_t* out = ray_vec_new(RAY_I64, n);
     if (!out || RAY_IS_ERR(out)) return out;
@@ -1524,7 +1530,7 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
                  * DATOM-tagged (audit #1.5) — everywhere else (the "a"
                  * column included) a plain I64/SYM cell is a genuine,
                  * untagged value and the lenient compare is correct. */
-                bool strict_tag = c == 2 && strcmp(body->pred, "eav") == 0;
+                bool strict_tag = c == 2 && strcmp(body->pred, DL_EAV_PRED) == 0;
                 ray_t* filtered = dl_filter_eq(body_tbl, c, body->const_vals[c],
                                                 body->const_types[c], strict_tag);
                 ray_release(body_tbl);
@@ -1696,7 +1702,7 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
             ray_retain(neg_tbl);
             for (int c = 0; c < body->arity; c++) {
                 if (body->vars[c] == DL_CONST) {
-                    bool strict_tag = c == 2 && strcmp(body->pred, "eav") == 0;
+                    bool strict_tag = c == 2 && strcmp(body->pred, DL_EAV_PRED) == 0;
                     ray_t* filtered = dl_filter_eq(neg_tbl, c, body->const_vals[c],
                                                     body->const_types[c], strict_tag);
                     ray_release(neg_tbl);
@@ -2834,7 +2840,7 @@ static void dl_build_source_prov(dl_program_t* prog, dl_rel_t* rel,
                          * mismatch an F64 literal against an I64 column
                          * (and vice versa). strict_tag mirrors dl_compile_rule:
                          * only the "eav" relation's v column is ever tagged. */
-                        bool strict_tag = c == 2 && strcmp(body->pred, "eav") == 0;
+                        bool strict_tag = c == 2 && strcmp(body->pred, DL_EAV_PRED) == 0;
                         if (!dl_col_eq_row(bcol, br, body->const_vals[c],
                                            body->const_types[c], strict_tag)) {
                             match = false; break;
@@ -3917,6 +3923,13 @@ static ray_t* dl_set_body_pos(dl_rule_t* rule, int bidx, int pos,
         dl_body_set_const_typed(rule, bidx, pos, bits, RAY_F64);
     } else if (val->type == -RAY_SYM) {
         dl_body_set_const_typed(rule, bidx, pos, val->i64, RAY_SYM);
+    } else if (val->type == -RAY_STR) {
+        /* Same treatment as the literal STR branch above: intern as sym
+         * so `(set s "Alice")` followed by `(where (?e :name s))` agrees
+         * with writing the literal `(where (?e :name "Alice"))` inline —
+         * both end up as a RAY_STR-typed constant naming the same sym. */
+        int64_t sym = ray_sym_intern(ray_str_ptr(val), ray_str_len(val));
+        dl_body_set_const_typed(rule, bidx, pos, sym, RAY_STR);
     } else {
         ray_release(val);
         return ray_error("type", "rule: unsupported constant type in body");
@@ -3938,9 +3951,9 @@ static ray_t* dl_parse_body_clause(dl_rule_t* rule, ray_t* clause,
 
     /* -- Triple pattern: (?e :attr ?v) -- */
     if (dl_is_triple_pattern(clause)) {
-        /* Register as 3-arity atom on "eav" relation:
+        /* Register as 3-arity atom on the DL_EAV_PRED relation:
          * position 0 = entity, 1 = attr (constant), 2 = value */
-        int bidx = dl_rule_add_atom(rule, "eav", 3);
+        int bidx = dl_rule_add_atom(rule, DL_EAV_PRED, 3);
         if (bidx < 0) return ray_error("domain", "rule: too many body literals");
 
         ray_t* err;
@@ -3963,7 +3976,7 @@ static ray_t* dl_parse_body_clause(dl_rule_t* rule, ray_t* clause,
 
         if (dl_is_triple_pattern(inner)) {
             /* Negated triple: (not (?e :attr ?v)) */
-            int bidx = dl_rule_add_neg(rule, "eav", 3);
+            int bidx = dl_rule_add_neg(rule, DL_EAV_PRED, 3);
             if (bidx < 0) return ray_error("domain", "rule: too many body literals");
 
             ray_t* err;
@@ -4211,6 +4224,10 @@ static ray_t* dl_parse_rule_from_head_and_body(dl_rule_t* out, ray_t* head,
         } else if (harg->type == -RAY_I64) {
             dl_rule_head_const_typed(out, i, harg->i64, RAY_I64);
         } else if (harg->type == -RAY_SYM) {
+            /* Unlike dl_set_body_pos (body positions), a head position
+             * never evaluates a bare symbol as a bound-variable reference
+             * -- it is always taken as the literal symbol constant here,
+             * quoted or not. */
             dl_rule_head_const_typed(out, i, harg->i64, RAY_SYM);
         } else if (harg->type == -RAY_F64) {
             int64_t bits;
@@ -4407,13 +4424,29 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
                  * RUNTIME id (sym-domain Phase 2) — the EAV table may
                  * carry FILE-domain columns.  Raw-copy fast path when
                  * the column is runtime-domain (exact no-op pre-flip).
-                 * Mirrors the env-backed EDB conversion below. */
+                 * Mirrors the env-backed EDB conversion below.
+                 *
+                 * v column (c == 2), audit #1.5: a hand-built or
+                 * deserialized datoms table can carry the value column as
+                 * a genuine RAY_SYM vector rather than assert-fact's
+                 * DATOM-tagged I64 encoding. A RAY_SYM column can only
+                 * ever hold a symbol, never an integer, so OR-ing in
+                 * DL_DATOM_TAG_SYM here is unambiguous — it makes these
+                 * cells agree with assert-fact's own tagging so
+                 * dl_col_eq_row's strict_tag path (below) matches a SYM/
+                 * STR literal against them instead of silently returning
+                 * zero rows. A *legacy* I64 v column holding bare
+                 * (untagged) sym ids is deliberately left unmatched by
+                 * strict_tag -- that bare-integer ambiguity is exactly
+                 * what tagging removes (see DL_DATOM_TAG_SYM above). */
                 ray_t* i64col = ray_vec_new(RAY_I64, nrows_db);
                 if (i64col && !RAY_IS_ERR(i64col)) {
                     i64col->len = nrows_db;
                     int64_t* d = (int64_t*)ray_data(i64col);
-                    for (int64_t r = 0; r < nrows_db; r++)
-                        d[r] = sym_cell_runtime_id(col, r);
+                    for (int64_t r = 0; r < nrows_db; r++) {
+                        int64_t id = sym_cell_runtime_id(col, r);
+                        d[r] = (c == 2) ? (DL_DATOM_TAG_SYM | id) : id;
+                    }
                     eav_tbl = ray_table_add_col(eav_tbl, ray_table_col_name(db, c), i64col);
                     ray_release(i64col);
                 }
@@ -4421,7 +4454,7 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
                 eav_tbl = ray_table_add_col(eav_tbl, ray_table_col_name(db, c), col);
             }
         }
-        dl_add_edb(prog, "eav", eav_tbl, 3);
+        dl_add_edb(prog, DL_EAV_PRED, eav_tbl, 3);
         ray_release(eav_tbl);
     }
 
@@ -4497,7 +4530,7 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
             }
 
             if (!pred_name || pred_name[0] == '\0') continue;
-            if (strcmp(pred_name, "eav") == 0) continue;
+            if (strcmp(pred_name, DL_EAV_PRED) == 0) continue;
             if (dl_find_rel(prog, pred_name) >= 0) continue;
 
             int64_t env_sym = ray_sym_intern(pred_name, strlen(pred_name));
@@ -4553,9 +4586,24 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
                      * so each cell must be re-expressed as a RUNTIME id
                      * (sym-domain Phase 2) — env tables may carry
                      * FILE-domain columns.  Raw-copy fast path when the
-                     * column is runtime-domain (exact no-op pre-flip). */
-                    for (int64_t r = 0; r < nrows_env; r++)
-                        d[r] = sym_cell_runtime_id(col, r);
+                     * column is runtime-domain (exact no-op pre-flip).
+                     *
+                     * DL_DATOM_TAG_SYM (audit #1.5): tag column 2 (the v
+                     * column) the same way the primary eav table above
+                     * does, but ONLY when this table is registered under
+                     * DL_EAV_PRED itself -- every other env-bound relation
+                     * is an ordinary user predicate, never DATOM-tagged.
+                     * The `strcmp(pred_name, DL_EAV_PRED) == 0 continue`
+                     * a few lines up currently makes that case
+                     * unreachable (a rule body can't yet name an
+                     * env-bound table "eav"), but the check is kept here
+                     * so this loop stays correct if that skip is ever
+                     * relaxed. */
+                    bool tag_v = c == 2 && strcmp(pred_name, DL_EAV_PRED) == 0;
+                    for (int64_t r = 0; r < nrows_env; r++) {
+                        int64_t id = sym_cell_runtime_id(col, r);
+                        d[r] = tag_v ? (DL_DATOM_TAG_SYM | id) : id;
+                    }
                     next_clean = ray_table_add_col(clean, ray_table_col_name(env_val, c), i64col);
                     ray_release(i64col);
                 } else {

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -1025,8 +1025,15 @@ static ray_t* dl_antijoin_tables(ray_t* left, ray_t* right,
  * storage without the frontend having to know which is which. */
 static bool dl_col_eq_row(ray_t* col, int64_t row, int64_t value,
                           int8_t const_type) {
+    if (col->type == RAY_F64) {
+        double cell = ((double*)ray_data(col))[row];
+        if (const_type == RAY_F64) { double v; memcpy(&v, &value, sizeof v); return cell == v; }
+        if (const_type == RAY_I64) return cell == (double)value;
+        return false;
+    }
     if (col->type == RAY_I64) {
         int64_t cell = ((int64_t*)ray_data(col))[row];
+        if (const_type == RAY_F64) { double v; memcpy(&v, &value, sizeof v); return (double)cell == v; }
         if (cell == value) return true;
         int64_t cell_tag = cell & (int64_t)0x6000000000000000;
         if (cell_tag == 0) return false;  /* plain int column */
@@ -1095,12 +1102,11 @@ static ray_t* dl_filter_eq(ray_t* tbl, int col_idx, int64_t value,
 
     ray_t* col = ray_table_get_col_idx(tbl, col_idx);
     if (!col) { ray_retain(tbl); return tbl; }
-    /* Non-numeric, non-sym keys: not supported by this filter — pass
-     * through (retained) rather than miscompare via raw memcpy. */
-    if (col->type != RAY_I64 && col->type != RAY_SYM) {
-        ray_retain(tbl);
-        return tbl;
-    }
+    /* Non-numeric, non-sym keys: not supported by this filter — raise a
+     * type error rather than silently passing every row through. */
+    if (col->type != RAY_I64 && col->type != RAY_SYM && col->type != RAY_F64)
+        return ray_error("type", "datalog: constant filter on unsupported column type %s",
+                         ray_type_name(col->type));
 
     /* sym-domain Phase 2: for a SYM column, `value` is a runtime-domain
      * literal id (datalog constants intern at parse), while the cells
@@ -3736,6 +3742,11 @@ static ray_t* dl_set_body_pos(dl_rule_t* rule, int bidx, int pos,
         dl_body_set_const_typed(rule, bidx, pos, node->i64, RAY_I64);
         return NULL;
     }
+    if (node->type == -RAY_F64) {
+        int64_t bits; memcpy(&bits, &node->f64, sizeof bits);
+        dl_body_set_const_typed(rule, bidx, pos, bits, RAY_F64);
+        return NULL;
+    }
     if (node->type == -RAY_SYM) {
         ray_t* s = ray_sym_str(node->i64);
         if (s && strcmp(ray_str_ptr(s), "_") == 0) {
@@ -3768,6 +3779,9 @@ static ray_t* dl_set_body_pos(dl_rule_t* rule, int bidx, int pos,
         return val ? val : ray_error("type", "rule: cannot evaluate constant in body");
     if (val->type == -RAY_I64) {
         dl_body_set_const_typed(rule, bidx, pos, val->i64, RAY_I64);
+    } else if (val->type == -RAY_F64) {
+        int64_t bits; memcpy(&bits, &val->f64, sizeof bits);
+        dl_body_set_const_typed(rule, bidx, pos, bits, RAY_F64);
     } else if (val->type == -RAY_SYM) {
         dl_body_set_const_typed(rule, bidx, pos, val->i64, RAY_SYM);
     } else {

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -2717,11 +2717,20 @@ static void dl_build_source_prov(dl_program_t* prog, dl_rel_t* rel,
                 for (int c = 0; c < body->arity; c++) {
                     ray_t* bcol = ray_table_get_col_idx(brel->table, c);
                     if (!bcol) { match = false; break; }
-                    int64_t cell = ((int64_t*)ray_data(bcol))[br];
                     int     v    = body->vars[c];
                     if (v == DL_CONST) {
-                        if (cell != body->const_vals[c]) { match = false; break; }
+                        /* Type-aware compare — matches dl_col_eq_row's
+                         * rules (incl. F64 columns/literals and
+                         * DATOM-tagged I64 columns) rather than a raw
+                         * int64 bit-compare, which would silently
+                         * mismatch an F64 literal against an I64 column
+                         * (and vice versa). */
+                        if (!dl_col_eq_row(bcol, br, body->const_vals[c],
+                                           body->const_types[c])) {
+                            match = false; break;
+                        }
                     } else if (var_set[v]) {
+                        int64_t cell = ((int64_t*)ray_data(bcol))[br];
                         if (cell != var_vals[v])         { match = false; break; }
                     }
                     /* body-only variable: unconstrained, always matches */

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -1328,7 +1328,7 @@ static ray_t* dl_project(ray_t* tbl, const int* col_indices, int n_out,
 }
 
 ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
-                          int delta_pos, int rule_idx, ray_graph_t* g) {
+                          const dl_delta_t* delta, int rule_idx, ray_graph_t* g) {
     /* Materializing approach: execute body atoms one at a time.
      *
      * For each positive body atom, we get the relation table and apply
@@ -1352,7 +1352,11 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
         int rel_idx = dl_find_rel(prog, body->pred);
         if (rel_idx < 0) { if (accum) ray_release(accum); return NULL; }
         dl_rel_t* rel = &prog->rels[rel_idx];
-        ray_t* body_tbl = rel->table;
+        /* Semi-naive: exactly one body position reads the iteration delta;
+         * every other occurrence of the same predicate reads the full
+         * relation so old×new combinations are derived (audit §1.1). */
+        ray_t* body_tbl = (delta && delta->pos == b && delta->table)
+                        ? delta->table : rel->table;
         ray_retain(body_tbl);
 
         /* Apply constant filters */
@@ -2711,7 +2715,7 @@ static void dl_build_provenance(dl_program_t* prog) {
             ray_graph_t* g = ray_graph_new(NULL);
             if (!g) continue;
 
-            ray_op_t* output = dl_compile_rule(prog, rule, -1, r, g);
+            ray_op_t* output = dl_compile_rule(prog, rule, NULL, r, g);
             if (!output) { ray_graph_free(g); continue; }
 
             ray_t* raw = ray_execute(g, output);
@@ -2806,7 +2810,7 @@ int dl_eval(dl_program_t* prog) {
             ray_graph_t* g = ray_graph_new(NULL);
             if (!g) { prog->eval_err = true; continue; }
 
-            ray_op_t* output = dl_compile_rule(prog, rule, -1, stratum_rule_idx[ri], g);
+            ray_op_t* output = dl_compile_rule(prog, rule, NULL, stratum_rule_idx[ri], g);
             if (!output) {
                 /* dl_compile_rule marks eval_err on genuine failures; a bare
                  * NULL means "rule has no rows this pass" — not a fault. */
@@ -2924,21 +2928,13 @@ int dl_eval(dl_program_t* prog) {
                     if (!delta_tables[body_rel] ||
                         ray_table_nrows(delta_tables[body_rel]) == 0) continue;
 
-                    /* Swap in delta relation for this body position */
-                    ray_t* saved = prog->rels[body_rel].table;
-                    prog->rels[body_rel].table = delta_tables[body_rel];
-
+                    dl_delta_t d = { b, delta_tables[body_rel] };
                     ray_graph_t* g = ray_graph_new(NULL);
-                    if (!g) {
-                        prog->rels[body_rel].table = saved;
-                        prog->eval_err = true;
-                        continue;
-                    }
+                    if (!g) { prog->eval_err = true; continue; }
 
-                    ray_op_t* output = dl_compile_rule(prog, rule, b, stratum_rule_idx[ri], g);
+                    ray_op_t* output = dl_compile_rule(prog, rule, &d, stratum_rule_idx[ri], g);
                     if (!output) {
                         ray_graph_free(g);
-                        prog->rels[body_rel].table = saved;
                         /* dl_compile_rule sets eval_err itself on genuine
                          * failures; NULL without the flag means "rule yields
                          * no rows this iteration" and should not fault. */
@@ -2947,7 +2943,6 @@ int dl_eval(dl_program_t* prog) {
 
                     ray_t* raw_result = ray_execute(g, output);
                     ray_graph_free(g);
-                    prog->rels[body_rel].table = saved;
 
                     if (!raw_result) continue;
                     if (RAY_IS_ERR(raw_result)) { prog->eval_err = true; ray_error_free(raw_result); continue; }

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -1080,9 +1080,21 @@ static ray_t* dl_antijoin_tables(ray_t* left, ray_t* right,
  * back to a payload compare when the cell carries the matching tag —
  * so a body literal can pin both an untagged RAY_SYM column built
  * from a rule head and a DATOM-tagged RAY_I64 column built from EAV
- * storage without the frontend having to know which is which. */
+ * storage without the frontend having to know which is which.
+ *
+ * `strict_tag` narrows that leniency for the one column where it would
+ * otherwise reopen the audit #1.5 ambiguity: the "eav" relation's v
+ * column, the only column any frontend ever writes a DATOM tag into.
+ * A plain integer stored there via assert-fact (e.g. a symbol's own
+ * intern id, round-tripped through pull as a bare I64 and re-asserted)
+ * can coincide numerically with a symbol/string literal's intern id;
+ * without strict_tag the direct `cell == value` compare below would
+ * wrongly call that a match. Callers pass strict_tag only for that
+ * column — every other column (the "a" column included, and any
+ * rule-derived relation) is never DATOM-tagged, so the lenient direct
+ * compare remains correct and necessary there. */
 static bool dl_col_eq_row(ray_t* col, int64_t row, int64_t value,
-                          int8_t const_type) {
+                          int8_t const_type, bool strict_tag) {
     if (col->type == RAY_F64) {
         double cell = ((double*)ray_data(col))[row];
         if (const_type == RAY_F64) { double v; memcpy(&v, &value, sizeof v); return cell == v; }
@@ -1092,15 +1104,17 @@ static bool dl_col_eq_row(ray_t* col, int64_t row, int64_t value,
     if (col->type == RAY_I64) {
         int64_t cell = ((int64_t*)ray_data(col))[row];
         if (const_type == RAY_F64) { double v; memcpy(&v, &value, sizeof v); return (double)cell == v; }
-        if (cell == value) return true;
-        int64_t cell_tag = cell & (int64_t)0x6000000000000000;
+        if (!strict_tag || (const_type != RAY_STR && const_type != RAY_SYM)) {
+            if (cell == value) return true;
+        }
+        int64_t cell_tag = cell & DL_DATOM_TAG_MASK;
         if (cell_tag == 0) return false;  /* plain int column */
-        int64_t cell_payload = cell & (int64_t)0x1FFFFFFFFFFFFFFF;
+        int64_t cell_payload = cell & DL_DATOM_PAYLOAD;
         if (const_type == RAY_STR &&
-            cell_tag == (int64_t)0x4000000000000000)
+            cell_tag == DL_DATOM_TAG_STR)
             return cell_payload == value;
         if (const_type == RAY_SYM &&
-            cell_tag == (int64_t)0x2000000000000000)
+            cell_tag == DL_DATOM_TAG_SYM)
             return cell_payload == value;
         return false;
     }
@@ -1148,8 +1162,28 @@ static ray_t* dl_table_take_mask(ray_t* tbl, const uint8_t* keep, int64_t count)
     return out;
 }
 
+/* Strip the DATOM tag from every cell of an I64 result column so
+ * query projection returns plain intern ids like the rest of the
+ * user-visible API (pull, scan-eav). Returns a retained reference to
+ * `col` unchanged when it's not I64 or carries no tagged cell, so the
+ * common case is a cheap no-op. */
+static ray_t* dl_untag_i64_col(ray_t* col) {
+    if (col->type != RAY_I64) { ray_retain(col); return col; }
+    int64_t n = col->len;
+    const int64_t* d = (const int64_t*)ray_data(col);
+    int64_t i = 0;
+    while (i < n && !(d[i] & DL_DATOM_TAG_MASK)) i++;
+    if (i == n) { ray_retain(col); return col; }
+    ray_t* out = ray_vec_new(RAY_I64, n);
+    if (!out || RAY_IS_ERR(out)) return out;
+    out->len = n;
+    int64_t* o = (int64_t*)ray_data(out);
+    for (int64_t r = 0; r < n; r++) o[r] = dl_datom_untag(d[r]);
+    return out;
+}
+
 static ray_t* dl_filter_eq(ray_t* tbl, int col_idx, int64_t value,
-                           int8_t const_type) {
+                           int8_t const_type, bool strict_tag) {
     /* Contract: always return an owned reference (rc bumped) so the
      * caller can release uniformly.  Every pass-through must therefore
      * retain — else the caller's `ray_release(body_tbl); body_tbl =
@@ -1190,7 +1224,7 @@ static ray_t* dl_filter_eq(ray_t* tbl, int col_idx, int64_t value,
     uint8_t* keep = (uint8_t*)ray_data(keep_block);
     int64_t count = 0;
     for (int64_t r = 0; r < nrows; r++) {
-        keep[r] = dl_col_eq_row(col, r, value, const_type) ? 1 : 0;
+        keep[r] = dl_col_eq_row(col, r, value, const_type, strict_tag) ? 1 : 0;
         count += keep[r];
     }
 
@@ -1476,8 +1510,13 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
         /* Apply constant filters */
         for (int c = 0; c < body->arity; c++) {
             if (body->vars[c] == DL_CONST) {
+                /* Only the "eav" relation's v column (position 2) is ever
+                 * DATOM-tagged (audit #1.5) — everywhere else (the "a"
+                 * column included) a plain I64/SYM cell is a genuine,
+                 * untagged value and the lenient compare is correct. */
+                bool strict_tag = c == 2 && strcmp(body->pred, "eav") == 0;
                 ray_t* filtered = dl_filter_eq(body_tbl, c, body->const_vals[c],
-                                                body->const_types[c]);
+                                                body->const_types[c], strict_tag);
                 ray_release(body_tbl);
                 if (!filtered) {
                     /* Treat as genuine failure — dl_filter_eq returns an
@@ -1647,8 +1686,9 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
             ray_retain(neg_tbl);
             for (int c = 0; c < body->arity; c++) {
                 if (body->vars[c] == DL_CONST) {
+                    bool strict_tag = c == 2 && strcmp(body->pred, "eav") == 0;
                     ray_t* filtered = dl_filter_eq(neg_tbl, c, body->const_vals[c],
-                                                    body->const_types[c]);
+                                                    body->const_types[c], strict_tag);
                     ray_release(neg_tbl);
                     if (!filtered) {
                         ray_release(accum);
@@ -2782,9 +2822,11 @@ static void dl_build_source_prov(dl_program_t* prog, dl_rel_t* rel,
                          * DATOM-tagged I64 columns) rather than a raw
                          * int64 bit-compare, which would silently
                          * mismatch an F64 literal against an I64 column
-                         * (and vice versa). */
+                         * (and vice versa). strict_tag mirrors dl_compile_rule:
+                         * only the "eav" relation's v column is ever tagged. */
+                        bool strict_tag = c == 2 && strcmp(body->pred, "eav") == 0;
                         if (!dl_col_eq_row(bcol, br, body->const_vals[c],
-                                           body->const_types[c])) {
+                                           body->const_types[c], strict_tag)) {
                             match = false; break;
                         }
                     } else if (var_set[v]) {
@@ -3317,7 +3359,7 @@ ray_t* ray_assert_fact_fn(ray_t** args, int64_t n) {
     if (value->type == -RAY_I64) {
         v_val = value->i64;
     } else if (value->type == -RAY_SYM) {
-        v_val = value->i64;  /* sym intern ID is already i64 */
+        v_val = DL_DATOM_TAG_SYM | value->i64;  /* tag so it can't collide with a plain integer */
     } else {
         return ray_error("type", "assert-fact: value must be an integer or symbol");
     }
@@ -3385,7 +3427,7 @@ ray_t* ray_retract_fact_fn(ray_t** args, int64_t n) {
     if (value->type == -RAY_I64)
         match_v = value->i64;
     else if (value->type == -RAY_SYM)
-        match_v = value->i64;
+        match_v = DL_DATOM_TAG_SYM | value->i64;  /* same tag assert-fact wrote */
     else
         return ray_error("type", "retract-fact: value must be an integer or symbol");
 
@@ -3484,7 +3526,8 @@ ray_t* ray_scan_eav_fn(ray_t** args, int64_t n) {
             if (a_val == attr_id) {
                 re = ray_vec_append(re, &e_data[r]);
                 if (RAY_IS_ERR(re)) { ray_release(rv); return re; }
-                rv = ray_vec_append(rv, &v_data[r]);
+                int64_t v_val = dl_datom_untag(v_data[r]);
+                rv = ray_vec_append(rv, &v_val);
                 if (RAY_IS_ERR(rv)) { ray_release(re); return rv; }
             }
         }
@@ -3527,7 +3570,7 @@ ray_t* ray_scan_eav_fn(ray_t** args, int64_t n) {
             if (e_data[r] != entity_id) continue;
             int64_t a_val = ray_read_sym(ray_data(a_col), r, a_col->type, a_col->attrs);
             if (a_val == attr_id) {
-                return ray_i64(v_data[r]);
+                return ray_i64(dl_datom_untag(v_data[r]));
             }
         }
 
@@ -3598,7 +3641,7 @@ ray_t* ray_pull_fn(ray_t** args, int64_t n) {
         keys = ray_vec_append(keys, &a_val);
         if (RAY_IS_ERR(keys)) { ray_release(vals); return keys; }
 
-        ray_t* val = ray_i64(v_data[r]);
+        ray_t* val = ray_i64(dl_datom_untag(v_data[r]));
         if (RAY_IS_ERR(val)) { ray_release(keys); ray_release(vals); return val; }
         vals = ray_list_append(vals, val);
         ray_release(val);
@@ -3816,22 +3859,35 @@ static ray_t* dl_set_body_pos(dl_rule_t* rule, int bidx, int pos,
     }
     if (node->type == -RAY_SYM) {
         ray_t* s = ray_sym_str(node->i64);
-        if (s && strcmp(ray_str_ptr(s), "_") == 0) {
-            /* Wildcard: create a fresh variable. Bound-check against the
-             * fixed var-map size — the named path (dl_var_get_or_create)
-             * already guards this; without the same guard here a rule with
-             * >256 wildcards would write past vars->syms[]. */
+        bool is_wildcard = s && strcmp(ray_str_ptr(s), "_") == 0;
+        if (is_wildcard) {
+            /* Wildcard: create a fresh variable, quoted or not ('_' and
+             * bare _ are both the wildcard, never a variable reference).
+             * Bound-check against the fixed var-map size — the named path
+             * (dl_var_get_or_create) already guards this; without the same
+             * guard here a rule with >256 wildcards would write past
+             * vars->syms[]. */
             if (vars->n >= DL_MAX_ARITY * DL_MAX_BODY)
                 return ray_error("domain", "rule: too many variables");
             int vi = vars->n++;
             vars->syms[vi] = -1 - vi;
             dl_body_set_var(rule, bidx, pos, vi);
-        } else {
-            dl_body_set_const_typed(rule, bidx, pos, node->i64, RAY_SYM);
+            return NULL;
         }
-        return NULL;
-    }
-    if (node->type == -RAY_STR) {
+        if (node->attrs & ATTR_QUOTED) {
+            /* 'foo / :foo — a literal symbol constant. */
+            dl_body_set_const_typed(rule, bidx, pos, node->i64, RAY_SYM);
+            return NULL;
+        }
+        /* Bare, unquoted symbol: a reference to a host-language bound
+         * variable (e.g. `sid` from `(set sid ...)`), not a literal.
+         * Fall through to the ray_eval fallback below so it resolves to
+         * the variable's current value instead of being (mis)treated as
+         * the literal symbol sharing its name — audit #1.5: this is
+         * exactly the kind of value that can carry a DATOM-tagged v-column
+         * payload, so it must reach dl_col_eq_row with the *evaluated*
+         * constant's real type (I64/SYM/...), not always RAY_SYM. */
+    } else if (node->type == -RAY_STR) {
         /* Quoted string literal in body: intern as sym so it compares
          * equal to other sym-interned constants. Record the source type
          * as RAY_STR so the row-equality helper can also try a tagged-
@@ -4578,8 +4634,12 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
     ray_t* result = ray_table_new(n_find_vars);
     for (int i = 0; i < n_find_vars && i < (int)ncols; i++) {
         ray_t* col = ray_table_get_col_idx(raw, i);
-        if (col)
-            result = ray_table_add_col(result, find_var_syms[i], col);
+        if (!col) continue;
+        ray_t* clean = dl_untag_i64_col(col);   /* returns retained col when nothing is tagged */
+        if (!clean || RAY_IS_ERR(clean)) { ray_release(result); dl_program_free(prog); ray_release(db);
+            return clean ? clean : ray_error("memory", "query: untag"); }
+        result = ray_table_add_col(result, find_var_syms[i], clean);
+        ray_release(clean);
     }
 
     /* Handle empty result: ensure schema is correct */

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -805,7 +805,7 @@ static ray_t* dl_eval_expr(dl_expr_t* expr, ray_t* accum,
                 case OP_ADD: od[r] = ld[r] + rd[r]; break;
                 case OP_SUB: od[r] = ld[r] - rd[r]; break;
                 case OP_MUL: od[r] = ld[r] * rd[r]; break;
-                case OP_DIV: od[r] = rd[r] != 0.0 ? ld[r] / rd[r] : 0.0; break;
+                case OP_DIV: od[r] = ld[r] / rd[r]; break;
                 default:     od[r] = 0.0; break;
                 }
             }
@@ -823,12 +823,14 @@ static ray_t* dl_eval_expr(dl_expr_t* expr, ray_t* accum,
         int64_t* rd = (int64_t*)ray_data(rv);
         int64_t* od = (int64_t*)ray_data(out);
         for (int64_t r = 0; r < nrows; r++) {
+            int64_t a = ld[r], b = rd[r], o;
+            if (a == NULL_I64 || b == NULL_I64) { od[r] = NULL_I64; continue; }
             switch (expr->binop) {
-            case OP_ADD: od[r] = ld[r] + rd[r]; break;
-            case OP_SUB: od[r] = ld[r] - rd[r]; break;
-            case OP_MUL: od[r] = ld[r] * rd[r]; break;
-            case OP_DIV: od[r] = rd[r] != 0 ? ld[r] / rd[r] : 0; break;
-            default:     od[r] = 0; break;
+            case OP_ADD: od[r] = __builtin_add_overflow(a, b, &o) ? NULL_I64 : o; break;
+            case OP_SUB: od[r] = __builtin_sub_overflow(a, b, &o) ? NULL_I64 : o; break;
+            case OP_MUL: od[r] = __builtin_mul_overflow(a, b, &o) ? NULL_I64 : o; break;
+            case OP_DIV: od[r] = (b == 0 || (a == INT64_MIN && b == -1)) ? NULL_I64 : a / b; break;
+            default:     od[r] = NULL_I64; break;
             }
         }
         ray_release(lv);

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -4177,6 +4177,12 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
         return ray_error("type", "query: expected (find ...) as second argument");
     }
 
+    if (find_len - 1 > DL_MAX_ARITY) {
+        ray_release(db);
+        return ray_error("domain", "query: find supports at most %d variables, got %lld",
+                         DL_MAX_ARITY, (long long)(find_len - 1));
+    }
+
     /* Collect find variable sym IDs */
     int64_t find_var_syms[DL_MAX_ARITY];
     int n_find_vars = 0;
@@ -4431,6 +4437,22 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
                 return ray_error("domain", "query: failed to register env-backed EDB table");
             }
             ray_release(clean);
+        }
+    }
+
+    /* Admission: every body predicate must now resolve to a relation —
+     * an EDB, an env-bound table registered above, or a rule head (IDB
+     * created by dl_add_rule). Anything else is a typo, not "no rows". */
+    for (int ri = 0; ri < prog->n_rules; ri++) {
+        dl_rule_t* rr = &prog->rules[ri];
+        for (int bi = 0; bi < rr->n_body; bi++) {
+            dl_body_t* bd = &rr->body[bi];
+            const char* pn = (bd->type == DL_POS || bd->type == DL_NEG) ? bd->pred
+                           : (bd->type == DL_AGG) ? bd->agg_pred : NULL;
+            if (!pn || !pn[0] || dl_find_rel(prog, pn) >= 0) continue;
+            dl_program_free(prog);
+            ray_release(db);
+            return ray_error("domain", "query: unknown relation '%s'", pn);
         }
     }
 

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -1092,7 +1092,17 @@ static ray_t* dl_antijoin_tables(ray_t* left, ray_t* right,
  * wrongly call that a match. Callers pass strict_tag only for that
  * column — every other column (the "a" column included, and any
  * rule-derived relation) is never DATOM-tagged, so the lenient direct
- * compare remains correct and necessary there. */
+ * compare remains correct and necessary there.
+ *
+ * Audit #1.5 is about integers vs symbols, not strings vs symbols:
+ * assert-fact only ever stores an integer or a symbol, so a `"foo"` STR
+ * literal in a triple pattern can only mean the symbol named "foo" — the
+ * frontend comment above already interns a STR literal as a sym for
+ * exactly this reason. So under strict_tag a RAY_STR literal matches a
+ * DL_DATOM_TAG_SYM-tagged cell by payload (as well as a STR-tagged one,
+ * should a future frontend ever write that tag); a RAY_SYM literal
+ * matches only a SYM-tagged cell; a RAY_I64 literal matches only a
+ * genuinely untagged cell, numerically. */
 static bool dl_col_eq_row(ray_t* col, int64_t row, int64_t value,
                           int8_t const_type, bool strict_tag) {
     if (col->type == RAY_F64) {
@@ -1111,7 +1121,7 @@ static bool dl_col_eq_row(ray_t* col, int64_t row, int64_t value,
         if (cell_tag == 0) return false;  /* plain int column */
         int64_t cell_payload = cell & DL_DATOM_PAYLOAD;
         if (const_type == RAY_STR &&
-            cell_tag == DL_DATOM_TAG_STR)
+            (cell_tag == DL_DATOM_TAG_STR || cell_tag == DL_DATOM_TAG_SYM))
             return cell_payload == value;
         if (const_type == RAY_SYM &&
             cell_tag == DL_DATOM_TAG_SYM)

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -1626,6 +1626,13 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
                 ray_t* result = dl_antijoin_tables(accum, neg_tbl, lkeys, rkeys, n_keys);
                 ray_release(accum);
                 accum = result;
+            } else if (ray_table_nrows(neg_tbl) > 0) {
+                /* No join keys: the negated literal is ground (or all-fresh
+                 * variables). A non-empty match falsifies every accumulated
+                 * row (audit §1.3); an empty match leaves accum untouched. */
+                ray_t* empty = dl_table_take_mask(accum, NULL, 0);
+                ray_release(accum);
+                accum = empty;
             }
             ray_release(neg_tbl);
             break;

--- a/src/ops/datalog.h
+++ b/src/ops/datalog.h
@@ -90,13 +90,33 @@ typedef struct dl_expr {
 /* Variable index sentinel: constant value, not a variable */
 #define DL_CONST    (-1)
 
+/* Predicate name of the built-in 3-arity entity/attribute/value relation
+ * that ray_query_fn registers from the `db` argument (and that the triple-
+ * pattern `(?e :attr ?v)` sugar compiles atoms against). This is the only
+ * relation whose column 2 (the v column) is ever DATOM-tagged (below) --
+ * the strict_tag gates in dl_col_eq_row's callers, and the two
+ * dl_rule_add_atom(rule, DL_EAV_PRED, 3) triple-pattern call sites, all key
+ * off this one name so the coupling between "this predicate" and "this
+ * column may carry a DATOM tag" is explicit and in one place. */
+#define DL_EAV_PRED "eav"
+
 /* ===== DATOM value tag scheme (v column of a datoms table) =====
  * assert-fact stores a symbol/string value in an otherwise-plain I64
  * cell with one of these tags OR'd into the top bits so it can never
  * collide with a bare integer equal to the same intern id. dl_col_eq_row
  * strips the tag (via the const_type of the body literal) to compare;
  * user-visible reads (pull, scan-eav, query projection) strip it via
- * dl_datom_untag so callers keep seeing plain intern ids. */
+ * dl_datom_untag so callers keep seeing plain intern ids.
+ *
+ * Value-range limit: only the top 3 bits (61-63) are reserved for the tag
+ * and its sign guard (see dl_datom_untag below), so a *positive* I64 value
+ * of 2^61 or greater stored in the datoms v column -- or appearing in any
+ * I64 query result column that flows through dl_untag_i64_col -- has its
+ * top bits indistinguishable from a tag and is masked down to its low 61
+ * bits on output. This is a pre-existing limit of reusing the top bits for
+ * tagging, not something this fix introduces further constraints on; it
+ * simply means the v column (and any I64 result derived from it) is not a
+ * safe place to store the full 63-bit positive integer range. */
 #define DL_DATOM_TAG_SYM   ((int64_t)0x2000000000000000)
 #define DL_DATOM_TAG_STR   ((int64_t)0x4000000000000000)
 #define DL_DATOM_TAG_MASK  ((int64_t)0x6000000000000000)

--- a/src/ops/datalog.h
+++ b/src/ops/datalog.h
@@ -90,6 +90,25 @@ typedef struct dl_expr {
 /* Variable index sentinel: constant value, not a variable */
 #define DL_CONST    (-1)
 
+/* ===== DATOM value tag scheme (v column of a datoms table) =====
+ * assert-fact stores a symbol/string value in an otherwise-plain I64
+ * cell with one of these tags OR'd into the top bits so it can never
+ * collide with a bare integer equal to the same intern id. dl_col_eq_row
+ * strips the tag (via the const_type of the body literal) to compare;
+ * user-visible reads (pull, scan-eav, query projection) strip it via
+ * dl_datom_untag so callers keep seeing plain intern ids. */
+#define DL_DATOM_TAG_SYM   ((int64_t)0x2000000000000000)
+#define DL_DATOM_TAG_STR   ((int64_t)0x4000000000000000)
+#define DL_DATOM_TAG_MASK  ((int64_t)0x6000000000000000)
+#define DL_DATOM_PAYLOAD   ((int64_t)0x1FFFFFFFFFFFFFFF)
+/* A negative plain integer has every high bit set by sign extension, so it
+ * spuriously matches DL_DATOM_TAG_MASK; guard with v >= 0 since a genuine
+ * tagged cell is always non-negative (built from a small, non-negative
+ * intern id OR'd with a tag that never sets the sign bit) -- without this,
+ * untagging would corrupt ordinary negative I64 result values (e.g. from
+ * datalog arithmetic) by masking off their sign-extended high bits. */
+static inline int64_t dl_datom_untag(int64_t v) { return (v >= 0 && (v & DL_DATOM_TAG_MASK)) ? (v & DL_DATOM_PAYLOAD) : v; }
+
 /* Maximum arity for any relation */
 #define DL_MAX_ARITY 16
 

--- a/src/ops/datalog.h
+++ b/src/ops/datalog.h
@@ -342,6 +342,28 @@ dl_expr_t* dl_expr_var(int var_idx);
 /* Create a binary operation expression (OP_ADD, OP_SUB, OP_MUL, OP_DIV) */
 dl_expr_t* dl_expr_binop(int op, dl_expr_t* left, dl_expr_t* right);
 
+/* ===== Expression tree ownership =====
+ *
+ * A dl_rule_t owns the expression trees its body[] points to
+ * (assign_expr, cmp_lhs_expr, cmp_rhs_expr). dl_add_rule deep-clones the
+ * rule it is given, so the caller retains ownership of the trees it built
+ * and must free them itself (dl_rule_free_exprs). dl_program_free frees
+ * the expression trees owned by every rule in the program. The rules in
+ * g_dl_rules[] own their trees until ray_dl_reset_rules frees them. */
+
+/* Recursively free an expression tree. NULL-safe. */
+void dl_expr_free(dl_expr_t* e);
+
+/* Deep-copy an expression tree. NULL -> NULL. Returns NULL on OOM. */
+dl_expr_t* dl_expr_clone(const dl_expr_t* e);
+
+/* Free and NULL every expression tree owned by rule->body[]. */
+void dl_rule_free_exprs(dl_rule_t* rule);
+
+/* Replace every expression in rule->body[] with a deep clone of itself.
+ * Returns 0 on success, -1 on OOM (rule is left expr-free on failure). */
+int dl_rule_clone_exprs(dl_rule_t* rule);
+
 /* ===== Internal (used by compiler) ===== */
 
 /* Find relation by name. Returns index or -1. */

--- a/src/ops/datalog.h
+++ b/src/ops/datalog.h
@@ -351,11 +351,19 @@ int dl_find_rel(dl_program_t* prog, const char* name);
  * Creates it with the correct arity if it doesn't exist yet. */
 int dl_ensure_idb(dl_program_t* prog, const char* name, int arity);
 
+/* Which body position, if any, reads the semi-naive delta instead of
+ * the full relation. NULL delta = evaluate against full relations. */
+typedef struct {
+    int     pos;    /* index into rule->body[] */
+    ray_t*  table;  /* delta table for that position (borrowed) */
+} dl_delta_t;
+
 /* Compile one rule into a ray_graph_t for one fixpoint iteration.
- * delta_pos: which body atom uses the delta relation (-1 for initial pass).
+ * delta: which body position (if any) reads the semi-naive delta table
+ * instead of the full relation; NULL means evaluate against full relations.
  * rule_idx: index of this rule in prog->rules (used for provenance).
  * Returns the output node in g that produces new head tuples. */
 ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
-                          int delta_pos, int rule_idx, ray_graph_t* g);
+                          const dl_delta_t* delta, int rule_idx, ray_graph_t* g);
 
 #endif /* RAYFORCE_DATALOG_H */

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -114,3 +114,13 @@
 (set sd (retract-fact sd 1 'name 'Alice))
 (count (query sd (find ?e) (where (?e :name 'Alice)))) -- 0
 (count sd) -- 1
+
+;; §1.5 a hand-built datoms table whose v column is a genuine RAY_SYM
+;; vector (not assert-fact's DATOM-tagged I64 encoding) must still match
+;; a SYM/STR literal -- ray_query_fn tags column 2 the same way when
+;; converting a RAY_SYM v column to I64. A *legacy* I64 v column holding
+;; bare (untagged) sym ids stays deliberately unmatched by strict_tag:
+;; that bare-integer ambiguity is exactly what tagging removes.
+(set handbuilt (table ['e 'a 'v] (list [1 2] ['name 'name] ['Alice 'Bob])))
+(count (query handbuilt (find ?e) (where (?e :name 'Alice)))) -- 1
+(sym-name (at (at (query handbuilt (find ?v) (where (1 :name ?v))) '?v) 0)) -- 'Alice

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -74,12 +74,16 @@
 (set ld (assert-fact ld 2 'v 2))
 (set lq (fn [i] (count (query ld (find ?e ?y) (where (?e :v ?x) (= ?y (+ ?x 1)))))))
 (map lq (til 50))
-;; Two throw-away (.sys.mem) reads warm the measurement path itself -- each
-;; (get (.sys.mem) 'bytes-allocated) call retains its own boxed result, a
-;; fixed cost unrelated to the datalog query loop below -- before the real
-;; baseline is taken, so lb0 and the final read are directly comparable.
-(set lb_warm1 (get (.sys.mem) 'bytes-allocated))
-(set lb_warm2 (get (.sys.mem) 'bytes-allocated))
+;; `(set lb0 ...)` permanently retains its own boxed result -- a fixed cost
+;; unrelated to the datalog query loop below -- which would bias a single
+;; capture against every later comparison. Re-binding lb0 a second time
+;; replaces that box with an identically-sized one: the old box's release
+;; and the new box's allocation net to zero, so this second, self-paid
+;; capture is the true zero-cost baseline (verified empirically: a single
+;; capture reads a nonzero, non-scaling residual on every later read no
+;; matter how many throw-away reads precede it; re-binding the same name
+;; converges to exactly 0).
+(set lb0 (get (.sys.mem) 'bytes-allocated))
 (set lb0 (get (.sys.mem) 'bytes-allocated))
 (map lq (til 200))
 (- (get (.sys.mem) 'bytes-allocated) lb0) -- 0

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -74,6 +74,12 @@
 (set ld (assert-fact ld 2 'v 2))
 (set lq (fn [i] (count (query ld (find ?e ?y) (where (?e :v ?x) (= ?y (+ ?x 1)))))))
 (map lq (til 50))
+;; Two throw-away (.sys.mem) reads warm the measurement path itself -- each
+;; (get (.sys.mem) 'bytes-allocated) call retains its own boxed result, a
+;; fixed cost unrelated to the datalog query loop below -- before the real
+;; baseline is taken, so lb0 and the final read are directly comparable.
+(set lb_warm1 (get (.sys.mem) 'bytes-allocated))
+(set lb_warm2 (get (.sys.mem) 'bytes-allocated))
 (set lb0 (get (.sys.mem) 'bytes-allocated))
 (map lq (til 200))
 (- (get (.sys.mem) 'bytes-allocated) lb0) -- 0

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -108,6 +108,9 @@
 ;; user-visible reads still return plain intern ids
 (sym-name (at (at (query sd (find ?n) (where (1 :name ?n))) '?n) 0)) -- 'Alice
 (sym-name (get (pull sd 1) 'name)) -- 'Alice
+;; a "foo" STR literal means the symbol named "foo" (assert-fact only ever
+;; stores an integer or a symbol), so it matches the SYM-tagged cell too.
+(count (query sd (find ?e) (where (?e :name "Alice")))) -- 1
 (set sd (retract-fact sd 1 'name 'Alice))
 (count (query sd (find ?e) (where (?e :name 'Alice)))) -- 0
 (count sd) -- 1

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -1,0 +1,22 @@
+;; Regressions for docs/superpowers/specs/2026-09-08-datalog-audit.md.
+;; Chain 1->2->...->8 (7 edges). Full transitive closure = 7*8/2 = 28 pairs.
+(set g (datoms))
+(set g (assert-fact g 1 'edge 2))
+(set g (assert-fact g 2 'edge 3))
+(set g (assert-fact g 3 'edge 4))
+(set g (assert-fact g 4 'edge 5))
+(set g (assert-fact g 5 'edge 6))
+(set g (assert-fact g 6 'edge 7))
+(set g (assert-fact g 7 'edge 8))
+
+;; §1.1 linear (already correct) and non-linear closure must agree.
+(rule (lin ?x ?y) (?x :edge ?y))
+(rule (lin ?x ?z) (?x :edge ?y) (lin ?y ?z))
+(count (query g (find ?x ?y) (where (lin ?x ?y)))) -- 28
+(rule (nl ?x ?y) (?x :edge ?y))
+(rule (nl ?x ?z) (nl ?x ?y) (nl ?y ?z))
+(count (query g (find ?x ?y) (where (nl ?x ?y)))) -- 28
+;; the three pairs the old evaluator dropped
+(count (query g (find ?x ?y) (where (nl ?x ?y) (== ?x 1) (== ?y 6)))) -- 1
+(count (query g (find ?x ?y) (where (nl ?x ?y) (== ?x 2) (== ?y 7)))) -- 1
+(count (query g (find ?x ?y) (where (nl ?x ?y) (== ?x 3) (== ?y 8)))) -- 1

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -95,3 +95,19 @@
 (at (at (query ad (find ?y) (where (?e :v ?x) (= ?y (* ?x -9223372036854775807)))) '?y) 0) -- -9223372036854775807
 (at (at (query ad (find ?y) (where (?e :v ?x) (= ?y (/ ?x 0)))) '?y) 0) -- 0Nl
 (at (at (query ad (find ?y) (where (?e :v ?x) (= ?y (- ?x 3)))) '?y) 0) -- -2
+
+;; §1.5 a symbol value and an integer equal to its intern id are different values.
+(set sd (datoms))
+(set sd (assert-fact sd 1 'name 'Alice))
+(set sid (get (pull sd 1) 'name))
+(set sd (assert-fact sd 2 'name sid))
+(count (query sd (find ?e) (where (?e :name 'Alice)))) -- 1
+(at (at (query sd (find ?e) (where (?e :name 'Alice))) '?e) 0) -- 1
+(count (query sd (find ?e) (where (?e :name sid)))) -- 1
+(at (at (query sd (find ?e) (where (?e :name sid))) '?e) 0) -- 2
+;; user-visible reads still return plain intern ids
+(sym-name (at (at (query sd (find ?n) (where (1 :name ?n))) '?n) 0)) -- 'Alice
+(sym-name (get (pull sd 1) 'name)) -- 'Alice
+(set sd (retract-fact sd 1 'name 'Alice))
+(count (query sd (find ?e) (where (?e :name 'Alice)))) -- 0
+(count sd) -- 1

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -35,3 +35,18 @@
 (count (query g (find ?x) (where (?x :edge ?y) (not (1 :edge 9))))) -- 7
 (count (query g (find ?x) (where (?x :edge ?y) (not (_ :edge 8))))) -- 0
 (count (query g (find ?x) (where (?x :edge ?y) (not (_ :edge 99))))) -- 7
+
+;; §1.4 constant filters over F64 columns match numerically; other types error.
+(set pts (table [pts__c0 pts__c1] (list [1 2 3] [1.0 2.0 3.0])))
+(count (query g (find ?x) (where (pts ?x 2)))) -- 1
+(count (query g (find ?x) (where (pts ?x 2.0)))) -- 1
+(at (at (query g (find ?x) (where (pts ?x 2.0))) '?x) 0) -- 2
+(count (query g (find ?x) (where (pts ?x 7)))) -- 0
+(set strs (table [strs__c0 strs__c1] (list [1 2] ["a" "b"])))
+;; ray_fmt() only renders a RAY_ERROR's 7-byte code, not the detail text
+;; ray_error() stashes in the thread-local buffer, so the visible text is
+;; "error: domain" (query: evaluation failed wraps the inner "type" error
+;; from dl_filter_eq as "domain") -- matches the existing `query: ... !-
+;; domain` idiom used elsewhere for evaluation failures, e.g.
+;; datalog_branch_cov.rfl:274.
+(query g (find ?x) (where (strs ?x 1))) !- domain

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -20,3 +20,12 @@
 (count (query g (find ?x ?y) (where (nl ?x ?y) (== ?x 1) (== ?y 6)))) -- 1
 (count (query g (find ?x ?y) (where (nl ?x ?y) (== ?x 2) (== ?y 7)))) -- 1
 (count (query g (find ?x ?y) (where (nl ?x ?y) (== ?x 3) (== ?y 8)))) -- 1
+
+;; §1.2 a repeated variable inside one atom is an equality constraint.
+(count (query g (find ?x) (where (?x :edge ?x)))) -- 0
+(count (query g (find ?x) (where (lin ?x ?x)))) -- 0
+(set g2 (assert-fact g 5 'edge 5))
+(count (query g2 (find ?x) (where (?x :edge ?x)))) -- 1
+(at (at (query g2 (find ?x) (where (?x :edge ?x))) '?x) 0) -- 5
+;; ... and inside a negated atom: every node except the one with a self-loop
+(count (query g2 (find ?x) (where (?x :edge ?y) (not (?x :edge ?x))))) -- 6

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -67,3 +67,13 @@
 ;; §7.3 an unknown relation is an error, not an empty result.
 (query g (find ?x) (where (nosuch ?x))) !- domain
 (query g (find ?x) (where (?x :edge ?y) (not (nosuch ?x)))) !- domain
+
+;; §2.1 repeated queries with an arithmetic expression must not grow the heap.
+(set ld (datoms))
+(set ld (assert-fact ld 1 'v 1))
+(set ld (assert-fact ld 2 'v 2))
+(set lq (fn [i] (count (query ld (find ?e ?y) (where (?e :v ?x) (= ?y (+ ?x 1)))))))
+(map lq (til 50))
+(set lb0 (get (.sys.mem) 'bytes-allocated))
+(map lq (til 200))
+(- (get (.sys.mem) 'bytes-allocated) lb0) -- 0

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -58,3 +58,12 @@
 ;; domain` idiom used elsewhere for evaluation failures, e.g.
 ;; datalog_branch_cov.rfl:274.
 (query g (find ?x) (where (strs ?x 1))) !- domain
+
+;; §1.6 a find clause wider than DL_MAX_ARITY (16) errors instead of truncating.
+(set w (datoms))
+(set w (assert-fact w 1 'a 1))
+(count (key (query w (find ?a ?b ?c ?d ?e ?f ?g ?h ?i ?j ?k ?l ?m ?n ?o ?p) (where (?a :a ?b) (?a :a ?c) (?a :a ?d) (?a :a ?e) (?a :a ?f) (?a :a ?g) (?a :a ?h) (?a :a ?i) (?a :a ?j) (?a :a ?k) (?a :a ?l) (?a :a ?m) (?a :a ?n) (?a :a ?o) (?a :a ?p))))) -- 16
+(query w (find ?a ?b ?c ?d ?e ?f ?g ?h ?i ?j ?k ?l ?m ?n ?o ?p ?q) (where (?a :a ?b))) !- domain
+;; §7.3 an unknown relation is an error, not an empty result.
+(query g (find ?x) (where (nosuch ?x))) !- domain
+(query g (find ?x) (where (?x :edge ?y) (not (nosuch ?x)))) !- domain

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -87,3 +87,11 @@
 (set lb0 (get (.sys.mem) 'bytes-allocated))
 (map lq (til 200))
 (- (get (.sys.mem) 'bytes-allocated) lb0) -- 0
+
+;; §2.2 integer overflow and division by zero are null, never undefined behaviour.
+(set ad (datoms))
+(set ad (assert-fact ad 1 'v 1))
+(at (at (query ad (find ?y) (where (?e :v ?x) (= ?y (+ ?x 9223372036854775807)))) '?y) 0) -- 0Nl
+(at (at (query ad (find ?y) (where (?e :v ?x) (= ?y (* ?x -9223372036854775807)))) '?y) 0) -- -9223372036854775807
+(at (at (query ad (find ?y) (where (?e :v ?x) (= ?y (/ ?x 0)))) '?y) 0) -- 0Nl
+(at (at (query ad (find ?y) (where (?e :v ?x) (= ?y (- ?x 3)))) '?y) 0) -- -2

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -42,6 +42,14 @@
 (count (query g (find ?x) (where (pts ?x 2.0)))) -- 1
 (at (at (query g (find ?x) (where (pts ?x 2.0))) '?x) 0) -- 2
 (count (query g (find ?x) (where (pts ?x 7)))) -- 0
+;; review follow-up: an F64 literal against an I64 EDB column must also
+;; match numerically (dl_col_eq_row's `col->type == RAY_I64 &&
+;; const_type == RAY_F64` branch) -- the assertions above only exercise
+;; F64/I64 literals against an F64 column.
+(set ints (table [ints__c0 ints__c1] (list [1 2 3] [10 20 30])))
+(count (query g (find ?x) (where (ints ?x 20.0)))) -- 1
+(at (at (query g (find ?x) (where (ints ?x 20.0))) '?x) 0) -- 2
+(count (query g (find ?x) (where (ints ?x 21.0)))) -- 0
 (set strs (table [strs__c0 strs__c1] (list [1 2] ["a" "b"])))
 ;; ray_fmt() only renders a RAY_ERROR's 7-byte code, not the detail text
 ;; ray_error() stashes in the thread-local buffer, so the visible text is

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -29,3 +29,9 @@
 (at (at (query g2 (find ?x) (where (?x :edge ?x))) '?x) 0) -- 5
 ;; ... and inside a negated atom: every node except the one with a self-loop
 (count (query g2 (find ?x) (where (?x :edge ?y) (not (?x :edge ?x))))) -- 6
+
+;; §1.3 a negated atom with no shared variables is a guard, not a no-op.
+(count (query g (find ?x) (where (?x :edge ?y) (not (1 :edge 2))))) -- 0
+(count (query g (find ?x) (where (?x :edge ?y) (not (1 :edge 9))))) -- 7
+(count (query g (find ?x) (where (?x :edge ?y) (not (_ :edge 8))))) -- 0
+(count (query g (find ?x) (where (?x :edge ?y) (not (_ :edge 99))))) -- 7

--- a/test/rfl/datalog/datalog_branch_cov.rfl
+++ b/test/rfl/datalog/datalog_branch_cov.rfl
@@ -168,10 +168,14 @@
 
 ;; ════════════════════════ string literal in body position ═════════════════════════
 ;; Exercises the RAY_STR branch in dl_set_body_pos (line 3582-3589).
-;; "Alice" interned as sym matches the DATOM-tagged cell via tag-aware compare.
+;; Updated for audit #1.5 (task 8): assert-fact now tags a symbol value
+;; with DL_DATOM_TAG_SYM, and dl_col_eq_row requires an exact tag match, so
+;; a "foo" STR literal (which targets a STR-tagged cell) no longer matches
+;; a value stored via a 'foo SYM literal -- a string and a symbol are now
+;; distinct values, same as an integer and a symbol are.
 (set Db (datoms))
 (set Db (assert-fact Db 1 'name 'Alice))
-(count (query Db (find ?e) (where (?e :name "Alice")))) -- 1
+(count (query Db (find ?e) (where (?e :name "Alice")))) -- 0
 ;; string that does NOT match any stored value
 (count (query Db (find ?e) (where (?e :name "Nonexistent")))) -- 0
 

--- a/test/rfl/datalog/datalog_branch_cov.rfl
+++ b/test/rfl/datalog/datalog_branch_cov.rfl
@@ -212,8 +212,9 @@
 (count (query Empty (find ?n) (where (zero-count ?n)) (rules ((zero-count ?n) (count ?n empty_src))))) -- 1
 
 ;; ════════════════════════ query with inline rules — body references unknown predicate ═════════════════════════
+;; nonexistent-rel resolves to no relation at all — admission error, not empty (audit §7.3).
 (set Db (datoms))
-(count (query Db (find ?x) (where (phantom ?x)) (rules ((phantom ?x) (nonexistent-rel ?x))))) -- 0
+(query Db (find ?x) (where (phantom ?x)) (rules ((phantom ?x) (nonexistent-rel ?x)))) !- domain
 
 ;; ════════════════════════ neg with no shared keys (n_keys==0) ═════════════════════════
 (set Db (datoms))
@@ -366,12 +367,12 @@
 (at (at (query Db (find ?s) (where (asum ?s)) (rules ((asum ?s) (sum ?s agg_env 1)))) '?s) 0) -- 100
 
 ;; ════════════════════════ dl_find_rel returns -1 for unknown body pred ═════════════════════════
-;; Exercises line 1297 (rel_idx < 0 => return NULL) in dl_compile_rule.
 ;; When a positive body atom references a predicate unknown to the program,
-;; compile_rule returns NULL silently (no eval_err, just 0 rows).
+;; the admission check now rejects it up front (audit §7.3), instead of
+;; compile_rule silently returning NULL (no eval_err, just 0 rows).
 (set Db (datoms))
 (set Db (assert-fact Db 1 'tag 'x))
-(count (query Db (find ?e) (where (uses-unknown ?e)) (rules ((uses-unknown ?e) (no-such-pred ?e ?v))))) -- 0
+(query Db (find ?e) (where (uses-unknown ?e)) (rules ((uses-unknown ?e) (no-such-pred ?e ?v)))) !- domain
 
 ;; ════════════════════════ table_antijoin: left empty ═════════════════════════
 ;; Exercises the ray_table_nrows(left)==0 early return in table_antijoin (line 2368).

--- a/test/rfl/datalog/datalog_branch_cov.rfl
+++ b/test/rfl/datalog/datalog_branch_cov.rfl
@@ -117,14 +117,16 @@
 (sum (at (query Db (find ?e ?y) (where (?e :val ?x) (= ?y (+ ?x 0.5)) (> ?y 20.0))) '?y)) -- 51.0
 
 ;; ════════════════════════ integer division by zero in expressions ═════════════════════════
-;; Exercises the rd[r] != 0 ? ... : 0 branch in i64 binop path (line 748).
-;; Division by 0 → result is 0 for each row; ?y = 0 for all 3 rows.
+;; Exercises the (b == 0 || ...) ? NULL_I64 : a / b branch in the i64 binop path.
+;; §2.2: division by 0 is null, matching the host `/`; ?y = 0Nl for all 3 rows,
+;; and sum() over an all-null i64 column is null.
 (count (query Db (find ?e ?y) (where (?e :val ?x) (= ?y (/ ?x 0))))) -- 3
-(sum (at (query Db (find ?e ?y) (where (?e :val ?x) (= ?y (/ ?x 0)))) '?y)) -- 0
+(sum (at (query Db (find ?e ?y) (where (?e :val ?x) (= ?y (/ ?x 0)))) '?y)) -- 0Nl
 
-;; Exercises the rd[r] != 0.0 ? ... : 0.0 branch in f64 binop path (line 725).
+;; §2.2: f64 division by zero follows IEEE (matches the host `/`): ?x/0.0 -> +inf
+;; for each row, and sum() of all-+inf collapses to NaN (formats as 0Nf).
 (count (query Db (find ?e ?y) (where (?e :val ?x) (= ?y (/ ?x 0.0))))) -- 3
-(sum (at (query Db (find ?e ?y) (where (?e :val ?x) (= ?y (/ ?x 0.0)))) '?y)) -- 0.0
+(sum (at (query Db (find ?e ?y) (where (?e :val ?x) (= ?y (/ ?x 0.0)))) '?y)) -- 0Nf
 
 ;; ════════════════════════ f64 subtraction, multiplication, division in expressions ═════════════════════════
 ;; - ?x 0.5: {9.5, 19.5, 29.5}; > 10.0 keeps {19.5, 29.5} = 49.0.

--- a/test/rfl/datalog/datalog_branch_cov.rfl
+++ b/test/rfl/datalog/datalog_branch_cov.rfl
@@ -168,14 +168,10 @@
 
 ;; ════════════════════════ string literal in body position ═════════════════════════
 ;; Exercises the RAY_STR branch in dl_set_body_pos (line 3582-3589).
-;; Updated for audit #1.5 (task 8): assert-fact now tags a symbol value
-;; with DL_DATOM_TAG_SYM, and dl_col_eq_row requires an exact tag match, so
-;; a "foo" STR literal (which targets a STR-tagged cell) no longer matches
-;; a value stored via a 'foo SYM literal -- a string and a symbol are now
-;; distinct values, same as an integer and a symbol are.
+;; "Alice" interned as sym matches the DATOM-tagged cell via tag-aware compare.
 (set Db (datoms))
 (set Db (assert-fact Db 1 'name 'Alice))
-(count (query Db (find ?e) (where (?e :name "Alice")))) -- 0
+(count (query Db (find ?e) (where (?e :name "Alice")))) -- 1
 ;; string that does NOT match any stored value
 (count (query Db (find ?e) (where (?e :name "Nonexistent")))) -- 0
 

--- a/test/rfl/datalog/datalog_coverage.rfl
+++ b/test/rfl/datalog/datalog_coverage.rfl
@@ -412,8 +412,11 @@
 (count (query Edb (find ?e) (where (gi ?e)) (rules ((gi ?e) (?e :age (+ 10 20)))))) -- 1
 ;; (first ['admin 'user]) → sym 'admin ; matches entity 1's role.
 (count (query Edb (find ?e) (where (gs ?e)) (rules ((gs ?e) (?e :role (first ['admin 'user])))))) -- 1
-;; evaluates to a float → unsupported constant type in body.
-(query Edb (find ?e) (where (gb ?e)) (rules ((gb ?e) (?e :age (+ 1.0 2.0))))) !- type
+;; evaluates to a float → F64 body constants are now supported (audit
+;; §1.4, task 4): compares numerically against the I64 age column, and
+;; 3.0 matches neither entity's age, so the result is empty rather than
+;; an error.
+(count (query Edb (find ?e) (where (gb ?e)) (rules ((gb ?e) (?e :age (+ 1.0 2.0)))))) -- 0
 
 ;; ════════════════════════ recursive rule via inline rules (no globals) ═════════════════════════
 ;; Chain 1→2→3→4: TC pairs = (1,2),(1,3),(1,4),(2,3),(2,4),(3,4) — 6 rows.

--- a/test/rfl/datalog/datalog_coverage.rfl
+++ b/test/rfl/datalog/datalog_coverage.rfl
@@ -303,8 +303,9 @@
 
 ;; body shape guards — non-list body clause
 (query Db (find ?e) (where 1)) !- type
-;; reference to unknown predicate at eval time — empty result, not error
-(count (query Db (find ?e) (where ('weird ?e)))) -- 0
+;; reference to unknown predicate at eval time is now an admission error,
+;; not an empty result (audit §7.3).
+(query Db (find ?e) (where ('weird ?e))) !- domain
 
 ;; ════════════════════════ empty-result schema preservation (4201-4211) ═════════════════════════
 ;; Even when the result is empty, the schema must reflect the find vars.
@@ -353,9 +354,10 @@
 (asc (at qPairs '?l)) -- [1 2 3]
 (asc (at qPairs '?r)) -- [10 20 30]
 
-;; reference relation with arity-mismatch — not registered, 0 rows.
+;; reference relation with arity-mismatch — not registered, so `tri` is now
+;; an unknown relation (admission error, not 0 rows; audit §7.3).
 (set tri (table ['a 'b 'c] (list [1] [2] [3])))
-(count (query Db2 (find ?x ?y) (where (tri ?x ?y)))) -- 0
+(query Db2 (find ?x ?y) (where (tri ?x ?y))) !- domain
 
 ;; env-backed table whose 2nd column is RAY_SYM (auto-converted to I64 via
 ;; ray_read_sym branch — lines 4120-4140).

--- a/test/test_datalog.c
+++ b/test/test_datalog.c
@@ -2513,6 +2513,36 @@ static test_result_t test_nonlinear_closure_chain(void) {
     PASS();
 }
 
+/* Audit §1.4: an I64 literal against an F64 EDB column must filter, not
+ * pass the whole table through. */
+static test_result_t test_const_filter_f64_column(void) {
+    int64_t ids[] = {1, 2, 3};
+    double  xs[]  = {1.0, 2.0, 3.0};
+    ray_t* c0 = ray_vec_from_raw(RAY_I64, ids, 3);
+    ray_t* c1 = ray_vec_from_raw(RAY_F64, xs, 3);
+    ray_t* pts = ray_table_new(2);
+    pts = ray_table_add_col(pts, ray_sym_intern("pts__c0", 7), c0);
+    pts = ray_table_add_col(pts, ray_sym_intern("pts__c1", 7), c1);
+
+    dl_program_t* prog = dl_program_new();
+    TEST_ASSERT_EQ_I(dl_add_edb(prog, "pts", pts, 2), 0);
+    dl_rule_t r;                          /* q(X) :- pts(X, 2) */
+    dl_rule_init(&r, "q", 1);
+    dl_rule_head_var(&r, 0, 0);
+    int b = dl_rule_add_atom(&r, "pts", 2);
+    dl_body_set_var(&r, b, 0, 0);
+    dl_body_set_const_typed(&r, b, 1, 2, RAY_I64);
+    TEST_ASSERT_EQ_I(dl_add_rule(prog, &r), 0);
+    TEST_ASSERT_EQ_I(dl_eval(prog), 0);
+    ray_t* out = dl_query(prog, "q");
+    TEST_ASSERT_NOT_NULL(out);
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(out), 1);
+    TEST_ASSERT_EQ_I((int)((int64_t*)ray_data(ray_table_get_col_idx(out, 0)))[0], 2);
+    dl_program_free(prog);
+    ray_release(pts); ray_release(c0); ray_release(c1);
+    PASS();
+}
+
 const test_entry_t datalog_entries[] = {
     { "datalog/source_provenance", test_source_provenance, datalog_setup, datalog_teardown },
     { "datalog/source_prov_requires_flag", test_source_prov_requires_flag, datalog_setup, datalog_teardown },
@@ -2578,6 +2608,7 @@ const test_entry_t datalog_entries[] = {
     { "datalog/rule_add_interval_overflow", test_rule_add_interval_overflow, datalog_setup, datalog_teardown },
     { "datalog/edb_over_arity_domain_guard", test_edb_over_arity_domain_guard, datalog_setup, datalog_teardown },
     { "datalog/nonlinear_closure_chain", test_nonlinear_closure_chain, datalog_setup, datalog_teardown },
+    { "datalog/const_filter_f64_column", test_const_filter_f64_column, datalog_setup, datalog_teardown },
     { NULL, NULL, NULL, NULL },
 };
 

--- a/test/test_datalog.c
+++ b/test/test_datalog.c
@@ -2533,13 +2533,107 @@ static test_result_t test_const_filter_f64_column(void) {
     dl_body_set_var(&r, b, 0, 0);
     dl_body_set_const_typed(&r, b, 1, 2, RAY_I64);
     TEST_ASSERT_EQ_I(dl_add_rule(prog, &r), 0);
+
+    /* q2(Y) :- pts(1.0, Y) — an F64 literal against the I64 id column
+     * (pos 0), exercising dl_col_eq_row's `col->type == RAY_I64 &&
+     * const_type == RAY_F64` branch (`(double)cell == v`), which the
+     * first rule above never reaches (its F64 literal always targets
+     * the F64 column). */
+    double one = 1.0;
+    int64_t one_bits; memcpy(&one_bits, &one, sizeof one_bits);
+    dl_rule_t r2;
+    dl_rule_init(&r2, "q2", 1);
+    dl_rule_head_var(&r2, 0, 0);
+    int b2 = dl_rule_add_atom(&r2, "pts", 2);
+    dl_body_set_const_typed(&r2, b2, 0, one_bits, RAY_F64);
+    dl_body_set_var(&r2, b2, 1, 0);
+    TEST_ASSERT_EQ_I(dl_add_rule(prog, &r2), 1);
+
     TEST_ASSERT_EQ_I(dl_eval(prog), 0);
     ray_t* out = dl_query(prog, "q");
     TEST_ASSERT_NOT_NULL(out);
     TEST_ASSERT_EQ_I((int)ray_table_nrows(out), 1);
     TEST_ASSERT_EQ_I((int)((int64_t*)ray_data(ray_table_get_col_idx(out, 0)))[0], 2);
+
+    ray_t* out2 = dl_query(prog, "q2");
+    TEST_ASSERT_NOT_NULL(out2);
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(out2), 1);
+    TEST_ASSERT_EQ_F(((double*)ray_data(ray_table_get_col_idx(out2, 0)))[0], 1.0, 1e-12);
+
     dl_program_free(prog);
     ray_release(pts); ray_release(c0); ray_release(c1);
+    PASS();
+}
+
+/* Audit §1.4 (review follow-up): source provenance for a constant body
+ * slot must use the same type-aware equality as dl_filter_eq (an F64
+ * literal against an I64 column), not a raw int64 bit-compare — see
+ * dl_build_source_prov's const-slot branch, which previously read
+ * `((int64_t*)ray_data(bcol))[br] != body->const_vals[c]` directly. */
+static test_result_t test_source_prov_f64_const_body_slot(void) {
+    int64_t e_vals[] = {1, 2, 3};
+    int64_t k_vals[] = {7, 7, 9};
+    ray_t* e_col = ray_vec_from_raw(RAY_I64, e_vals, 3);
+    ray_t* k_col = ray_vec_from_raw(RAY_I64, k_vals, 3);
+    TEST_ASSERT_NOT_NULL(e_col);
+    TEST_ASSERT_NOT_NULL(k_col);
+
+    ray_t* kv = ray_table_new(2);
+    kv = ray_table_add_col(kv, ray_sym_intern("kv__c0", 6), e_col);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(kv));
+    kv = ray_table_add_col(kv, ray_sym_intern("kv__c1", 6), k_col);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(kv));
+
+    dl_program_t* prog = dl_program_new();
+    TEST_ASSERT_NOT_NULL(prog);
+    prog->flags |= DL_FLAG_PROVENANCE;
+
+    int kv_idx = dl_add_edb(prog, "kv", kv, 2);
+    TEST_ASSERT_EQ_I(kv_idx, 0);
+
+    /* hit(E) :- kv(E, 7.0) — F64 literal against the I64 k column. */
+    double seven = 7.0;
+    int64_t seven_bits; memcpy(&seven_bits, &seven, sizeof seven_bits);
+    dl_rule_t rule;
+    dl_rule_init(&rule, "hit", 1);
+    dl_rule_head_var(&rule, 0, 0);
+    int body = dl_rule_add_atom(&rule, "kv", 2);
+    dl_body_set_var(&rule, body, 0, 0);                          /* E */
+    dl_body_set_const_typed(&rule, body, 1, seven_bits, RAY_F64); /* constant 7.0 */
+    rule.n_vars = 1;
+    TEST_ASSERT_EQ_I(dl_add_rule(prog, &rule), 0);
+
+    TEST_ASSERT_EQ_I(dl_eval(prog), 0);
+
+    ray_t* out = dl_query(prog, "hit");
+    TEST_ASSERT_NOT_NULL(out);
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(out), 2);
+
+    ray_t* offsets = dl_get_provenance_src_offsets(prog, "hit");
+    ray_t* data    = dl_get_provenance_src_data(prog, "hit");
+    TEST_ASSERT_NOT_NULL(offsets);
+    TEST_ASSERT_NOT_NULL(data);
+    TEST_ASSERT_EQ_I((int)ray_len(offsets), 3);
+    TEST_ASSERT_EQ_I((int)ray_len(data), 2);
+    int64_t* off = (int64_t*)ray_data(offsets);
+    TEST_ASSERT_EQ_I((int)off[0], 0);
+    TEST_ASSERT_EQ_I((int)off[1], 1);
+    TEST_ASSERT_EQ_I((int)off[2], 2);
+    /* Both refs must point at relation kv (idx 0), rows 0 and 1 — never row 2
+     * (kv(3,9), which does not equal 7.0). Before routing through
+     * dl_col_eq_row, the raw int64 compare `9 != <bits of 7.0>` happened to
+     * still reject row 2, but rows 0/1 (`7 != <bits of 7.0>`) would also have
+     * been wrongly rejected, leaving provenance empty. */
+    int64_t* sd = (int64_t*)ray_data(data);
+    for (int i = 0; i < 2; i++) {
+        TEST_ASSERT_EQ_I((int)(sd[i] >> 32), kv_idx);
+        TEST_ASSERT_TRUE((sd[i] & 0xffffffff) != 2);
+    }
+
+    dl_program_free(prog);
+    ray_release(kv);
+    ray_release(e_col);
+    ray_release(k_col);
     PASS();
 }
 
@@ -2547,6 +2641,7 @@ const test_entry_t datalog_entries[] = {
     { "datalog/source_provenance", test_source_provenance, datalog_setup, datalog_teardown },
     { "datalog/source_prov_requires_flag", test_source_prov_requires_flag, datalog_setup, datalog_teardown },
     { "datalog/source_prov_const_body_slot", test_source_prov_const_body_slot, datalog_setup, datalog_teardown },
+    { "datalog/source_prov_f64_const_body_slot", test_source_prov_f64_const_body_slot, datalog_setup, datalog_teardown },
     { "datalog/source_prov_buffer_grow", test_source_prov_buffer_grow, datalog_setup, datalog_teardown },
     { "datalog/cmp_const_filter", test_cmp_const_filter, datalog_setup, datalog_teardown },
     { "datalog/arith_assignment", test_arith_assignment, datalog_setup, datalog_teardown },

--- a/test/test_datalog.c
+++ b/test/test_datalog.c
@@ -2675,6 +2675,41 @@ static test_result_t test_source_prov_f64_const_body_slot(void) {
     PASS();
 }
 
+/* Audit §2.1: dl_add_rule deep-copies expression trees, so two programs can
+ * hold the same rule and each free its own copy; the caller frees the
+ * original. Under ASan a shared tree would double-free here. */
+static test_result_t test_rule_expr_ownership(void) {
+    dl_rule_t r;                              /* q(Y) :- p(X), Y = X + 1 */
+    dl_rule_init(&r, "q", 1);
+    dl_rule_head_var(&r, 0, 1);
+    int b = dl_rule_add_atom(&r, "p", 1);
+    dl_body_set_var(&r, b, 0, 0);
+    dl_expr_t* e = dl_expr_binop(OP_ADD, dl_expr_var(0), dl_expr_const(1));
+    TEST_ASSERT_TRUE(dl_rule_add_assign(&r, 1, OP_ADD, e) >= 0);
+
+    int64_t v[] = {1};
+    ray_t* c = ray_vec_from_raw(RAY_I64, v, 1);
+    ray_t* p = ray_table_new(1);
+    p = ray_table_add_col(p, ray_sym_intern("p__c0", 5), c);
+
+    dl_program_t* a = dl_program_new();
+    dl_program_t* bprog = dl_program_new();
+    dl_add_edb(a, "p", p, 1);  dl_add_edb(bprog, "p", p, 1);
+    TEST_ASSERT_EQ_I(dl_add_rule(a, &r), 0);
+    TEST_ASSERT_EQ_I(dl_add_rule(bprog, &r), 0);
+    TEST_ASSERT_TRUE(a->rules[0].body[1].assign_expr != r.body[1].assign_expr);
+    TEST_ASSERT_TRUE(a->rules[0].body[1].assign_expr != bprog->rules[0].body[1].assign_expr);
+    TEST_ASSERT_EQ_I(dl_eval(a), 0);
+    TEST_ASSERT_EQ_I((int)((int64_t*)ray_data(ray_table_get_col_idx(dl_query(a, "q"), 0)))[0], 2);
+
+    dl_program_free(a);
+    dl_program_free(bprog);
+    dl_rule_free_exprs(&r);
+    TEST_ASSERT_TRUE(r.body[1].assign_expr == NULL);
+    ray_release(p); ray_release(c);
+    PASS();
+}
+
 const test_entry_t datalog_entries[] = {
     { "datalog/source_provenance", test_source_provenance, datalog_setup, datalog_teardown },
     { "datalog/source_prov_requires_flag", test_source_prov_requires_flag, datalog_setup, datalog_teardown },
@@ -2743,6 +2778,7 @@ const test_entry_t datalog_entries[] = {
     { "datalog/edb_over_arity_domain_guard", test_edb_over_arity_domain_guard, datalog_setup, datalog_teardown },
     { "datalog/nonlinear_closure_chain", test_nonlinear_closure_chain, datalog_setup, datalog_teardown },
     { "datalog/const_filter_f64_column", test_const_filter_f64_column, datalog_setup, datalog_teardown },
+    { "datalog/rule_expr_ownership", test_rule_expr_ownership, datalog_setup, datalog_teardown },
     { NULL, NULL, NULL, NULL },
 };
 

--- a/test/test_datalog.c
+++ b/test/test_datalog.c
@@ -2470,6 +2470,49 @@ static test_result_t test_edb_over_arity_domain_guard(void) {
     PASS();
 }
 
+/* Audit §1.1: p(X,Z) :- p(X,Y), p(Y,Z) over a 7-edge chain must produce the
+ * same 28 pairs as the linear formulation. The old fixpoint loop swapped the
+ * whole relation for its delta, so both body occurrences of `p` read the
+ * delta and old×new combinations were never joined. */
+static test_result_t test_nonlinear_closure_chain(void) {
+    int64_t src[7], dst[7];
+    for (int i = 0; i < 7; i++) { src[i] = i + 1; dst[i] = i + 2; }
+    ray_t* c0 = ray_vec_from_raw(RAY_I64, src, 7);
+    ray_t* c1 = ray_vec_from_raw(RAY_I64, dst, 7);
+    ray_t* edge = ray_table_new(2);
+    edge = ray_table_add_col(edge, ray_sym_intern("edge__c0", 8), c0);
+    edge = ray_table_add_col(edge, ray_sym_intern("edge__c1", 8), c1);
+
+    dl_program_t* prog = dl_program_new();
+    TEST_ASSERT_NOT_NULL(prog);
+    TEST_ASSERT_EQ_I(dl_add_edb(prog, "edge", edge, 2), 0);
+
+    dl_rule_t r1;                      /* p(X,Y) :- edge(X,Y) */
+    dl_rule_init(&r1, "p", 2);
+    dl_rule_head_var(&r1, 0, 0); dl_rule_head_var(&r1, 1, 1);
+    int b = dl_rule_add_atom(&r1, "edge", 2);
+    dl_body_set_var(&r1, b, 0, 0); dl_body_set_var(&r1, b, 1, 1);
+    TEST_ASSERT_EQ_I(dl_add_rule(prog, &r1), 0);
+
+    dl_rule_t r2;                      /* p(X,Z) :- p(X,Y), p(Y,Z) */
+    dl_rule_init(&r2, "p", 2);
+    dl_rule_head_var(&r2, 0, 0); dl_rule_head_var(&r2, 1, 2);
+    int b1 = dl_rule_add_atom(&r2, "p", 2);
+    dl_body_set_var(&r2, b1, 0, 0); dl_body_set_var(&r2, b1, 1, 1);
+    int b2 = dl_rule_add_atom(&r2, "p", 2);
+    dl_body_set_var(&r2, b2, 0, 1); dl_body_set_var(&r2, b2, 1, 2);
+    TEST_ASSERT_EQ_I(dl_add_rule(prog, &r2), 1);
+
+    TEST_ASSERT_EQ_I(dl_eval(prog), 0);
+    ray_t* out = dl_query(prog, "p");
+    TEST_ASSERT_NOT_NULL(out);
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(out), 28);
+
+    dl_program_free(prog);
+    ray_release(edge); ray_release(c0); ray_release(c1);
+    PASS();
+}
+
 const test_entry_t datalog_entries[] = {
     { "datalog/source_provenance", test_source_provenance, datalog_setup, datalog_teardown },
     { "datalog/source_prov_requires_flag", test_source_prov_requires_flag, datalog_setup, datalog_teardown },
@@ -2534,6 +2577,7 @@ const test_entry_t datalog_entries[] = {
     { "datalog/rule_add_interval", test_rule_add_interval, datalog_setup, datalog_teardown },
     { "datalog/rule_add_interval_overflow", test_rule_add_interval_overflow, datalog_setup, datalog_teardown },
     { "datalog/edb_over_arity_domain_guard", test_edb_over_arity_domain_guard, datalog_setup, datalog_teardown },
+    { "datalog/nonlinear_closure_chain", test_nonlinear_closure_chain, datalog_setup, datalog_teardown },
     { NULL, NULL, NULL, NULL },
 };
 

--- a/test/test_datalog.c
+++ b/test/test_datalog.c
@@ -36,6 +36,10 @@
 #include <stdlib.h>        /* abort in datalog_rf_setup */
 #include <string.h>
 
+/* ray_error_msg() isn't in the public <rayforce.h> surface — src/ops/datalog.c
+ * itself reaches it the same way (see its own `extern` near the top). */
+extern const char* ray_error_msg(void);
+
 /* Full-runtime fixtures use the public runtime API from <rayforce.h>. */
 
 static void datalog_setup(void) {
@@ -2014,6 +2018,40 @@ static test_result_t test_eval_surfaces_compile_failure(void) {
     PASS();
 }
 
+/* Admission errors: a `find` clause wider than DL_MAX_ARITY (16) must be
+ * rejected instead of silently truncated, and a body predicate that
+ * resolves to no relation at all (not an EDB, env-bound table, or rule
+ * head) must be an error instead of an empty result.  Audit §1.6, §7.3. */
+static test_result_t test_query_admission_errors(void) {
+    ray_t* db = ray_eval_str(
+        "(do (set __qae_db (datoms)) (set __qae_db (assert-fact __qae_db 1 'a 1)))");
+    TEST_ASSERT_NOT_NULL(db);
+    TEST_ASSERT_TRUE(!RAY_IS_ERR(db));
+    ray_release(db);
+
+    /* (a) 17 find variables exceeds DL_MAX_ARITY (16). */
+    ray_t* r_wide = ray_eval_str(
+        "(query __qae_db (find ?a ?b ?c ?d ?e ?f ?g ?h ?i ?j ?k ?l ?m ?n ?o ?p ?q) "
+        "  (where (?a :a ?b)))");
+    TEST_ASSERT_NOT_NULL(r_wide);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(r_wide));
+    const char* msg_wide = ray_error_msg();
+    TEST_ASSERT_NOT_NULL(msg_wide);
+    TEST_ASSERT_TRUE(strstr(msg_wide, "find supports at most 16 variables") != NULL);
+    ray_error_free(r_wide);
+
+    /* (b) unknown relation referenced in the body. */
+    ray_t* r_unk = ray_eval_str("(query __qae_db (find ?x) (where (nosuch ?x)))");
+    TEST_ASSERT_NOT_NULL(r_unk);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(r_unk));
+    const char* msg_unk = ray_error_msg();
+    TEST_ASSERT_NOT_NULL(msg_unk);
+    TEST_ASSERT_TRUE(strstr(msg_unk, "unknown relation 'nosuch'") != NULL);
+    ray_error_free(r_unk);
+
+    PASS();
+}
+
 /* ray_release() is a deliberate no-op for RAY_ERROR objects, so callers
  * that claim to be "releasing" an error under the refcount API actually
  * leak the block.  ray_error_free() is the escape hatch that calls
@@ -2685,6 +2723,7 @@ const test_entry_t datalog_entries[] = {
     { "datalog/env_bound_edb_auto_register", test_env_bound_edb_auto_register, datalog_rf_setup, datalog_rf_teardown },
     { "datalog/env_bound_agg_auto_register", test_env_bound_agg_auto_register, datalog_rf_setup, datalog_rf_teardown },
     { "datalog/eval_surfaces_compile_failure", test_eval_surfaces_compile_failure, datalog_rf_setup, datalog_rf_teardown },
+    { "datalog/query_admission_errors", test_query_admission_errors, datalog_rf_setup, datalog_rf_teardown },
     { "datalog/error_free_reclaims", test_error_free_reclaims, datalog_rf_setup, datalog_rf_teardown },
     { "datalog/agg_scalar_f64", test_agg_scalar_f64, datalog_setup, datalog_teardown },
     { "datalog/agg_scalar_f64_sum_empty", test_agg_scalar_f64_sum_empty, datalog_setup, datalog_teardown },

--- a/test/test_lang.c
+++ b/test/test_lang.c
@@ -5055,7 +5055,8 @@ static test_result_t test_datalog_query_inline_rules(void) {
     TEST_ASSERT_EQ_I((int)ray_table_nrows(r_inline), 6);
     ray_release(r_inline);
 
-    /* Global foo rule — inline rules omit it; foo yields no rows */
+    /* Global foo rule — inline rules omit it, so `foo` resolves to no
+     * relation at all: an unknown-relation error, not an empty result. */
     ray_t* r_foo = ray_eval_str(
         "(do"
         "  (set db (datoms))"
@@ -5065,9 +5066,8 @@ static test_result_t test_datalog_query_inline_rules(void) {
         "    (rules ((path ?x ?y) (?x :edge ?y)))))"
     );
     TEST_ASSERT_TRUE(r_foo != NULL);
-    TEST_ASSERT_TRUE(!RAY_IS_ERR(r_foo));
-    TEST_ASSERT_EQ_I((int)ray_table_nrows(r_foo), 0);
-    ray_release(r_foo);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(r_foo));
+    ray_error_free(r_foo);
 
     ray_t* r_global = ray_eval_str(
         "(do"


### PR DESCRIPTION
Fixes every confirmed correctness finding of the 2026-09-08 Datalog audit (report in `/tmp/datalog_audit_2026-09-08.md`; all findings re-verified on dev @ 0e39bd88 before this work).

## Findings fixed

| Audit item | Fix | Test |
|---|---|---|
| §1.1 non-linear recursion lost tuples (25 of 28 pairs) | semi-naive delta keyed by body position (`dl_delta_t`), no more whole-relation swap | `audit_regressions.rfl`, `test_nonlinear_closure_chain` |
| §1.2 repeated variable inside one atom ignored | column-equality pre-filter for positive and negated atoms (`dl_filter_repeated_vars`) | `audit_regressions.rfl` |
| §1.3 negation with no shared variables skipped | ground negated literal acts as a guard | `audit_regressions.rfl` |
| §1.4 unsupported filter type passed every row | F64 columns compare numerically against I64/F64 literals; other column types are a type error; F64 literals accepted in bodies | `audit_regressions.rfl`, `test_const_filter_f64_column`, provenance variant |
| §1.5 symbol and equal integer indistinguishable in datoms | `assert-fact`/`retract-fact` tag symbol values with the DATOM SYM tag the compare path already understood; query projection, `pull`, `scan-eav` strip it | `audit_regressions.rfl` |
| §1.6 `find` wider than 16 silently truncated | admission error | `audit_regressions.rfl`, `test_query_admission_errors` |
| §7.3 unknown relation gave an empty result | admission error `unknown relation 'x'` | same |
| §2.1 384 B leaked per arithmetic query | expression trees are owned per rule: `dl_add_rule` deep-clones, `dl_program_free` frees, parse-time rules freed on every path | RFL leak test asserting 0 growth over 200 queries; `test_rule_expr_ownership` |
| §2.2 signed overflow UB in expressions | checked I64 arithmetic: overflow, div by zero, `INT64_MIN/-1`, null operand → `0Nl` (matches the host language) | `audit_regressions.rfl` |
| §3 docs overstated the optimizer | reference describes the materialising evaluator, arithmetic contract, limits, symbol storage | — |

## Behaviour changes to be aware of
- A bare, unquoted symbol in a `where`/rule body position is now evaluated as a variable reference (quoted and keyword symbols stay literals; head arguments unchanged).
- The raw datoms table shows tagged large integers for symbol values; every user-visible read strips them. Positive integers of 2^61 and above cannot be stored in the datoms `v` column without masking (documented).
- Existing tests that had pinned the old behaviour (F64 literal rejected, unknown predicate → empty, `/ 0` → `0`) were updated to the new contract.

## Verification
`make test`: 3776 of 3776 passed, 0 UBSan `runtime error` lines (grepped; the harness does not fail on them).

https://claude.ai/code/session_019RxzDYWuuTMBmo9H8qcno5
