### PR TITLE
fix(journal): preserve archives when rolls share a timestamp

### DIFF
--- a/src/store/journal.c
+++ b/src/store/journal.c
@@ -790,6 +790,15 @@ ray_err_t ray_journal_roll(void) {
     int  n = snprintf(archive, sizeof(archive), "%s.%s.log", g_journal.base, stamp);
     if (n <= 0 || (size_t)n >= sizeof(archive)) return RAY_ERR_DOMAIN;
 
+    /* Rolls can happen more than once during a single UTC second.  Keep the
+     * readable timestamp for the common case, but never let rename() replace
+     * an earlier archive when the timestamp collides. */
+    for (unsigned int suffix = 1; file_exists(archive); suffix++) {
+        n = snprintf(archive, sizeof(archive), "%s.%s.%u.log",
+                     g_journal.base, stamp, suffix);
+        if (n <= 0 || (size_t)n >= sizeof(archive)) return RAY_ERR_DOMAIN;
+    }
+
     int flush_rc = fflush(g_journal.fp);
     int close_rc = fclose(g_journal.fp);
     g_journal.fp = NULL;

--- a/test/test_journal.c
+++ b/test/test_journal.c
@@ -982,6 +982,15 @@ static test_result_t test_journal_roll_twice(void) {
     ray_journal_validate(lpath, &chunks, NULL);
     TEST_ASSERT_EQ_I(chunks, 0);
 
+    /* Two rolls in one second must leave both archived segments intact. */
+    char pattern[300];
+    snprintf(pattern, sizeof(pattern), "%s.*.log", base);
+    glob_t archives;
+    memset(&archives, 0, sizeof(archives));
+    TEST_ASSERT_EQ_I(glob(pattern, 0, NULL, &archives), 0);
+    TEST_ASSERT_EQ_U(archives.gl_pathc, 2);
+    globfree(&archives);
+
     TEST_ASSERT_EQ_I(ray_journal_close(), RAY_OK);
     cleanup_base(base);
     PASS();


### PR DESCRIPTION
## How it looks from the user's side

A service rolls its journal twice during the same UTC second.

**Before** - both rolls target the same `base.YYYY.MM.DDTHH.MM.SSZ.log` path, so the second roll replaces the first archive and its journal entries are lost.

**After** - the first archive keeps the timestamped name and subsequent collisions use unique names such as `base.YYYY.MM.DDTHH.MM.SSZ.1.log`, preserving every segment.

## Root cause

`ray_journal_roll` generated archive names with second-level precision and passed them to `rename()`, which replaces an existing destination.

## Fix

Probe the timestamped archive path before closing the journal. If it already exists, append an incrementing numeric suffix until an unused path is found.

## Tests

- `./rayforce.test --filter journal/roll_twice`
- `make test` with the repository's non-ASAN debug flags
- Result: 3779 of 3780 passed, 1 skipped, 0 failed