### PR TITLE
feat(idx): consult the hash index from vector-needle find / in / dict at, admit STR, carry across concat

### DIFF
--- a/docs/docs/queries/attributes.md
+++ b/docs/docs/queries/attributes.md
@@ -3,13 +3,13 @@
 Semantic properties stamped onto columns — `sorted`, `unique`, `grouped`, `parted`.  Where an [accelerator index](indexes.md) is a *physical* structure (a hash table, a permutation), a column attribute is an *assertion about meaning*: this column is non-descending, these values are distinct.  The `.attr.*` family layers over the same storage as `.idx.*`, but its contract is semantic, not structural.
 
 !!! note "v1 status"
-    The four attributes, their strict verify-on-set kernels, and the `(.attr.*)` Rayfall surface are shipped. `sorted` and `unique` are numeric; the backing-index attributes `grouped` and `parted` also support symbol columns.
+    The four attributes, their strict verify-on-set kernels, and the `(.attr.*)` Rayfall surface are shipped. `sorted` and `parted` are numeric (`parted` also takes symbols); `unique` and `grouped` take numeric, symbol and string columns.
 
 ## Why Attributes Are Separate from Indexes
 
 An [accelerator index](indexes.md) answers *"what structure is attached?"* — a zonemap, a hash table, a sort permutation.  A column attribute answers a different question: *"what is semantically true of these values?"*  The two markers (`sorted`, `unique`) carry no allocation at all — they are cheap flags.  The two backing-index attributes (`grouped`, `parted`) do reuse the index layer underneath (so a `grouped` or `parted` column also shows up via `.idx.has?` and `.idx.info`), but `.attr.*` exists to assert a *property* the engine can trust, not merely to build a structure.
 
-The payoff is that consumers can trust a stamped attribute unconditionally. Besides the [as-of join executor](joins.md#pre-sorted-fast-path), filters and grouped aggregation use the physical layout directly.
+The payoff is that consumers can trust a stamped attribute unconditionally. Besides the [as-of join executor](joins.md#pre-sorted-fast-path), filters and grouped aggregation use the physical layout directly, and a keyed lookup against a `grouped` vector — `find` or `in` with a vector of needles, `at` on a dict keyed by it — probes the hash once per needle instead of building one over the whole vector per call.
 
 ## The Four Attributes
 
@@ -108,7 +108,9 @@ But a column holds at most one backing index — setting `grouped` or `parted` r
 
 ## Conservative Propagation
 
-Attributes propagate **conservatively**.  Only operations that trivially preserve the values — a refcount / copy-on-write copy, a plain rebind — keep the attributes.  *Any* transform that could change ordering, length, or values (arithmetic, `filter` / `where`, `reverse`, `concat`, reordering `take`) **drops** them.  This keeps the invariant honest: a held attribute always reflects the current bytes.
+Attributes propagate **conservatively**.  Only operations that trivially preserve the values — a refcount / copy-on-write copy, a plain rebind — keep the attributes.  *Any* transform that could change ordering, length, or values (arithmetic, `filter` / `where`, `reverse`, reordering `take`) **drops** them.  This keeps the invariant honest: a held attribute always reflects the current bytes.
+
+One append shape is the exception.  `(concat v rows)` and `(concat v atom)` on a `grouped` vector keep the hash (and a `unique` marker) when **every appended key is new** — the existing groups are copied and each appended row becomes a group of its own, so an append-only keyed vector never pays a rebuild.  An appended row that repeats a key, a null, or a symbol from another domain leaves the result a plain vector, exactly as before; `sorted` is always dropped by `concat`.
 
 ```lisp
 ; Arithmetic drops the marker (and a backing index).
@@ -118,6 +120,10 @@ Attributes propagate **conservatively**.  Only operations that trivially preserv
 ; Reorder / concat drop the marker.
 (.attr.get (reverse (.attr.set 'sorted [1 2 3])))               ; ⇒ no attributes
 (.attr.get (concat (.attr.set 'sorted [1 2 3]) [0 1]))          ; ⇒ no attributes
+
+; An append of NEW keys carries a hash index (and `unique`); a repeat drops it.
+(.attr.get (concat (.attr.set 'unique (.attr.set 'grouped [1 2 3])) [4 5]))   ; ⇒ ['unique 'grouped]
+(.attr.get (concat (.attr.set 'grouped [1 2 3]) [3]))                          ; ⇒ no attributes
 
 ; Plain rebind preserves.
 (set _s (.attr.set 'sorted [1 2 3]))
@@ -162,9 +168,9 @@ For a partitioned join `(asof-join [Key Time] L R)`, if the single numeric equal
 
 ## Caveats and Limits
 
-- **Type support.** `sorted` and `unique` accept numeric types. `grouped` and `parted` also accept `SYM`; `STR` remains unsupported.
+- **Type support.** `sorted` accepts numeric types; `parted` numeric and `SYM`. `unique` and `grouped` accept numeric, `SYM` and `STR` — a `STR` hash is keyed on a 64-bit hash of the bytes with the payload compared on every hit, so a content-keyed column (a digest) carries an index like any other.  A `STR` `grouped` column persists its hash through a splayed save in place of the automatic string dictionary (one index per column).
 - **Strict verify, no silent stamping.**  `.attr.set` errors on violation rather than recording a property it cannot confirm; this is what lets consumers trust the stamp unconditionally.
-- **Conservative propagation.**  Only copy / rebind preserve attributes; every transform drops them.  Re-assert with `.attr.set` after a transform.
+- **Conservative propagation.**  Only copy / rebind preserve attributes; every transform drops them, except an append of new keys onto a `grouped` vector (see above).  Re-assert with `.attr.set` after any other transform.
 - **One backing index per column.**  `grouped` and `parted` share the [accelerator-index](indexes.md) slot, so a column carries at most one of them at a time; the markers are separate and free.
 
 ## Quick Reference

--- a/docs/docs/queries/indexes.md
+++ b/docs/docs/queries/indexes.md
@@ -23,7 +23,8 @@ The executor consults indexes at five sites.  Each site has a specific consumpti
 | `.idx.hash` / `part` backing | `where key IN …` + `group by key` | Resolve only the requested key slices and aggregate them directly, skipping filter scan and group discovery. Part slices stream as contiguous ranges. |
 | `.idx.sort` | ORDER BY — single ascending key | The pre-built permutation is reused directly rather than re-sorting.  Descending ORDER BY falls back to recompute (reversing the perm would swap tie-group positions relative to stable DESC sort). |
 | `.idx.sort` | `distinct` | Walk the sort permutation once to collect first-occurrence row ids per distinct value — O(n) with no hash table.  SYM/GUID/STR columns fall back. |
-| `.idx.hash` | `find` | Hash-chain probe returns the minimum row id matching the needle, or a provably-absent signal.  Integer-family needles only; float and cross-family needles fall through to the scan. |
+| `.idx.hash` | `find` | Hash-chain probe returns the minimum row id matching the needle, or a provably-absent signal.  Integer-family, `SYM` and `STR` needles against a column of the same family; float and cross-family needles fall through to the scan.  A **vector** of needles probes once per needle — nothing is built per call. |
+| `.idx.hash` | `in` — `(in needles v)` with `v` indexed, and `(at d keys)` on a dict keyed by an indexed vector | One probe per needle, same type matrix as `find`.  Without an index, `find` / `in` hash whichever side is smaller and scan the other once. |
 
 ### Eligibility conditions (uniform)
 
@@ -34,7 +35,7 @@ All five sites apply the same prechecks before consulting an index:
 - **Not parted / not MAPCOMMON:** parted and MAPCOMMON columns skip routing at the filter and IN sites.
 - **Default table:** filter and IN sites only route columns from the query's default table (non-default table references are skipped).
 
-Mutation auto-drops the attached index — the in-place mutators (`(insert 'v val)`, `(alter 'v set i val)`, `(alter 'v concat vals)`) call `ray_index_drop()` before writing, so a mutated column always has `HAS_INDEX` clear afterward.  Reattach explicitly after the write.
+Mutation auto-drops the attached index — the in-place mutators (`(insert 'v val)`, `(alter 'v set i val)`) call `ray_index_drop()` before writing, so a mutated column always has `HAS_INDEX` clear afterward.  Reattach explicitly after the write.  The one append that keeps a hash index is `concat` (and `(alter 'v concat vals)`, which rebinds to a `concat` result) when every appended key is new — see [Common Workflows](#common-workflows).
 
 ### Fallback guarantee
 
@@ -93,7 +94,7 @@ Each kind has a one-arg attach builtin.  Attaching is idempotent — if a differ
 
 `(.idx.zone v)   (.idx.hash v)   (.idx.sort v)   (.idx.bloom v)`
 
-Attach an index of the named kind to a vector `v`.  Returns the column with the new index attached (the underlying values are unchanged).  All kinds accept the numeric/boolean types `RAY_BOOL`, `RAY_U8`, `RAY_I16`, `RAY_I32`, `RAY_I64`, `RAY_F32`, `RAY_F64`, `RAY_DATE`, `RAY_TIME`, `RAY_TIMESTAMP`; `.idx.hash` **additionally** accepts `RAY_SYM`.  `RAY_STR` (and `RAY_SYM` on the non-hash kinds) is deferred to v2.
+Attach an index of the named kind to a vector `v`.  Returns the column with the new index attached (the underlying values are unchanged).  All kinds accept the numeric/boolean types `RAY_BOOL`, `RAY_U8`, `RAY_I16`, `RAY_I32`, `RAY_I64`, `RAY_F32`, `RAY_F64`, `RAY_DATE`, `RAY_TIME`, `RAY_TIMESTAMP`; `.idx.hash` **additionally** accepts `RAY_SYM` (keyed on domain ids) and `RAY_STR` (keyed on a 64-bit hash of the bytes, payload compared on every hit).  `RAY_SYM` / `RAY_STR` on the non-hash kinds is deferred to v2.
 
 ### Examples
 
@@ -133,7 +134,7 @@ Indexed columns participate in normal operations transparently.  `(sum vh)`, `(a
 
 ### Mutation Drops the Index
 
-The Rayfall in-place mutators — `(insert 'v val)` for append and `(alter 'v set i val)` / `(alter 'v concat val)` for set / append — invalidate the attached index.  The mutator paths drop the index transparently, restore the original nullmap bytes, and proceed with the write.  Subsequent `(.idx.has?)` calls return false; reattach the index after the write if you want index routing on the updated column.
+The Rayfall in-place mutators — `(insert 'v val)` for append and `(alter 'v set i val)` for set — invalidate the attached index.  The mutator paths drop the index transparently, restore the original nullmap bytes, and proceed with the write.  Subsequent `(.idx.has?)` calls return false; reattach the index after the write if you want index routing on the updated column.  `(alter 'v concat val)` rebinds `v` to `(concat v val)`, so a hash index survives it when every appended key is new (see below).
 
 ```lisp
 (set v [5 1 9 3 7])
@@ -157,8 +158,12 @@ An accelerator index uses bytes 0–7 of the column's [nullmap union](https://gi
 (in 700 v)                   ; ⇒ true   (700 = 7 × 100) — hash-chain probe
 (in 701 v)                   ; ⇒ false
 (find v 700)                 ; ⇒ 100    — hash fast path returns minimum row id
+(find v [700 701 6993])      ; ⇒ [100 0N 999] — one probe per needle
+(in [700 701] v)             ; ⇒ [true false]
 (set v (.idx.drop v))         ; optional early release; mutators auto-drop
 ```
+
+An append of new keys keeps the hash: `(concat v [7000 7007])` carries the index over (see [Attributes — Conservative Propagation](attributes.md#conservative-propagation)); an appended repeat drops it as before.
 
 ### Range scans on a stable column
 

--- a/src/ops/builtins.c
+++ b/src/ops/builtins.c
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include "lang/eval.h"
 #include "lang/internal.h"
+#include "ops/idxop.h"       /* ray_index_carry_append: keep a hash index across concat */
 #include "lang/env.h"
 #include "core/platform.h"   /* ray_vm_map_fd_ro / ray_vm_unmap_file (tracked) */
 #include "vec/vec.h"
@@ -3344,8 +3345,13 @@ ray_t* ray_concat_fn(ray_t* a, ray_t* b) {
         return str_vec_concat_atom(b, a, true);
     /* Vector concat: same type — delegate to ray_vec_concat which handles
      * null bitmap propagation, SYM width promotion, and STR pool merging. */
-    if (ray_is_vec(a) && ray_is_vec(b) && a->type == b->type)
-        return ray_vec_concat(a, b);
+    if (ray_is_vec(a) && ray_is_vec(b) && a->type == b->type) {
+        ray_t* r = ray_vec_concat(a, b);
+        /* An append onto an indexed vector keeps the index when every
+         * appended key is new (see ray_index_carry_append). */
+        if (r && !RAY_IS_ERR(r) && ray_index_has(a)) ray_index_carry_append(a, r);
+        return r;
+    }
     /* Concat typed vec + boxed list or boxed list + typed vec -> boxed list */
     if ((ray_is_vec(a) && b->type == RAY_LIST) || (a->type == RAY_LIST && ray_is_vec(b))) {
         ray_t* la = (a->type == RAY_LIST) ? a : NULL;
@@ -3493,6 +3499,7 @@ ray_t* ray_concat_fn(ray_t* a, ray_t* b) {
          * and null-ness of the trailing atom (sentinel written raw at na). */
         if (ray_vec_may_have_nulls(a) || RAY_ATOM_IS_NULL(b))
             result->attrs |= RAY_ATTR_HAS_NULLS;
+        if (ray_index_has(a)) ray_index_carry_append(a, result);
         return result;
     }
     /* Atom + atom of same type -> 2-element vector */

--- a/src/ops/collection.c
+++ b/src/ops/collection.c
@@ -381,6 +381,55 @@ static bool hashset_insert(hashset_t* hs, int64_t i) {
     return true;
 }
 
+/* Vector-needle find with the NEEDLES hashed and the haystack scanned once:
+ * out[i] = first row of `hay` equal to needle i, NULL_I64 on a miss.  The
+ * alternative (hash the haystack, probe the needles) costs a hash build over
+ * the big side per call; this costs one over the small side plus a scan that
+ * stops as soon as every distinct needle has been seen.  `first` is indexed
+ * by the hashset's representative row (the first needle inserted with that
+ * key), so duplicate needles share one answer and a null needle matches the
+ * haystack's first null exactly as the haystack-hashed path does.
+ * Returns false only on OOM (caller falls back). */
+static bool find_hash_needles(ray_t* hay, ray_t* nd, int64_t* out, bool* any_null) {
+    int64_t m = nd->len, n = hay->len;
+    hashset_t hs;
+    if (!hashset_init(&hs, nd, m)) return false;
+    int64_t* first = (int64_t*)ray_sys_alloc((size_t)(m > 0 ? m : 1) * sizeof(int64_t));
+    if (!first) { hashset_destroy(&hs); return false; }
+    int64_t distinct = 0;
+    for (int64_t j = 0; j < m; j++) {
+        first[j] = -1;
+        if (hashset_insert(&hs, j)) distinct++;
+    }
+    int8_t ht = hay->type; void* hd = ray_data(hay);
+    int64_t found = 0;
+    for (int64_t r = 0; r < n && found < distinct; r++) {
+        int64_t rep = hashset_find_xrow(&hs, hay, r, ht, hd);
+        if (rep != HS_EMPTY && first[rep] < 0) { first[rep] = r; found++; }
+    }
+    int8_t nt = nd->type; void* ndd = ray_data(nd);
+    for (int64_t i = 0; i < m; i++) {
+        int64_t rep = hashset_find_xrow(&hs, nd, i, nt, ndd);
+        int64_t pos = (rep == HS_EMPTY) ? -1 : first[rep];
+        if (pos < 0) { out[i] = NULL_I64; *any_null = true; }
+        else out[i] = pos;
+    }
+    ray_sys_free(first);
+    hashset_destroy(&hs);
+    return true;
+}
+
+/* Hash the smaller side only when the scan side probes cheaply: SYM rows
+ * from a DIFFERENT domain than the needles would need a per-row string
+ * translation (hashset_find_xrow's cross-domain arm) — hashing the
+ * haystack and translating the few needles is the right orientation there. */
+static bool find_needle_side_ok(ray_t* hay, ray_t* nd) {
+    if (nd->len >= hay->len) return false;
+    if (hay->type == RAY_SYM && nd->type == RAY_SYM &&
+        ray_sym_vec_domain(hay) != ray_sym_vec_domain(nd)) return false;
+    return true;
+}
+
 /* ══════════════════════════════════════════
  * Higher-order functions
  * ══════════════════════════════════════════ */
@@ -1301,6 +1350,26 @@ ray_t* ray_in_fn(ray_t* val, ray_t* vec) {
          * hashset over `vec` once, probe per element of `val`.  Was
          * O(len(val)×len(vec)); now O(len(val)+len(vec)). */
         if (ray_is_vec(val) && ray_is_vec(vec)) {
+            /* Attached hash index on the set: one probe per needle, nothing
+             * built per call.  Null needles miss (the index is consulted on
+             * null-free sets only), matching the hashset path below. */
+            if (ray_index_has(vec)) {
+                ray_idx_consults[IDX_SITE_IN]++;
+                int64_t* pos = (int64_t*)ray_sys_alloc((size_t)vlen * sizeof(int64_t));
+                if (!pos) return ray_error("oom", NULL);
+                bool miss = false;
+                if (ray_index_find_vec(vec, val, pos, &miss)) {
+                    ray_idx_hits[IDX_SITE_IN]++;
+                    ray_t* result = ray_vec_new(RAY_BOOL, vlen);
+                    if (RAY_IS_ERR(result)) { ray_sys_free(pos); return result; }
+                    result->len = vlen;
+                    bool* out = (bool*)ray_data(result);
+                    for (int64_t i = 0; i < vlen; i++) out[i] = pos[i] != NULL_I64;
+                    ray_sys_free(pos);
+                    return result;
+                }
+                ray_sys_free(pos);
+            }
             /* Typed kernel first: verdict-LUT for SYM, SIMD small-set for
              * ints, pool-parallel — the same engine the fused WHERE path
              * uses.  Gated off null-bearing operands: this hashset path
@@ -1317,6 +1386,18 @@ ray_t* ray_in_fn(ray_t* val, ray_t* vec) {
             if (RAY_IS_ERR(result)) return result;
             result->len = vlen;
             bool* out = (bool*)ray_data(result);
+            /* Fewer needles than set rows: hash the needles and scan the
+             * set once instead of hashing the whole set per call. */
+            if (find_needle_side_ok(vec, val)) {
+                int64_t* pos = (int64_t*)ray_sys_alloc((size_t)vlen * sizeof(int64_t));
+                bool miss = false;
+                if (pos && find_hash_needles(vec, val, pos, &miss)) {
+                    for (int64_t i = 0; i < vlen; i++) out[i] = pos[i] != NULL_I64;
+                    ray_sys_free(pos);
+                    return result;
+                }
+                if (pos) ray_sys_free(pos);
+            }
             hashset_t hs;
             if (!hashset_init(&hs, vec, vec->len)) {
                 ray_release(result);
@@ -2301,6 +2382,41 @@ ray_t* ray_at_fn(ray_t* vec, ray_t* idx) {
             int64_t n = ray_len(idx);
             ray_t* out = ray_list_new(n);
             if (!out || RAY_IS_ERR(out)) return out ? out : ray_error("oom", NULL);
+            /* Typed keys probed by a typed vector of the same type: resolve
+             * every position in one `find` (attached hash index, else one
+             * hash build) instead of a scan of the keys per probe.  The
+             * per-key path below stays for mixed shapes; a sliced key vector
+             * probed with nulls also stays there — the scalar lookup reads a
+             * slice's nulls through its parent, which the hash does not. */
+            ray_t* dkeys = ray_dict_keys(vec);
+            ray_t* dvals = ray_dict_vals(vec);
+            if (dkeys && dvals && ray_is_vec(dkeys) && ray_is_vec(idx) &&
+                idx->type == dkeys->type &&
+                !((dkeys->attrs & RAY_ATTR_SLICE) && (idx->attrs & RAY_ATTR_HAS_NULLS))) {
+                ray_t* pos = ray_find_fn(dkeys, idx);
+                if (!pos || RAY_IS_ERR(pos)) { ray_release(out); return pos ? pos : ray_error("oom", NULL); }
+                const int64_t* pd = (const int64_t*)ray_data(pos);
+                int64_t nvals = ray_len(dvals);
+                for (int64_t i = 0; i < n; i++) {
+                    ray_t* value;
+                    if (pd[i] == NULL_I64 || pd[i] < 0 || pd[i] >= nvals) {
+                        value = ray_typed_null(-RAY_I64);   /* 0Nl for missing key */
+                    } else {
+                        int alloc = 0;
+                        value = collection_elem(dvals, pd[i], &alloc);
+                        if (value && !RAY_IS_ERR(value) && !alloc) ray_retain(value);
+                    }
+                    if (!value || RAY_IS_ERR(value)) {
+                        ray_release(pos); ray_release(out);
+                        return value ? value : ray_error("oom", NULL);
+                    }
+                    out = ray_list_append(out, value);
+                    ray_release(value);
+                    if (!out || RAY_IS_ERR(out)) { ray_release(pos); return out ? out : ray_error("oom", NULL); }
+                }
+                ray_release(pos);
+                return out;
+            }
             for (int64_t i = 0; i < n; i++) {
                 int allocated = 0;
                 ray_t* key = collection_elem(idx, i, &allocated);
@@ -2456,18 +2572,35 @@ ray_t* ray_find_fn(ray_t* vec, ray_t* val) {
         int64_t* out = (int64_t*)ray_data(result);
         bool any_null = false;
 
-        /* Hash fast path: both sides typed vecs — O(n+m), mirrors ray_in_fn. */
+        /* Both sides typed vecs — O(n+m).  In order of preference:
+         *   1. an attached hash index on the haystack: one probe per needle,
+         *      nothing built per call;
+         *   2. fewer needles than rows: hash the needles, scan the haystack
+         *      once (find_hash_needles);
+         *   3. hash the haystack, probe the needles (mirrors ray_in_fn). */
         if (ray_is_vec(val) && ray_is_vec(vec)) {
-            hashset_t hs;
-            if (!hashset_init(&hs, vec, vec->len)) { ray_release(result); return ray_error("oom", NULL); }
-            for (int64_t j = 0; j < vec->len; j++) hashset_insert(&hs, j);
-            int8_t vt = val->type; void* vd = ray_data(val);
-            for (int64_t i = 0; i < vlen; i++) {
-                int64_t row = hashset_find_xrow(&hs, val, i, vt, vd);
-                if (row == HS_EMPTY) { out[i] = NULL_I64; any_null = true; }
-                else out[i] = row;
+            bool done = false;
+            if (ray_index_has(vec)) {
+                ray_idx_consults[IDX_SITE_FIND]++;
+                if (ray_index_find_vec(vec, val, out, &any_null)) {
+                    ray_idx_hits[IDX_SITE_FIND]++;
+                    done = true;
+                }
             }
-            hashset_destroy(&hs);
+            if (!done && find_needle_side_ok(vec, val))
+                done = find_hash_needles(vec, val, out, &any_null);
+            if (!done) {
+                hashset_t hs;
+                if (!hashset_init(&hs, vec, vec->len)) { ray_release(result); return ray_error("oom", NULL); }
+                for (int64_t j = 0; j < vec->len; j++) hashset_insert(&hs, j);
+                int8_t vt = val->type; void* vd = ray_data(val);
+                for (int64_t i = 0; i < vlen; i++) {
+                    int64_t row = hashset_find_xrow(&hs, val, i, vt, vd);
+                    if (row == HS_EMPTY) { out[i] = NULL_I64; any_null = true; }
+                    else out[i] = row;
+                }
+                hashset_destroy(&hs);
+            }
         } else {
             /* Fallback (LIST/mixed): per-element scalar find into the dense buffer. */
             for (int64_t j = 0; j < vlen; j++) {
@@ -2490,33 +2623,20 @@ ray_t* ray_find_fn(ray_t* vec, ray_t* val) {
         bool has_nulls = ray_vec_may_have_nulls(vec);
         bool val_null = RAY_ATOM_IS_NULL(val);
 
-        /* Hash-index fast path: integer-family needle against an indexed
-         * integer-family column without nulls.  Float and cross-family
-         * needles fall through to the scan (the scan owns promotion
-         * semantics; we do not replicate them here). */
-        if (!has_nulls && !val_null && ray_is_atom(val) && ray_index_has(vec)) {
-            int64_t needle = 0;
-            int eligible = 1;
-            switch (val->type) {
-            case -RAY_I64:
-            case -RAY_TIMESTAMP: needle = val->i64;              break;
-            case -RAY_I32:
-            case -RAY_DATE:
-            case -RAY_TIME:      needle = (int64_t)val->i32;     break;
-            case -RAY_I16:       needle = (int64_t)val->i16;     break;
-            case -RAY_BOOL:
-            case -RAY_U8:        needle = (int64_t)val->b8;      break;
-            default:             eligible = 0;                   break;
-            }
-            if (eligible) {
-                ray_idx_consults[IDX_SITE_FIND]++;
-                int64_t row = ray_index_find_row(vec, needle);
-                if (row >= -1) {   /* -2 means not eligible — fall through */
-                    ray_idx_hits[IDX_SITE_FIND]++;
-                    if (row < 0)
-                        return ray_typed_null(-RAY_I64);
-                    return make_i64(row);
-                }
+        /* Hash-index fast path: an integer-family, symbol or string needle
+         * against an indexed column of the same family (ray_index_find_atom
+         * owns the type matrix).  Float and cross-family needles fall
+         * through to the scan (the scan owns promotion semantics; we do
+         * not replicate them here). */
+        if (!val_null && ray_is_atom(val) && ray_index_has(vec) &&
+            (!has_nulls || vec->type == RAY_SYM)) {
+            ray_idx_consults[IDX_SITE_FIND]++;
+            int64_t row = ray_index_find_atom(vec, val);
+            if (row >= -1) {   /* -2 means not eligible — fall through */
+                ray_idx_hits[IDX_SITE_FIND]++;
+                if (row < 0)
+                    return ray_typed_null(-RAY_I64);
+                return make_i64(row);
             }
         }
 

--- a/src/ops/idxop.c
+++ b/src/ops/idxop.c
@@ -3104,7 +3104,7 @@ void ray_index_carry_append(ray_t* src, ray_t* dst) {
 
     int64_t n0 = src->len, n1 = dst->len, add = n1 - n0;
     int64_t og = sx->u.hash.n_groups, ok = sx->u.hash.n_keys;
-    if (og + add < og || ok + add < ok) return;
+    if (add > INT64_MAX - og || add > INT64_MAX - ok) return;   /* no signed overflow below */
     bool is_str = (t == RAY_STR);
 
     ray_t* gkeys = ray_vec_new(RAY_I64, og + add > 0 ? og + add : 1);

--- a/src/ops/idxop.c
+++ b/src/ops/idxop.c
@@ -31,6 +31,7 @@
 #include "lang/eval.h"
 #include "ops/ops.h"
 #include "ops/rowsel.h"
+#include "ops/hash.h"     /* ray_hash_bytes: STR hash-index key word */
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>
@@ -94,6 +95,41 @@ static uint64_t numeric_key_word(const uint8_t* base, int8_t type, int64_t i) {
     case 8: { int64_t t; memcpy(&t, base + i*8, 8); k =          t; break; }
     }
     return (uint64_t)k;
+}
+
+/* STR hash-index key word: a 64-bit hash of the bytes.  Two distinct
+ * strings may share a word, so every STR key compare in the builder and
+ * the probes ALSO compares the payload (str_rows_eq / str_row_eq_bytes)
+ * and keeps walking on a payload mismatch — the bucket table may hold two
+ * groups with the same word. */
+static inline uint64_t str_key_word(const char* p, size_t l) {
+    return p ? ray_hash_bytes(p, l) : 0;
+}
+
+/* Row i of `v` as the hash-index key word: numeric → numeric_key_word,
+ * SYM → the column-domain id (width-aware), STR → str_key_word. */
+static uint64_t hash_row_key_word(ray_t* v, const uint8_t* base, int64_t i) {
+    if (v->type == RAY_SYM) return (uint64_t)ray_read_sym(base, i, RAY_SYM, v->attrs);
+    if (v->type == RAY_STR) {
+        size_t l = 0;
+        const char* p = ray_str_vec_get(v, i, &l);
+        return str_key_word(p, l);
+    }
+    return numeric_key_word(base, v->type, i);
+}
+
+static bool str_row_eq_bytes(ray_t* v, int64_t i, const char* p, size_t l) {
+    size_t il = 0;
+    const char* ip = ray_str_vec_get(v, i, &il);
+    if (!ip) ip = "";
+    if (!p)  p  = "";
+    return il == l && memcmp(ip, p, l) == 0;
+}
+
+static bool str_rows_eq(ray_t* v, int64_t i, int64_t j) {
+    size_t jl = 0;
+    const char* jp = ray_str_vec_get(v, j, &jl);
+    return str_row_eq_bytes(v, i, jp, jl);
 }
 
 /* Returns true iff numeric vector v is non-descending.  v1 scope: rejects
@@ -177,14 +213,16 @@ static bool vec_all_distinct(const ray_t* v) {
     if (!slot) return false;
     const uint8_t* base = (const uint8_t*)ray_data((ray_t*)v);
     bool ok = true;
+    bool is_str = (v->type == RAY_STR);
     for (int64_t i = 0; i < n && ok; i++) {
         if (ray_vec_is_null((ray_t*)v, i)) continue;
-        uint64_t hi = numeric_key_word(base, v->type, i);
+        uint64_t hi = hash_row_key_word((ray_t*)v, base, i);
         uint64_t h = mix64(hi) & mask;
         for (;;) {
             int64_t cur = slot[h];
             if (cur == 0) { slot[h] = i + 1; break; }
-            if (numeric_key_word(base, v->type, cur - 1) == hi) { ok = false; break; } /* dup */
+            if (hash_row_key_word((ray_t*)v, base, cur - 1) == hi &&
+                (!is_str || str_rows_eq((ray_t*)v, cur - 1, i))) { ok = false; break; } /* dup */
             h = (h + 1) & mask;
         }
     }
@@ -794,7 +832,9 @@ ray_t* ray_index_attach_built(ray_t** vp, ray_t* idx) {
         return ray_error("type", "attach_built: not an index object");
     bool is_dict = (ray_index_payload(idx)->kind == RAY_IDX_DICT);
     bool is_hash = (ray_index_payload(idx)->kind == RAY_IDX_HASH);
-    ray_t* v = prepare_attach_ex(vp, "index", is_dict, is_hash);   /* rc=1 → ray_cow no-op */
+    /* STR carries the dict and (since the vector-needle find work) the hash;
+     * SYM carries the hash.  rc=1 → ray_cow no-op. */
+    ray_t* v = prepare_attach_ex(vp, "index", is_dict || is_hash, is_hash);
     if (RAY_IS_ERR(v)) return v;
     return attach_finalize(v, idx);
 }
@@ -938,8 +978,11 @@ ray_t* ray_index_inline_map(uint8_t* region) {
  * -------------------------------------------------------------------------- */
 
 ray_t* ray_index_attach_hash(ray_t** vp) {
-    ray_t* v = prepare_attach_ex(vp, "hash", false, true);  /* allow_sym: RAY_SYM uses domain ids */
+    /* allow_str: keyed on a byte hash with payload-verified compares;
+     * allow_sym: RAY_SYM uses domain ids. */
+    ray_t* v = prepare_attach_ex(vp, "hash", true, true);
     if (RAY_IS_ERR(v)) return v;
+    bool is_str = (v->type == RAY_STR);
 
     int64_t n = v->len;
     /* Build-time capacity: sized by rows for O(1) inserts. */
@@ -949,14 +992,19 @@ ray_t* ray_index_attach_hash(ray_t** vp) {
 
     ray_t* btab_hdr = NULL;
     ray_t* rgid_hdr = NULL;
+    ray_t* gfirst_hdr = NULL;
     int64_t* btab = (int64_t*)scratch_alloc(&btab_hdr,
                                             (size_t)bcap * sizeof(int64_t));
     int64_t* rgid = (int64_t*)scratch_alloc(&rgid_hdr,
                         (size_t)(n > 0 ? n : 1) * sizeof(int64_t));
+    /* STR: first row of each group, for the payload compare on a word hit. */
+    int64_t* gfirst = is_str ? (int64_t*)scratch_alloc(&gfirst_hdr,
+                        (size_t)(n > 0 ? n : 1) * sizeof(int64_t)) : NULL;
     ray_t* gkeys = ray_vec_new(RAY_I64, n > 0 ? n : 1);   /* worst case: all distinct */
-    if (!btab || !rgid || !gkeys || RAY_IS_ERR(gkeys)) {
+    if (!btab || !rgid || (is_str && !gfirst) || !gkeys || RAY_IS_ERR(gkeys)) {
         scratch_free(btab_hdr);
         scratch_free(rgid_hdr);
+        scratch_free(gfirst_hdr);
         if (gkeys && !RAY_IS_ERR(gkeys)) ray_release(gkeys);
         return ray_error("oom", NULL);
     }
@@ -970,29 +1018,32 @@ ray_t* ray_index_attach_hash(ray_t** vp) {
         if (RAY_UNLIKELY((i & 0xFFFF) == 0 && ray_interrupted())) {
             scratch_free(btab_hdr);
             scratch_free(rgid_hdr);
+            scratch_free(gfirst_hdr);
             ray_release(gkeys);
             return ray_error("cancel", "interrupted");
         }
         if (ray_vec_is_null(v, i)) { rgid[i] = -1; continue; }
-        int64_t kw = (v->type == RAY_SYM)
-            ? ray_read_sym(base, i, RAY_SYM, v->attrs)  /* domain id, width-aware */
-            : (int64_t)numeric_key_word(base, v->type, i);
+        int64_t kw = (int64_t)hash_row_key_word(v, base, i);
         uint64_t slot = mix64((uint64_t)kw) & bmask;
         for (;;) {
             int64_t gp1 = btab[slot];
             if (gp1 == 0) {
                 btab[slot] = n_groups + 1;
                 gk[n_groups] = kw;
+                if (gfirst) gfirst[n_groups] = i;
                 rgid[i] = n_groups;
                 n_groups++;
                 break;
             }
-            if (gk[gp1 - 1] == kw) { rgid[i] = gp1 - 1; break; }
+            /* STR: a word hit is only a group hit when the bytes agree. */
+            if (gk[gp1 - 1] == kw &&
+                (!is_str || str_rows_eq(v, gfirst[gp1 - 1], i))) { rgid[i] = gp1 - 1; break; }
             slot = (slot + 1) & bmask;
         }
         n_keys++;
     }
     scratch_free(btab_hdr);
+    scratch_free(gfirst_hdr);
     gkeys->len = n_groups;
 
     /* CSR slices: counting pass over rgid.  offs doubles as the fill
@@ -1180,6 +1231,37 @@ static ray_index_t* hash_probe_setup(ray_t* col, int64_t key,
         int64_t gp1 = tbl[slot];
         if (gp1 == 0) break;                 /* key absent */
         if (gk[gp1 - 1] == kw) { *gid = gp1 - 1; break; }
+        slot = (slot + 1) & ix->u.hash.mask;
+    }
+    return ix;
+}
+
+/* STR twin of hash_probe_setup: the key is the needle's bytes.  Walks the
+ * bucket table on the byte-hash word and confirms each word hit against the
+ * payload of the group's first row (rows[offs[gid]]) — a distinct string with
+ * the same word is a different group further along the chain. */
+static ray_index_t* hash_probe_setup_str(ray_t* col, const char* p, size_t l,
+                                         int64_t* gid) {
+    *gid = -1;
+    if (!col || RAY_IS_ERR(col) || !ray_is_vec(col) || col->type != RAY_STR) return NULL;
+    if (!(col->attrs & RAY_ATTR_HAS_INDEX) || !col->index) return NULL;
+    ray_index_t* ix = ray_index_payload(col->index);
+    if (ix->kind != RAY_IDX_HASH) return NULL;
+    if (ix->built_for_len != col->len) return NULL;
+    if (!ix->u.hash.table || !ix->u.hash.gkeys ||
+        !ix->u.hash.offs  || !ix->u.hash.rows) return NULL;
+
+    int64_t kw = (int64_t)str_key_word(p, l);
+    uint64_t slot = mix64((uint64_t)kw) & ix->u.hash.mask;
+    const int64_t* tbl = (const int64_t*)ray_data(ix->u.hash.table);
+    const int64_t* gk  = (const int64_t*)ray_data(ix->u.hash.gkeys);
+    const int64_t* of  = (const int64_t*)ray_data(ix->u.hash.offs);
+    const int64_t* rw  = (const int64_t*)ray_data(ix->u.hash.rows);
+    for (;;) {
+        int64_t gp1 = tbl[slot];
+        if (gp1 == 0) break;                 /* key absent */
+        if (gk[gp1 - 1] == kw &&
+            str_row_eq_bytes(col, rw[of[gp1 - 1]], p, l)) { *gid = gp1 - 1; break; }
         slot = (slot + 1) & ix->u.hash.mask;
     }
     return ix;
@@ -1573,6 +1655,9 @@ ray_t* ray_index_in_rowsel(ray_t* col, ray_t* set_vec) {
                                       : idx_fresh_nonull(col, kind))) return NULL;
     bool col_is_float = (col->type == RAY_F32 || col->type == RAY_F64);
     if (col_is_float) return NULL;
+    /* A STR hash index is keyed on byte hashes — the int64 probes below do
+     * not apply (the eval-level `in` consults it via ray_index_find_vec). */
+    if (col->type == RAY_STR) return NULL;
     bool col_is_sym = (col->type == RAY_SYM);
 
     /* set_vec must be a non-atom vec of the matching family: SYM set for a
@@ -2585,8 +2670,8 @@ static ray_t* attr_set_unique(ray_t* v) {
     if (!v || RAY_IS_ERR(v)) return v ? v : ray_error("type", "attr: null");
     if (!ray_is_vec(v))
         return ray_error("type", "unique: attribute applies to vectors only");
-    if (numeric_elem_size(v->type) == 0)
-        return ray_error("nyi", "unique: only numeric vectors supported in v1 (type %d)", (int)v->type);
+    if (numeric_elem_size(v->type) == 0 && v->type != RAY_SYM && v->type != RAY_STR)
+        return ray_error("nyi", "unique: only numeric/sym/str vectors supported (type %d)", (int)v->type);
     if (v->attrs & RAY_ATTR_SLICE)
         return ray_error("type", "unique: cannot attribute a slice; materialize first");
     if (!vec_all_distinct(v))
@@ -2744,6 +2829,7 @@ int64_t ray_index_find_row(ray_t* col, int64_t key) {
     if (!col || RAY_IS_ERR(col)) return -2;
     int8_t t = col->type;
     if (t == RAY_F32 || t == RAY_F64) return -2;
+    if (t == RAY_STR) return -2;   /* byte-keyed: see ray_index_find_atom */
 
     /* Nonzero symbol equality is safe even when other rows are null. */
     if (t == RAY_SYM) {
@@ -2860,6 +2946,9 @@ int ray_index_hash_group(ray_t* col, int64_t key,
     *rows_out = NULL;
     *n_out = 0;
     if (!idx_fresh(col, RAY_IDX_HASH)) return -1;
+    /* A STR hash is byte-keyed: an int64 key is not a probe of it, and
+     * "out of range" below would wrongly read as provably absent. */
+    if (col->type == RAY_STR) return -1;
     int64_t gid = -1;
     ray_index_t* ix = hash_probe_setup(col, key, &gid);
     if (!ix) {
@@ -2873,4 +2962,226 @@ int ray_index_hash_group(ray_t* col, int64_t key,
     *rows_out = rw + of[gid];
     *n_out = of[gid + 1] - of[gid];
     return 1;
+}
+
+/* --------------------------------------------------------------------------
+ * Hash-index find for one atom / a vector of needles (the eval-level `find`,
+ * `in` and dict lookup) and the append carry.  Keyed per column type:
+ * integer family → value (ray_index_find_row), SYM → the needle re-expressed
+ * in the COLUMN's domain, STR → the needle's bytes.
+ * -------------------------------------------------------------------------- */
+
+/* Integer-family atom → int64 key.  Returns false for any other atom kind
+ * (float and cross-family needles keep the scan's promotion semantics). */
+static bool int_atom_key(const ray_t* a, int64_t* k) {
+    switch (a->type) {
+    case -RAY_I64:
+    case -RAY_TIMESTAMP: *k = a->i64;            return true;
+    case -RAY_I32:
+    case -RAY_DATE:
+    case -RAY_TIME:      *k = (int64_t)a->i32;   return true;
+    case -RAY_I16:       *k = (int64_t)a->i16;   return true;
+    case -RAY_BOOL:
+    case -RAY_U8:        *k = (int64_t)a->b8;    return true;
+    default:             return false;
+    }
+}
+
+/* A runtime-domain symbol id → this column's domain id, or -1 when the
+ * column's domain does not hold the symbol (provably absent). */
+static int64_t sym_id_in_col_domain(ray_t* col, int64_t runtime_id) {
+    if (ray_sym_vec_domain(col) == ray_sym_runtime_domain()) return runtime_id;
+    ray_t* s = ray_sym_str(runtime_id);
+    if (!s) return -1;
+    return ray_sym_vec_lookup(col, ray_str_ptr(s), ray_str_len(s));
+}
+
+int64_t ray_index_find_atom(ray_t* col, ray_t* a) {
+    if (!col || RAY_IS_ERR(col) || !a || RAY_IS_ERR(a)) return -2;
+    if (!ray_is_atom(a) || RAY_ATOM_IS_NULL(a)) return -2;
+    /* SYM mirrors ray_index_find_row: a nonzero symbol probe is sound even
+     * when other rows are null, so only freshness is required there. */
+    if (col->type == RAY_SYM ? !idx_fresh(col, RAY_IDX_HASH)
+                             : !idx_fresh_nonull(col, RAY_IDX_HASH)) return -2;
+    switch (col->type) {
+    case RAY_SYM: {
+        if (a->type != -RAY_SYM) return -2;
+        int64_t id = sym_id_in_col_domain(col, a->i64);
+        if (id < 0) return -1;
+        return ray_index_find_row(col, id);   /* id 0 (SYM null) → -2 */
+    }
+    case RAY_STR: {
+        if (a->type != -RAY_STR) return -2;
+        int64_t gid = -1;
+        ray_index_t* ix = hash_probe_setup_str(col, ray_str_ptr(a), ray_str_len(a), &gid);
+        if (!ix) return -2;
+        if (gid < 0) return -1;
+        const int64_t* of = (const int64_t*)ray_data(ix->u.hash.offs);
+        const int64_t* rw = (const int64_t*)ray_data(ix->u.hash.rows);
+        return rw[of[gid]];
+    }
+    default: {
+        int64_t k = 0;
+        if (!int_atom_key(a, &k)) return -2;
+        return ray_index_find_row(col, k);
+    }
+    }
+}
+
+int ray_index_find_vec(ray_t* col, ray_t* nd, int64_t* out, bool* any_miss) {
+    if (!col || RAY_IS_ERR(col) || !nd || RAY_IS_ERR(nd) || !out) return 0;
+    if (!ray_is_vec(nd) || ray_is_atom(nd)) return 0;
+    if (col->type == RAY_SYM ? !idx_fresh(col, RAY_IDX_HASH)
+                             : !idx_fresh_nonull(col, RAY_IDX_HASH)) return 0;
+    int64_t m = nd->len;
+    bool miss = false;
+    const uint8_t* nb = (const uint8_t*)ray_data(nd);
+    bool nd_nulls = (nd->attrs & RAY_ATTR_HAS_NULLS) != 0;
+
+    if (col->type == RAY_SYM) {
+        if (nd->type != RAY_SYM) return 0;
+        bool same_dom = (ray_sym_vec_domain(col) == ray_sym_vec_domain(nd));
+        for (int64_t i = 0; i < m; i++) {
+            int64_t id;
+            if (same_dom) {
+                id = ray_read_sym(nb, i, RAY_SYM, nd->attrs);
+            } else {
+                ray_t* s = ray_sym_vec_cell(nd, i);
+                id = s ? ray_sym_vec_lookup(col, ray_str_ptr(s), ray_str_len(s)) : -1;
+            }
+            /* id 0 is the SYM null: the scan / hashset own null equality. */
+            int64_t r = (id < 0) ? -1 : ray_index_find_row(col, id);
+            if (r == -2) return 0;
+            if (r < 0) { out[i] = NULL_I64; miss = true; } else out[i] = r;
+        }
+    } else if (col->type == RAY_STR) {
+        if (nd->type != RAY_STR) return 0;
+        for (int64_t i = 0; i < m; i++) {
+            if (nd_nulls && ray_vec_is_null(nd, i)) { out[i] = NULL_I64; miss = true; continue; }
+            size_t l = 0;
+            const char* p = ray_str_vec_get(nd, i, &l);
+            int64_t gid = -1;
+            ray_index_t* ix = hash_probe_setup_str(col, p, l, &gid);
+            if (!ix) return 0;
+            if (gid < 0) { out[i] = NULL_I64; miss = true; continue; }
+            const int64_t* of = (const int64_t*)ray_data(ix->u.hash.offs);
+            const int64_t* rw = (const int64_t*)ray_data(ix->u.hash.rows);
+            out[i] = rw[of[gid]];
+        }
+    } else {
+        /* Integer-family column and needles only: float equality (NaN, -0)
+         * and cross-family promotion belong to the scan / hashset paths. */
+        if (col->type == RAY_F32 || col->type == RAY_F64) return 0;
+        if (nd->type == RAY_F32 || nd->type == RAY_F64 || numeric_elem_size(nd->type) == 0) return 0;
+        for (int64_t i = 0; i < m; i++) {
+            if (nd_nulls && ray_vec_is_null(nd, i)) { out[i] = NULL_I64; miss = true; continue; }
+            int64_t r = ray_index_find_row(col, set_vec_read_i64(nb, nd->type, i));
+            if (r == -2) return 0;
+            if (r < 0) { out[i] = NULL_I64; miss = true; } else out[i] = r;
+        }
+    }
+    if (any_miss) *any_miss = miss;
+    return 1;
+}
+
+/* Carry `src`'s hash index onto `dst`, a fresh vector holding src's rows
+ * followed by appended rows.  Rebuilds nothing over the old rows: the group
+ * tables are copied and each appended row is probed once and added as a new
+ * single-row group.  An appended row that repeats a key is left alone — the
+ * CSR row slices would need re-laying (O(n), the re-attach cost the carry
+ * exists to avoid) and a `unique` marker would stop being true — so dst
+ * simply stays unindexed, as every concat result did before. */
+void ray_index_carry_append(ray_t* src, ray_t* dst) {
+    if (!src || RAY_IS_ERR(src) || !dst || RAY_IS_ERR(dst)) return;
+    if (!ray_is_vec(dst) || dst->type != src->type || dst->len < src->len) return;
+    if (dst->attrs & (RAY_ATTR_HAS_NULLS | RAY_ATTR_SLICE | RAY_ATTR_HAS_INDEX)) return;
+    if (!idx_fresh_nonull(src, RAY_IDX_HASH)) return;
+    int8_t t = src->type;
+    if (t == RAY_F32 || t == RAY_F64) return;
+    if (t == RAY_SYM && ray_sym_vec_domain(src) != ray_sym_vec_domain(dst)) return;
+    ray_index_t* sx = ray_index_payload(src->index);
+    if (!sx->u.hash.table || !sx->u.hash.gkeys || !sx->u.hash.offs || !sx->u.hash.rows) return;
+
+    int64_t n0 = src->len, n1 = dst->len, add = n1 - n0;
+    int64_t og = sx->u.hash.n_groups, ok = sx->u.hash.n_keys;
+    if (og + add < og || ok + add < ok) return;
+    bool is_str = (t == RAY_STR);
+
+    ray_t* gkeys = ray_vec_new(RAY_I64, og + add > 0 ? og + add : 1);
+    ray_t* offs  = ray_vec_new(RAY_I64, og + add + 1);
+    ray_t* rows  = ray_vec_new(RAY_I64, ok + add > 0 ? ok + add : 1);
+    uint64_t cap = next_pow2((uint64_t)(og + add < 4 ? 8 : 2 * (og + add)));
+    if (cap < 8) cap = 8;
+    ray_t* table = ray_vec_new(RAY_I64, (int64_t)cap);
+    if (!gkeys || RAY_IS_ERR(gkeys) || !offs || RAY_IS_ERR(offs) ||
+        !rows || RAY_IS_ERR(rows) || !table || RAY_IS_ERR(table)) {
+        if (gkeys && !RAY_IS_ERR(gkeys)) ray_release(gkeys);
+        if (offs  && !RAY_IS_ERR(offs))  ray_release(offs);
+        if (rows  && !RAY_IS_ERR(rows))  ray_release(rows);
+        if (table && !RAY_IS_ERR(table)) ray_release(table);
+        return;
+    }
+    int64_t* gk  = (int64_t*)ray_data(gkeys);
+    int64_t* of  = (int64_t*)ray_data(offs);
+    int64_t* rw  = (int64_t*)ray_data(rows);
+    int64_t* tbl = (int64_t*)ray_data(table);
+    uint64_t mask = cap - 1;
+    memcpy(gk, ray_data(sx->u.hash.gkeys), (size_t)og * sizeof(int64_t));
+    memcpy(of, ray_data(sx->u.hash.offs),  (size_t)(og + 1) * sizeof(int64_t));
+    memcpy(rw, ray_data(sx->u.hash.rows),  (size_t)ok * sizeof(int64_t));
+    if (cap == sx->u.hash.mask + 1) {
+        /* Same capacity: the old slots are valid as they are. */
+        memcpy(tbl, ray_data(sx->u.hash.table), (size_t)cap * sizeof(int64_t));
+    } else {
+        memset(tbl, 0, (size_t)cap * sizeof(int64_t));
+        for (int64_t g = 0; g < og; g++) {
+            uint64_t slot = mix64((uint64_t)gk[g]) & mask;
+            while (tbl[slot] != 0) slot = (slot + 1) & mask;
+            tbl[slot] = g + 1;
+        }
+    }
+
+    /* Appended rows: probe with equality; a hit means a repeated key. */
+    const uint8_t* base = (const uint8_t*)ray_data(dst);
+    int64_t ng = og, nk = ok;
+    for (int64_t r = n0; r < n1; r++) {
+        int64_t kw = (int64_t)hash_row_key_word(dst, base, r);
+        uint64_t slot = mix64((uint64_t)kw) & mask;
+        for (;;) {
+            int64_t gp1 = tbl[slot];
+            if (gp1 == 0) break;
+            if (gk[gp1 - 1] == kw &&
+                (!is_str || str_rows_eq(dst, rw[of[gp1 - 1]], r))) {
+                ray_release(gkeys); ray_release(offs);
+                ray_release(rows);  ray_release(table);
+                return;                       /* repeated key: not carried */
+            }
+            slot = (slot + 1) & mask;
+        }
+        tbl[slot] = ng + 1;
+        gk[ng] = kw;
+        rw[nk] = r;
+        of[ng + 1] = nk + 1;
+        ng++; nk++;
+    }
+    gkeys->len = ng; offs->len = ng + 1; rows->len = nk; table->len = (int64_t)cap;
+
+    ray_t* idx = ray_index_alloc(RAY_IDX_HASH, t, n1);
+    if (!idx || RAY_IS_ERR(idx)) {
+        ray_release(gkeys); ray_release(offs); ray_release(rows); ray_release(table);
+        return;
+    }
+    ray_index_t* ix = ray_index_payload(idx);
+    ix->u.hash.table    = table;
+    ix->u.hash.gkeys    = gkeys;
+    ix->u.hash.offs     = offs;
+    ix->u.hash.rows     = rows;
+    ix->u.hash.mask     = mask;
+    ix->u.hash.n_keys   = nk;
+    ix->u.hash.n_groups = ng;
+    /* Every appended key is new, so `unique` stays true and a single-row
+     * group is trivially ordered by any column: the markers carry over. */
+    ix->u.hash.order_sym = sx->u.hash.order_sym;
+    ix->markers = sx->markers;
+    attach_finalize(dst, idx);
 }

--- a/src/ops/idxop.h
+++ b/src/ops/idxop.h
@@ -369,6 +369,35 @@ ray_t* ray_index_in_rowsel(ray_t* col, ray_t* set_vec);
  * scan correctly surfaces null-equality searches. */
 int64_t ray_index_find_row(ray_t* col, int64_t key);
 
+/* ===== Hash-index find: one atom / a vector of needles =====
+ *
+ * ray_index_find_atom: like ray_index_find_row but keyed by an ATOM, so it
+ * also serves SYM columns (the symbol re-expressed in the column's domain)
+ * and STR columns (the bytes).  Same contract: >= 0 first row, -1 provably
+ * absent, -2 not eligible (no fresh null-free hash index, null / float /
+ * cross-family needle) — caller falls back to the scan.
+ *
+ * ray_index_find_vec: one probe per needle of the typed vector `needles`
+ * into `out[needles->len]` (first matching row, NULL_I64 on a miss; a null
+ * needle misses — the index is only consulted on null-free columns).
+ * Returns 1 when handled, 0 when not eligible (out is then unspecified and
+ * the caller builds its own hash).  Integer-family needles for an
+ * integer-family column, SYM for SYM (any domain), STR for STR. */
+int64_t ray_index_find_atom(ray_t* col, ray_t* atom);
+int ray_index_find_vec(ray_t* col, ray_t* needles, int64_t* out, bool* any_miss);
+
+/* ===== Hash-index carry across an append =====
+ *
+ * `dst` is a fresh (rc=1, unsliced, unindexed, null-free) vector whose first
+ * src->len rows are src's rows and whose tail is appended rows.  When src
+ * carries a fresh null-free hash index and every appended row is a NEW key,
+ * dst gets an equivalent index in O(groups + appended) without re-hashing the
+ * old rows; markers (`unique`) and the within-group order symbol carry over.
+ * A repeated key, a float column, a SYM domain change or OOM leave dst
+ * unindexed (the caller re-attaches if it wants one).  Best-effort: never
+ * fails the append. */
+void ray_index_carry_append(ray_t* src, ray_t* dst);
+
 /* ===== Hash-index group slice (CSR accessor) =====
  *
  * Resolve `key` to its group's contiguous ascending row-id slice.

--- a/src/store/col.c
+++ b/src/store/col.c
@@ -875,7 +875,11 @@ static ray_err_t col_save_impl(ray_t* vec, const char* path, bool durable) {
             ray_index_t* ix = ray_index_payload(vec->index);
             header.attrs &= ~RAY_ATTR_HAS_INDEX;
             memcpy(header.aux, ix->saved_aux, 16);
-            persist_index = (vec->index != NULL);
+            /* STR indexes (dict, hash) are appended after the pool by the
+             * splayed builder (ray_col_append_index), which stamps the marker
+             * itself and refuses a file already carrying one — so a STR save
+             * must not stamp it here. */
+            persist_index = (vec->index != NULL) && vec->type != RAY_STR;
         }
 
         /* HAS_LINK rebase: target sym ID lives at header.aux[8..15],

--- a/src/store/splay.c
+++ b/src/store/splay.c
@@ -560,6 +560,24 @@ void ray_splay_build_indexes(const char* dir, ray_t* tbl) {
             continue;
         }
 
+        /* Explicit STR index: a grouped / unique hash on a STR column is keyed
+         * on byte hashes and row ids — neither depends on a domain — so the
+         * in-memory index persists verbatim, regardless of length.  It takes
+         * the column's single index slot: the size-gated auto dictionary
+         * below is not built for it. */
+        if (col->type == RAY_STR && ray_index_kind(col) == RAY_IDX_HASH) {
+            ray_t* nstr = ray_sym_str(ray_table_col_name(tbl, c));
+            if (nstr && !RAY_IS_ERR(nstr)) {
+                char path[1024];
+                int n = snprintf(path, sizeof(path), "%s/%.*s", dir,
+                                 (int)ray_str_len(nstr), ray_str_ptr(nstr));
+                if (n > 0 && n < (int)sizeof(path))
+                    (void)ray_col_append_index(path, ray_index_payload(col->index),
+                                               col->len, RAY_STR);
+            }
+            continue;
+        }
+
         if (col->len < (1 << 16)) continue;
 
         /* STR columns get a dictionary (group on int codes); numeric/temporal

--- a/src/table/dict.c
+++ b/src/table/dict.c
@@ -26,6 +26,7 @@
 #include "table.h"
 #include "table/sym.h"
 #include "lang/internal.h"   /* atom_eq for RAY_LIST key compares */
+#include "ops/idxop.h"       /* ray_index_find_atom: keyed lookup via an attached hash */
 #include <string.h>
 
 /* --------------------------------------------------------------------------
@@ -200,6 +201,13 @@ int64_t ray_dict_find_idx(ray_t* d, ray_t* key_atom) {
 
     /* Typed-vector keys: atom type must match. */
     if (key_atom->type != -kt) return -1;
+
+    /* Keys carrying a hash index (`.attr.set 'grouped` / `'unique`): one
+     * probe instead of the scan below.  -2 = not eligible → scan. */
+    if (ray_index_has(keys)) {
+        int64_t r = ray_index_find_atom(keys, key_atom);
+        if (r >= -1) return r;
+    }
 
     /* Null-aware probe: a null key atom matches only null slots; a non-null
      * key atom must match a non-null slot of equal value.  Without this, a

--- a/test/rfl/integration/attributes.rfl
+++ b/test/rfl/integration/attributes.rfl
@@ -70,8 +70,10 @@
 (.idx.has? (reverse (.attr.set 'grouped [1 1 2 3 3]))) -- false
 ;; concat of a sorted column with more data drops the marker
 (.attr.get (concat (.attr.set 'sorted [1 2 3]) [0 1])) -- (take ['a] 0)
-;; concat of a grouped column drops the backing index
-(.idx.has? (concat (.attr.set 'grouped [1 1 2 3 3]) [4 5])) -- false
+;; concat of a grouped column carries the backing index when every appended
+;; key is new (see ops/idx_find_in.rfl); a repeated key drops it
+(.idx.has? (concat (.attr.set 'grouped [1 1 2 3 3]) [4 5])) -- true
+(.idx.has? (concat (.attr.set 'grouped [1 1 2 3 3]) [3 4])) -- false
 ;; where-filtered selection off a sorted column drops the marker
 (.attr.get (at (.attr.set 'sorted [1 2 3 4 5]) (where [true false true false true]))) -- (take ['a] 0)
 ;; a plain rebind PRESERVES the marker (trivially-preserving)

--- a/test/rfl/ops/idx_find_in.rfl
+++ b/test/rfl/ops/idx_find_in.rfl
@@ -1,0 +1,154 @@
+;; Vector-needle find / in / dict lookup against an attached hash index, the
+;; STR hash attach, and the index carried across concat (issue #519).
+;;
+;; Every indexed answer is cross-checked against the same call on the plain
+;; vector (drop-differential): positions, duplicates, misses → null.  The
+;; index is consulted by find / in / at directly on the vector, so no query
+;; wrapper is needed to reach the routing site.
+
+;; ─────────────────────────── I64: find / in with a vector of needles ────────
+(set hi [10 20 30 10 50 10 70 10 90 100])          ;; 10 repeats: first at row 0
+(set gi (.attr.set 'grouped hi))
+(.attr.get gi) -- ['grouped]
+(find gi [50 10 999 100 10]) -- [4 0 0N 9 0]
+(find gi [50 10 999 100 10]) -- (find hi [50 10 999 100 10])
+(find gi [999]) -- [0N]
+(find gi []) -- (find hi [])
+(in [50 999 10] gi) -- [true false true]
+(in [50 999 10] gi) -- (in [50 999 10] hi)
+;; narrower needles probe the same keys; a float needle keeps the scan path
+(find gi (as 'i32 [30 31])) -- (find hi (as 'i32 [30 31]))
+(find gi [30.0 31.5]) -- (find hi [30.0 31.5])
+;; scalar find still answers through the index
+(find gi 70) -- 6
+(find gi 71) -- 0N
+;; unique marker on top of grouped: the same probes
+(set ui (.attr.set 'unique (.attr.set 'grouped [5 6 7 8])))
+(.attr.get ui) -- ['unique 'grouped]
+(find ui [8 5 9]) -- [3 0 0N]
+(in [8 9] ui) -- [true false]
+
+;; ─────────────────────────── the needle side hashed when smaller ───────────
+;; no index: fewer needles than rows hashes the needles and scans once — the
+;; answers (first occurrence, duplicates, misses, null needle) are unchanged
+(set big (concat (til 1000) [7 7 7]))
+(find big [7 999 1002 5000 7]) -- [7 999 0N 0N 7]
+(find big [0N 3]) -- [0N 3]
+(set bn (concat [1 0N 2] (til 500)))
+(find bn [0N 2 499]) -- [1 2 502]
+(in [7 5000 0] big) -- [true false true]
+(in [0N 2] bn) -- [true true]
+
+;; ─────────────────────────── SYM: same domain and a different one ──────────
+(set hs ['a 'b 'a 'c 'a 'b])
+(set gs (.attr.set 'grouped hs))
+(find gs ['c 'a 'z 'b]) -- [3 0 0N 1]
+(find gs ['c 'a 'z 'b]) -- (find hs ['c 'a 'z 'b])
+(in ['z 'b] gs) -- [false true]
+(find gs 'c) -- 3
+(find gs 'z) -- 0N
+;; unique now admits SYM
+(.attr.get (.attr.set 'unique ['x 'y 'z])) -- ['unique]
+(.attr.set 'unique ['x 'y 'x]) !- domain
+;; a splayed round trip puts the column in a FILE domain; the needles stay
+;; runtime-domain — the probe translates them through the column's domain
+(.sys.exec "rm -rf /tmp/rf-idx-find-sym")
+(.db.splayed.set "/tmp/rf-idx-find-sym/" (table ['k 'v] (list gs [1 2 3 4 5 6])))
+(set ls (at (.db.splayed.get "/tmp/rf-idx-find-sym/") 'k))
+(.attr.get ls) -- ['grouped]
+(find ls ['c 'a 'z 'b]) -- [3 0 0N 1]
+(in ['z 'b 'a] ls) -- [false true true]
+(find ls 'b) -- 1
+
+;; ─────────────────────────── STR: the hash attach is admitted ──────────────
+(set hstr ["alpha" "beta" "alpha" "gamma" "delta" "beta"])
+(set gstr (.attr.set 'grouped hstr))
+(.attr.get gstr) -- ['grouped]
+(.idx.has? gstr) -- true
+(at (.idx.info gstr) 'kind) -- 'hash
+(at (.idx.info gstr) 'n_groups) -- 4
+(find gstr ["gamma" "alpha" "zeta" "delta" "beta"]) -- [3 0 0N 4 1]
+(find gstr ["gamma" "alpha" "zeta" "delta" "beta"]) -- (find hstr ["gamma" "alpha" "zeta" "delta" "beta"])
+(in ["zeta" "beta" "delta"] gstr) -- [false true true]
+(in ["zeta" "beta" "delta"] gstr) -- (in ["zeta" "beta" "delta"] hstr)
+(find gstr "gamma") -- 3
+(find gstr "zeta") -- 0N
+;; an empty string is the STR null: such a vector keeps the scan semantics
+(find (.attr.set 'grouped ["a" "" "b"]) ["" "b" "c"]) -- (find ["a" "" "b"] ["" "b" "c"])
+;; the index rides the vector through ordinary reads
+(at gstr 3) -- "gamma"
+(count gstr) -- 6
+;; unique on STR: verified, then a marker on the hash
+(set ustr (.attr.set 'unique (.attr.set 'grouped ["k1" "k2" "k3"])))
+(.attr.get ustr) -- ['unique 'grouped]
+(.attr.set 'unique ["k1" "k2" "k1"]) !- domain
+(.attr.get (.attr.set 'unique ["k1" "k2"])) -- ['unique]
+;; long (out-of-line) strings hash and compare by their bytes too
+(set lstr (.attr.set 'grouped (as 'str (+ 1000000000000000000 (til 300)))))
+(find lstr (as 'str [1000000000000000299 1000000000000000000 1000000000000000300])) -- [299 0 0N]
+;; a splayed round trip keeps the STR hash
+(.sys.exec "rm -rf /tmp/rf-idx-find-str")
+(.db.splayed.set "/tmp/rf-idx-find-str/" (table ['k 'v] (list gstr [1 2 3 4 5 6])))
+(set lstr2 (at (.db.splayed.get "/tmp/rf-idx-find-str/") 'k))
+(.attr.get lstr2) -- ['grouped]
+(find lstr2 ["gamma" "alpha" "zeta" "delta" "beta"]) -- [3 0 0N 4 1]
+(in ["zeta" "beta"] lstr2) -- [false true]
+
+;; ─────────────────────────── dict lookup through the keys' index ───────────
+(set d (dict gstr [1 2 3 4 5 6]))
+(at d "gamma") -- 4
+(at d "zeta") -- 0N
+(at d ["gamma" "alpha" "zeta" "beta"]) -- (list 4 1 0N 2)
+(at d ["gamma" "alpha" "zeta" "beta"]) -- (at (dict hstr [1 2 3 4 5 6]) ["gamma" "alpha" "zeta" "beta"])
+(set di (dict gi (til 10)))
+(at di [50 10 999 100]) -- (list 4 0 0N 9)
+(at di [50 10 999 100]) -- (at (dict hi (til 10)) [50 10 999 100])
+(at di 70) -- 6
+(at di 71) -- 0N
+;; a dict with list values gathers the same elements
+(set dl (dict (.attr.set 'grouped [1 2 3]) (list "one" "two" "three")))
+(at dl [3 1 9]) -- (list "three" "one" 0N)
+
+;; ─────────────────────────── concat keeps the index for new keys ───────────
+(set c0 (.attr.set 'unique (.attr.set 'grouped [100 200 300])))
+(set c1 (concat c0 [400 500]))
+(.attr.get c1) -- ['unique 'grouped]
+(count c1) -- 5
+(find c1 [500 100 300 999]) -- [4 0 2 0N]
+(find c1 [500 100 300 999]) -- (find [100 200 300 400 500] [500 100 300 999])
+(in [400 999] c1) -- [true false]
+;; an atom appended is the same motion
+(set c2 (concat c1 600))
+(.attr.get c2) -- ['unique 'grouped]
+(find c2 [600 100]) -- [5 0]
+;; a repeated key is not carried: the result is a plain vector, as before
+(.attr.get (concat c0 [300 700])) -- (.attr.get [1 2])
+(find (concat c0 [300 700]) [300 700]) -- [2 4]
+;; grouped without unique: new keys carry, a repeat drops
+(.attr.get (concat gi [1 2 3])) -- ['grouped]
+(find (concat gi [1 2 3]) [3 10 1]) -- [12 0 10]
+(.attr.get (concat gi [10])) -- (.attr.get [1 2])
+;; many appends grow the bucket table past its load factor
+(set cg (concat (.attr.set 'grouped (til 5)) (+ 5 (til 2000))))
+(.attr.get cg) -- ['grouped]
+(at (.idx.info cg) 'n_groups) -- 2005
+(find cg [0 4 5 2004 2005]) -- [0 4 5 2004 0N]
+(find cg [0 4 5 2004 2005]) -- (find (til 2005) [0 4 5 2004 2005])
+(sum (find cg (til 2005))) -- (sum (til 2005))
+;; STR and SYM appends carry too
+(set cs (concat gstr ["epsilon"]))
+(.attr.get cs) -- ['grouped]
+(find cs ["epsilon" "alpha"]) -- [6 0]
+(.attr.get (concat gstr ["alpha"])) -- (.attr.get [1 2])
+(set csy (concat gs ['d]))
+(.attr.get csy) -- ['grouped]
+(find csy ['d 'a 'z]) -- [6 0 0N]
+;; a null appended leaves the result unindexed
+(.attr.get (concat c0 [0N])) -- (.attr.get [1 2])
+(find (concat c0 [0N]) [0N 300]) -- [3 2]
+;; the carried index persists like a built one
+(.sys.exec "rm -rf /tmp/rf-idx-find-carry")
+(.db.splayed.set "/tmp/rf-idx-find-carry/" (table ['k] (list c1)))
+(.attr.get (at (.db.splayed.get "/tmp/rf-idx-find-carry/") 'k)) -- ['unique 'grouped]
+(find (at (.db.splayed.get "/tmp/rf-idx-find-carry/") 'k) [500 999]) -- [4 0N]
+(.sys.exec "rm -rf /tmp/rf-idx-find-sym /tmp/rf-idx-find-str /tmp/rf-idx-find-carry")

--- a/test/rfl/ops/idxop_coverage.rfl
+++ b/test/rfl/ops/idxop_coverage.rfl
@@ -262,9 +262,10 @@
 (.idx.sort ['x 'y]) !- nyi
 (.idx.bloom ['p 'q]) !- nyi
 
-;; ── string vec also unsupported in v1 ──
+;; ── string vec: hash supported (byte-keyed, see ops/idx_find_in.rfl), the rest nyi ──
 (.idx.zone ["alpha" "beta"]) !- nyi
-(.idx.hash ["a" "b"]) !- nyi
+(.idx.has? (.idx.hash ["a" "b"])) -- true
+(.idx.sort ["a" "b"]) !- nyi
 
 ;; ── non-vector input (atom): ray_is_vec -> false -> "type" error ──
 (.idx.zone 42) !- type


### PR DESCRIPTION
Closes #519.

A keyed lookup against a large vector rebuilt a hash over the whole vector on every call, and nothing attachable changed that. Three changes, matching the issue's three asks, plus the dict lookup it mentions.

## What changes

**1. `find` / `in` with a vector of needles consult the attached hash index.** `ray_index_find_vec` probes a fresh hash index once per needle: integer family by value, SYM through the column's domain (same or file domain), STR by the needle's bytes. Scalar `find` and the dict scalar lookup go through `ray_index_find_atom`, which extends the old integer-only scalar path to SYM and STR. `(at dict keys)` with a typed key vector resolves every position with one `find` instead of a scan per probe.

Without an index, `find` and the hashset fallback of `in` now hash whichever side is smaller and scan the other once (early exit when every distinct needle has been seen). That is the orientation trick from the issue's workaround, made the default.

**2. `RAY_STR` is admitted to the hash attach** (`'grouped`, `'unique`, `.idx.hash`). The key word is a 64-bit hash of the bytes; every word hit in the builder and in the probes is confirmed against the payload of the group's first row, so a word collision becomes two groups rather than one merged group. The int64-keyed consults (eq/in rowsel, `ray_index_hash_group`, `ray_index_find_row`) decline a STR column instead of reading an out-of-range key as "provably absent". A STR hash persists through a splayed save verbatim (byte hashes and row ids are domain-free) in the column's single index slot, replacing the automatic string dictionary for that column.

**3. `concat` carries the index when every appended key is new.** `ray_index_carry_append` copies the CSR tables onto the concat result and adds each appended row as a single-row group; `unique` and the within-group order symbol carry over. A repeated key, a null, a float column or a SYM domain change leave the result a plain vector as before, so an insert loop with repeating keys never pays a hidden O(n) rebuild. Applies to `(concat v rows)`, `(concat v atom)` and therefore `(alter 'v concat ...)`.

## Numbers (release, 362k keys, 100 needles, same box)

| case | before | after |
|---|---|---|
| STR `find`, `'grouped` | 22 ms | 1 ms (15 ms with no index at all) |
| STR dict `at`, 100 probes | 139 ms | 1 ms |
| I64 / SYM `find`, `'grouped` | 8 / 9 ms | 0 ms |
| concat +100 rows onto indexed 362k I64 | index dropped | 4 ms, kept (re-attach: 7 ms; STR 9 vs 26 ms) |

One clarification for the reporter: `'unique` alone attaches a marker with no table, so the issue's "I64 with 'unique" cells never had an index to consult. `'grouped` (optionally with `'unique` on top) attaches the hash these paths use. Docs updated accordingly.

## Tests

`test/rfl/ops/idx_find_in.rfl`: drop-differential for I64, SYM (same and file domain), STR; duplicates, misses, null needles; the small-side orientation; dict lookups; concat carry including bucket-table growth, repeat / null / STR / SYM cases; splayed round trips of STR and carried indexes. Two existing expectations updated: `.idx.hash` on STR now succeeds; concat of new keys keeps the index. Full suite: 3784/3784, no UBSan output.

## Not in this PR

- `(== strcol "x")` in a `where` still scans a STR hash (the filter decode is int-keyed).
- A `'unique`-only marker on a STR column does not persist (numeric ones do).

https://claude.ai/code/session_017fCcYRuzNagw6nmLqZ9zbU
