### PR TITLE
perf(datalog): fixpoint loop — uncapped monotone strata, incremental row set, in-place union

### DIFF
--- a/bench/datalog/BASELINE.md
+++ b/bench/datalog/BASELINE.md
@@ -136,3 +136,47 @@ Total allocation for linear N=512, measured with `(.mem.ts (count (query db (fin
 | after | 73,245,632 | 22,891 | 36,702,400 | 102,932,959 |
 
 25.8x less total allocation. Peak live is unchanged (the relation itself is the same size); what disappears is the full copy of the relation made once per iteration.
+
+## After Task 14 (old/new split for multi-recursive rules, `8c75dade` + this commit)
+
+- Change under test: `dl_delta_t` carries `prev_nrows[]` — the row count each IDB of the stratum had at the start of the previous iteration. Since `table_union` appends the delta at the end of the relation, that count is the length of the "old" prefix. A positive body atom **before** the delta position now reads a `dl_table_head` view of that prefix (zero-copy `ray_vec_slice` columns) instead of the full relation; the atom at the delta position reads Δ, atoms after it read the full relation. `p(X,Z) :- p(X,Y), p(Y,Z)` therefore derives Δ⋈Δ once instead of twice. An empty prefix (iteration 0) short-circuits the rule instance entirely.
+- Prefix-path trigger counts (temporary counter, removed before commit), `tc_chain` N=128: nonlinear 6 head views + 1 empty-prefix short-circuit; linear 0 / 0 — the linear rule's recursive atom is the last positive atom, so nothing ever sits before the delta position and the path is never taken. Linear is unaffected by construction.
+- Same methodology and machine as above (min-of-3 wall time via `date +%s%N`, `RAYFORCE_CORES=2`, `./rayforce` freshly built with `make -j8 release`). Load average right after the run: 1.20 0.97 0.77.
+
+```
+linear N=   64 rows=    2080 min_ms=     14 ok
+linear N=  128 rows=    8256 min_ms=     25 ok
+linear N=  256 rows=   32896 min_ms=     47 ok
+linear N=  512 rows=  131328 min_ms=    110 ok
+linear N= 1024 rows=  524800 min_ms=    332 ok
+```
+
+```
+nonlinear N=   64 rows=    2080 min_ms=     10 ok
+nonlinear N=  128 rows=    8256 min_ms=     26 ok
+nonlinear N=  256 rows=   32896 min_ms=    136 ok
+nonlinear N=  512 rows=  131328 min_ms=    837 ok
+nonlinear N= 1024 rows=  524800 min_ms=   7495 ok
+```
+
+Every N reports `ok` with the expected row count.
+
+| N | After Task 13 (nonlinear) | After Task 14 (nonlinear) | speedup |
+|---|---|---|---|
+| 64 | 10 ms | 10 ms | 1.0x |
+| 128 | 27 ms | 26 ms | 1.0x |
+| 256 | 142 ms | 136 ms | 1.04x |
+| 512 | 905 ms | 837 ms | 1.08x |
+| 1024 | 8304 ms | 7495 ms | 1.11x |
+
+| N | After Task 13 (linear) | After Task 14 (linear) |
+|---|---|---|
+| 64 | 14 ms | 14 ms |
+| 128 | 24 ms | 25 ms |
+| 256 | 49 ms | 47 ms |
+| 512 | 112 ms | 110 ms |
+| 1024 | 340 ms | 332 ms |
+
+Linear does not regress (it is within noise, and the prefix path is provably never taken there).
+
+Non-linear gains ~8-11% at the large N, not the order-of-magnitude the linear shape got from Task 13. The reason is the shape of the work that is removed: on a chain, the second delta rule instance (`p_old ⋈ Δp`) loses exactly the `Δp ⋈ Δp` pairs, which are a small fraction of `P ⋈ Δp` once `P` is much larger than `Δp` — by construction the saving is bounded by |Δ|²/(|P|·|Δ|) = |Δ|/|P| of the join work per iteration. The nonlinear shape remains dominated by the join producing a candidate table far larger than the relation and the `table_distinct` that collapses it; closing that gap needs a different plan (index-nested-loop on the delta, or dedup fused into the join), not a better delta split.

--- a/bench/datalog/BASELINE.md
+++ b/bench/datalog/BASELINE.md
@@ -1,0 +1,37 @@
+# Chain transitive-closure baseline
+
+- Date: 2026-09-11
+- Commit: 04bbb81193a3bcc8d34b73a5d68042a3030063a1 (branch perf/datalog-fixpoint, cut from fix/datalog-audit)
+- Machine: 8 logical CPUs (`nproc`), Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz
+- RAYFORCE_CORES=2 (fixed for all runs)
+- Methodology: min-of-3 wall time per N, via `date +%s%N` around each process invocation (includes process start-up). Load average at run time: 0.02 0.37 0.55 (idle machine, nothing else heavy running).
+- `./rayforce` is a release build at the commit above (built prior to this task; not rebuilt here since no sources changed).
+
+Expected/known limitation before Task 11: the current evaluator has an iteration cap, so some chain sizes report `evaluation failed` instead of the correct row count. This is recorded honestly below as `WRONG(...)`, not worked around.
+
+## linear mode: `(rule (tc ?x ?z) (edge ?x ?y) (tc ?y ?z))`
+
+```
+linear N=   64 rows=    2080 min_ms=     36 ok
+linear N=  128 rows=    8256 min_ms=    105 ok
+linear N=  256 rows=   32896 min_ms=    490 ok
+linear N=  512 rows=  131328 min_ms=   1740 ok
+linear N= 1024 rows=  524800 min_ms=  10513 WRONG(error: domain: query: evaluation failed)
+```
+
+## nonlinear mode: `(rule (tc ?x ?z) (tc ?x ?y) (tc ?y ?z))`
+
+```
+nonlinear N=   64 rows=    2080 min_ms=     11 ok
+nonlinear N=  128 rows=    8256 min_ms=     30 ok
+nonlinear N=  256 rows=   32896 min_ms=    131 ok
+nonlinear N=  512 rows=  131328 min_ms=    889 ok
+nonlinear N= 1024 rows=  524800 min_ms=   8310 ok
+```
+
+## Notes
+
+- N=8 sanity check (by hand, before the sweep): both `linear` and `nonlinear` generated programs for N=8 print `36` (= 8*9/2), matching the expected chain transitive-closure row count. `(+ 1 (til 8))` / `(+ 2 (til 8))` yield I64 vectors as required for the env-bound EDB table.
+- linear N=1024 hits the evaluator's iteration cap and fails with `error: domain: query: evaluation failed`; nonlinear N=1024 does not fail at this N (doubling-style closure needs fewer fixpoint iterations than the linear left-recursive rule for the same chain length). This asymmetry is expected to close, or at least be characterized precisely, once Task 11 addresses the fixpoint iteration cap.
+- Runtime dominates with N: for linear mode the min_ms grows roughly quadratically-ish across doublings of N up to 512, consistent with materializing an O(N^2) `tc` relation each time; process start-up overhead is a fixed few ms and is not separated out here (documented as acceptable per the task brief).
+- Bugfix applied to the runner relative to the brief's literal script: the brief's `printf` call left `$ok` unquoted, which word-splits the `WRONG(...)` string (it contains spaces/colons) and corrupts the row's formatting via printf's format-string-reuse behavior when it sees extra arguments. Quoted `"$ok"` in `bench/datalog/tc_chain.sh` to fix this; no other behavioral change.

--- a/bench/datalog/BASELINE.md
+++ b/bench/datalog/BASELINE.md
@@ -180,3 +180,54 @@ Every N reports `ok` with the expected row count.
 Linear does not regress (it is within noise, and the prefix path is provably never taken there).
 
 Non-linear gains ~8-11% at the large N, not the order-of-magnitude the linear shape got from Task 13. The reason is the shape of the work that is removed: on a chain, the second delta rule instance (`p_old ⋈ Δp`) loses exactly the `Δp ⋈ Δp` pairs, which are a small fraction of `P ⋈ Δp` once `P` is much larger than `Δp` — by construction the saving is bounded by |Δ|²/(|P|·|Δ|) = |Δ|/|P| of the join work per iteration. The nonlinear shape remains dominated by the join producing a candidate table far larger than the relation and the `table_distinct` that collapses it; closing that gap needs a different plan (index-nested-loop on the delta, or dedup fused into the join), not a better delta split.
+
+## After final fix wave (9b32dd4c + the final-review fixes this commit introduces)
+
+- Date: 2026-09-11
+- Change under test: the whole-branch final-review fixes. The only one that
+  touches the hot compile path is the narrowed DATOM untagging: `dl_compile_rule`
+  now carries a `bool var_from_v[DL_MAX_ARITY * DL_MAX_BODY]` alongside
+  `var_col[]` and propagates it into `dl_rel_t.col_from_v` at projection, so
+  `ray_query_fn` untags only result columns that can hold a value from a datoms
+  `v` column. That is one extra 256-byte memset per rule compile plus a few
+  per-variable boolean assignments — no extra passes over data.
+- Same methodology and machine as the sections above (min-of-3 wall time via
+  `date +%s%N`, `RAYFORCE_CORES=2`, `./rayforce` freshly built with
+  `make -j8 release`). Load average right after the run: 1.34 0.98 0.59.
+
+```
+linear N=   64 rows=    2080 min_ms=     14 ok
+linear N=  128 rows=    8256 min_ms=     24 ok
+linear N=  256 rows=   32896 min_ms=     47 ok
+linear N=  512 rows=  131328 min_ms=    108 ok
+linear N= 1024 rows=  524800 min_ms=    332 ok
+```
+
+```
+nonlinear N=   64 rows=    2080 min_ms=     10 ok
+nonlinear N=  128 rows=    8256 min_ms=     26 ok
+nonlinear N=  256 rows=   32896 min_ms=    134 ok
+nonlinear N=  512 rows=  131328 min_ms=    831 ok
+nonlinear N= 1024 rows=  524800 min_ms=   7421 ok
+```
+
+Every N still reports `ok` with the expected row count.
+
+| N | After Task 14 (linear) | After final fix wave | delta |
+|---|---|---|---|
+| 64 | 14 ms | 14 ms | 0% |
+| 128 | 25 ms | 24 ms | -4% |
+| 256 | 47 ms | 47 ms | 0% |
+| 512 | 110 ms | 108 ms | -2% |
+| 1024 | 332 ms | 332 ms | 0% |
+
+| N | After Task 14 (nonlinear) | After final fix wave | delta |
+|---|---|---|---|
+| 64 | 10 ms | 10 ms | 0% |
+| 128 | 26 ms | 26 ms | 0% |
+| 256 | 136 ms | 134 ms | -1% |
+| 512 | 837 ms | 831 ms | -1% |
+| 1024 | 7495 ms | 7421 ms | -1% |
+
+Every point is within run-to-run noise of the Task 14 numbers; the
+per-variable tag tracking costs nothing measurable.

--- a/bench/datalog/BASELINE.md
+++ b/bench/datalog/BASELINE.md
@@ -35,3 +35,20 @@ nonlinear N= 1024 rows=  524800 min_ms=   8310 ok
 - linear N=1024 hits the evaluator's iteration cap and fails with `error: domain: query: evaluation failed`; nonlinear N=1024 does not fail at this N (doubling-style closure needs fewer fixpoint iterations than the linear left-recursive rule for the same chain length). This asymmetry is expected to close, or at least be characterized precisely, once Task 11 addresses the fixpoint iteration cap.
 - Runtime dominates with N: for linear mode the min_ms grows roughly quadratically-ish across doublings of N up to 512, consistent with materializing an O(N^2) `tc` relation each time; process start-up overhead is a fixed few ms and is not separated out here (documented as acceptable per the task brief).
 - Bugfix applied to the runner relative to the brief's literal script: the brief's `printf` call left `$ok` unquoted, which word-splits the `WRONG(...)` string (it contains spaces/colons) and corrupts the row's formatting via printf's format-string-reuse behavior when it sees extra arguments. Quoted `"$ok"` in `bench/datalog/tc_chain.sh` to fix this; no other behavioral change.
+
+## After Task 11 (17e4f5f1)
+
+- Date: 2026-09-11
+- Commit: 17e4f5f18f501089442b20c62ce9f9d53fa4b84f (branch perf/datalog-fixpoint) plus the uncommitted Task 11 working-tree changes this section's own commit introduces (same convention as the base entry above, which cites the commit the bench code lived at rather than a not-yet-created commit).
+- Change under test: `dl_eval`'s fixpoint loop now runs uncapped for strata whose rules contain only relational literals (no `DL_ASSIGN` / `DL_BUILTIN` / `DL_INTERVAL`); the `DL_MAX_ITER_NONMONOTONE` (1000) cap now applies only to strata that can manufacture new values. The linear `tc` rule's stratum is pure-relational, so it is no longer capped.
+- Same methodology and machine as above (min-of-3 wall time via `date +%s%N`, `RAYFORCE_CORES=2`, `./rayforce` freshly built with `make -j8 release` at this commit).
+
+```
+linear N=   64 rows=    2080 min_ms=     37 ok
+linear N=  128 rows=    8256 min_ms=    105 ok
+linear N=  256 rows=   32896 min_ms=    499 ok
+linear N=  512 rows=  131328 min_ms=   1733 ok
+linear N= 1024 rows=  524800 min_ms=  10853 ok
+```
+
+N=1024 linear, which previously reported `WRONG(error: domain: query: evaluation failed)`, now reports `ok` with the correct 524800 rows. Timings at N<=512 are within noise of the pre-Task-11 baseline (same monotone-stratum code path, just no longer capped), confirming the uncapped loop adds no measurable overhead for chains that already converged well under 1000 iterations.

--- a/bench/datalog/BASELINE.md
+++ b/bench/datalog/BASELINE.md
@@ -52,3 +52,42 @@ linear N= 1024 rows=  524800 min_ms=  10853 ok
 ```
 
 N=1024 linear, which previously reported `WRONG(error: domain: query: evaluation failed)`, now reports `ok` with the correct 524800 rows. Timings at N<=512 are within noise of the pre-Task-11 baseline (same monotone-stratum code path, just no longer capped), confirming the uncapped loop adds no measurable overhead for chains that already converged well under 1000 iterations.
+
+## After Task 12 (pre-commit HEAD 9707dd00 + the Task 12 working-tree changes)
+
+- Date: 2026-09-11
+- Commit: 9707dd00 (branch `perf/datalog-fixpoint`) plus the uncommitted Task 12 working-tree changes this section's own commit introduces (same convention as the sections above).
+- Change under test: each IDB keeps one open-addressing row set (`dl_rowset_t`) alive for the whole stratum. A fixpoint iteration probes only the candidate tuples and inserts the accepted ones, instead of `table_distinct(new)` + `table_antijoin(new, rel->table)` re-hashing the entire derived relation every iteration. A candidate table *larger* than the relation is still collapsed by the vectorised `table_distinct` first (the non-linear rule shape manufactures far more duplicates than the relation holds, and the vectorised hash beats the scalar probe there); the budget is the relation's own row count, no new tunable.
+- Same methodology and machine as above (min-of-3 wall time via `date +%s%N`, `RAYFORCE_CORES=2`, `./rayforce` freshly built with `make -j8 release`). Load average at run time: 1.19 0.91 0.70.
+
+```
+linear N=   64 rows=    2080 min_ms=     14 ok
+linear N=  128 rows=    8256 min_ms=     24 ok
+linear N=  256 rows=   32896 min_ms=     53 ok
+linear N=  512 rows=  131328 min_ms=    161 ok
+linear N= 1024 rows=  524800 min_ms=   1324 ok
+```
+
+```
+nonlinear N=   64 rows=    2080 min_ms=     10 ok
+nonlinear N=  128 rows=    8256 min_ms=     28 ok
+nonlinear N=  256 rows=   32896 min_ms=    126 ok
+nonlinear N=  512 rows=  131328 min_ms=    879 ok
+nonlinear N= 1024 rows=  524800 min_ms=   8295 ok
+```
+
+Every N reports `ok` with the expected row count.
+
+Linear (the shape this task targets — a small delta joined against a growing relation):
+
+| N | After Task 11 | After Task 12 | speedup |
+|---|---|---|---|
+| 64 | 37 ms | 14 ms | 2.6x |
+| 128 | 105 ms | 24 ms | 4.4x |
+| 256 | 499 ms | 53 ms | 9.4x |
+| 512 | 1733 ms | 161 ms | **10.8x** |
+| 1024 | 10853 ms | 1324 ms | **8.2x** |
+
+Non-linear is unchanged within noise (889 -> 879 ms at N=512, 8310 -> 8295 ms at N=1024): there the candidate table dwarfs the relation, so the pre-dedup guard keeps the vectorised `table_distinct` in front of the row-set probe and only the per-iteration `table_antijoin` is removed — a cost that is small next to the join and the distinct at that shape.
+
+Measured without the pre-dedup guard, non-linear regressed sharply (N=512 1810 ms, N=1024 22819 ms) because the scalar per-row probe and the per-row `dl_table_take_mask` copy ran over a candidate table many times the size of the relation. That measurement is why the guard exists.

--- a/bench/datalog/BASELINE.md
+++ b/bench/datalog/BASELINE.md
@@ -91,3 +91,48 @@ Linear (the shape this task targets — a small delta joined against a growing r
 Non-linear is unchanged within noise (889 -> 879 ms at N=512, 8310 -> 8295 ms at N=1024): there the candidate table dwarfs the relation, so the pre-dedup guard keeps the vectorised `table_distinct` in front of the row-set probe and only the per-iteration `table_antijoin` is removed — a cost that is small next to the join and the distinct at that shape.
 
 Measured without the pre-dedup guard, non-linear regressed sharply (N=512 1810 ms, N=1024 22819 ms) because the scalar per-row probe and the per-row `dl_table_take_mask` copy ran over a candidate table many times the size of the relation. That measurement is why the guard exists.
+
+## After Task 13 (pre-commit HEAD 32e65461 + the Task 13 working-tree changes)
+
+- Date: 2026-09-11
+- Commit: 32e65461 (branch `perf/datalog-fixpoint`) plus the uncommitted Task 13 working-tree changes this section's own commit introduces (same convention as the sections above).
+- Change under test: `dl_eval` no longer keeps the dead `prev_tables[]` (set and released every iteration, never read), which pinned every IDB column at refcount > 1; and `table_union` appends `b`'s rows into `a`'s columns in place (`ray_vec_append_raw`) when `a`, its column list and every column are uniquely owned, non-slice, non-arena, same-typed and neither SYM nor STR. The per-iteration merge is then amortised O(delta) instead of O(relation).
+- Fast-path hit rate on this benchmark (measured with a temporary counter, removed before commit): linear N=512 1021 hits / 0 misses, nonlinear N=512 26 hits / 0 misses — 100%.
+- Same methodology and machine as above (min-of-3 wall time via `date +%s%N`, `RAYFORCE_CORES=2`, `./rayforce` freshly built with `make -j8 release`). Load average at run time: 1.23 1.07 0.81.
+
+```
+linear N=   64 rows=    2080 min_ms=     14 ok
+linear N=  128 rows=    8256 min_ms=     24 ok
+linear N=  256 rows=   32896 min_ms=     49 ok
+linear N=  512 rows=  131328 min_ms=    112 ok
+linear N= 1024 rows=  524800 min_ms=    340 ok
+```
+
+```
+nonlinear N=   64 rows=    2080 min_ms=     10 ok
+nonlinear N=  128 rows=    8256 min_ms=     27 ok
+nonlinear N=  256 rows=   32896 min_ms=    142 ok
+nonlinear N=  512 rows=  131328 min_ms=    905 ok
+nonlinear N= 1024 rows=  524800 min_ms=   8304 ok
+```
+
+Every N reports `ok` with the expected row count.
+
+| N | After Task 12 (linear) | After Task 13 (linear) | speedup |
+|---|---|---|---|
+| 64 | 14 ms | 14 ms | 1.0x |
+| 128 | 24 ms | 24 ms | 1.0x |
+| 256 | 53 ms | 49 ms | 1.1x |
+| 512 | 161 ms | 112 ms | 1.4x |
+| 1024 | 1324 ms | 340 ms | **3.9x** |
+
+The win grows with N because the copy this removes was proportional to the relation size times the iteration count. Non-linear is unchanged within noise (879 -> 905 ms at N=512, 8295 -> 8304 ms at N=1024): that shape converges in ~26 iterations, so only 26 unions happen and the copy was never the bottleneck there; its cost is the join and the distinct over a candidate table much larger than the relation.
+
+Total allocation for linear N=512, measured with `(.mem.ts (count (query db (find ?x ?y) (where (tc ?x ?y)))))` on release builds before and after this task's changes:
+
+| | allocated-bytes | alloc-count | peak-live-bytes | time-ns |
+|---|---|---|---|---|
+| before (32e65461) | 1,888,396,288 | 27,988 | 35,654,208 | 162,667,333 |
+| after | 73,245,632 | 22,891 | 36,702,400 | 102,932,959 |
+
+25.8x less total allocation. Peak live is unchanged (the relation itself is the same size); what disappears is the full copy of the relation made once per iteration.

--- a/bench/datalog/gen_chain.sh
+++ b/bench/datalog/gen_chain.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# usage: gen_chain.sh N [linear|nonlinear]   -> rfl on stdout
+N=${1:?N}; MODE=${2:-linear}
+cat <<EOF
+(set edge (table [edge__c0 edge__c1] (list (+ 1 (til $N)) (+ 2 (til $N)))))
+(set db (datoms))
+(rule (tc ?x ?y) (edge ?x ?y))
+EOF
+if [ "$MODE" = nonlinear ]; then
+  echo '(rule (tc ?x ?z) (tc ?x ?y) (tc ?y ?z))'
+else
+  echo '(rule (tc ?x ?z) (edge ?x ?y) (tc ?y ?z))'
+fi
+cat <<EOF
+(set r (query db (find ?x ?y) (where (tc ?x ?y))))
+(println (count r))
+EOF

--- a/bench/datalog/tc_chain.sh
+++ b/bench/datalog/tc_chain.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# usage: tc_chain.sh [linear|nonlinear] [BIN]
+set -u
+MODE=${1:-linear}; BIN=${2:-./rayforce}
+HERE=$(cd "$(dirname "$0")" && pwd)
+for N in 64 128 256 512 1024; do
+  f=$(mktemp /tmp/tc_XXXX.rfl); "$HERE/gen_chain.sh" $N $MODE > "$f"
+  want=$(( N * (N + 1) / 2 )); best=999999
+  for rep in 1 2 3; do
+    s=$(date +%s%N); out=$(RAYFORCE_CORES=2 "$BIN" "$f" 2>&1 | tail -1); e=$(date +%s%N)
+    ms=$(( (e - s) / 1000000 )); [ $ms -lt $best ] && best=$ms
+  done
+  ok=$([ "$out" = "$want" ] && echo ok || echo "WRONG($out)")
+  printf "%s N=%5d rows=%8d min_ms=%7d %s\n" "$MODE" $N $want $best "$ok"
+  rm -f "$f"
+done

--- a/docs/docs/guides/datalog-reference.md
+++ b/docs/docs/guides/datalog-reference.md
@@ -506,8 +506,16 @@ A datoms table whose `v` column is a real symbol vector (hand-built or
 loaded) is also recognised as holding symbols. A legacy table whose `v`
 column holds bare integer intern ids is not — those integers stay integers
 and are not matched against a symbol or keyword literal. Positive integer
-values of 2^61 and above cannot be stored in the `v` column or returned
-from a query without being masked; this is a limit of the tag encoding.
+values of 2^61 and above cannot be stored in the `v` column without being
+masked on the way out; this is a limit of the tag encoding, and it applies
+only to values that live in (or are derived from) the datoms `v` column.
+Every other column — an ordinary relation's column, or a value computed by
+Datalog arithmetic — is returned verbatim, whatever its magnitude.
+
+A derived relation fed both a symbol projected from `v` and an equal bare
+integer from another source matches both on a symbol literal: outside the
+`eav` relation the comparison is deliberately lenient about the tag, so the
+two values are indistinguishable once they share a column.
 
 ## Complete Example
 

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -34,6 +34,8 @@
 #include "ops/hash.h"          /* ray_hash_i64, ray_hash_combine */
 #include "ops/internal.h"      /* col_propagate_str_pool */
 #include "mem/sys.h"           /* ray_sys_alloc / ray_sys_free */
+#include "mem/cow.h"           /* ray_rc_sync (unique-ownership test) */
+#include "table/table.h"       /* ray_table_cols_mut */
 #include "lang/format.h"       /* ray_type_name (error context) */
 #include <string.h>
 #include <stdio.h>
@@ -2502,6 +2504,13 @@ static ray_t* restore_names(ray_t* tbl, ray_t* src) {
     return out;
 }
 
+/* Uniquely owned by us: rc == 1 and not arena backed (ray_cow refuses to copy
+ * arena blocks, so a shared arena block would be mutated in place). */
+static inline bool dl_sole_owner(ray_t* v) {
+    if (!v || RAY_IS_ERR(v) || (v->attrs & RAY_ATTR_ARENA)) return false;
+    return (RAY_LIKELY(!ray_rc_sync) ? v->rc : ray_atomic_load(&v->rc)) == 1;
+}
+
 /* Create a table by concatenating all rows from tables a and b (same schema).
  * Uses column-wise ray_vec_concat. Returns new owned table with a's names. */
 static ray_t* table_union(ray_t* a, ray_t* b) {
@@ -2537,8 +2546,54 @@ static ray_t* table_union(ray_t* a, ray_t* b) {
         return ray_error("schema", "table_union: column count mismatch");
     int64_t ncols = ncols_a;
 
-    if (ray_table_nrows(a) == 0) { ray_retain(b); return b; }
-    if (ray_table_nrows(b) == 0) { ray_retain(a); return a; }
+    int64_t nrows_a = ray_table_nrows(a), nrows_b = ray_table_nrows(b);
+    if (nrows_a == 0) { ray_retain(b); return b; }
+    if (nrows_b == 0) { ray_retain(a); return a; }
+
+    /* Fast path: `a` owns everything it holds, so b's rows can be appended to
+     * a's columns in place instead of concatenating into a fresh table.  This
+     * is the fixpoint loop's merge (rel->table <- rel->table + delta), which
+     * is otherwise O(relation) per iteration.  Preconditions, all required:
+     *   - a and b are distinct tables (else the memcpy source is the block
+     *     being reallocated);
+     *   - a's table block and column list are uniquely owned
+     *     (ray_table_cols_mut), so no other table sees these slots;
+     *   - every column of a is a uniquely owned, non-slice, non-arena fixed
+     *     width vector whose type matches b's, and neither SYM (domain/width
+     *     adoption is ray_vec_concat's job) nor STR (pooled payloads).
+     * Rectangularity is checked too: a short column would silently misalign.
+     * The row order is a's rows then b's — the row set built in the fixpoint
+     * loop indexes rows of a and depends on it. */
+    ray_t** slots = a != b && ncols > 0 ? ray_table_cols_mut(a) : NULL;
+    if (slots) {
+        bool ok = true;
+        for (int64_t c = 0; c < ncols && ok; c++) {
+            ray_t* ca = slots[c];
+            ray_t* cb = ray_table_get_col_idx(b, c);
+            ok = ca && cb && !RAY_IS_ERR(cb) && ca->type == cb->type &&
+                 ray_is_vec(ca) && ca->type != RAY_SYM && ca->type != RAY_STR &&
+                 !(ca->attrs & RAY_ATTR_SLICE) && dl_sole_owner(ca) &&
+                 ca->len == nrows_a && cb->len == nrows_b;
+        }
+        if (ok) {
+            for (int64_t c = 0; c < ncols; c++) {
+                ray_t* cb = ray_table_get_col_idx(b, c);
+                ray_t* grown = ray_vec_append_raw(slots[c], ray_data(cb), cb->len);
+                if (!grown || RAY_IS_ERR(grown)) {
+                    /* Columns before c already grew; a is left inconsistent,
+                     * which every caller treats as a hard evaluation failure
+                     * (the relation is dropped, not reused). */
+                    return grown ? grown : ray_error("memory", "table_union: append");
+                }
+                /* A reallocating append frees the old block, so the slot is
+                 * overwritten, never released. */
+                slots[c] = grown;
+                if (cb->attrs & RAY_ATTR_HAS_NULLS) grown->attrs |= RAY_ATTR_HAS_NULLS;
+            }
+            ray_retain(a);
+            return a;
+        }
+    }
 
     ray_t* out = ray_table_new((int)ncols);
     if (!out || RAY_IS_ERR(out))
@@ -3279,7 +3334,6 @@ int dl_eval(dl_program_t* prog) {
         /* Phase B: Semi-naive loop — iterate with delta relations */
         /* For each IDB predicate in this stratum, compute delta as the
          * difference between current and previous table states. */
-        ray_t* prev_tables[DL_MAX_RELS];
         ray_t* delta_tables[DL_MAX_RELS];
         /* One persistent row set per IDB, alive for the whole stratum: the
          * per-iteration delta is "candidate rows whose key is new" instead
@@ -3288,7 +3342,6 @@ int dl_eval(dl_program_t* prog) {
         /* Latched once a relation's set cannot be built (unsupported column
          * type, or OOM): stop retrying and stay on the generic path. */
         bool set_off[DL_MAX_RELS];
-        memset(prev_tables, 0, sizeof(prev_tables));
         memset(delta_tables, 0, sizeof(delta_tables));
         memset(sets, 0, sizeof(sets));
         memset(set_off, 0, sizeof(set_off));
@@ -3300,21 +3353,6 @@ int dl_eval(dl_program_t* prog) {
             if (rel->is_idb) {
                 ray_retain(rel->table);
                 delta_tables[rel_idx] = rel->table;
-                /* prev = empty table with same schema as the relation.
-                 * Column types must match rel->table so later ray_vec_concat
-                 * calls don't reject the merge when the relation has
-                 * non-i64 columns (e.g. RAY_SYM from head-constant slots). */
-                prev_tables[rel_idx] = ray_table_new(rel->arity);
-                for (int c = 0; c < rel->arity && c < DL_MAX_ARITY; c++) {
-                    ray_t* src = ray_table_get_col_idx(rel->table, c);
-                    int8_t ctype = src ? src->type : RAY_I64;
-                    ray_t* empty_col = ray_vec_new(ctype, 0);
-                    if (empty_col && !RAY_IS_ERR(empty_col)) {
-                        prev_tables[rel_idx] = ray_table_add_col(
-                            prev_tables[rel_idx], rel->col_names[c], empty_col);
-                        ray_release(empty_col);
-                    }
-                }
                 /* Seed the row set from the post-Phase-A relation.  A
                  * failure (OOM, or a column type the set can't key on)
                  * leaves the set zeroed and latches set_off, which keeps
@@ -3347,14 +3385,12 @@ int dl_eval(dl_program_t* prog) {
         int64_t max_iter = monotone ? INT64_MAX : DL_MAX_ITER_NONMONOTONE;
         bool converged = false;
         for (int64_t iter = 0; iter < max_iter; iter++) {
-            /* Cancellation checkpoint (per fixpoint iteration).  prev_tables /
-             * delta_tables are live here, so mirror the stratum cleanup below
-             * before returning to avoid a leak. */
+            /* Cancellation checkpoint (per fixpoint iteration).  delta_tables
+             * and the row sets are live here, so mirror the stratum cleanup
+             * below before returning to avoid a leak. */
             if (RAY_UNLIKELY(ray_interrupted())) {
                 for (int p = 0; p < prog->strata_sizes[s]; p++) {
                     int rel_idx = prog->strata[s][p];
-                    if (prev_tables[rel_idx] && !RAY_IS_ERR(prev_tables[rel_idx]))
-                        ray_release(prev_tables[rel_idx]);
                     if (delta_tables[rel_idx] && !RAY_IS_ERR(delta_tables[rel_idx]))
                         ray_release(delta_tables[rel_idx]);
                     dl_rowset_free(&sets[rel_idx]);
@@ -3549,15 +3585,6 @@ int dl_eval(dl_program_t* prog) {
                     }
                 }
             }
-
-            /* Update prev tables */
-            for (int p = 0; p < prog->strata_sizes[s]; p++) {
-                int rel_idx = prog->strata[s][p];
-                if (prev_tables[rel_idx] && !RAY_IS_ERR(prev_tables[rel_idx]))
-                    ray_release(prev_tables[rel_idx]);
-                ray_retain(prog->rels[rel_idx].table);
-                prev_tables[rel_idx] = prog->rels[rel_idx].table;
-            }
         }
 
         /* Non-convergence: the fixpoint loop exhausted max_iter while deltas
@@ -3580,8 +3607,6 @@ int dl_eval(dl_program_t* prog) {
         /* Cleanup stratum temporaries */
         for (int p = 0; p < prog->strata_sizes[s]; p++) {
             int rel_idx = prog->strata[s][p];
-            if (prev_tables[rel_idx] && !RAY_IS_ERR(prev_tables[rel_idx]))
-                ray_release(prev_tables[rel_idx]);
             if (delta_tables[rel_idx] && !RAY_IS_ERR(delta_tables[rel_idx]))
                 ray_release(delta_tables[rel_idx]);
             dl_rowset_free(&sets[rel_idx]);

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -1493,6 +1493,43 @@ static ray_t* dl_project(ray_t* tbl, const int* col_indices, int n_out,
     return out;
 }
 
+/* Zero-copy view of the first `n` rows of `tbl`.
+ *
+ * Each column becomes a ray_vec_slice view onto the parent column, so the
+ * view costs one header per column instead of a full copy.  Every reader in
+ * this file goes through ray_data(), which resolves RAY_ATTR_SLICE to the
+ * parent's storage plus the offset (and ray_sym_vec_domain follows
+ * slice_parent for SYM), so the views are safe to filter, join and project.
+ *
+ * The slices retain the parent columns, which would block the in-place
+ * append in table_union -- but the view lives only inside dl_compile_rule
+ * (dl_project copies out of it, and accum is released before the rule's
+ * graph is executed), and the fixpoint merges only after every rule of the
+ * iteration has run, so refcounts are back to 1 by then.
+ *
+ * Returns an owned table, or a RAY_ERROR. */
+static ray_t* dl_table_head(ray_t* tbl, int64_t n) {
+    int64_t ncols = ray_table_ncols(tbl);
+    ray_t* out = ray_table_new((int)ncols);
+    if (!out) return ray_error("memory", "dl_table_head: table_new");
+    if (RAY_IS_ERR(out)) return out;
+    for (int64_t c = 0; c < ncols; c++) {
+        ray_t* src = ray_table_get_col_idx(tbl, c);
+        if (!src) { ray_release(out); return ray_error("domain", "dl_table_head: missing source column"); }
+        ray_t* view = ray_vec_slice(src, 0, n);
+        if (!view) { ray_release(out); return ray_error("memory", "dl_table_head: vec_slice"); }
+        if (RAY_IS_ERR(view)) { ray_release(out); return view; }
+        ray_t* next = ray_table_add_col(out, ray_table_col_name(tbl, c), view);
+        ray_release(view);
+        /* ray_table_add_col releases its input table on every failure
+         * path, so `out` must not be released again here. */
+        if (!next || RAY_IS_ERR(next))
+            return next ? next : ray_error("memory", "dl_table_head: add_col");
+        out = next;
+    }
+    return out;
+}
+
 ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
                           const dl_delta_t* delta, int rule_idx, ray_graph_t* g) {
     /* Materializing approach: execute body atoms one at a time.
@@ -1521,9 +1558,32 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
         /* Semi-naive: exactly one body position reads the iteration delta;
          * every other occurrence of the same predicate reads the full
          * relation so old×new combinations are derived (audit §1.1). */
-        ray_t* body_tbl = (delta && delta->pos == b && delta->table)
-                        ? delta->table : rel->table;
-        ray_retain(body_tbl);
+        ray_t* body_tbl;
+        int64_t head_n = -1;
+        if (delta && delta->prev_nrows && delta->pos > b && rel->is_idb)
+            head_n = delta->prev_nrows[rel_idx];
+        if (delta && delta->pos == b && delta->table) {
+            body_tbl = delta->table;
+            ray_retain(body_tbl);
+        } else if (head_n >= 0 && head_n < ray_table_nrows(rel->table)) {
+            /* Old/new split: this atom sits before the delta position, so it
+             * must read the relation as it was BEFORE the delta was merged.
+             * An empty prefix makes the rule's inner join empty -- bail out
+             * with "no rows this iteration" (NULL without eval_err) rather
+             * than build a zero-row view whose column schema would be
+             * rebuilt by the empty-join path. */
+            if (head_n == 0) { if (accum) ray_release(accum); return NULL; }
+            body_tbl = dl_table_head(rel->table, head_n);
+            if (!body_tbl || RAY_IS_ERR(body_tbl)) {
+                if (body_tbl) ray_error_free(body_tbl);
+                if (accum) ray_release(accum);
+                prog->eval_err = true;
+                return NULL;
+            }
+        } else {
+            body_tbl = rel->table;
+            ray_retain(body_tbl);
+        }
 
         /* Apply constant filters */
         for (int c = 0; c < body->arity; c++) {
@@ -3353,9 +3413,18 @@ int dl_eval(dl_program_t* prog) {
         /* Latched once a relation's set cannot be built (unsupported column
          * type, or OOM): stop retrying and stay on the generic path. */
         bool set_off[DL_MAX_RELS];
+        /* Old/new split (see dl_delta_t): the row count each IDB of this
+         * stratum had at the start of the PREVIOUS iteration, i.e. the
+         * length of the prefix of rel->table that predates the current
+         * delta.  table_union appends the delta to the end of the
+         * relation, so "old" is always a prefix.  -1 = no prefix (EDBs and
+         * relations outside this stratum: they never change here, so every
+         * atom reads them in full). */
+        int64_t prev_nrows[DL_MAX_RELS];
         memset(delta_tables, 0, sizeof(delta_tables));
         memset(sets, 0, sizeof(sets));
         memset(set_off, 0, sizeof(set_off));
+        for (int i = 0; i < DL_MAX_RELS; i++) prev_nrows[i] = -1;
 
         /* Initially, delta = full table (all tuples are new) */
         for (int p = 0; p < prog->strata_sizes[s]; p++) {
@@ -3364,6 +3433,9 @@ int dl_eval(dl_program_t* prog) {
             if (rel->is_idb) {
                 ray_retain(rel->table);
                 delta_tables[rel_idx] = rel->table;
+                /* The first delta is the whole relation, so nothing is
+                 * old yet: the prefix before it is empty. */
+                prev_nrows[rel_idx] = 0;
                 /* Seed the row set from the post-Phase-A relation.  A
                  * failure (OOM, or a column type the set can't key on)
                  * leaves the set zeroed and latches set_off, which keeps
@@ -3443,7 +3515,7 @@ int dl_eval(dl_program_t* prog) {
                     if (!delta_tables[body_rel] ||
                         ray_table_nrows(delta_tables[body_rel]) == 0) continue;
 
-                    dl_delta_t d = { b, delta_tables[body_rel] };
+                    dl_delta_t d = { b, delta_tables[body_rel], prev_nrows };
                     ray_graph_t* g = ray_graph_new(NULL);
                     if (!g) { prog->eval_err = true; continue; }
 
@@ -3497,6 +3569,15 @@ int dl_eval(dl_program_t* prog) {
                 int rel_idx = prog->strata[s][p];
                 dl_rel_t* rel = &prog->rels[rel_idx];
                 if (!rel->is_idb) continue;
+
+                /* Snapshot the pre-merge size before anything below can
+                 * grow the relation: from the next iteration's point of
+                 * view this is exactly the "old" prefix, whatever path the
+                 * delta extraction below takes.  It must be updated even
+                 * when this relation derives nothing this round (another
+                 * relation's delta can keep the fixpoint running), or an
+                 * atom reading the prefix would miss rows derived earlier. */
+                prev_nrows[rel_idx] = ray_table_nrows(rel->table);
 
                 /* Free old delta */
                 if (delta_tables[rel_idx] && !RAY_IS_ERR(delta_tables[rel_idx]))

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -3082,10 +3082,22 @@ int dl_eval(dl_program_t* prog) {
             }
         }
 
-        /* Semi-naive iteration */
-        int max_iter = 1000;
+        /* Semi-naive iteration.
+         *
+         * Iteration budget: a stratum whose rules contain only relational
+         * literals is monotone over a finite domain and must converge, so it
+         * runs uncapped (cancellation still checked each iteration). Rules
+         * that compute new values (assignment / builtin / interval) can grow
+         * the domain forever and keep the cap. */
+        bool monotone = true;
+        for (int ri = 0; ri < n_stratum_rules && monotone; ri++)
+            for (int b = 0; b < stratum_rules[ri]->n_body; b++) {
+                int t = stratum_rules[ri]->body[b].type;
+                if (t == DL_ASSIGN || t == DL_BUILTIN || t == DL_INTERVAL) { monotone = false; break; }
+            }
+        int64_t max_iter = monotone ? INT64_MAX : DL_MAX_ITER_NONMONOTONE;
         bool converged = false;
-        for (int iter = 0; iter < max_iter; iter++) {
+        for (int64_t iter = 0; iter < max_iter; iter++) {
             /* Cancellation checkpoint (per fixpoint iteration).  prev_tables /
              * delta_tables are live here, so mirror the stratum cleanup below
              * before returning to avoid a leak. */
@@ -3249,8 +3261,16 @@ int dl_eval(dl_program_t* prog) {
          * returning the truncated fixpoint. For well-formed Datalog over a
          * finite EDB the loop converges in far fewer than max_iter steps, so
          * hitting the cap signals a runaway/ill-formed program. */
-        if (!converged)
+        if (!converged) {
             prog->eval_err = true;
+            /* Creating (and immediately freeing) the error leaves its
+             * detail text in the thread-local buffer that ray_query_fn
+             * reads via ray_error_msg() after dl_eval fails -- see
+             * ray_verror in src/core/runtime.c, which writes the message
+             * at creation time, not at free time. */
+            ray_error_free(ray_error("domain",
+                "fixpoint did not converge after %d iterations", DL_MAX_ITER_NONMONOTONE));
+        }
 
         /* Cleanup stratum temporaries */
         for (int p = 0; p < prog->strata_sizes[s]; p++) {

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -2689,7 +2689,7 @@ static ray_t* table_antijoin(ray_t* left, ray_t* right) {
  * ======================================================================== */
 
 /* Hash all columns of ref at row r into a single key. */
-static uint64_t dl_row_hash(int64_t** col_data, int64_t ncols, int64_t r) {
+static uint64_t dl_prov_row_hash(int64_t** col_data, int64_t ncols, int64_t r) {
     uint64_t h = ray_hash_i64(col_data[0][r]);
     for (int64_t c = 1; c < ncols; c++)
         h = ray_hash_combine(h, ray_hash_i64(col_data[c][r]));
@@ -2697,7 +2697,7 @@ static uint64_t dl_row_hash(int64_t** col_data, int64_t ncols, int64_t r) {
 }
 
 /* Check if rows match across `ncols` columns. */
-static bool dl_row_eq(int64_t** a_cols, int64_t ar,
+static bool dl_prov_row_eq(int64_t** a_cols, int64_t ar,
                      int64_t** b_cols, int64_t br, int64_t ncols) {
     for (int64_t c = 0; c < ncols; c++)
         if (a_cols[c][ar] != b_cols[c][br]) return false;
@@ -2716,9 +2716,9 @@ typedef struct {
     int64_t  mask;
     int64_t** ref_cols;    /* cached column data ptrs for ref */
     int64_t  ncols;
-} dl_rowset_t;
+} dl_provset_t;
 
-static bool dl_rowset_init(dl_rowset_t* rs, ray_t* ref) {
+static bool dl_provset_init(dl_provset_t* rs, ray_t* ref) {
     int64_t ncols = ray_table_ncols(ref);
     int64_t nrows = ray_table_nrows(ref);
     rs->ncols = ncols;
@@ -2742,7 +2742,7 @@ static bool dl_rowset_init(dl_rowset_t* rs, ray_t* ref) {
     for (int64_t i = 0; i < cap; i++) rs->slots[i] = -1;
 
     for (int64_t r = 0; r < nrows; r++) {
-        uint64_t h = dl_row_hash(rs->ref_cols, ncols, r);
+        uint64_t h = dl_prov_row_hash(rs->ref_cols, ncols, r);
         int64_t s = (int64_t)(h & (uint64_t)rs->mask);
         while (rs->slots[s] != -1) s = (s + 1) & rs->mask;
         rs->slots[s] = r;
@@ -2750,18 +2750,18 @@ static bool dl_rowset_init(dl_rowset_t* rs, ray_t* ref) {
     return true;
 }
 
-static void dl_rowset_destroy(dl_rowset_t* rs) {
+static void dl_provset_destroy(dl_provset_t* rs) {
     if (rs->block) { ray_release(rs->block); rs->block = NULL; }
     if (rs->ref_cols) { ray_sys_free(rs->ref_cols); rs->ref_cols = NULL; }
 }
 
 /* True if the row at `tbl_cols[..][row]` is present in the set. */
-static bool dl_rowset_contains(dl_rowset_t* rs, int64_t** tbl_cols, int64_t row) {
-    uint64_t h = dl_row_hash(tbl_cols, rs->ncols, row);
+static bool dl_provset_contains(dl_provset_t* rs, int64_t** tbl_cols, int64_t row) {
+    uint64_t h = dl_prov_row_hash(tbl_cols, rs->ncols, row);
     int64_t s = (int64_t)(h & (uint64_t)rs->mask);
     while (rs->slots[s] != -1) {
         int64_t r = rs->slots[s];
-        if (dl_row_eq(tbl_cols, row, rs->ref_cols, r, rs->ncols))
+        if (dl_prov_row_eq(tbl_cols, row, rs->ref_cols, r, rs->ncols))
             return true;
         s = (s + 1) & rs->mask;
     }
@@ -2935,8 +2935,8 @@ static void dl_build_provenance(dl_program_t* prog) {
             /* Mark rows in rel->table that appear in derived.  Build a
              * hashset over `derived` once and probe per row of rel —
              * was O(nrows × derived_rows × ncols), now O(nrows + derived_rows). */
-            dl_rowset_t rs;
-            if (dl_rowset_init(&rs, derived)) {
+            dl_provset_t rs;
+            if (dl_provset_init(&rs, derived)) {
                 int64_t ncols_t = ray_table_ncols(rel->table);
                 int64_t** tbl_cols = (int64_t**)ray_sys_alloc(sizeof(int64_t*) * (size_t)ncols_t);
                 if (tbl_cols) {
@@ -2946,12 +2946,12 @@ static void dl_build_provenance(dl_program_t* prog) {
                     }
                     for (int64_t row = 0; row < nrows; row++) {
                         if (pd[row] >= 0) continue;
-                        if (dl_rowset_contains(&rs, tbl_cols, row))
+                        if (dl_provset_contains(&rs, tbl_cols, row))
                             pd[row] = r;
                     }
                     ray_sys_free(tbl_cols);
                 }
-                dl_rowset_destroy(&rs);
+                dl_provset_destroy(&rs);
             }
             ray_release(derived);
         }
@@ -2961,6 +2961,223 @@ static void dl_build_provenance(dl_program_t* prog) {
 
         dl_build_source_prov(prog, rel, nrows, pd);
     }
+}
+
+/* ========================================================================
+ * Incremental row set (dl_rowset_t)
+ *
+ * The semi-naive loop used to run table_distinct(new) + table_antijoin(new,
+ * rel->table) every iteration, re-hashing the whole derived relation each
+ * time — O(iterations x |relation|).  Instead each IDB keeps one
+ * open-addressing set of its rows alive for the whole stratum: a candidate
+ * tuple is probed once and inserted on acceptance.
+ *
+ * Row-index contract: entries are row indices into the relation table the
+ * set was built from.  dl_rowset_extract_new hands accepted candidate k the
+ * index nrows(full) + k, so the caller MUST append the returned delta to
+ * `full` in order (table_union concatenates column-wise, preserving a's rows
+ * then b's) and must not otherwise rebuild the table.
+ *
+ * Cell comparison: cells are compared as raw 64-bit keys (SYM ids read at
+ * the column's adaptive width, F64 bit patterns).  A SYM id is only
+ * meaningful within its column's domain, so dl_rowset_comparable() gates the
+ * fast path on `full` and `cand` agreeing on type and SYM domain per column;
+ * when they don't, dl_eval falls back to distinct+antijoin for that
+ * iteration and rebuilds the set afterwards (ray_vec_concat re-expresses
+ * cross-domain SYM cells into the runtime domain, which would invalidate
+ * every stored hash).
+ * ======================================================================== */
+
+/* The 64-bit key a cell contributes to the row identity. */
+static uint64_t dl_cell_key(ray_t* col, int64_t row) {
+    if (col->type == RAY_F64) {
+        uint64_t v;
+        memcpy(&v, &((const double*)ray_data(col))[row], sizeof(v));
+        return v;
+    }
+    return (uint64_t)dl_cell_i64(col, row);
+}
+
+static uint64_t dl_row_hash(ray_t* tbl, int64_t row, int64_t ncols) {
+    uint64_t h = 0x243F6A8885A308D3ULL;
+    for (int64_t c = 0; c < ncols; c++) {
+        uint64_t v = dl_cell_key(ray_table_get_col_idx(tbl, c), row);
+        h = (h ^ v) * 0x9E3779B97F4A7C15ULL;
+        h ^= h >> 29;
+    }
+    return h | 1;   /* never 0: 0 marks an empty slot */
+}
+
+static bool dl_row_eq(ray_t* ta, int64_t ra, ray_t* tb, int64_t rb, int64_t ncols) {
+    for (int64_t c = 0; c < ncols; c++) {
+        if (dl_cell_key(ray_table_get_col_idx(ta, c), ra) !=
+            dl_cell_key(ray_table_get_col_idx(tb, c), rb))
+            return false;
+    }
+    return true;
+}
+
+/* Every column must be one of the types dl_cell_key can read. */
+static bool dl_rowset_types_ok(ray_t* tbl) {
+    if (!tbl || RAY_IS_ERR(tbl)) return false;
+    int64_t nc = ray_table_ncols(tbl);
+    if (nc <= 0) return false;
+    for (int64_t c = 0; c < nc; c++) {
+        ray_t* col = ray_table_get_col_idx(tbl, c);
+        if (!col) return false;
+        if (col->type != RAY_I64 && col->type != RAY_SYM && col->type != RAY_F64)
+            return false;
+    }
+    return true;
+}
+
+/* True when rows of `full` and `cand` may be compared as raw cell keys:
+ * matching column count, matching per-column type, and — for SYM — the same
+ * resolution domain (ids from different domains index different
+ * dictionaries and must never be raw-compared). */
+static bool dl_rowset_comparable(ray_t* full, ray_t* cand) {
+    if (!dl_rowset_types_ok(full) || !dl_rowset_types_ok(cand)) return false;
+    int64_t nc = ray_table_ncols(full);
+    if (nc != ray_table_ncols(cand)) return false;
+    for (int64_t c = 0; c < nc; c++) {
+        ray_t* a = ray_table_get_col_idx(full, c);
+        ray_t* b = ray_table_get_col_idx(cand, c);
+        if (a->type != b->type) return false;
+        if (a->type == RAY_SYM && ray_sym_vec_domain(a) != ray_sym_vec_domain(b))
+            return false;
+    }
+    return true;
+}
+
+int dl_rowset_init(dl_rowset_t* s, int64_t expected_rows) {
+    memset(s, 0, sizeof(*s));
+    int64_t cap = 16;
+    while (cap < (int64_t)1 << 40 && cap * 7 < expected_rows * 10) cap <<= 1;
+    ray_t* hb = ray_alloc((size_t)cap * sizeof(uint64_t));
+    ray_t* rb = ray_alloc((size_t)cap * sizeof(int64_t));
+    if (!hb || RAY_IS_ERR(hb) || !rb || RAY_IS_ERR(rb)) {
+        if (hb) { if (RAY_IS_ERR(hb)) ray_error_free(hb); else ray_free(hb); }
+        if (rb) { if (RAY_IS_ERR(rb)) ray_error_free(rb); else ray_free(rb); }
+        return -1;
+    }
+    s->hblock = hb;
+    s->rblock = rb;
+    s->hashes = (uint64_t*)ray_data(hb);
+    s->rows = (int64_t*)ray_data(rb);
+    memset(s->hashes, 0, (size_t)cap * sizeof(uint64_t));
+    s->cap = cap;
+    s->n = 0;
+    return 0;
+}
+
+void dl_rowset_free(dl_rowset_t* s) {
+    if (!s) return;
+    if (s->hblock) ray_free(s->hblock);
+    if (s->rblock) ray_free(s->rblock);
+    memset(s, 0, sizeof(*s));
+}
+
+/* Rehash into a larger table.  Hash and row index are both stored, so this
+ * needs no access to the relation. */
+static int dl_rowset_grow(dl_rowset_t* s) {
+    dl_rowset_t t;
+    if (dl_rowset_init(&t, s->n * 2 + 16) < 0) return -1;
+    for (int64_t i = 0; i < s->cap; i++) {
+        if (!s->hashes[i]) continue;
+        int64_t j = (int64_t)(s->hashes[i] & (uint64_t)(t.cap - 1));
+        while (t.hashes[j]) j = (j + 1) & (t.cap - 1);
+        t.hashes[j] = s->hashes[i];
+        t.rows[j] = s->rows[i];
+    }
+    t.n = s->n;
+    dl_rowset_free(s);
+    *s = t;
+    return 0;
+}
+
+int dl_rowset_add_table(dl_rowset_t* s, ray_t* tbl) {
+    if (!s || !s->cap) return -1;
+    if (!tbl || RAY_IS_ERR(tbl)) return -1;
+    int64_t n = ray_table_nrows(tbl);
+    if (n == 0) return 0;
+    if (!dl_rowset_types_ok(tbl)) return -1;
+    int64_t ncols = ray_table_ncols(tbl);
+    for (int64_t r = 0; r < n; r++) {
+        if ((s->n + 1) * 10 > s->cap * 7 && dl_rowset_grow(s) < 0) return -1;
+        uint64_t h = dl_row_hash(tbl, r, ncols);
+        int64_t j = (int64_t)(h & (uint64_t)(s->cap - 1));
+        bool found = false;
+        while (s->hashes[j]) {
+            if (s->hashes[j] == h && dl_row_eq(tbl, s->rows[j], tbl, r, ncols)) {
+                found = true;
+                break;
+            }
+            j = (j + 1) & (s->cap - 1);
+        }
+        if (found) continue;   /* duplicate row inside tbl */
+        s->hashes[j] = h;
+        s->rows[j] = r;
+        s->n++;
+    }
+    return 0;
+}
+
+ray_t* dl_rowset_extract_new(dl_rowset_t* s, ray_t* full, ray_t* cand) {
+    if (!s || !s->cap) return ray_error("domain", "rowset: uninitialized set");
+    if (!cand || RAY_IS_ERR(cand)) return ray_error("domain", "rowset: bad candidate");
+    int64_t n = ray_table_nrows(cand);
+    int64_t ncols = ray_table_ncols(cand);
+    int64_t base = full && !RAY_IS_ERR(full) ? ray_table_nrows(full) : 0;
+
+    ray_t* keep_block = ray_alloc((size_t)(n > 0 ? n : 1));
+    if (!keep_block || RAY_IS_ERR(keep_block)) {
+        if (keep_block) ray_error_free(keep_block);
+        return ray_error("memory", "rowset: mask alloc");
+    }
+    uint8_t* keep = (uint8_t*)ray_data(keep_block);
+    memset(keep, 0, (size_t)(n > 0 ? n : 1));
+
+    /* kmap[k] = the cand row accepted as set entry base + k, so a probe can
+     * resolve an entry that refers to a row not yet appended to `full`. */
+    ray_t* map_block = ray_alloc((size_t)(n > 0 ? n : 1) * sizeof(int64_t));
+    if (!map_block || RAY_IS_ERR(map_block)) {
+        if (map_block) ray_error_free(map_block);
+        ray_free(keep_block);
+        return ray_error("memory", "rowset: map alloc");
+    }
+    int64_t* kmap = (int64_t*)ray_data(map_block);
+
+    int64_t accepted = 0;
+    for (int64_t r = 0; r < n; r++) {
+        if ((s->n + 1) * 10 > s->cap * 7 && dl_rowset_grow(s) < 0) {
+            ray_free(keep_block);
+            ray_free(map_block);
+            return ray_error("memory", "rowset: grow");
+        }
+        uint64_t h = dl_row_hash(cand, r, ncols);
+        int64_t j = (int64_t)(h & (uint64_t)(s->cap - 1));
+        bool found = false;
+        while (s->hashes[j]) {
+            if (s->hashes[j] == h) {
+                int64_t rr = s->rows[j];
+                bool eq = rr < base ? dl_row_eq(full, rr, cand, r, ncols)
+                                    : dl_row_eq(cand, kmap[rr - base], cand, r, ncols);
+                if (eq) { found = true; break; }
+            }
+            j = (j + 1) & (s->cap - 1);
+        }
+        if (found) continue;
+        s->hashes[j] = h;
+        s->rows[j] = base + accepted;
+        s->n++;
+        kmap[accepted++] = r;
+        keep[r] = 1;
+    }
+
+    ray_t* out = dl_table_take_mask(cand, keep, accepted);
+    ray_free(keep_block);
+    ray_free(map_block);
+    return out;
 }
 
 /* ========================================================================
@@ -3054,8 +3271,13 @@ int dl_eval(dl_program_t* prog) {
          * difference between current and previous table states. */
         ray_t* prev_tables[DL_MAX_RELS];
         ray_t* delta_tables[DL_MAX_RELS];
+        /* One persistent row set per IDB, alive for the whole stratum: the
+         * per-iteration delta is "candidate rows whose key is new" instead
+         * of table_distinct + table_antijoin over the full relation. */
+        dl_rowset_t sets[DL_MAX_RELS];
         memset(prev_tables, 0, sizeof(prev_tables));
         memset(delta_tables, 0, sizeof(delta_tables));
+        memset(sets, 0, sizeof(sets));
 
         /* Initially, delta = full table (all tuples are new) */
         for (int p = 0; p < prog->strata_sizes[s]; p++) {
@@ -3079,6 +3301,13 @@ int dl_eval(dl_program_t* prog) {
                         ray_release(empty_col);
                     }
                 }
+                /* Seed the row set from the post-Phase-A relation.  A
+                 * failure (OOM, or a column type the set can't key on)
+                 * leaves the set zeroed, which simply keeps the generic
+                 * distinct+antijoin path for this relation. */
+                if (dl_rowset_init(&sets[rel_idx], ray_table_nrows(rel->table) * 2 + 16) == 0 &&
+                    dl_rowset_add_table(&sets[rel_idx], rel->table) < 0)
+                    dl_rowset_free(&sets[rel_idx]);
             }
         }
 
@@ -3108,6 +3337,7 @@ int dl_eval(dl_program_t* prog) {
                         ray_release(prev_tables[rel_idx]);
                     if (delta_tables[rel_idx] && !RAY_IS_ERR(delta_tables[rel_idx]))
                         ray_release(delta_tables[rel_idx]);
+                    dl_rowset_free(&sets[rel_idx]);
                 }
                 prog->eval_err = true;
                 return -1;
@@ -3215,33 +3445,86 @@ int dl_eval(dl_program_t* prog) {
                     continue;
                 }
 
-                /* Deduplicate */
-                ray_t* deduped = table_distinct(new_tuples);
-                ray_release(new_tuples);
-                if (!deduped) { prog->eval_err = true; continue; }
-                if (RAY_IS_ERR(deduped)) { prog->eval_err = true; ray_error_free(deduped); continue; }
+                /* A candidate table larger than the relation itself comes
+                 * from a join that manufactured mostly duplicates (the
+                 * non-linear `tc(x,y),tc(y,z)` shape): collapse it with the
+                 * vectorised table_distinct first, which is far cheaper per
+                 * row than the scalar probe below.  When the candidate is
+                 * already no bigger than the relation the probe alone wins,
+                 * since it avoids building a second hash table.  The budget
+                 * is the relation's own size — no new tunable. */
+                if (ray_table_nrows(new_tuples) > ray_table_nrows(rel->table)) {
+                    ray_t* pre = table_distinct(new_tuples);
+                    if (pre && !RAY_IS_ERR(pre)) {
+                        ray_release(new_tuples);
+                        new_tuples = pre;
+                    } else if (pre) {
+                        /* A distinct failure is not fatal on its own: the
+                         * paths below still produce a correct delta from
+                         * the un-deduplicated candidate. */
+                        ray_error_free(pre);
+                    }
+                }
 
-                /* Subtract existing relation to get true delta */
-                ray_t* delta = table_antijoin(deduped, rel->table);
-                ray_release(deduped);
-                if (!delta) { prog->eval_err = true; continue; }
-                if (RAY_IS_ERR(delta)) { prog->eval_err = true; ray_error_free(delta); continue; }
+                /* Delta = candidate rows not already in the relation,
+                 * deduplicated among themselves. */
+                ray_t* delta;
+                bool rebuild_set = false;
+                if (sets[rel_idx].cap &&
+                    dl_rowset_comparable(rel->table, new_tuples)) {
+                    delta = dl_rowset_extract_new(&sets[rel_idx], rel->table, new_tuples);
+                    ray_release(new_tuples);
+                    if (!delta || RAY_IS_ERR(delta)) {
+                        prog->eval_err = true;
+                        if (delta) ray_error_free(delta);
+                        /* Row indices in the set may now be inconsistent. */
+                        dl_rowset_free(&sets[rel_idx]);
+                        continue;
+                    }
+                } else {
+                    /* No usable set, or `new_tuples` disagrees with the
+                     * relation on column type or SYM resolution domain —
+                     * raw cell keys are not comparable across domains, and
+                     * the table_union below would re-express both sides into
+                     * the runtime domain, invalidating every stored hash.
+                     * Take the generic path and rebuild the set after. */
+                    rebuild_set = true;
+                    ray_t* deduped = table_distinct(new_tuples);
+                    ray_release(new_tuples);
+                    if (!deduped) { prog->eval_err = true; continue; }
+                    if (RAY_IS_ERR(deduped)) { prog->eval_err = true; ray_error_free(deduped); continue; }
+
+                    delta = table_antijoin(deduped, rel->table);
+                    ray_release(deduped);
+                    if (!delta) { prog->eval_err = true; continue; }
+                    if (RAY_IS_ERR(delta)) { prog->eval_err = true; ray_error_free(delta); continue; }
+                }
 
                 delta_tables[rel_idx] = delta;
 
                 /* Merge delta into full relation.  A merge failure here
                  * leaves delta_tables set but rel->table stale — that would
-                 * desync the fixpoint, so treat it as a hard failure. */
+                 * desync the fixpoint, so treat it as a hard failure.
+                 * This must stay immediately after the extraction: the set
+                 * assigned accepted candidate k the row index
+                 * nrows(rel->table) + k, and table_union concatenates
+                 * column-wise, so the relation's rows keep that order. */
                 if (ray_table_nrows(delta) > 0) {
                     ray_t* merged = table_union(rel->table, delta);
-                    if (!merged) { prog->eval_err = true; continue; }
-                    if (RAY_IS_ERR(merged)) {
+                    if (!merged || RAY_IS_ERR(merged)) {
                         prog->eval_err = true;
-                        ray_error_free(merged);
+                        if (merged) ray_error_free(merged);
+                        dl_rowset_free(&sets[rel_idx]);
                         continue;
                     }
                     ray_release(rel->table);
                     rel->table = merged;
+                }
+                if (rebuild_set) {
+                    dl_rowset_free(&sets[rel_idx]);
+                    if (dl_rowset_init(&sets[rel_idx], ray_table_nrows(rel->table) * 2 + 16) == 0 &&
+                        dl_rowset_add_table(&sets[rel_idx], rel->table) < 0)
+                        dl_rowset_free(&sets[rel_idx]);
                 }
             }
 
@@ -3279,6 +3562,7 @@ int dl_eval(dl_program_t* prog) {
                 ray_release(prev_tables[rel_idx]);
             if (delta_tables[rel_idx] && !RAY_IS_ERR(delta_tables[rel_idx]))
                 ray_release(delta_tables[rel_idx]);
+            dl_rowset_free(&sets[rel_idx]);
         }
     }
 

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -60,7 +60,7 @@ dl_program_t* dl_program_new(void) {
 
 /* Recover the ray_t header from a dl_program_t pointer for ray_free. */
 static inline ray_t* dl_prog_block(dl_program_t* prog) {
-    return (ray_t*)((char*)prog - 32);  /* ray_data is at offset 32 */
+    return (ray_t*)((char*)prog - offsetof(ray_t, data));
 }
 
 void dl_program_free(dl_program_t* prog) {
@@ -130,6 +130,12 @@ int dl_add_edb(dl_program_t* prog, const char* name, ray_t* table, int arity) {
         if (!col) { ray_release(new_tbl); return -1; }
         new_tbl = ray_table_add_col(new_tbl, rel->col_names[c], col);
         if (RAY_IS_ERR(new_tbl)) return -1;
+        /* Tag provenance (see dl_rel_t.col_from_v): the `eav` relation's v
+         * column is the only EDB column that can hold a DATOM-tagged value.
+         * Sniffing other EDBs for tag-shaped bits is not an option -- a
+         * plain integer >= 2^61 is indistinguishable from a tagged cell,
+         * which is the very confusion this flag removes. */
+        if (c == 2 && strcmp(name, DL_EAV_PRED) == 0) rel->col_from_v[c] = true;
     }
     rel->table = new_tbl;
 
@@ -442,7 +448,9 @@ dl_expr_t* dl_expr_binop(int op, dl_expr_t* left, dl_expr_t* right) {
 
 /* dl_expr_alloc allocates a ray_alloc block whose ray_data() is the
  * dl_expr_t node; recover the block header to free it. */
-static inline ray_t* dl_expr_block(dl_expr_t* e) { return (ray_t*)((char*)e - 32); }
+static inline ray_t* dl_expr_block(dl_expr_t* e) {
+    return (ray_t*)((char*)e - offsetof(ray_t, data));
+}
 
 void dl_expr_free(dl_expr_t* e) {
     if (!e) return;
@@ -916,8 +924,13 @@ static ray_t* dl_builtin_duration_since(ray_t* tbl, int t1_col, int t2_col,
     if (!col || RAY_IS_ERR(col)) { ray_retain(tbl); return tbl; }
     col->len = nrows;
     int64_t* d = (int64_t*)ray_data(col);
-    for (int64_t r = 0; r < nrows; r++)
-        d[r] = t2[r] - t1[r];
+    /* Checked arithmetic, same contract as dl_eval_expr: a null operand or
+     * an overflowing subtraction yields the I64 null. */
+    for (int64_t r = 0; r < nrows; r++) {
+        int64_t a = t2[r], b = t1[r], o;
+        if (a == NULL_I64 || b == NULL_I64) { d[r] = NULL_I64; continue; }
+        d[r] = __builtin_sub_overflow(a, b, &o) ? NULL_I64 : o;
+    }
 
     ray_t* out = dl_table_add_computed_col(tbl, col, out_name);
     ray_release(col);
@@ -934,8 +947,12 @@ static ray_t* dl_builtin_abs(ray_t* tbl, int x_col, const char* out_name) {
     if (!col || RAY_IS_ERR(col)) { ray_retain(tbl); return tbl; }
     col->len = nrows;
     int64_t* d = (int64_t*)ray_data(col);
-    for (int64_t r = 0; r < nrows; r++)
-        d[r] = xd[r] < 0 ? -xd[r] : xd[r];
+    /* Checked arithmetic, same contract as dl_eval_expr: a null operand, or
+     * INT64_MIN whose negation is not representable, yields the I64 null. */
+    for (int64_t r = 0; r < nrows; r++) {
+        int64_t x = xd[r];
+        d[r] = (x == NULL_I64) ? NULL_I64 : (x < 0 ? -x : x);
+    }
 
     ray_t* out = dl_table_add_computed_col(tbl, col, out_name);
     ray_release(col);
@@ -1167,8 +1184,10 @@ static ray_t* dl_table_take_mask(ray_t* tbl, const uint8_t* keep, int64_t count)
         if (src->type == RAY_STR) col_propagate_str_pool(dst, src);
         ray_t* next = ray_table_add_col(out, ray_table_col_name(tbl, c), dst);
         ray_release(dst);
-        if (!next) { ray_release(out); return ray_error("memory", "dl_table_take_mask: add_col"); }
-        if (RAY_IS_ERR(next)) { ray_release(out); return next; }
+        /* ray_table_add_col releases its input table on every failure
+         * path, so `out` must not be released again here. */
+        if (!next) return ray_error("memory", "dl_table_take_mask: add_col");
+        if (RAY_IS_ERR(next)) return next;
         out = next;
     }
     return out;
@@ -1447,16 +1466,10 @@ static ray_t* dl_project(ray_t* tbl, const int* col_indices, int n_out,
             if (src->type == RAY_SYM) ray_sym_vec_adopt_domain(dst, src);
             ray_t* next = ray_table_add_col(out, head_rel->col_names[c], dst);
             ray_release(dst);
-            /* Release the partial `out` on failure — ray_table_add_col
-             * does not free its input on error. */
-            if (!next) {
-                ray_release(out);
-                return ray_error("memory", "dl_project: add_col");
-            }
-            if (RAY_IS_ERR(next)) {
-                ray_release(out);
-                return next;
-            }
+            /* ray_table_add_col releases its input table on every failure
+             * path, so `out` must not be released again here. */
+            if (!next) return ray_error("memory", "dl_project: add_col");
+            if (RAY_IS_ERR(next)) return next;
             out = next;
         } else {
             /* Constant head slot: materialize an owned broadcast column. */
@@ -1479,14 +1492,10 @@ static ray_t* dl_project(ray_t* tbl, const int* col_indices, int n_out,
             }
             ray_t* next = ray_table_add_col(out, head_rel->col_names[c], bcast);
             ray_release(bcast);
-            if (!next) {
-                ray_release(out);
-                return ray_error("memory", "dl_project: add_col");
-            }
-            if (RAY_IS_ERR(next)) {
-                ray_release(out);
-                return next;
-            }
+            /* ray_table_add_col releases its input table on every failure
+             * path, so `out` must not be released again here. */
+            if (!next) return ray_error("memory", "dl_project: add_col");
+            if (RAY_IS_ERR(next)) return next;
             out = next;
         }
     }
@@ -1516,6 +1525,8 @@ static ray_t* dl_table_head(ray_t* tbl, int64_t n) {
     for (int64_t c = 0; c < ncols; c++) {
         ray_t* src = ray_table_get_col_idx(tbl, c);
         if (!src) { ray_release(out); return ray_error("domain", "dl_table_head: missing source column"); }
+        /* Offset is always 0 here (a prefix view), which keeps this clear of
+         * ray_data_slice_path's byte-vs-element offset scaling. */
         ray_t* view = ray_vec_slice(src, 0, n);
         if (!view) { ray_release(out); return ray_error("memory", "dl_table_head: vec_slice"); }
         if (RAY_IS_ERR(view)) { ray_release(out); return view; }
@@ -1543,7 +1554,14 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
      */
     int var_col[DL_MAX_ARITY * DL_MAX_BODY];  /* column index in accum per variable */
     bool var_bound[DL_MAX_ARITY * DL_MAX_BODY];
+    /* var_from_v[v]: the value bound to v may carry a DATOM tag because it
+     * came (possibly transitively) from a datoms `v` column.  Only such
+     * columns are untagged on query output -- see dl_rel_t.col_from_v.
+     * A variable joined from two sources keeps the flag if either side had
+     * it (conservative). */
+    bool var_from_v[DL_MAX_ARITY * DL_MAX_BODY];
     memset(var_bound, 0, sizeof(var_bound));
+    memset(var_from_v, 0, sizeof(var_from_v));
     memset(var_col, -1, sizeof(var_col));
 
     ray_t* accum = NULL;  /* accumulated result table */
@@ -1633,6 +1651,7 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
                 if (!var_bound[v]) {
                     var_bound[v] = true;
                     var_col[v] = c;
+                    var_from_v[v] = c < DL_MAX_ARITY && rel->col_from_v[c];
                 }
             }
         } else {
@@ -1646,6 +1665,8 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
                     lkeys[n_jk] = var_col[v];
                     rkeys[n_jk] = c;
                     n_jk++;
+                    /* Conservative: a join key is "from v" if either side was. */
+                    if (c < DL_MAX_ARITY && rel->col_from_v[c]) var_from_v[v] = true;
                 }
             }
 
@@ -1662,6 +1683,14 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
             ray_release(accum);
             ray_release(body_tbl);
             accum = joined;
+            /* A failed join must not leave accum NULL: the next body atom
+             * would then be treated as the first one and the rule would
+             * silently produce an unjoined (wrong) result. */
+            if (!accum || RAY_IS_ERR(accum)) {
+                if (accum) ray_error_free(accum);
+                prog->eval_err = true;
+                return NULL;
+            }
 
             /* Bind new variables: their columns come after left columns in join output.
              * Join output = [all left cols] + [non-key right cols].
@@ -1686,6 +1715,7 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
                 if (!var_bound[v]) {
                     var_bound[v] = true;
                     var_col[v] = right_col_map[c];
+                    var_from_v[v] = c < DL_MAX_ARITY && rel->col_from_v[c];
                 }
             }
         }
@@ -1727,16 +1757,14 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
         int64_t unit_sym = ray_sym_intern("_unit", 5);
         ray_t* accum_unit = ray_table_add_col(accum, unit_sym, one_val);
         ray_release(one_val);
-        /* ray_table_add_col doesn't free `accum` on error — release it
-         * ourselves so the partially-built table isn't leaked. */
+        /* ray_table_add_col releases `accum` on every failure path, so it
+         * must not be released again here. */
         if (!accum_unit) {
-            ray_release(accum);
             prog->eval_err = true;
             return NULL;
         }
         if (RAY_IS_ERR(accum_unit)) {
             ray_error_free(accum_unit);
-            ray_release(accum);
             prog->eval_err = true;
             return NULL;
         }
@@ -1854,6 +1882,7 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
 
             var_bound[body->assign_var] = true;
             var_col[body->assign_var] = new_col_idx;
+            var_from_v[body->assign_var] = false;  /* computed value */
             break;
         }
 
@@ -2005,10 +2034,21 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
                     int kv = body->agg_group_key_vars[i];
                     var_bound[kv] = true;
                     var_col[kv] = i;
+                    int gkc = body->agg_group_key_cols[i];
+                    var_from_v[kv] = src_rel && gkc >= 0 && gkc < DL_MAX_ARITY &&
+                                     src_rel->col_from_v[gkc];
                 }
                 /* Bind target variable to the aggregate column (last column) */
                 var_bound[body->agg_target_var] = true;
                 var_col[body->agg_target_var] = nk;  /* agg column immediately follows keys */
+                /* min/max carry a source cell through verbatim, so they keep
+                 * the source column's tag provenance; count/sum/avg compute a
+                 * fresh number that is never tagged. */
+                var_from_v[body->agg_target_var] =
+                    (body->agg_op == DL_AGG_MIN || body->agg_op == DL_AGG_MAX) &&
+                    src_rel && body->agg_value_col >= 0 &&
+                    body->agg_value_col < DL_MAX_ARITY &&
+                    src_rel->col_from_v[body->agg_value_col];
                 break;
             }
             /* -------- existing scalar path below unchanged -------- */
@@ -2184,6 +2224,10 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
 
             var_bound[body->agg_target_var] = true;
             var_col[body->agg_target_var] = new_col_idx;
+            var_from_v[body->agg_target_var] =
+                (body->agg_op == DL_AGG_MIN || body->agg_op == DL_AGG_MAX) &&
+                body->agg_value_col >= 0 && body->agg_value_col < DL_MAX_ARITY &&
+                prog->rels[src_idx].col_from_v[body->agg_value_col];
             break;
         }
 
@@ -2209,6 +2253,7 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
                 accum = result;
                 var_bound[d_var] = true;
                 var_col[d_var] = new_idx;
+                var_from_v[d_var] = false;  /* computed value */
                 break;
             }
             case DL_BUILTIN_ABS: {
@@ -2222,6 +2267,7 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
                 accum = result;
                 var_bound[y_var] = true;
                 var_col[y_var] = new_idx;
+                var_from_v[y_var] = false;  /* computed value */
                 break;
             }
             }
@@ -2426,15 +2472,17 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
                 if (src->type == RAY_SYM) ray_sym_vec_adopt_domain(dst, src);
                 ray_t* next = ray_table_add_col(out, ray_table_col_name(accum, c), dst);
                 ray_release(dst);
+                /* ray_table_add_col releases `out` on every failure path,
+                 * so it must not be released again here. */
                 if (!next) {
-                    ray_release(out); ray_free(mask_block);
+                    ray_free(mask_block);
                     ray_release(accum);
                     prog->eval_err = true;
                     return NULL;
                 }
                 if (RAY_IS_ERR(next)) {
                     ray_error_free(next);
-                    ray_release(out); ray_free(mask_block);
+                    ray_free(mask_block);
                     ray_release(accum);
                     prog->eval_err = true;
                     return NULL;
@@ -2454,9 +2502,11 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
 
             var_bound[body->interval_start_var] = true;
             var_col[body->interval_start_var] = start_col;
+            var_from_v[body->interval_start_var] = false;
 
             var_bound[body->interval_end_var] = true;
             var_col[body->interval_end_var] = end_col;
+            var_from_v[body->interval_end_var] = false;
             break;
         }
         } /* switch */
@@ -2474,6 +2524,11 @@ ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
             proj_cols[c] = -1;
         } else {
             proj_cols[c] = var_col[v];
+            /* Tag provenance flows with the value into the head column, and
+             * is OR-accumulated across rules and fixpoint iterations: a
+             * column is "from v" if any derivation could put a tagged value
+             * there (conservative, matching the old unconditional untag). */
+            if (c < DL_MAX_ARITY && var_from_v[v]) head_rel->col_from_v[c] = true;
         }
     }
 
@@ -3660,10 +3715,20 @@ int dl_eval(dl_program_t* prog) {
                 if (ray_table_nrows(delta) > 0) {
                     ray_t* merged = table_union(rel->table, delta);
                     if (!merged || RAY_IS_ERR(merged)) {
+                        /* The relation could not absorb its delta, so the
+                         * fixpoint is desynced.  Continuing would re-derive
+                         * the same rows forever in an uncapped monotone
+                         * stratum, so bail out of the whole evaluation
+                         * (mirroring the cancellation cleanup above). */
                         prog->eval_err = true;
                         if (merged) ray_error_free(merged);
-                        dl_rowset_free(&sets[rel_idx]);
-                        continue;
+                        for (int q = 0; q < prog->strata_sizes[s]; q++) {
+                            int rq = prog->strata[s][q];
+                            if (delta_tables[rq] && !RAY_IS_ERR(delta_tables[rq]))
+                                ray_release(delta_tables[rq]);
+                            dl_rowset_free(&sets[rq]);
+                        }
+                        return -1;
                     }
                     ray_release(rel->table);
                     rel->table = merged;
@@ -4199,7 +4264,13 @@ static dl_expr_t* dl_build_expr(ray_t* node, dl_var_map_t* vars) {
                 if (op >= 0) {
                     dl_expr_t* l = dl_build_expr(elems[1], vars);
                     dl_expr_t* r = dl_build_expr(elems[2], vars);
-                    if (l && r) return dl_expr_binop(op, l, r);
+                    /* dl_expr_binop only takes ownership when it succeeds;
+                     * a half-built operand pair must not leak either. */
+                    dl_expr_t* b = (l && r) ? dl_expr_binop(op, l, r) : NULL;
+                    if (b) return b;
+                    dl_expr_free(l);
+                    dl_expr_free(r);
+                    return NULL;
                 }
             }
         }
@@ -4557,8 +4628,11 @@ static ray_t* dl_parse_body_clause(dl_rule_t* rule, ray_t* clause,
         dl_expr_t* expr = dl_build_expr(ce[2], vars);
         if (!expr)
             return ray_error("type", "rule: cannot parse assignment expression");
-        if (dl_rule_add_assign(rule, target_vi, DL_OP_EQ, expr) < 0)
+        if (dl_rule_add_assign(rule, target_vi, DL_OP_EQ, expr) < 0) {
+            /* dl_rule_add_assign takes ownership only when it succeeds. */
+            dl_expr_free(expr);
             return ray_error("domain", "rule: too many body literals");
+        }
         return NULL;
     }
 
@@ -4603,10 +4677,19 @@ static ray_t* dl_parse_body_clause(dl_rule_t* rule, ray_t* clause,
             dl_expr_t* le = dl_build_expr(ce[1], vars);
             dl_expr_t* re = (clen > 2) ? dl_build_expr(ce[2], vars) : NULL;
             if (le && re) {
-                if (dl_rule_add_cmp_expr(rule, cmp_op, le, re) < 0)
+                /* dl_rule_add_cmp_expr takes ownership of both trees only
+                 * when it succeeds; free them on the error return. */
+                if (dl_rule_add_cmp_expr(rule, cmp_op, le, re) < 0) {
+                    dl_expr_free(le);
+                    dl_expr_free(re);
                     return ray_error("domain", "rule: too many body literals");
-            } else
+                }
+            } else {
+                /* One operand may have parsed fine — free whichever did. */
+                dl_expr_free(le);
+                dl_expr_free(re);
                 return ray_error("type", "rule: cannot parse comparison operands");
+            }
         }
         return NULL;
     }
@@ -4649,6 +4732,13 @@ static ray_t* dl_parse_rule_from_head_and_body(dl_rule_t* out, ray_t* head,
 
     if (ray_str_len(head_name_str) == 1 && ray_str_ptr(head_name_str)[0] == '_')
         return ray_error("domain", "rule: _ is reserved as wildcard");
+
+    /* The `eav` relation is the built-in datoms EDB registered by
+     * ray_query_fn, and its v column is the only DATOM-tagged column in the
+     * engine.  A user rule deriving into it would either be silently
+     * shadowed by the EDB or feed untagged rows into tag-aware compares. */
+    if (strcmp(ray_str_ptr(head_name_str), DL_EAV_PRED) == 0)
+        return ray_error("domain", "rule: head predicate 'eav' is reserved");
 
     int head_arity = (int)(hlen - 1);
     /* head_vars[]/head_consts[] are fixed-size (DL_MAX_ARITY). A head literal
@@ -4731,6 +4821,14 @@ ray_t* ray_rule_fn(ray_t** args, int64_t n) {
      * ray_dl_reset_rules — no clone/free here. */
     memcpy(&g_dl_rules[g_dl_n_rules++], &rule, sizeof(dl_rule_t));
     return ray_bool(true);
+}
+
+/* Predicate a body literal reads from, or NULL when the literal is not a
+ * relational one (comparison, assignment, builtin, interval). */
+static const char* dl_body_pred_name(const dl_body_t* bd) {
+    return (bd->type == DL_POS || bd->type == DL_NEG) ? bd->pred
+         : (bd->type == DL_AGG)                       ? bd->agg_pred
+                                                      : NULL;
 }
 
 /* (query db (find ?a ?b ...) (where clause1 clause2 ...) [(rules ...)])
@@ -5079,13 +5177,38 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
 
     /* Admission: every body predicate must now resolve to a relation —
      * an EDB, an env-bound table registered above, or a rule head (IDB
-     * created by dl_add_rule). Anything else is a typo, not "no rows". */
+     * created by dl_add_rule). Anything else is a typo, not "no rows".
+     *
+     * Only rules this query can actually reach are checked.  All global
+     * rules are copied into the program (stratification must see them),
+     * but a stale global rule mentioning a relation that is not bound in
+     * this session must not fail every unrelated query — only queries that
+     * depend on it. */
+    bool rule_live[DL_MAX_RULES];
+    memset(rule_live, 0, sizeof(rule_live));
+    for (int ri = 0; ri < prog->n_rules; ri++)
+        if (strcmp(prog->rules[ri].head_pred, "__query") == 0) rule_live[ri] = true;
+    for (bool changed = true; changed;) {
+        changed = false;
+        for (int ri = 0; ri < prog->n_rules; ri++) {
+            if (!rule_live[ri]) continue;
+            dl_rule_t* rr = &prog->rules[ri];
+            for (int bi = 0; bi < rr->n_body; bi++) {
+                const char* pn = dl_body_pred_name(&rr->body[bi]);
+                if (!pn || !pn[0]) continue;
+                for (int rj = 0; rj < prog->n_rules; rj++)
+                    if (!rule_live[rj] && strcmp(prog->rules[rj].head_pred, pn) == 0) {
+                        rule_live[rj] = true;
+                        changed = true;
+                    }
+            }
+        }
+    }
     for (int ri = 0; ri < prog->n_rules; ri++) {
+        if (!rule_live[ri]) continue;
         dl_rule_t* rr = &prog->rules[ri];
         for (int bi = 0; bi < rr->n_body; bi++) {
-            dl_body_t* bd = &rr->body[bi];
-            const char* pn = (bd->type == DL_POS || bd->type == DL_NEG) ? bd->pred
-                           : (bd->type == DL_AGG) ? bd->agg_pred : NULL;
+            const char* pn = dl_body_pred_name(&rr->body[bi]);
             if (!pn || !pn[0] || dl_find_rel(prog, pn) >= 0) continue;
             dl_program_free(prog);
             ray_release(db);
@@ -5133,10 +5256,21 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
     int64_t nrows = ray_table_nrows(raw);
     int64_t ncols = ray_table_ncols(raw);
     ray_t* result = ray_table_new(n_find_vars);
+    /* Only columns whose values can have come from a datoms `v` column are
+     * untagged (dl_rel_t.col_from_v): a plain I64 column of large hashes, or
+     * an arithmetic result >= 2^61, must reach the caller verbatim. */
+    int qidx = dl_find_rel(prog, "__query");
+    const bool* from_v = (qidx >= 0) ? prog->rels[qidx].col_from_v : NULL;
     for (int i = 0; i < n_find_vars && i < (int)ncols; i++) {
         ray_t* col = ray_table_get_col_idx(raw, i);
         if (!col) continue;
-        ray_t* clean = dl_untag_i64_col(col);   /* returns retained col when nothing is tagged */
+        ray_t* clean;
+        if (from_v && i < DL_MAX_ARITY && from_v[i]) {
+            clean = dl_untag_i64_col(col);  /* returns retained col when nothing is tagged */
+        } else {
+            ray_retain(col);
+            clean = col;
+        }
         if (!clean || RAY_IS_ERR(clean)) { ray_release(result); dl_program_free(prog); ray_release(db);
             return clean ? clean : ray_error("memory", "query: untag"); }
         result = ray_table_add_col(result, find_var_syms[i], clean);

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -2563,7 +2563,11 @@ static ray_t* table_union(ray_t* a, ray_t* b) {
      *     adoption is ray_vec_concat's job) nor STR (pooled payloads).
      * Rectangularity is checked too: a short column would silently misalign.
      * The row order is a's rows then b's — the row set built in the fixpoint
-     * loop indexes rows of a and depends on it. */
+     * loop indexes rows of a and depends on it.
+     * ray_vec_append_raw also clears RAY_ATTR_SORTED and drops any attached
+     * index, but it does not clear RAY_ATTR_HAS_LINK; datalog IDB columns are
+     * plain derived vectors and are never link-tagged, so that is moot here —
+     * a future caller of this path with linked columns would have to. */
     ray_t** slots = a != b && ncols > 0 ? ray_table_cols_mut(a) : NULL;
     if (slots) {
         bool ok = true;
@@ -2580,9 +2584,16 @@ static ray_t* table_union(ray_t* a, ray_t* b) {
                 ray_t* cb = ray_table_get_col_idx(b, c);
                 ray_t* grown = ray_vec_append_raw(slots[c], ray_data(cb), cb->len);
                 if (!grown || RAY_IS_ERR(grown)) {
-                    /* Columns before c already grew; a is left inconsistent,
-                     * which every caller treats as a hard evaluation failure
-                     * (the relation is dropped, not reused). */
+                    /* Roll the already-grown columns back to a's row count so
+                     * `a` stays rectangular.  The callers set eval_err and
+                     * *continue* the fixpoint loop, which keeps reading
+                     * rel->table (ray_table_nrows reports column 0's length),
+                     * so a half-grown relation would be read out of bounds on
+                     * every later column.  Only the length is rewound: the
+                     * capacity and the rows up to nrows_a are untouched, and
+                     * column c itself never changed (ray_vec_append_raw fails
+                     * before mutating when its reserve fails). */
+                    for (int64_t k = 0; k < c; k++) slots[k]->len = nrows_a;
                     return grown ? grown : ray_error("memory", "table_union: append");
                 }
                 /* A reallocating append frees the old block, so the slot is

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -1418,14 +1418,10 @@ static ray_t* dl_project(ray_t* tbl, const int* col_indices, int n_out,
                     }
                     ray_t* next = ray_table_add_col(out, head_rel->col_names[c], ecol);
                     ray_release(ecol);
-                    if (!next) {
-                        ray_release(out);
-                        return ray_error("memory", "dl_project: add_col");
-                    }
-                    if (RAY_IS_ERR(next)) {
-                        ray_release(out);
-                        return next;
-                    }
+                    /* ray_table_add_col releases its input table on every
+                     * failure path, so `out` must not be released again. */
+                    if (!next) return ray_error("memory", "dl_project: add_col");
+                    if (RAY_IS_ERR(next)) return next;
                     out = next;
                     continue;
                 }
@@ -2747,14 +2743,10 @@ static ray_t* table_union(ray_t* a, ray_t* b) {
         }
         ray_t* next = ray_table_add_col(out, ray_table_col_name(a, c), merged);
         ray_release(merged);
-        if (!next) {
-            ray_release(out);
-            return ray_error("memory", "table_union: add_col");
-        }
-        if (RAY_IS_ERR(next)) {
-            ray_release(out);
-            return next;
-        }
+        /* ray_table_add_col releases its input table on every failure
+         * path, so `out` must not be released again here. */
+        if (!next) return ray_error("memory", "table_union: add_col");
+        if (RAY_IS_ERR(next)) return next;
         out = next;
     }
     return out;
@@ -3722,6 +3714,13 @@ int dl_eval(dl_program_t* prog) {
                          * (mirroring the cancellation cleanup above). */
                         prog->eval_err = true;
                         if (merged) ray_error_free(merged);
+                        /* Candidate tables belonging to relations further
+                         * along this pass have not been consumed yet (the
+                         * ones already visited were released above). */
+                        for (int q = p + 1; q < prog->strata_sizes[s]; q++) {
+                            ray_t* nt = new_tuples_per_rel[prog->strata[s][q]];
+                            if (nt && !RAY_IS_ERR(nt)) ray_release(nt);
+                        }
                         for (int q = 0; q < prog->strata_sizes[s]; q++) {
                             int rq = prog->strata[s][q];
                             if (delta_tables[rq] && !RAY_IS_ERR(delta_tables[rq]))
@@ -5150,15 +5149,15 @@ ray_t* ray_query_fn(ray_t** args, int64_t n) {
                 } else {
                     next_clean = ray_table_add_col(clean, ray_table_col_name(env_val, c), col);
                 }
+                /* ray_table_add_col releases `clean` on every failure
+                 * path, so it must not be released again here. */
                 if (!next_clean) {
-                    ray_release(clean);
                     dl_program_free(prog);
                     ray_release(db);
                     return ray_error("memory", "query: failed to build env-backed EDB table");
                 }
                 if (RAY_IS_ERR(next_clean)) {
                     ray_error_free(next_clean);
-                    ray_release(clean);
                     dl_program_free(prog);
                     ray_release(db);
                     return ray_error("memory", "query: failed to build env-backed EDB table");

--- a/src/ops/datalog.c
+++ b/src/ops/datalog.c
@@ -2988,13 +2988,17 @@ static void dl_build_provenance(dl_program_t* prog) {
  * every stored hash).
  * ======================================================================== */
 
-/* The 64-bit key a cell contributes to the row identity. */
+/* The 64-bit key a cell contributes to the row identity.
+ *
+ * F64 goes through canon_f64_key (ops/internal.h) — the same fold the
+ * grouping kernels use for ray_distinct: -0.0 keys as +0.0 and every NaN
+ * payload as one canonical NaN.  Raw bit patterns would make this set and
+ * the vectorised table_distinct in front of it disagree about row identity,
+ * so on an F64-keyed IDB whether two rows counted as the same would depend
+ * on which of the two paths an iteration happened to take. */
 static uint64_t dl_cell_key(ray_t* col, int64_t row) {
-    if (col->type == RAY_F64) {
-        uint64_t v;
-        memcpy(&v, &((const double*)ray_data(col))[row], sizeof(v));
-        return v;
-    }
+    if (col->type == RAY_F64)
+        return (uint64_t)canon_f64_key(((const double*)ray_data(col))[row]);
     return (uint64_t)dl_cell_i64(col, row);
 }
 
@@ -3125,6 +3129,12 @@ int dl_rowset_add_table(dl_rowset_t* s, ray_t* tbl) {
 ray_t* dl_rowset_extract_new(dl_rowset_t* s, ray_t* full, ray_t* cand) {
     if (!s || !s->cap) return ray_error("domain", "rowset: uninitialized set");
     if (!cand || RAY_IS_ERR(cand)) return ray_error("domain", "rowset: bad candidate");
+    /* A populated set's entries index `full`; without a readable `full`
+     * they cannot be resolved, and treating base as 0 would silently
+     * reinterpret every existing entry as a candidate row. */
+    if (!full || RAY_IS_ERR(full)) {
+        if (s->n > 0) return ray_error("domain", "rowset: missing relation for a populated set");
+    }
     int64_t n = ray_table_nrows(cand);
     int64_t ncols = ray_table_ncols(cand);
     int64_t base = full && !RAY_IS_ERR(full) ? ray_table_nrows(full) : 0;
@@ -3275,9 +3285,13 @@ int dl_eval(dl_program_t* prog) {
          * per-iteration delta is "candidate rows whose key is new" instead
          * of table_distinct + table_antijoin over the full relation. */
         dl_rowset_t sets[DL_MAX_RELS];
+        /* Latched once a relation's set cannot be built (unsupported column
+         * type, or OOM): stop retrying and stay on the generic path. */
+        bool set_off[DL_MAX_RELS];
         memset(prev_tables, 0, sizeof(prev_tables));
         memset(delta_tables, 0, sizeof(delta_tables));
         memset(sets, 0, sizeof(sets));
+        memset(set_off, 0, sizeof(set_off));
 
         /* Initially, delta = full table (all tuples are new) */
         for (int p = 0; p < prog->strata_sizes[s]; p++) {
@@ -3303,11 +3317,17 @@ int dl_eval(dl_program_t* prog) {
                 }
                 /* Seed the row set from the post-Phase-A relation.  A
                  * failure (OOM, or a column type the set can't key on)
-                 * leaves the set zeroed, which simply keeps the generic
-                 * distinct+antijoin path for this relation. */
-                if (dl_rowset_init(&sets[rel_idx], ray_table_nrows(rel->table) * 2 + 16) == 0 &&
-                    dl_rowset_add_table(&sets[rel_idx], rel->table) < 0)
+                 * leaves the set zeroed and latches set_off, which keeps
+                 * the generic distinct+antijoin path for this relation for
+                 * the rest of the stratum.  The latch matters: an
+                 * unsupported column type cannot change mid-fixpoint, and
+                 * without it every iteration would pay a failed
+                 * init+add_table before falling back anyway. */
+                if (dl_rowset_init(&sets[rel_idx], ray_table_nrows(rel->table) * 2 + 16) < 0 ||
+                    dl_rowset_add_table(&sets[rel_idx], rel->table) < 0) {
                     dl_rowset_free(&sets[rel_idx]);
+                    set_off[rel_idx] = true;
+                }
             }
         }
 
@@ -3520,11 +3540,13 @@ int dl_eval(dl_program_t* prog) {
                     ray_release(rel->table);
                     rel->table = merged;
                 }
-                if (rebuild_set) {
+                if (rebuild_set && !set_off[rel_idx]) {
                     dl_rowset_free(&sets[rel_idx]);
-                    if (dl_rowset_init(&sets[rel_idx], ray_table_nrows(rel->table) * 2 + 16) == 0 &&
-                        dl_rowset_add_table(&sets[rel_idx], rel->table) < 0)
+                    if (dl_rowset_init(&sets[rel_idx], ray_table_nrows(rel->table) * 2 + 16) < 0 ||
+                        dl_rowset_add_table(&sets[rel_idx], rel->table) < 0) {
                         dl_rowset_free(&sets[rel_idx]);
+                        set_off[rel_idx] = true;
+                    }
                 }
             }
 

--- a/src/ops/datalog.h
+++ b/src/ops/datalog.h
@@ -211,6 +211,14 @@ typedef struct {
     int     arity;                  /* number of columns */
     bool    is_idb;                 /* true = derived (intensional) */
     int64_t col_names[DL_MAX_ARITY]; /* interned column name symbols */
+    /* Per-column "may carry a DATOM tag" provenance.  Only values that came
+     * from a datoms `v` column can be tagged, so only those columns are
+     * untagged on output (dl_untag_i64_col in ray_query_fn) -- a plain I64
+     * column of large hashes, or an arithmetic result >= 2^61, must be
+     * returned verbatim.  Seeded in dl_add_edb for the `eav` relation's v
+     * column -- the only EDB column that can hold a tagged value -- and
+     * propagated into IDB head columns by dl_compile_rule's projection. */
+    bool    col_from_v[DL_MAX_ARITY];
     ray_t*  prov_col;               /* provenance column (when DL_FLAG_PROVENANCE) */
     ray_t*  prov_src_offsets;       /* CSR offsets into prov_src_data, length nrows+1 */
     ray_t*  prov_src_data;          /* packed source refs: (rel_idx << 32) | row_idx */

--- a/src/ops/datalog.h
+++ b/src/ops/datalog.h
@@ -433,4 +433,38 @@ typedef struct {
 ray_op_t* dl_compile_rule(dl_program_t* prog, dl_rule_t* rule,
                           const dl_delta_t* delta, int rule_idx, ray_graph_t* g);
 
+/* ===== internal — exposed for tests ===== */
+
+/* Open-addressing set of relation rows, maintained across one stratum's
+ * fixpoint so each iteration probes only the candidate tuples instead of
+ * re-hashing the whole derived relation (table_distinct + table_antijoin).
+ *
+ * `rows[]` are row indices into the relation table the set was built from;
+ * the contract is that accepted delta rows are appended to that table, in
+ * order, immediately after dl_rowset_extract_new returns. */
+typedef struct {
+    ray_t*    hblock;   /* backing allocation for hashes (ray_alloc) */
+    ray_t*    rblock;   /* backing allocation for rows   (ray_alloc) */
+    uint64_t* hashes;   /* 0 = empty slot; a stored hash is always |1 */
+    int64_t*  rows;     /* row index into the owning relation's table */
+    int64_t   cap;      /* power of two */
+    int64_t   n;        /* live entries */
+} dl_rowset_t;
+
+/* Allocate a table sized for `expected_rows` at <=70% load. Returns 0, or
+ * -1 on OOM (the set is left zeroed, i.e. safe to free and unusable). */
+int dl_rowset_init(dl_rowset_t* s, int64_t expected_rows);
+
+/* Release the set's storage and zero it. NULL-safe on an already-freed set. */
+void dl_rowset_free(dl_rowset_t* s);
+
+/* Insert every distinct row of `tbl` with its own row index. Returns 0/-1. */
+int dl_rowset_add_table(dl_rowset_t* s, ray_t* tbl);
+
+/* Rows of `cand` that are neither in the set (whose entries index `full`)
+ * nor earlier duplicates within `cand`, as an owned table in candidate
+ * order; accepted rows enter the set as nrows(full) + k. Caller must append
+ * the result to `full` in order. Returns an owned table or RAY_ERROR. */
+ray_t* dl_rowset_extract_new(dl_rowset_t* s, ray_t* full, ray_t* cand);
+
 #endif /* RAYFORCE_DATALOG_H */

--- a/src/ops/datalog.h
+++ b/src/ops/datalog.h
@@ -423,6 +423,17 @@ int dl_ensure_idb(dl_program_t* prog, const char* name, int arity);
 typedef struct {
     int     pos;    /* index into rule->body[] */
     ray_t*  table;  /* delta table for that position (borrowed) */
+    /* Textbook semi-naive old/new split, indexed by relation index:
+     * the number of rows relation r had at the START of the previous
+     * iteration -- i.e. the length of the prefix of rel->table that is
+     * "old" with respect to this iteration's delta.  Body atoms BEFORE
+     * `pos` read that prefix, the atom at `pos` reads `table`, and atoms
+     * AFTER `pos` read the full relation, so a rule with several
+     * recursive atoms derives delta x delta exactly once instead of once
+     * per recursive position.  -1 means "no prefix known, use the full
+     * relation" (EDBs, relations outside the current stratum); NULL means
+     * the whole array is unavailable (full, non-semi-naive evaluation). */
+    const int64_t* prev_nrows;
 } dl_delta_t;
 
 /* Compile one rule into a ray_graph_t for one fixpoint iteration.

--- a/src/ops/datalog.h
+++ b/src/ops/datalog.h
@@ -61,6 +61,12 @@
 
 #define DL_AGG_MAX_KEYS 8
 
+/* Fixpoint iteration cap for strata whose rules can manufacture new values
+ * (DL_ASSIGN / DL_BUILTIN / DL_INTERVAL literals) and therefore are not
+ * guaranteed to terminate over a finite domain. Purely relational
+ * (monotone) strata run uncapped -- see dl_eval in datalog.c. */
+#define DL_MAX_ITER_NONMONOTONE 1000
+
 /* ===== Assignment operators (for DL_ASSIGN) ===== */
 #define DL_OP_EQ    0   /* simple assignment: X = expr */
 

--- a/src/ops/datalog.h
+++ b/src/ops/datalog.h
@@ -464,7 +464,12 @@ int dl_rowset_add_table(dl_rowset_t* s, ray_t* tbl);
 /* Rows of `cand` that are neither in the set (whose entries index `full`)
  * nor earlier duplicates within `cand`, as an owned table in candidate
  * order; accepted rows enter the set as nrows(full) + k. Caller must append
- * the result to `full` in order. Returns an owned table or RAY_ERROR. */
+ * the result to `full` in order. Returns an owned table or RAY_ERROR.
+ *
+ * Rows are compared as raw cell keys, so the caller MUST first establish
+ * that `full` and `cand` agree column-wise on type and — for SYM — on
+ * resolution domain; dl_eval does this with dl_rowset_comparable() and
+ * falls back to table_distinct + table_antijoin when they do not. */
 ray_t* dl_rowset_extract_new(dl_rowset_t* s, ray_t* full, ray_t* cand);
 
 #endif /* RAYFORCE_DATALOG_H */

--- a/src/table/table.c
+++ b/src/table/table.c
@@ -23,6 +23,7 @@
 
 #include "table.h"
 #include "mem/heap.h"
+#include "mem/cow.h"    /* ray_rc_sync */
 #include "ops/ops.h"
 #include "lang/format.h"
 #include <string.h>
@@ -233,6 +234,26 @@ void ray_table_set_col_idx(ray_t* tbl, int64_t idx, ray_t* col_vec) {
     ray_retain(col_vec);
     ray_release(cv[idx]);
     cv[idx] = col_vec;
+}
+
+/* --------------------------------------------------------------------------
+ * ray_table_cols_mut — borrowed slot array of the column list, but only when
+ * the table block and that list are both uniquely owned (rc == 1, not arena
+ * backed).  NULL otherwise, so a caller can never mutate a list another table
+ * still sees.  Unlike ray_table_set_col_idx this hands out the raw slots: it
+ * is for in-place column growth, where ray_vec_append_raw may realloc (and
+ * free) the old column block and the slot must simply be overwritten with the
+ * new pointer — releasing the previous one would touch freed memory.
+ * -------------------------------------------------------------------------- */
+
+ray_t** ray_table_cols_mut(ray_t* tbl) {
+    if (!tbl || RAY_IS_ERR(tbl) || tbl->type != RAY_TABLE) return NULL;
+    if (tbl->attrs & RAY_ATTR_ARENA) return NULL;
+    if ((RAY_LIKELY(!ray_rc_sync) ? tbl->rc : ray_atomic_load(&tbl->rc)) != 1) return NULL;
+    ray_t* cols = tbl_cols(tbl);
+    if (!cols || RAY_IS_ERR(cols) || (cols->attrs & RAY_ATTR_ARENA)) return NULL;
+    if ((RAY_LIKELY(!ray_rc_sync) ? cols->rc : ray_atomic_load(&cols->rc)) != 1) return NULL;
+    return (ray_t**)ray_data(cols);
 }
 
 /* --------------------------------------------------------------------------

--- a/src/table/table.h
+++ b/src/table/table.h
@@ -37,4 +37,10 @@
 
 int64_t ray_parted_nrows(ray_t* parted_col);
 
+/* Borrowed column-slot array of `tbl`, or NULL unless the table block and its
+ * column list are both uniquely owned.  For in-place column growth: the caller
+ * overwrites a slot with a column it grew (and thus owns); the previous
+ * pointer must NOT be released — a reallocating append already freed it. */
+ray_t** ray_table_cols_mut(ray_t* tbl);
+
 #endif /* RAY_TABLE_H */

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -125,6 +125,29 @@
 (count (query handbuilt (find ?e) (where (?e :name 'Alice)))) -- 1
 (sym-name (at (at (query handbuilt (find ?v) (where (1 :name ?v))) '?v) 0)) -- 'Alice
 
+;; Final review #9: `eav` is the built-in datoms relation; a rule may not
+;; derive into it.
+(rule (eav ?x ?y ?z) (?x :edge ?y)) !- domain
+
+;; Final review #5: only values that can have come from a datoms `v` column
+;; are untagged on output.  A plain I64 EDB column holding 2^61 / 2^62 --
+;; whose top bits look like a DATOM tag -- must come back verbatim.
+(set big (table [big__c0] (list [2305843009213693952 4611686018427387904])))
+(count (query g (find ?x) (where (big ?x)))) -- 2
+(at (at (query g (find ?x) (where (big ?x))) '?x) 0) -- 2305843009213693952
+(at (at (query g (find ?x) (where (big ?x))) '?x) 1) -- 4611686018427387904
+
+(query g (find ?x) (where (?x :edge ?y) (> (+ ?x 1) "z"))) !- type
+;; (the no-leak side of this is test_datalog.c's rule_expr_error_paths_no_leak:
+;;  `try` itself leaks ~64 bytes per caught error, which would swamp the
+;;  bytes-allocated technique used in §2.1 above.)
+
+;; Final review #3: a stale global rule naming an unbound relation only
+;; fails the queries that actually use it.
+(rule (stale ?x) (nosuchtable ?x))
+(count (query g (find ?x ?y) (where (lin ?x ?y)))) -- 28
+(query g (find ?x) (where (stale ?x))) !- domain
+
 ;; §4 pure Datalog is never cut off by an iteration cap.
 (set longedge (table [longedge__c0 longedge__c1] (list (til 1100) (+ 1 (til 1100)))))
 (rule (reach ?y) (longedge 0 ?y))

--- a/test/rfl/datalog/audit_regressions.rfl
+++ b/test/rfl/datalog/audit_regressions.rfl
@@ -124,3 +124,13 @@
 (set handbuilt (table ['e 'a 'v] (list [1 2] ['name 'name] ['Alice 'Bob])))
 (count (query handbuilt (find ?e) (where (?e :name 'Alice)))) -- 1
 (sym-name (at (at (query handbuilt (find ?v) (where (1 :name ?v))) '?v) 0)) -- 'Alice
+
+;; §4 pure Datalog is never cut off by an iteration cap.
+(set longedge (table [longedge__c0 longedge__c1] (list (til 1100) (+ 1 (til 1100)))))
+(rule (reach ?y) (longedge 0 ?y))
+(rule (reach ?z) (reach ?y) (longedge ?y ?z))
+(count (query g (find ?y) (where (reach ?y)))) -- 1100
+;; ... but a rule that manufactures new integers forever is still stopped.
+(rule (nat ?x) (longedge 0 ?x))
+(rule (nat ?y) (nat ?x) (= ?y (+ ?x 1)))
+(query g (find ?x) (where (nat ?x))) !- domain

--- a/test/rfl/datalog/datalog_coverage.rfl
+++ b/test/rfl/datalog/datalog_coverage.rfl
@@ -569,15 +569,22 @@
 
 
 ;; --- Claim 4: fixpoint non-convergence must error loudly, not return a partial result ---
-;; Reachability over a linear chain needs ~N iterations. The loop caps at 1000.
+;; Reachability over a linear chain needs ~N iterations. Pure relational
+;; (monotone) strata run uncapped as of Task 11 -- see
+;; docs/superpowers/specs/2026-09-08-datalog-audit.md §4 -- so this always
+;; converges to the correct count regardless of chain length; the
+;; 1000-iteration cap now applies only to strata with assignment/builtin/
+;; interval literals (see test/rfl/datalog/audit_regressions.rfl §4 for that
+;; non-convergence case).
 (set DbF (datoms))
 (set seedF (table ['n] (list [0])))
-;; 500-edge chain converges (~500 iters < 1000) -> correct count.
+;; 500-edge chain converges (~500 iters) -> correct count.
 (set edge500 (table ['from 'to] (list (til 500) (+ (til 500) 1))))
 (count (query DbF (find ?y) (where (reachA ?y)) (rules ((reachA ?y) (seedF ?x) (edge500 ?x ?y)) ((reachA ?y) (reachA ?x) (edge500 ?x ?y))))) -- 500
-;; 1100-edge chain needs >1000 iters -> non-convergence -> loud error (was silent partial).
+;; 1100-edge chain (>1000 iters -- would have hit the old blanket cap) ->
+;; still converges correctly now that the cap only guards non-monotone strata.
 (set edge1100 (table ['from 'to] (list (til 1100) (+ (til 1100) 1))))
-(query DbF (find ?y) (where (reachB ?y)) (rules ((reachB ?y) (seedF ?x) (edge1100 ?x ?y)) ((reachB ?y) (reachB ?x) (edge1100 ?x ?y)))) !- domain
+(count (query DbF (find ?y) (where (reachB ?y)) (rules ((reachB ?y) (seedF ?x) (edge1100 ?x ?y)) ((reachB ?y) (reachB ?x) (edge1100 ?x ?y))))) -- 1100
 
 ;; --- Claim 7: repeated-variable self-join (?x :edge ?x) returns only self-loops ---
 ;; Verified-correct behavior (review flagged as possibly asymmetric; it is not).

--- a/test/test_datalog.c
+++ b/test/test_datalog.c
@@ -2052,6 +2052,33 @@ static test_result_t test_query_admission_errors(void) {
     PASS();
 }
 
+/* Task 11: a stratum with an assignment literal can manufacture new values
+ * forever, so it keeps the DL_MAX_ITER_NONMONOTONE cap and must report the
+ * specific "fixpoint did not converge" message (not just a generic
+ * "evaluation failed") when it hits that cap. One row grows by exactly one
+ * new integer per iteration, so 1000 iterations finish quickly even under
+ * ASan. */
+static test_result_t test_fixpoint_nonconvergence_message(void) {
+    ray_t* seed = ray_eval_str(
+        "(do (set __fnm_db (datoms)) (set __fnm_db (assert-fact __fnm_db 0 'edge 1)))");
+    TEST_ASSERT_NOT_NULL(seed);
+    TEST_ASSERT_TRUE(!RAY_IS_ERR(seed));
+    ray_release(seed);
+
+    ray_t* r = ray_eval_str(
+        "(query __fnm_db (find ?x) (where (nat ?x)) "
+        "  (rules ((nat ?x) (?x :edge ?y)) "
+        "         ((nat ?y) (nat ?x) (= ?y (+ ?x 1)))))");
+    TEST_ASSERT_NOT_NULL(r);
+    TEST_ASSERT_TRUE(RAY_IS_ERR(r));
+    const char* msg = ray_error_msg();
+    TEST_ASSERT_NOT_NULL(msg);
+    TEST_ASSERT_TRUE(strstr(msg, "fixpoint did not converge") != NULL);
+    ray_error_free(r);
+
+    PASS();
+}
+
 /* ray_release() is a deliberate no-op for RAY_ERROR objects, so callers
  * that claim to be "releasing" an error under the refcount API actually
  * leak the block.  ray_error_free() is the escape hatch that calls
@@ -2759,6 +2786,7 @@ const test_entry_t datalog_entries[] = {
     { "datalog/env_bound_agg_auto_register", test_env_bound_agg_auto_register, datalog_rf_setup, datalog_rf_teardown },
     { "datalog/eval_surfaces_compile_failure", test_eval_surfaces_compile_failure, datalog_rf_setup, datalog_rf_teardown },
     { "datalog/query_admission_errors", test_query_admission_errors, datalog_rf_setup, datalog_rf_teardown },
+    { "datalog/fixpoint_nonconvergence_message", test_fixpoint_nonconvergence_message, datalog_rf_setup, datalog_rf_teardown },
     { "datalog/error_free_reclaims", test_error_free_reclaims, datalog_rf_setup, datalog_rf_teardown },
     { "datalog/agg_scalar_f64", test_agg_scalar_f64, datalog_setup, datalog_teardown },
     { "datalog/agg_scalar_f64_sum_empty", test_agg_scalar_f64_sum_empty, datalog_setup, datalog_teardown },

--- a/test/test_datalog.c
+++ b/test/test_datalog.c
@@ -2737,6 +2737,81 @@ static test_result_t test_rule_expr_ownership(void) {
     PASS();
 }
 
+/* ===== dl_rowset_t: incremental row set (Task 12) ===== */
+
+/* Candidate rows are deduped against the existing relation AND among
+ * themselves, in first-occurrence order. */
+static test_result_t test_rowset_extract_new(void) {
+    int64_t a0[] = {1, 2, 3}, a1[] = {10, 20, 30};
+    ray_t* fa = ray_table_new(2);
+    fa = ray_table_add_col(fa, ray_sym_intern("x", 1), ray_vec_from_raw(RAY_I64, a0, 3));
+    fa = ray_table_add_col(fa, ray_sym_intern("y", 1), ray_vec_from_raw(RAY_I64, a1, 3));
+    int64_t c0[] = {2, 4, 4, 3}, c1[] = {20, 40, 40, 31};   /* (2,20) dup of full; (4,40) twice; (3,31) new */
+    ray_t* ca = ray_table_new(2);
+    ca = ray_table_add_col(ca, ray_sym_intern("x", 1), ray_vec_from_raw(RAY_I64, c0, 4));
+    ca = ray_table_add_col(ca, ray_sym_intern("y", 1), ray_vec_from_raw(RAY_I64, c1, 4));
+
+    dl_rowset_t s;
+    TEST_ASSERT_EQ_I(dl_rowset_init(&s, 4), 0);
+    TEST_ASSERT_EQ_I(dl_rowset_add_table(&s, fa), 0);
+    TEST_ASSERT_EQ_I((int)s.n, 3);
+    ray_t* delta = dl_rowset_extract_new(&s, fa, ca);
+    TEST_ASSERT_NOT_NULL(delta);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(delta));
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(delta), 2);
+    TEST_ASSERT_EQ_I((int)s.n, 5);
+    int64_t* dx = (int64_t*)ray_data(ray_table_get_col_idx(delta, 0));
+    TEST_ASSERT_EQ_I((int)dx[0], 4);
+    TEST_ASSERT_EQ_I((int)dx[1], 3);
+    ray_release(delta); dl_rowset_free(&s);
+    ray_release(fa); ray_release(ca);
+    PASS();
+}
+
+/* SYM columns: the two tables' sym vectors are built independently and at
+ * different adaptive widths (W64 vs W8).  Both resolve against the runtime
+ * domain, so equal symbols carry equal ids and must dedupe -- this is the
+ * property dl_rowset_comparable() guards before the fast path is taken. */
+static test_result_t test_rowset_extract_new_sym(void) {
+    int64_t sa = ray_sym_intern("alpha", 5);
+    int64_t sb = ray_sym_intern("beta", 4);
+    int64_t sc = ray_sym_intern("gamma", 5);
+
+    ray_t* fcol = ray_sym_vec_new(RAY_SYM_W64, 2);
+    TEST_ASSERT_NOT_NULL(fcol);
+    fcol->len = 2;
+    ray_write_sym(ray_data(fcol), 0, (uint64_t)sa, fcol->type, fcol->attrs);
+    ray_write_sym(ray_data(fcol), 1, (uint64_t)sb, fcol->type, fcol->attrs);
+    ray_t* full = ray_table_new(1);
+    full = ray_table_add_col(full, ray_sym_intern("s", 1), fcol);
+
+    /* Independently built, narrower storage, same runtime domain. */
+    ray_t* ccol = ray_sym_vec_new(RAY_SYM_W8, 3);
+    TEST_ASSERT_NOT_NULL(ccol);
+    ccol->len = 3;
+    ray_write_sym(ray_data(ccol), 0, (uint64_t)sb, ccol->type, ccol->attrs);   /* dup of full */
+    ray_write_sym(ray_data(ccol), 1, (uint64_t)sc, ccol->type, ccol->attrs);   /* new */
+    ray_write_sym(ray_data(ccol), 2, (uint64_t)sc, ccol->type, ccol->attrs);   /* dup within cand */
+    ray_t* cand = ray_table_new(1);
+    cand = ray_table_add_col(cand, ray_sym_intern("s", 1), ccol);
+
+    dl_rowset_t s;
+    TEST_ASSERT_EQ_I(dl_rowset_init(&s, 2), 0);
+    TEST_ASSERT_EQ_I(dl_rowset_add_table(&s, full), 0);
+    TEST_ASSERT_EQ_I((int)s.n, 2);
+    ray_t* delta = dl_rowset_extract_new(&s, full, cand);
+    TEST_ASSERT_NOT_NULL(delta);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(delta));
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(delta), 1);
+    TEST_ASSERT_EQ_I((int)s.n, 3);
+    ray_t* dcol = ray_table_get_col_idx(delta, 0);
+    TEST_ASSERT_EQ_I((int)ray_read_sym(ray_data(dcol), 0, dcol->type, dcol->attrs), (int)sc);
+    ray_release(delta); dl_rowset_free(&s);
+    ray_release(full); ray_release(cand);
+    ray_release(fcol); ray_release(ccol);
+    PASS();
+}
+
 const test_entry_t datalog_entries[] = {
     { "datalog/source_provenance", test_source_provenance, datalog_setup, datalog_teardown },
     { "datalog/source_prov_requires_flag", test_source_prov_requires_flag, datalog_setup, datalog_teardown },
@@ -2807,6 +2882,8 @@ const test_entry_t datalog_entries[] = {
     { "datalog/nonlinear_closure_chain", test_nonlinear_closure_chain, datalog_setup, datalog_teardown },
     { "datalog/const_filter_f64_column", test_const_filter_f64_column, datalog_setup, datalog_teardown },
     { "datalog/rule_expr_ownership", test_rule_expr_ownership, datalog_setup, datalog_teardown },
+    { "datalog/rowset_extract_new", test_rowset_extract_new, datalog_setup, datalog_teardown },
+    { "datalog/rowset_extract_new_sym", test_rowset_extract_new_sym, datalog_setup, datalog_teardown },
     { NULL, NULL, NULL, NULL },
 };
 

--- a/test/test_datalog.c
+++ b/test/test_datalog.c
@@ -2405,6 +2405,142 @@ static test_result_t test_builtin_abs(void) {
     PASS();
 }
 
+/* Audit final review #2: a rule clause whose expression tree is built but
+ * then rejected must free that tree.  Three shapes:
+ *   - a comparison where one operand parses and the other does not,
+ *   - a comparison at DL_MAX_BODY capacity (dl_rule_add_cmp_expr fails),
+ *   - an assignment at DL_MAX_BODY capacity (dl_rule_add_assign fails).
+ *   - a nested arithmetic expression whose inner operand parses and whose
+ *     outer one does not (dl_build_expr's own binop path).
+ * Each leaked one or more dl_expr_t blocks before the fix, so live bytes
+ * climbed linearly with the repetition count.  (The equivalent RFL check is
+ * not possible: catching the error with `try` leaks ~64 bytes per call on
+ * its own, unrelated to datalog.) */
+static test_result_t test_rule_expr_error_paths_no_leak(void) {
+    /* 16 body atoms == DL_MAX_BODY, so the 17th clause is always rejected. */
+    #define SIXTEEN "(a ?x) (a ?x) (a ?x) (a ?x) (a ?x) (a ?x) (a ?x) (a ?x) " \
+                    "(a ?x) (a ?x) (a ?x) (a ?x) (a ?x) (a ?x) (a ?x) (a ?x) "
+    static const char* const srcs[] = {
+        "(rule (q ?x) (a ?x) (> (+ ?x 1) \"z\"))",
+        "(rule (q ?y) (a ?x) (= ?y (+ (+ ?x 1) \"z\")))",
+        "(rule (q ?x) " SIXTEEN "(> (+ ?x 1) (* ?x 2)))",
+        "(rule (q ?y) " SIXTEEN "(= ?y (+ ?x 1)))",
+    };
+    #undef SIXTEEN
+    const int n_srcs = (int)(sizeof(srcs) / sizeof(srcs[0]));
+
+    /* Warm up: the first evaluation of each form interns symbols and grows
+     * parser-side caches, which is a one-off cost, not a leak. */
+    for (int i = 0; i < n_srcs; i++)
+        for (int w = 0; w < 4; w++) {
+            ray_t* e = ray_eval_str(srcs[i]);
+            TEST_ASSERT_NOT_NULL(e);
+            TEST_ASSERT_TRUE(RAY_IS_ERR(e));
+            ray_error_free(e);
+        }
+
+    ray_mem_stats_t before, after;
+    ray_mem_stats(&before);
+    for (int it = 0; it < 200; it++)
+        for (int i = 0; i < n_srcs; i++) {
+            ray_t* e = ray_eval_str(srcs[i]);
+            TEST_ASSERT_TRUE(e && RAY_IS_ERR(e));
+            ray_error_free(e);
+        }
+    ray_mem_stats(&after);
+
+    TEST_ASSERT((after.bytes_allocated) <= (before.bytes_allocated),
+                "rejected rule clauses free their expression trees");
+    PASS();
+}
+
+/* Audit final review #4: dl_builtin_duration_since must not compute a
+ * signed overflow (UB).  T2 = INT64_MAX, T1 = -1 overflows, and a NULL_I64
+ * operand poisons the result; both yield the I64 null. */
+static test_result_t test_builtin_duration_since_overflow(void) {
+    /* One row only: a key column holding two values this far apart makes
+     * the group-by engine's (max - min + 1) range computation overflow,
+     * which is a separate, pre-existing issue not under test here. */
+    int64_t t1_vals[] = { -1 };
+    int64_t t2_vals[] = { INT64_MAX };
+    ray_t* c1 = ray_vec_from_raw(RAY_I64, t1_vals, 1);
+    ray_t* c2 = ray_vec_from_raw(RAY_I64, t2_vals, 1);
+    ray_t* span = ray_table_new(2);
+    span = ray_table_add_col(span, ray_sym_intern("span__c0", 8), c1);
+    span = ray_table_add_col(span, ray_sym_intern("span__c1", 8), c2);
+
+    dl_program_t* prog = dl_program_new();
+    TEST_ASSERT_EQ_I(dl_add_edb(prog, "span", span, 2), 0);
+
+    dl_rule_t r;
+    dl_rule_init(&r, "dur", 3);
+    dl_rule_head_var(&r, 0, 0);
+    dl_rule_head_var(&r, 1, 1);
+    dl_rule_head_var(&r, 2, 2);
+    int body = dl_rule_add_atom(&r, "span", 2);
+    dl_body_set_var(&r, body, 0, 0);
+    dl_body_set_var(&r, body, 1, 1);
+    int bi = dl_rule_add_builtin(&r, DL_BUILTIN_DURATION_SINCE, 3);
+    TEST_ASSERT((bi) >= (0), "bi >= 0");
+    dl_body_set_var(&r, bi, 0, 0);
+    dl_body_set_var(&r, bi, 1, 1);
+    dl_body_set_var(&r, bi, 2, 2);
+    r.n_vars = 3;
+    TEST_ASSERT_EQ_I(dl_add_rule(prog, &r), 0);
+    TEST_ASSERT_EQ_I(dl_eval(prog), 0);
+
+    ray_t* out = dl_query(prog, "dur");
+    TEST_ASSERT_NOT_NULL(out);
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(out), 1);
+    ray_t* dcol = ray_table_get_col_idx(out, 2);
+    TEST_ASSERT_NOT_NULL(dcol);
+    int64_t* dd = (int64_t*)ray_data(dcol);
+    TEST_ASSERT(dd[0] == NULL_I64, "INT64_MAX - (-1) is the I64 null");
+
+    dl_program_free(prog);
+    ray_release(span); ray_release(c1); ray_release(c2);
+    PASS();
+}
+
+/* Audit final review #4: -INT64_MIN is not representable, so dl_builtin_abs
+ * must yield the I64 null there instead of negating (UB). */
+static test_result_t test_builtin_abs_int64_min(void) {
+    /* One row only — see the note in the duration_since test above. */
+    int64_t vals[] = { INT64_MIN };
+    ray_t* col = ray_vec_from_raw(RAY_I64, vals, 1);
+    ray_t* signed_t = ray_table_new(1);
+    signed_t = ray_table_add_col(signed_t, ray_sym_intern("signed__c0", 10), col);
+
+    dl_program_t* prog = dl_program_new();
+    TEST_ASSERT_EQ_I(dl_add_edb(prog, "signed", signed_t, 1), 0);
+
+    dl_rule_t r;
+    dl_rule_init(&r, "pos", 2);
+    dl_rule_head_var(&r, 0, 0);
+    dl_rule_head_var(&r, 1, 1);
+    int body = dl_rule_add_atom(&r, "signed", 1);
+    dl_body_set_var(&r, body, 0, 0);
+    int bi = dl_rule_add_builtin(&r, DL_BUILTIN_ABS, 2);
+    TEST_ASSERT((bi) >= (0), "bi >= 0");
+    dl_body_set_var(&r, bi, 0, 0);
+    dl_body_set_var(&r, bi, 1, 1);
+    r.n_vars = 2;
+    TEST_ASSERT_EQ_I(dl_add_rule(prog, &r), 0);
+    TEST_ASSERT_EQ_I(dl_eval(prog), 0);
+
+    ray_t* out = dl_query(prog, "pos");
+    TEST_ASSERT_NOT_NULL(out);
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(out), 1);
+    ray_t* ycol = ray_table_get_col_idx(out, 1);
+    TEST_ASSERT_NOT_NULL(ycol);
+    int64_t* yd = (int64_t*)ray_data(ycol);
+    TEST_ASSERT(yd[0] == NULL_I64, "|INT64_MIN| is the I64 null");
+
+    dl_program_free(prog);
+    ray_release(signed_t); ray_release(col);
+    PASS();
+}
+
 /* dl_rule_add_builtin guard: returning -1 when n_body has reached
  * DL_MAX_BODY.  Saturate the body literals first, then the next
  * builtin add must report -1. */
@@ -3100,6 +3236,9 @@ const test_entry_t datalog_entries[] = {
     { "datalog/builtin_before_empty", test_builtin_before_empty, datalog_setup, datalog_teardown },
     { "datalog/builtin_duration_since", test_builtin_duration_since, datalog_setup, datalog_teardown },
     { "datalog/builtin_abs", test_builtin_abs, datalog_setup, datalog_teardown },
+    { "datalog/rule_expr_error_paths_no_leak", test_rule_expr_error_paths_no_leak, datalog_rf_setup, datalog_rf_teardown },
+    { "datalog/builtin_duration_since_overflow", test_builtin_duration_since_overflow, datalog_setup, datalog_teardown },
+    { "datalog/builtin_abs_int64_min", test_builtin_abs_int64_min, datalog_setup, datalog_teardown },
     { "datalog/rule_add_builtin_overflow", test_rule_add_builtin_overflow, datalog_setup, datalog_teardown },
     { "datalog/rule_add_interval", test_rule_add_interval, datalog_setup, datalog_teardown },
     { "datalog/rule_add_interval_overflow", test_rule_add_interval_overflow, datalog_setup, datalog_teardown },

--- a/test/test_datalog.c
+++ b/test/test_datalog.c
@@ -2812,6 +2812,175 @@ static test_result_t test_rowset_extract_new_sym(void) {
     PASS();
 }
 
+/* F64 row identity must fold exactly as the engine's distinct does
+ * (canon_f64_key / group.c): -0.0 keys as +0.0 and every NaN payload as one
+ * canonical NaN.  If it did not, an IDB with an F64 column would give
+ * different answers depending on whether an iteration went through the row
+ * set or through the vectorised table_distinct in front of it. */
+static test_result_t test_rowset_f64_canonical_keys(void) {
+    int64_t k0[] = {1};
+    double  v0[] = {0.0};                      /* relation holds (1, +0.0) */
+    ray_t* full = ray_table_new(2);
+    full = ray_table_add_col(full, ray_sym_intern("k", 1), ray_vec_from_raw(RAY_I64, k0, 1));
+    full = ray_table_add_col(full, ray_sym_intern("v", 1), ray_vec_from_raw(RAY_F64, v0, 1));
+
+    /* Two NaNs with different payloads, built by punning so the bit
+     * patterns really do differ. */
+    uint64_t nan_a_bits = 0x7FF8000000000001ULL;
+    uint64_t nan_b_bits = 0x7FF8000000000002ULL;
+    double nan_a, nan_b;
+    memcpy(&nan_a, &nan_a_bits, sizeof(nan_a));
+    memcpy(&nan_b, &nan_b_bits, sizeof(nan_b));
+    TEST_ASSERT_TRUE(nan_a != nan_a);
+    TEST_ASSERT_TRUE(nan_b != nan_b);
+
+    int64_t k1[] = {1, 1, 1};
+    double  v1[] = {-0.0, 0.0, 0.0};
+    ray_t* cand = ray_table_new(2);
+    cand = ray_table_add_col(cand, ray_sym_intern("k", 1), ray_vec_from_raw(RAY_I64, k1, 3));
+    ray_t* cv = ray_vec_from_raw(RAY_F64, v1, 3);
+    ((double*)ray_data(cv))[1] = nan_a;
+    ((double*)ray_data(cv))[2] = nan_b;
+    cand = ray_table_add_col(cand, ray_sym_intern("v", 1), cv);
+
+    dl_rowset_t s;
+    TEST_ASSERT_EQ_I(dl_rowset_init(&s, 4), 0);
+    TEST_ASSERT_EQ_I(dl_rowset_add_table(&s, full), 0);
+    TEST_ASSERT_EQ_I((int)s.n, 1);
+
+    /* (1,-0.0) folds onto the stored (1,+0.0); the two NaNs fold onto each
+     * other, so exactly one new row survives. */
+    ray_t* delta = dl_rowset_extract_new(&s, full, cand);
+    TEST_ASSERT_NOT_NULL(delta);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(delta));
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(delta), 1);
+    TEST_ASSERT_EQ_I((int)s.n, 2);
+    double dv = ((double*)ray_data(ray_table_get_col_idx(delta, 1)))[0];
+    TEST_ASSERT_TRUE(dv != dv);   /* the surviving row is the NaN one */
+
+    ray_release(delta); dl_rowset_free(&s);
+    ray_release(full); ray_release(cand); ray_release(cv);
+    PASS();
+}
+
+/* The fallback path in dl_eval rebuilds the set from the merged relation
+ * (free + init + add_table) after a distinct/antijoin iteration, because
+ * ray_vec_concat may have re-expressed SYM cells.  Exercise that exact
+ * sequence: entries seeded from A must be discarded and re-derived against
+ * A-union-B, and a later extraction must reject candidates matching rows
+ * from either half. */
+static test_result_t test_rowset_rebuild_after_fallback(void) {
+    int64_t a0[] = {1, 2}, a1[] = {10, 20};
+    ray_t* ta = ray_table_new(2);
+    ta = ray_table_add_col(ta, ray_sym_intern("x", 1), ray_vec_from_raw(RAY_I64, a0, 2));
+    ta = ray_table_add_col(ta, ray_sym_intern("y", 1), ray_vec_from_raw(RAY_I64, a1, 2));
+
+    dl_rowset_t s;
+    TEST_ASSERT_EQ_I(dl_rowset_init(&s, 2), 0);
+    TEST_ASSERT_EQ_I(dl_rowset_add_table(&s, ta), 0);
+    TEST_ASSERT_EQ_I((int)s.n, 2);
+
+    /* An iteration took the generic path and appended B to the relation. */
+    int64_t m0[] = {1, 2, 3, 4}, m1[] = {10, 20, 30, 40};
+    ray_t* merged = ray_table_new(2);
+    merged = ray_table_add_col(merged, ray_sym_intern("x", 1), ray_vec_from_raw(RAY_I64, m0, 4));
+    merged = ray_table_add_col(merged, ray_sym_intern("y", 1), ray_vec_from_raw(RAY_I64, m1, 4));
+
+    dl_rowset_free(&s);
+    TEST_ASSERT_EQ_I((int)s.cap, 0);
+    TEST_ASSERT_EQ_I(dl_rowset_init(&s, 4), 0);
+    TEST_ASSERT_EQ_I(dl_rowset_add_table(&s, merged), 0);
+    TEST_ASSERT_EQ_I((int)s.n, 4);
+
+    /* Candidates overlapping the A half (1,10), the B half (4,40), a repeat
+     * of the B half, and one genuinely new row. */
+    int64_t c0[] = {1, 4, 4, 5}, c1[] = {10, 40, 40, 50};
+    ray_t* cand = ray_table_new(2);
+    cand = ray_table_add_col(cand, ray_sym_intern("x", 1), ray_vec_from_raw(RAY_I64, c0, 4));
+    cand = ray_table_add_col(cand, ray_sym_intern("y", 1), ray_vec_from_raw(RAY_I64, c1, 4));
+
+    ray_t* delta = dl_rowset_extract_new(&s, merged, cand);
+    TEST_ASSERT_NOT_NULL(delta);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(delta));
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(delta), 1);
+    TEST_ASSERT_EQ_I((int)s.n, 5);
+    TEST_ASSERT_EQ_I((int)((int64_t*)ray_data(ray_table_get_col_idx(delta, 0)))[0], 5);
+    TEST_ASSERT_EQ_I((int)((int64_t*)ray_data(ray_table_get_col_idx(delta, 1)))[0], 50);
+
+    /* The new row was recorded at index nrows(merged) + 0, so re-offering it
+     * against the once-more-extended relation must still be rejected. */
+    int64_t u0[] = {1, 2, 3, 4, 5}, u1[] = {10, 20, 30, 40, 50};
+    ray_t* merged2 = ray_table_new(2);
+    merged2 = ray_table_add_col(merged2, ray_sym_intern("x", 1), ray_vec_from_raw(RAY_I64, u0, 5));
+    merged2 = ray_table_add_col(merged2, ray_sym_intern("y", 1), ray_vec_from_raw(RAY_I64, u1, 5));
+    ray_t* delta2 = dl_rowset_extract_new(&s, merged2, cand);
+    TEST_ASSERT_NOT_NULL(delta2);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(delta2));
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(delta2), 0);
+    TEST_ASSERT_EQ_I((int)s.n, 5);
+
+    ray_release(delta); ray_release(delta2); dl_rowset_free(&s);
+    ray_release(ta); ray_release(merged); ray_release(merged2); ray_release(cand);
+    PASS();
+}
+
+/* dl_eval's fallback branch, end to end: an IDB whose columns are RAY_STR
+ * cannot be keyed by the row set (dl_cell_key reads only I64/SYM/F64), so
+ * seeding fails, `set_off` latches, and the whole stratum runs on
+ * table_distinct + table_antijoin.  The closure must still come out right.
+ * Recursion is required — a non-recursive rule never reaches the merge
+ * block this guards. */
+static test_result_t test_rowset_fallback_unsupported_coltype(void) {
+    static const char* const froms[] = {"a", "b", "c"};
+    static const char* const tos[]   = {"b", "c", "d"};
+    const uint32_t lens[] = {1, 1, 1};
+    ray_t* fc = ray_str_vec_from_parts(froms, lens, NULL, 3);
+    ray_t* tc_col = ray_str_vec_from_parts(tos, lens, NULL, 3);
+    TEST_ASSERT_NOT_NULL(fc);
+    TEST_ASSERT_NOT_NULL(tc_col);
+    TEST_ASSERT_EQ_I(fc->type, RAY_STR);
+
+    ray_t* edge = ray_table_new(2);
+    edge = ray_table_add_col(edge, ray_sym_intern("edge__c0", 8), fc);
+    edge = ray_table_add_col(edge, ray_sym_intern("edge__c1", 8), tc_col);
+
+    dl_program_t* prog = dl_program_new();
+    TEST_ASSERT_TRUE(dl_add_edb(prog, "edge", edge, 2) >= 0);
+
+    /* tc(?x, ?y) :- (edge ?x ?y) */
+    dl_rule_t base; dl_rule_init(&base, "tc", 2);
+    dl_rule_head_var(&base, 0, 0);
+    dl_rule_head_var(&base, 1, 1);
+    int b0 = dl_rule_add_atom(&base, "edge", 2);
+    dl_body_set_var(&base, b0, 0, 0);
+    dl_body_set_var(&base, b0, 1, 1);
+    base.n_vars = 2;
+    dl_add_rule(prog, &base);
+
+    /* tc(?x, ?z) :- (edge ?x ?y) (tc ?y ?z) */
+    dl_rule_t rec; dl_rule_init(&rec, "tc", 2);
+    dl_rule_head_var(&rec, 0, 0);
+    dl_rule_head_var(&rec, 1, 2);
+    int r0 = dl_rule_add_atom(&rec, "edge", 2);
+    dl_body_set_var(&rec, r0, 0, 0);
+    dl_body_set_var(&rec, r0, 1, 1);
+    int r1 = dl_rule_add_atom(&rec, "tc", 2);
+    dl_body_set_var(&rec, r1, 0, 1);
+    dl_body_set_var(&rec, r1, 1, 2);
+    rec.n_vars = 3;
+    dl_add_rule(prog, &rec);
+
+    TEST_ASSERT_EQ_I(dl_eval(prog), 0);
+    ray_t* out = dl_query(prog, "tc");
+    TEST_ASSERT_NOT_NULL(out);
+    /* a->b,c,d  b->c,d  c->d */
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(out), 6);
+
+    dl_program_free(prog);
+    ray_release(edge); ray_release(fc); ray_release(tc_col);
+    PASS();
+}
+
 const test_entry_t datalog_entries[] = {
     { "datalog/source_provenance", test_source_provenance, datalog_setup, datalog_teardown },
     { "datalog/source_prov_requires_flag", test_source_prov_requires_flag, datalog_setup, datalog_teardown },
@@ -2884,6 +3053,9 @@ const test_entry_t datalog_entries[] = {
     { "datalog/rule_expr_ownership", test_rule_expr_ownership, datalog_setup, datalog_teardown },
     { "datalog/rowset_extract_new", test_rowset_extract_new, datalog_setup, datalog_teardown },
     { "datalog/rowset_extract_new_sym", test_rowset_extract_new_sym, datalog_setup, datalog_teardown },
+    { "datalog/rowset_f64_canonical_keys", test_rowset_f64_canonical_keys, datalog_setup, datalog_teardown },
+    { "datalog/rowset_rebuild_after_fallback", test_rowset_rebuild_after_fallback, datalog_setup, datalog_teardown },
+    { "datalog/rowset_fallback_unsupported_coltype", test_rowset_fallback_unsupported_coltype, datalog_setup, datalog_teardown },
     { NULL, NULL, NULL, NULL },
 };
 

--- a/test/test_datalog.c
+++ b/test/test_datalog.c
@@ -2578,6 +2578,62 @@ static test_result_t test_nonlinear_closure_chain(void) {
     PASS();
 }
 
+/* Old/new split (Task 14): a rule with THREE recursive atoms.  Positions 0
+ * and 1 read the pre-iteration prefix of `p` whenever the delta sits to
+ * their right, so every derivation must still be found exactly as with the
+ * full relation.  The third rule is logically redundant (it derives nothing
+ * the two-atom rule misses), so the oracle stays the plain transitive
+ * closure of a 7-edge chain: 8 nodes, 28 ordered pairs. */
+static test_result_t test_nonlinear_three_atom_closure(void) {
+    int64_t src[7], dst[7];
+    for (int i = 0; i < 7; i++) { src[i] = i + 1; dst[i] = i + 2; }
+    ray_t* c0 = ray_vec_from_raw(RAY_I64, src, 7);
+    ray_t* c1 = ray_vec_from_raw(RAY_I64, dst, 7);
+    ray_t* edge = ray_table_new(2);
+    edge = ray_table_add_col(edge, ray_sym_intern("edge__c0", 8), c0);
+    edge = ray_table_add_col(edge, ray_sym_intern("edge__c1", 8), c1);
+
+    dl_program_t* prog = dl_program_new();
+    TEST_ASSERT_NOT_NULL(prog);
+    TEST_ASSERT_EQ_I(dl_add_edb(prog, "edge", edge, 2), 0);
+
+    dl_rule_t r1;                      /* p(X,Y) :- edge(X,Y) */
+    dl_rule_init(&r1, "p", 2);
+    dl_rule_head_var(&r1, 0, 0); dl_rule_head_var(&r1, 1, 1);
+    int b = dl_rule_add_atom(&r1, "edge", 2);
+    dl_body_set_var(&r1, b, 0, 0); dl_body_set_var(&r1, b, 1, 1);
+    TEST_ASSERT_EQ_I(dl_add_rule(prog, &r1), 0);
+
+    dl_rule_t r2;                      /* p(X,Z) :- p(X,Y), p(Y,Z) */
+    dl_rule_init(&r2, "p", 2);
+    dl_rule_head_var(&r2, 0, 0); dl_rule_head_var(&r2, 1, 2);
+    int b1 = dl_rule_add_atom(&r2, "p", 2);
+    dl_body_set_var(&r2, b1, 0, 0); dl_body_set_var(&r2, b1, 1, 1);
+    int b2 = dl_rule_add_atom(&r2, "p", 2);
+    dl_body_set_var(&r2, b2, 0, 1); dl_body_set_var(&r2, b2, 1, 2);
+    TEST_ASSERT_EQ_I(dl_add_rule(prog, &r2), 1);
+
+    dl_rule_t r3;                      /* p(X,W) :- p(X,Y), p(Y,Z), p(Z,W) */
+    dl_rule_init(&r3, "p", 2);
+    dl_rule_head_var(&r3, 0, 0); dl_rule_head_var(&r3, 1, 3);
+    int b3 = dl_rule_add_atom(&r3, "p", 2);
+    dl_body_set_var(&r3, b3, 0, 0); dl_body_set_var(&r3, b3, 1, 1);
+    int b4 = dl_rule_add_atom(&r3, "p", 2);
+    dl_body_set_var(&r3, b4, 0, 1); dl_body_set_var(&r3, b4, 1, 2);
+    int b5 = dl_rule_add_atom(&r3, "p", 2);
+    dl_body_set_var(&r3, b5, 0, 2); dl_body_set_var(&r3, b5, 1, 3);
+    TEST_ASSERT_EQ_I(dl_add_rule(prog, &r3), 2);
+
+    TEST_ASSERT_EQ_I(dl_eval(prog), 0);
+    ray_t* out = dl_query(prog, "p");
+    TEST_ASSERT_NOT_NULL(out);
+    TEST_ASSERT_EQ_I((int)ray_table_nrows(out), 28);
+
+    dl_program_free(prog);
+    ray_release(edge); ray_release(c0); ray_release(c1);
+    PASS();
+}
+
 /* Audit §1.4: an I64 literal against an F64 EDB column must filter, not
  * pass the whole table through. */
 static test_result_t test_const_filter_f64_column(void) {
@@ -3049,6 +3105,7 @@ const test_entry_t datalog_entries[] = {
     { "datalog/rule_add_interval_overflow", test_rule_add_interval_overflow, datalog_setup, datalog_teardown },
     { "datalog/edb_over_arity_domain_guard", test_edb_over_arity_domain_guard, datalog_setup, datalog_teardown },
     { "datalog/nonlinear_closure_chain", test_nonlinear_closure_chain, datalog_setup, datalog_teardown },
+    { "datalog/nonlinear_three_atom_closure", test_nonlinear_three_atom_closure, datalog_setup, datalog_teardown },
     { "datalog/const_filter_f64_column", test_const_filter_f64_column, datalog_setup, datalog_teardown },
     { "datalog/rule_expr_ownership", test_rule_expr_ownership, datalog_setup, datalog_teardown },
     { "datalog/rowset_extract_new", test_rowset_extract_new, datalog_setup, datalog_teardown },

--- a/test/test_vec.c
+++ b/test/test_vec.c
@@ -90,6 +90,39 @@ static test_result_t test_vec_append(void) {
     PASS();
 }
 
+/* ---- vec_append_raw (bulk append: growth + COW isolation) -------------- */
+
+static test_result_t test_vec_append_raw_grows(void) {
+    int64_t a[] = {1, 2}, b[] = {3, 4, 5};
+    ray_t* v = ray_vec_from_raw(RAY_I64, a, 2);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(v));
+
+    /* Bulk append past the initial capacity keeps both runs in order. */
+    v = ray_vec_append_raw(v, b, 3);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(v));
+    TEST_ASSERT_EQ_I(v->len, 5);
+    int64_t* d = (int64_t*)ray_data(v);
+    for (int i = 0; i < 5; i++) TEST_ASSERT_EQ_I(d[i], i + 1);
+
+    /* Appending n == 0 is a no-op that returns the same vector. */
+    ray_t* same = ray_vec_append_raw(v, b, 0);
+    TEST_ASSERT_TRUE(same == v);
+
+    /* Shared vector (rc == 2) must be copied, leaving the sharer intact. */
+    ray_t* shared = v;
+    ray_retain(shared);
+    ray_t* w = ray_vec_append_raw(v, b, 1);
+    TEST_ASSERT_FALSE(RAY_IS_ERR(w));
+    TEST_ASSERT_TRUE(w != shared);
+    TEST_ASSERT_EQ_I(shared->len, 5);
+    TEST_ASSERT_EQ_I(w->len, 6);
+    TEST_ASSERT_EQ_I(((int64_t*)ray_data(w))[5], 3);
+
+    ray_release(w);
+    ray_release(shared);
+    PASS();
+}
+
 /* ---- vec_get ----------------------------------------------------------- */
 
 static test_result_t test_vec_get(void) {
@@ -2266,6 +2299,7 @@ const test_entry_t vec_entries[] = {
     { "vec/slice_release_parent_ref", test_vec_slice_release_parent_ref, vec_setup, vec_teardown },
     { "vec/null_large_release", test_vec_null_large_release, vec_setup, vec_teardown },
     { "vec/append_grow", test_vec_append_grow, vec_setup, vec_teardown },
+    { "vec/append_raw_grows", test_vec_append_raw_grows, vec_setup, vec_teardown },
     { "vec/type_correctness", test_vec_type_correctness, vec_setup, vec_teardown },
     { "vec/empty", test_vec_empty, vec_setup, vec_teardown },
     { "vec/bool", test_vec_bool, vec_setup, vec_teardown },


### PR DESCRIPTION
Stacked on #513 (`fix/datalog-audit`); merge that first. Addresses audit §4 (iteration cap, quadratic copying in the fixpoint loop).

## Changes
1. **Benchmark harness** `bench/datalog/tc_chain.sh` (chain transitive closure, linear and non-linear rule, min-of-3, `RAYFORCE_CORES=2`) with `BASELINE.md` recording every step.
2. **No iteration cap for monotone strata**: strata with only relational literals always converge over a finite EDB and run uncapped (cancellation still checked per iteration); strata with assignment/builtin/interval literals keep `DL_MAX_ITER_NONMONOTONE` and report `fixpoint did not converge`. A 1024-edge chain previously failed with `evaluation failed`.
3. **Incremental row set per derived relation** replaces the per-iteration `table_distinct` + `table_antijoin` (which re-hashed the whole relation every iteration). F64 keys use the engine's canonical fold; a comparability gate (type + symbol domain) falls back to the old path; candidates larger than the relation are collapsed with `table_distinct` first.
4. **In-place relation growth**: the never-read `prev_tables[]` retention is removed so `table_union` can append in place when the relation is uniquely owned (rolled back on mid-append failure).
5. **Old/new split** for rules with several recursive atoms: atoms before the delta position read a zero-copy prefix view of the relation.
6. Final-review fix wave: double releases after a failing `ray_table_add_col`, expression leaks on parser error paths, admission check limited to rules reachable from the query, checked `abs`/`duration_since`, untagging limited to columns bound from the datoms `v` column, reserved `eav` head predicate.

## Numbers (release build, 2 cores, min of 3)

| N | rows | before | after |
|---|---|---|---|
| 512 linear | 131 328 | 1740 ms, 1.89 GB allocated | 108 ms, 73 MB |
| 1024 linear | 524 800 | fails (cap) | 332 ms |
| 512 non-linear | 131 328 | 889 ms | 831 ms |
| 1024 non-linear | 524 800 | 8310 ms | 7421 ms |

The non-linear form is now dominated by its candidate joins, not by fixpoint bookkeeping.

## Verification
`make test`: 3787 of 3787 passed, 0 UBSan `runtime error` lines. Every benchmark point checks the row count `N(N+1)/2`.

## Known follow-ups (not in this PR)
- `agg_engine.c:217` `max - min + 1` overflows for extreme I64 keys (pre-existing).
- ~64 bytes leak per error caught by `try` (pre-existing).
- A datoms table bound in the environment and used as a plain 3-ary relation keeps tagged `v` values.
- No mutual-recursion oracle test yet.

https://claude.ai/code/session_019RxzDYWuuTMBmo9H8qcno5
