### PR TITLE
fix(group): table distinct declared zero-length agg VLAs on the hash path (#515)

### DIFF
--- a/src/ops/group.c
+++ b/src/ops/group.c
@@ -13695,9 +13695,12 @@ v2_emit:;
         /* Pre-allocate agg result vectors.  These VLAs scale with n_aggs
          * (the ≤8-agg ht_path guard is retired — 9/17/65-agg legacy shapes
          * reach here); ght_compute_layout has already accepted this n_aggs,
-         * so it is within the layout stride/slot budget. */
-        agg_out_t agg_outs[n_aggs];
-        ray_t* agg_cols[n_aggs];
+         * so it is within the layout stride/slot budget.  Sized by vla_aggs,
+         * not n_aggs: a table `distinct` is a grouped plan with zero
+         * aggregates, and a zero-length VLA is UB (#515) — the sanitized
+         * build aborted here.  Every loop below is bounded by n_aggs. */
+        agg_out_t agg_outs[vla_aggs];
+        ray_t* agg_cols[vla_aggs];
         for (uint32_t a = 0; a < n_aggs; a++) {
             uint16_t agg_op = ext->agg_ops[a];
             ray_t* agg_col = agg_vecs[a];

--- a/test/rfl/group/distinct_zero_agg_vla.rfl
+++ b/test/rfl/group/distinct_zero_agg_vla.rfl
@@ -1,0 +1,20 @@
+;; distinct_zero_agg_vla.rfl — table `distinct` is a grouped plan with no
+;; aggregates (#515).
+;;
+;; Regression: once the input is large enough to take the hash group path,
+;; exec_group_run sized its agg result scratch as `agg_outs[n_aggs]` with
+;; n_aggs == 0.  A zero-length VLA is undefined behaviour; the release build
+;; tolerated it and answered correctly, the sanitized debug build aborted with
+;; "variable length array bound evaluates to non-positive value 0".  The
+;; reported shape is a STR key column at 100,000 rows / 9,000 distinct values.
+(set N 100000)
+(set x (til N))
+(set m (- x (* 9000 (div x 9000))))
+(set sk (map (fn [i] (concat "acct" (as 'str i))) (til 9000)))
+(set s (at sk m))
+(count (distinct (table ['a] (list s)))) -- 9000
+
+;; Same zero-aggregate path with a SYM key and with a two-column key.
+(set ss (as 'sym s))
+(count (distinct (table ['a] (list ss)))) -- 9000
+(count (distinct (table ['a 'b] (list s (- x (* 7 (div x 7))))))) -- 63000


### PR DESCRIPTION
## What & why

A table `distinct` is executed as a grouped plan with no aggregates. Once the input is large enough to take the hash group path, `exec_group_run` declared `agg_outs[n_aggs]` / `agg_cols[n_aggs]` with `n_aggs == 0`. A zero-length VLA is undefined behaviour (C17 6.7.6.2p5); the release build tolerated it and answered correctly, but the default sanitized debug build aborted with `variable length array bound evaluates to non-positive value 0`.

The function already carries a `vla_aggs` (= max(n_aggs, 1)) guard for its other aggregate scratch. This sizes both VLAs by that guard. Every loop over them is bounded by `n_aggs`, so behaviour is unchanged for real aggregates. The other variable-bound VLAs in `group.c` were checked: key-sized ones use `vla_keys`, and the expression-input scratch sits behind an early return that fires when there are no aggregates.

Adds `test/rfl/group/distinct_zero_agg_vla.rfl` with the reported STR-key shape (100k rows / 9k distinct) plus SYM and two-column keys. Before the fix the sanitized test binary aborts on it; after, it passes and the full suite reports 3777/3777 with no UBSan runtime errors.

Closes #515

## Checklist

- [x] PR targets `dev` (not `master`)
- [x] Commits follow Conventional Commits (`feat:` / `fix:` / `perf:` / `docs:` / …)
- [x] `make` builds cleanly (no new warnings)
- [x] `make test` passes; tests added/updated for behaviour changes

https://claude.ai/code/session_01UQRURGab9d9Fjma6uekEzY
